### PR TITLE
Add CI step to upload coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,19 @@ jobs:
     - name: Run pytest BLUEPRINT
       shell: bash -l {0}
       run: |
-        pytest --cov=BLUEPRINT --cov-report html:htmlcov_BLUEPRINT tests/BLUEPRINT --reactor
+        pytest --cov=BLUEPRINT \
+               --cov-report html:htmlcov_BLUEPRINT \
+               tests/BLUEPRINT --reactor
 
     - name: Run pytest bluemira
       shell: bash -l {0}
       run: |
-        pytest --cov=bluemira --cov-report html:htmlcov_bluemira tests/bluemira
+        pytest --cov=bluemira \
+               --cov-report html:htmlcov_bluemira \
+               --cov-report xml \
+               tests/bluemira --reactor
+
+    - name: "Upload coverage to Codecov"
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true


### PR DESCRIPTION
## Linked Issues

Closes #539 

## Description

Adds an upload to Codecov of the coverage.xml file produced by the bluemira tests to our CI job. Also switches on the reactor tests for bluemira.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
