### PR TITLE
Reduce loop warnings

### DIFF
--- a/BLUEPRINT/geometry/loop.py
+++ b/BLUEPRINT/geometry/loop.py
@@ -93,7 +93,10 @@ class Loop(GeomBase):
     the third coordinate with np.zeros(N)
     """
 
+    warning_printed = False
+
     def __init__(self, x=None, y=None, z=None, enforce_ccw=True):
+        self._print_warning()
         self.x = x
         self.y = y
         self.z = z
@@ -109,6 +112,13 @@ class Loop(GeomBase):
 
         self.inner = None
         self.outer = None
+
+    def _print_warning(self):
+        if not Loop.warning_printed:
+            bluemira_warn(
+                type(self).__module__ + "." + type(self).__name__ + " is deprecated."
+            )
+            Loop.warning_printed = True
 
     @classmethod
     def from_dict(cls, xyz_dict):

--- a/bluemira/geometry/_deprecated_loop.py
+++ b/bluemira/geometry/_deprecated_loop.py
@@ -106,10 +106,7 @@ class Loop(GeomBase):
         "outer",
     ]
 
-    warning_printed = False
-
     def __init__(self, x=None, y=None, z=None, enforce_ccw=True):
-        self._print_warning()
         self.x = x
         self.y = y
         self.z = z
@@ -131,13 +128,6 @@ class Loop(GeomBase):
             if enforce_ccw:
                 self.reverse()
         self._remove_duplicates(enforce_ccw)
-
-    def _print_warning(self):
-        if not Loop.warning_printed:
-            bluemira_warn(
-                type(self).__module__ + "." + type(self).__name__ + " is deprecated."
-            )
-            Loop.warning_printed = True
 
     @classmethod
     def from_dict(cls, xyz_dict):


### PR DESCRIPTION
Add deprecation warning to deprecated loop with class-level static bool to prevent multiple prints.

I think this should really be done more automatically via decorations, but this is just a quick fix to keep @sebkahn  happy.

Closes #348 