### PR TITLE
Color cycle for `Component`

### DIFF
--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -34,6 +34,7 @@ from bluemira.codes import _freecadapi as cadapi
 
 from .error import DisplayError
 from .plotter import DisplayOptions
+from .palettes import BLUE_PALETTE
 
 
 DEFAULT_DISPLAY_OPTIONS = {
@@ -227,6 +228,7 @@ class DisplayableCAD:
     def __init__(self):
         super().__init__()
         self._display_cad_options: DisplayCADOptions = DisplayCADOptions()
+        self._display_cad_options.color = next(BLUE_PALETTE)
 
     @property
     def display_cad_options(self) -> DisplayCADOptions:

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -25,6 +25,7 @@ Colour palettes
 
 from typing import Union
 import numpy as np
+from itertools import cycle
 import seaborn as sns
 import matplotlib.colors as colors
 
@@ -41,7 +42,15 @@ class ColorPalette:
 
     def __init__(self, palette_map):
         self._dict = palette_map
-        self._palette = sns.color_palette(list(palette_map.values()))
+        color_list = list(palette_map.values())
+        self._palette = sns.color_palette(color_list)
+        self._cycle = cycle(color_list)
+
+    def __next__(self):
+        """
+        Get the next color in the ColorPalette
+        """
+        return next(self._cycle)
 
     def __setitem__(self, idx_or_key: Union[int, str], value):
         """

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -33,6 +33,7 @@ from typing import Optional, Union, List
 import bluemira.geometry as geo
 
 from .error import DisplayError
+from .palettes import BLUE_PALETTE
 
 
 DEFAULT_PLOT_OPTIONS = {
@@ -725,6 +726,7 @@ class Plottable:
     def __init__(self):
         super().__init__()
         self._plot_options: PlotOptions = PlotOptions()
+        self._plot_options.face_options["color"] = next(BLUE_PALETTE)
 
     @property
     def plot_options(self) -> PlotOptions:

--- a/examples/geometry/plotting_tutorial.py
+++ b/examples/geometry/plotting_tutorial.py
@@ -363,6 +363,9 @@ w1face = BluemiraFace(wire1)
 #
 # Creates a `PhysicalComponent` and plots it in the xz plane
 
+# Note that if no face colour is set, a colour from the default palette will be chosen
+# by default. This will not be the same every time.
+
 # %%
 c = PhysicalComponent("Comp", face)
 c.plot_options.plane = "xz"
@@ -422,8 +425,10 @@ print(f"component plotter options: {c.plot_options}")
 display.show_cad(face)
 
 # %%[markdown]
-# Fow what concern Components, the component function show_cad is used.
+# For what concern Components, the component function show_cad is used.
 
+# Note that if no colour is set, a colour from the default palette will be chosen
+# by default. This will not be the same every time.
 # %%
 group.show_cad()
 


### PR DESCRIPTION
## Linked Issues
Closes #406 

## Description
Makes `ColorPalette` a pseudo-generator by providing access to an underlying color cycle.

Overrides default colors for `Plottable` and `Displayable` classes which are used as mixins for `Component`. I went with leaving default colors (grey) for under-the-hood plotters, so this should only affect the default behaviour for component display.

## Interface Changes

This should only affect the default behaviour for component display. No API change but appearance will change.

Note that the color cycle is not reset for each component, so consistent colors will always require configuration. This is just to colour things differently when no defaults are overridden.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
