### PR TITLE
Fix CI

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - pyside2=5.13.2
   - scipy=1.4.1
   - graphviz
-  - pip=21.1.3
+  - pip
   - pip:
-    - -r file:../requirements.txt
-    - -r file:../requirements-develop.txt
+    - -r ../requirements.txt
+    - -r ../requirements-develop.txt


### PR DESCRIPTION
I suspect the CI is failing due to changes in the latest miniforge version (and how it works with the miniconda setup package)... trying with a static version rather than "latest".

Closes #100 