### PR TITLE
🐛 missing AR for inscribed rectangle

### DIFF
--- a/bluemira/equilibria/positioner.py
+++ b/bluemira/equilibria/positioner.py
@@ -703,7 +703,9 @@ class RegionMapper:
         for no, (name, region) in enumerate(self.regions.items()):
             coil = self._coilset.coils[self._name_converter(name)]
             self.max_currents[no] = get_max_current(
-                *inscribed_rect_in_poly(region.loop.x, region.loop.z, coil.x, coil.z),
+                *inscribed_rect_in_poly(
+                    region.loop.x, region.loop.z, coil.x, coil.z, coil.dx / coil.dz
+                ),
                 coil.j_max,
             )
 


### PR DESCRIPTION
This seems to have been removed in the port over from the old blueprint repo