### PR TITLE
Add inequality constraint to `SextupleArc`

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -640,6 +640,38 @@ class SextupleArc(GeometryParameterisation):
         )
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
+        self.n_ineq_constraints = 1
+
+    def shape_ineq_constraints(self, constraint, x_norm, grad):
+        """
+        Inequality constraint function for the variable vector of the geometry
+        parameterisation.
+
+        Parameters
+        ----------
+        constraint: np.ndarray
+            Contraint vector (assign in place)
+        x: np.ndarray
+            Normalised vector of free variables
+        grad: np.ndarray
+            Gradient matrix of the constraint (assign in place)
+        """
+        x_actual = self._process_x_norm_fixed(x_norm)
+
+        _, _, _, _, _, _, _, a1, a2, a3, a4, a5 = x_actual
+
+        constraint[0] = a1 + a2 + a3 + a4 + a5 - 360
+        var_strings = ["a1", "a2", "a3", "a4", "a5"]
+
+        if grad.size > 0:
+            g = np.zeros(len(x_norm))
+            for var in var_strings:
+                if not self.variables[var].fixed:
+                    g[self._get_x_norm_index(var)] = 1
+
+            grad[0, :] = g
+
+        return constraint
 
     @staticmethod
     def _project_centroid(xc, zc, xi, zi, ri):


### PR DESCRIPTION
## Linked Issues

Need to be able to optimise SextupleArc shapes that make sense (all angles sum to 360). Note that the 6th arc is determined the rest of the constraints, and doesn't exist if sum(a[1..5])  == 360.

## Description

Adds an inequality constraint to SextupleArc

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
