### PR TITLE
Divertor target swap

### DIFF
--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -136,6 +136,11 @@ def get_tangent_vector(point_on_loop, loop):
 
     # Return normalised tangent vector
     tangent_norm = tangent / np.linalg.norm(tangent)
+
+    # Fixing the tangent vector direction to be concordant with the x-axis
+    if tangent_norm[0] > 0:
+        tangent_norm = -tangent_norm
+
     return tangent_norm
 
 
@@ -510,14 +515,9 @@ class DivertorBuilder:
         """
         # Find the tangent to the approriate flux loop at the outer strike point
         tangent = get_tangent_vector(outer_strike, flux_loop)
-        if tangent[0] > 0:
-            tangent = -tangent
 
         # Get the outer target points
-        (
-            outer_target_internal_point,
-            outer_target_external_point,
-        ) = self.make_divertor_target(
+        (outer_target_pfr_end, outer_target_sol_end) = self.make_divertor_target(
             outer_strike,
             tangent,
             vertical_target=self.inputs["div_vertical_outer_target"],
@@ -536,10 +536,10 @@ class DivertorBuilder:
         # Select the top and bottom limits for the guide lines
         z_x_point = self.points["x_point"]["z_low"]
         outer_leg_external_top_limit = [div_top_right, z_x_point]
-        outer_leg_external_bottom_limit = outer_target_external_point
+        outer_leg_external_bottom_limit = outer_target_sol_end
 
         outer_leg_internal_top_limit = middle_point
-        outer_leg_internal_bottom_limit = outer_target_internal_point
+        outer_leg_internal_bottom_limit = outer_target_pfr_end
 
         # Make the guide lines
         external_guide_line = make_guide_line(
@@ -560,7 +560,7 @@ class DivertorBuilder:
             internal_guide_line.x,
             internal_guide_line.z,
             [middle_point[0], middle_point[1]],
-            outer_target_internal_point,
+            outer_target_pfr_end,
             degree_in,
         )
 
@@ -570,7 +570,7 @@ class DivertorBuilder:
             external_guide_line.x,
             external_guide_line.z,
             [div_top_right, z_x_point],
-            outer_target_external_point,
+            outer_target_sol_end,
             degree_out,
         )
 
@@ -607,21 +607,17 @@ class DivertorBuilder:
         """
         # Find the tangent to the approriate flux loop at the outer strike point
         tangent = get_tangent_vector(inner_strike, flux_loop)
-        if tangent[0] > 0:
-            tangent = -tangent
-
-        degree = self.inner_leg_polyfit_degree
 
         # Get the outer target points
-        (
-            inner_target_internal_point,
-            inner_target_external_point,
-        ) = self.make_divertor_target(
+        (inner_target_pfr_end, inner_target_sol_end,) = self.make_divertor_target(
             inner_strike,
             tangent,
             vertical_target=self.inputs["div_vertical_inner_target"],
             outer_target=False,
         )
+
+        # Select the degree of the fitting polynomial
+        degree = self.inner_leg_polyfit_degree
 
         # Select those points along the given flux line below the X point
         inner_leg_central_guide_line = flux_loop
@@ -640,7 +636,7 @@ class DivertorBuilder:
         # Select those points along the top-clipped flux line above the
         # inner target internal point height
         bottom_clip_inner_leg_central_guide_line = np.where(
-            inner_leg_central_guide_line.z > inner_target_internal_point[1],
+            inner_leg_central_guide_line.z > inner_target_pfr_end[1],
         )
 
         # Create a new Loop from the points selected along the flux line
@@ -656,7 +652,7 @@ class DivertorBuilder:
             inner_leg_central_guide_line.x,
             inner_leg_central_guide_line.z,
             [middle_point[0], middle_point[1]],
-            inner_target_internal_point,
+            inner_target_pfr_end,
             degree,
         )
 
@@ -666,7 +662,7 @@ class DivertorBuilder:
             inner_leg_central_guide_line.x,
             inner_leg_central_guide_line.z,
             [div_top_left, z_x_point],
-            inner_target_external_point,
+            inner_target_sol_end,
             degree,
         )
 

--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -607,6 +607,8 @@ class DivertorBuilder:
         """
         # Find the tangent to the approriate flux loop at the outer strike point
         tangent = get_tangent_vector(inner_strike, flux_loop)
+        if tangent[0] > 0:
+            tangent = -tangent
 
         degree = self.inner_leg_polyfit_degree
 

--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -486,9 +486,8 @@ class DivertorBuilder:
             ) or (vertical_target and sol_target_end[0] < pfr_target_end[0])
 
         if swap_points:
-            tmp = pfr_target_end
-            pfr_target_end = sol_target_end
-            sol_target_end = tmp
+            pfr_target_end = -pfr_target_end
+            sol_target_end = -sol_target_end
 
         # Add the strike point to diffs to get the absolute positions
         # of the end points of the target

--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -510,6 +510,8 @@ class DivertorBuilder:
         """
         # Find the tangent to the approriate flux loop at the outer strike point
         tangent = get_tangent_vector(outer_strike, flux_loop)
+        if tangent[0] > 0:
+            tangent = -tangent
 
         # Get the outer target points
         (

--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -466,28 +466,19 @@ class DivertorBuilder:
 
         # if horizontal target
         if not vertical_target:
-            target_par = rotate_vector_2d(tangent, np.radians(theta_target * sign))
+            target_par = rotate_vector_2d(
+                tangent, np.radians(180 + (theta_target * sign))
+            )
         # if vertical target
         else:
-            target_par = rotate_vector_2d(tangent, np.radians(-theta_target * sign))
+            target_par = rotate_vector_2d(
+                tangent, np.radians(360 - (theta_target * sign))
+            )
 
         # Create relative vectors whose length will be the offset distance
         # from the strike point
         pfr_target_end = -target_par * target_length_pfr * sign
         sol_target_end = target_par * target_length_sol * sign
-
-        # Swap if we got the wrong way round
-        if outer_target:
-            swap_points = sol_target_end[0] < pfr_target_end[0]
-        # for the inner target
-        else:
-            swap_points = (
-                not vertical_target and sol_target_end[0] > pfr_target_end[0]
-            ) or (vertical_target and sol_target_end[0] < pfr_target_end[0])
-
-        if swap_points:
-            pfr_target_end = -pfr_target_end
-            sol_target_end = -sol_target_end
 
         # Add the strike point to diffs to get the absolute positions
         # of the end points of the target

--- a/tests/BLUEPRINT/systems/test_firstwall.py
+++ b/tests/BLUEPRINT/systems/test_firstwall.py
@@ -189,7 +189,7 @@ class TestFirstWallDN:
             outer_target=True,
         )
         assert tar_out[0][0] > self.firstwall.points["x_point"]["x"]
-        assert tar_out[0][0] < tar_out[1][0]
+        assert tar_out[0][0] > tar_out[1][0]
 
     def test_make_divertor_inner_target(self):
         div_builder = self.firstwall.divertor_builder

--- a/tests/BLUEPRINT/systems/test_firstwall.py
+++ b/tests/BLUEPRINT/systems/test_firstwall.py
@@ -188,8 +188,11 @@ class TestFirstWallDN:
             vertical_target=True,
             outer_target=True,
         )
-        assert tar_out[0][0] > self.firstwall.points["x_point"]["x"]
-        assert tar_out[0][0] > tar_out[1][0]
+        tar_pfr_end = tar_out[0]
+        tar_sol_end = tar_out[1]
+        assert tangent[0] < 0
+        assert tar_sol_end[0] > self.firstwall.points["x_point"]["x"]
+        assert tar_sol_end[0] > tar_pfr_end[0]
 
     def test_make_divertor_inner_target(self):
         div_builder = self.firstwall.divertor_builder
@@ -202,8 +205,11 @@ class TestFirstWallDN:
             vertical_target=False,
             outer_target=False,
         )
-        assert tar_in[0][0] < self.firstwall.points["x_point"]["x"]
-        assert tar_in[0][0] > tar_in[1][0]
+        tar_pfr_end = tar_in[0]
+        tar_sol_end = tar_in[1]
+        assert tangent[0] < 0
+        assert tar_pfr_end[0] < self.firstwall.points["x_point"]["x"]
+        assert tar_pfr_end[0] > tar_sol_end[0]
 
     @pytest.mark.parametrize("ints_from_psi", [True, False])
     def test_make_divertor_from_koz(self, ints_from_psi):


### PR DESCRIPTION
#432 

In some cases, depending on the target type (horizontal or vertical), the plasma flux region side and the scrape off layer side of the target appeared to be swapped.

Now it should work. Sorry @sebkahn, I didn't find any more elegant way.