### PR TITLE
Clean up `Plottable` API and add labels to plots

### DIFF
--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -407,7 +407,7 @@ class BasePlotter(ABC):
         """
         pass
 
-    def plot_3d(self, obj, ax=None, show: bool = True, *args, **kwargs):
+    def plot_3d(self, obj, ax=None, show: bool = True):
         """3D plotting method"""
         self._check_obj(obj)
 
@@ -780,7 +780,7 @@ class Plottable:
         """
         return _get_plotter_class(self)(self._plot_options)
 
-    def plot_2d(self, ax=None, show: bool = True, *args, **kwargs) -> None:
+    def plot_2d(self, ax=None, show: bool = True) -> None:
         """
         Default method to call display the object by calling into the Displayer's display
         method.
@@ -790,9 +790,9 @@ class Plottable:
         axes
             The axes that the plot has been displayed onto.
         """
-        return self._plotter.plot_2d(self, ax=ax, show=show, *args, **kwargs)
+        return self._plotter.plot_2d(self, ax=ax, show=show)
 
-    def plot_3d(self, ax=None, show: bool = True, *args, **kwargs) -> None:
+    def plot_3d(self, ax=None, show: bool = True) -> None:
         """
         Function to 3D plot a component.
 
@@ -801,4 +801,4 @@ class Plottable:
         axes
             The axes that the plot has been displayed onto.
         """
-        return self._plotter.plot_3d(self, ax=ax, show=show, *args, **kwargs)
+        return self._plotter.plot_3d(self, ax=ax, show=show)


### PR DESCRIPTION
## Linked Issues

Closes #505

## Description

* Adds labels to 2-D and 3-D plots, sidestepping some unintuitive inner workings of `BluemiraPlane`
* Removes args and kwargs from `Plottable` which were not used in the plotters, and I don't see how they would be.

Honestly, I always wanted a `something.plot(ax, **kwargs)` signature, but seeing as now everything goes through a `Plottable`, `Plotter` and its `PlotOptions` I don't really know if we can square that circle. Either way, the current interface is misleading (kwargs are not used), and this PR fixes that.

## Interface Changes

* Removes args and kwargs from `Plottable` which were not used in the plotters, and I don't see how they would be.

## Checklist

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
