### PR TITLE
Convert geometry tutorial to jupyter and add plotting

### DIFF
--- a/examples/geometry/geometry_tutorial.ipynb
+++ b/examples/geometry/geometry_tutorial.ipynb
@@ -1,0 +1,443 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import bluemira.geometry as geo\n",
+        "from bluemira.codes import _freecadapi as cadapi\n",
+        "from bluemira.display import plot_2d, show_cad\n",
+        "from bluemira.display.plotter import DEFAULT_PLOT_OPTIONS\n",
+        "from operator import itemgetter\n",
+        "\n",
+        "DEFAULT_PLOT_OPTIONS[\"plane\"] = \"xy\""
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# A simple tutorial for the bluemira geometric module\n",
+        "\n",
+        "## 1. Creation of a bluemira wire"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]\n",
+        "bmwire = geo.tools.make_polygon(pntslist)\n",
+        "print(f\"{bmwire=}\")\n",
+        "plot_2d(bmwire)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Same result using cadapi"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "wire = cadapi.make_polygon(pntslist)\n",
+        "print(f\"Freecad wire: {wire}, length: {wire.Length}, isClosed: {wire.isClosed()}\")\n",
+        "bmwire = geo.wire.BluemiraWire(wire, \"bmwire\")\n",
+        "print(f\"{bmwire=}\")\n",
+        "plot_2d(bmwire)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Creation of a closed bluemira wire"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmwire = geo.tools.make_polygon(pntslist, closed=True)\n",
+        "print(bmwire)\n",
+        "plot_2d(bmwire)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Make some operations on bluemira wire"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "ndiscr = 10"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3.1 Discretize in {ndiscr} points"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "points = bmwire.discretize(ndiscr)\n",
+        "print(f\"{points}\")\n",
+        "plot_2d(points)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3.2 Discretize considering the edges"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "points = bmwire.discretize(ndiscr, byedges=True)\n",
+        "print(f\"{points=}\")\n",
+        "plot_2d(points)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Creation of a bluemira face"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmface = geo.face.BluemiraFace(bmwire, \"bmface\")\n",
+        "print(f\"{bmface=}\")\n",
+        "plot_2d(bmface)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Scaling a bluemira wire\n",
+        "\n",
+        "**NOTE**: scale function modifies the original object\n",
+        "\n",
+        "### 5.1 Scale a BluemiraWire"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(f\"Original object: {bmwire}\")\n",
+        "bmwire.scale(2)\n",
+        "print(f\"Scaled object: {bmwire}\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**NOTE**: since bmface is connected to bmwire, a scale operation on bmwire also affect\n",
+        "bmface"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 5.2 Scale a BluemiraFace"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(f\"Original object: {bmface}\")\n",
+        "bmface.scale(2)\n",
+        "print(f\"Scaled object: {bmface}\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Saving as a STEP file"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "shapes = [bmwire._shape, bmface._shape]\n",
+        "print(shapes)\n",
+        "cadapi.save_as_STEP(shapes, \"geo_shapes\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Closing a BluemiraWire\n",
+        "\n",
+        "### 7.1 When boundary is list(Part.Wire)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]\n",
+        "wire = cadapi.make_polygon(pntslist, closed=False)\n",
+        "bmwire_nc = geo.wire.BluemiraWire(wire)\n",
+        "print(f\"Before close: {bmwire_nc}\")\n",
+        "print(f\"Boundary: {bmwire_nc.boundary}\")\n",
+        "bmwire_nc.close()\n",
+        "print(f\"After close: {bmwire_nc}\")\n",
+        "print(f\"Boundary: {bmwire_nc.boundary}\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 7.2 When boundary is list(BluemiraWire)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmwire_nc = geo.wire.BluemiraWire(geo.wire.BluemiraWire(wire))\n",
+        "print(bmwire_nc)\n",
+        "bmwire_nc.close()\n",
+        "print(bmwire_nc)\n",
+        "print(bmwire_nc.boundary)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. Translate"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmface.translate((5.0, 2.0, 0.0))\n",
+        "plot_2d(bmface)\n",
+        "geo.tools.save_as_STEP([bmwire, bmface], \"geo_translate\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 9. Bezier spline curve"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]\n",
+        "bmwire_nc = geo.tools.make_bspline(pntslist, closed=False)\n",
+        "print(bmwire_nc)\n",
+        "plot_2d(bmwire_nc)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Same result using cadapi"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "wire = cadapi.make_bspline(pntslist, closed=False)\n",
+        "bmwire_nc = geo.wire.BluemiraWire(wire)\n",
+        "print(bmwire_nc)\n",
+        "plot_2d(bmwire_nc)\n",
+        "geo.tools.save_as_STEP([bmwire_nc], \"geo_bspline\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 10. Revolve"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))\n",
+        "show_cad(bmsolid)\n",
+        "geo.tools.save_as_STEP([bmsolid], \"geo_revolve\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 11. Face and solid with hole"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "pntslist_out = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]\n",
+        "delta = 0.25\n",
+        "pntslist_in = [\n",
+        "    (1.0 - delta, 1.0 - delta, 0.0),\n",
+        "    (0.0 + delta, 1.0 - delta, 0.0),\n",
+        "    (0.0 + delta, 0.0 + delta, 0.0),\n",
+        "    (1.0 - delta, 0.0 + delta, 0.0),\n",
+        "]\n",
+        "wire_out = geo.tools.make_polygon(pntslist_out, closed=True)\n",
+        "wire_in = geo.tools.make_polygon(pntslist_in, closed=True)\n",
+        "bmface = geo.face.BluemiraFace([wire_out, wire_in])\n",
+        "plot_2d(bmface)\n",
+        "geo.tools.save_as_STEP([bmface], \"geo_face_with_hole\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))\n",
+        "show_cad(bmsolid)\n",
+        "geo.tools.save_as_STEP([bmsolid], \"geo_solid_with_hole\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 12. Solid creation from Shell"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "vertexes = [\n",
+        "    (0.0, 0.0, 0.0),\n",
+        "    (1.0, 0.0, 0.0),\n",
+        "    (1.0, 1.0, 0.0),\n",
+        "    (0.0, 1.0, 0.0),\n",
+        "    (0.0, 0.0, 1.0),\n",
+        "    (1.0, 0.0, 1.0),\n",
+        "    (1.0, 1.0, 1.0),\n",
+        "    (0.0, 1.0, 1.0),\n",
+        "]\n",
+        "\n",
+        "# faces creation\n",
+        "faces = []\n",
+        "v_index = [\n",
+        "    (0, 1, 2, 3),\n",
+        "    (5, 4, 7, 6),\n",
+        "    (0, 4, 5, 1),\n",
+        "    (1, 5, 6, 2),\n",
+        "    (2, 6, 7, 3),\n",
+        "    (3, 7, 4, 0),\n",
+        "]\n",
+        "for ind, value in enumerate(v_index):\n",
+        "    wire = geo.tools.make_polygon(list(itemgetter(*value)(vertexes)), closed=True)\n",
+        "    faces.append(geo.face.BluemiraFace(wire, \"face\" + str(ind)))\n",
+        "\n",
+        "# shell creation\n",
+        "shell = geo.shell.BluemiraShell(faces, \"shell\")\n",
+        "\n",
+        "# solid creation from shell\n",
+        "solid = geo.solid.BluemiraSolid(shell, \"solid\")\n",
+        "print(solid)\n",
+        "show_cad(solid)\n",
+        "geo.tools.save_as_STEP([solid], \"geo_cube\")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ],
+  "metadata": {
+    "anaconda-cloud": {},
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/examples/geometry/geometry_tutorial.py
+++ b/examples/geometry/geometry_tutorial.py
@@ -23,138 +23,223 @@
 Some examples of using bluemira geometry objects.
 """
 
+# %%
 import bluemira.geometry as geo
 from bluemira.codes import _freecadapi as cadapi
+from bluemira.display import plot_2d, show_cad
+from bluemira.display.plotter import DEFAULT_PLOT_OPTIONS
 from operator import itemgetter
 
-# Note: this tutorial shall to be translated into a set of pytests
+DEFAULT_PLOT_OPTIONS["plane"] = "xy"
 
-if __name__ == "__main__":
-    print("This is a simple tutorial for the geometric module.")
+# %%[markdown]
+# # A simple tutorial for the bluemira geometric module
+#
+# ## 1. Creation of a bluemira wire
 
-    print("1. Creation of a bluemira wire")
-    pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
-    bmwire = geo.tools.make_polygon(pntslist)
-    # # Same result using cadapi
-    # wire = cadapi.make_polygon(pntslist)
-    # print(f"Freecad wire: {wire}, length: {wire.Length}, isClosed: {wire.isClosed()}")
-    # bmwire = geo.wire.BluemiraWire(wire, "bmwire")
-    print(bmwire)
+# %%
+pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+bmwire = geo.tools.make_polygon(pntslist)
+print(f"{bmwire=}")
+plot_2d(bmwire)
 
-    print("2. Creation of a closed bluemira wire")
-    bmwire = geo.tools.make_polygon(pntslist, closed=True)
-    print(bmwire)
+# %%[markdown]
+# ### Same result using cadapi
 
-    print("3. Make some operations on bluemira wire")
-    ndiscr = 10
-    print(f"3.1 Discretize in {ndiscr} points")
-    points = bmwire.discretize(ndiscr)
-    print(points)
-    print("3.2 Discretize considering the edges")
-    points = bmwire.discretize(ndiscr, byedges=True)
-    print(points)
+# %%
+wire = cadapi.make_polygon(pntslist)
+print(f"Freecad wire: {wire}, length: {wire.Length}, isClosed: {wire.isClosed()}")
+bmwire = geo.wire.BluemiraWire(wire, "bmwire")
+print(f"{bmwire=}")
+plot_2d(bmwire)
 
-    print("4. Creation of a bluemira face")
-    bmface = geo.face.BluemiraFace(bmwire, "bmface")
-    print(bmface)
+# %%[markdown]
+# ## 2. Creation of a closed bluemira wire
 
-    print("5. Test of scale function.")
-    print("Note: scale function modifies the original object")
-    print("5.1 Scale a BluemiraWire")
-    print(f"Original object: {bmwire}")
-    bmwire.scale(2)
-    print(f"Scaled object: {bmwire}")
-    print(
-        "NOTE: since bmface is connected to bmwire, a scale operation on bmwire will"
-        " affect also bmface"
-    )
-    print("5.1 Scale a BluemiraFace")
-    print(f"Original object: {bmface}")
-    bmface.scale(2)
-    print(f"Scaled object: {bmface}")
+# %%
+bmwire = geo.tools.make_polygon(pntslist, closed=True)
+print(bmwire)
+plot_2d(bmwire)
 
-    print("6. Test Save as STEP file.")
-    shapes = [bmwire._shape, bmface._shape]
-    print(shapes)
-    cadapi.save_as_STEP(shapes)
+# %%[markdown]
+# ## 3. Make some operations on bluemira wire
 
-    print("7. Test BluemiraWire.close")
-    print("7.1 when boundary is list(Part.Wire)")
-    pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
-    wire = cadapi.make_polygon(pntslist, closed=False)
-    bmwire_nc = geo.wire.BluemiraWire(wire)
-    print(bmwire_nc)
-    bmwire_nc.close()
-    print(bmwire_nc)
-    print(bmwire_nc.boundary)
+# %%
+ndiscr = 10
 
-    print("7.2 when boundary is list(BluemiraWire)")
-    bmwire_nc = geo.wire.BluemiraWire(geo.wire.BluemiraWire(wire))
-    print(bmwire_nc)
-    bmwire_nc.close()
-    print(bmwire_nc)
-    print(bmwire_nc.boundary)
+# %%[markdown]
+# ### 3.1 Discretize in {ndiscr} points
 
-    print("7. Test Translate")
-    bmface.translate((5.0, 2.0, 0.0))
-    geo.tools.save_as_STEP([bmwire, bmface], "test_translate")
+# %%
+points = bmwire.discretize(ndiscr)
+print(f"{points}")
+plot_2d(points)
 
-    print("8. Test bspline")
-    pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
-    bmwire_nc = geo.tools.make_bspline(pntslist, closed=False)
-    # # Same result using cadapi
-    # wire = cadapi.make_bspline(pntslist, closed=False)
-    # bmwire_nc = geo.wire.BluemiraWire(wire)
-    print(bmwire_nc)
-    geo.tools.save_as_STEP([bmwire_nc], "test_bspline")
+# %%[markdown]
+# ### 3.2 Discretize considering the edges
 
-    print("9. Test revolve")
-    bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))
-    geo.tools.save_as_STEP([bmsolid], "test_revolve")
+# %%
+points = bmwire.discretize(ndiscr, byedges=True)
+print(f"{points=}")
+plot_2d(points)
 
-    print("10. Face and solid with hole")
-    pntslist_out = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
-    delta = 0.25
-    pntslist_in = [
-        (1.0 - delta, 1.0 - delta, 0.0),
-        (0.0 + delta, 1.0 - delta, 0.0),
-        (0.0 + delta, 0.0 + delta, 0.0),
-        (1.0 - delta, 0.0 + delta, 0.0),
-    ]
-    wire_out = geo.tools.make_polygon(pntslist_out, closed=True)
-    wire_in = geo.tools.make_polygon(pntslist_in, closed=True)
-    bmface = geo.face.BluemiraFace([wire_out, wire_in])
-    geo.tools.save_as_STEP([bmface], "test_face_with_hole")
-    bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))
-    geo.tools.save_as_STEP([bmsolid], "test_solid_with_hole")
+# %%[markdown]
+# ## 4. Creation of a bluemira face
 
-    print("11. Solid creation from Shell")
-    vertexes = [
-        (0.0, 0.0, 0.0),
-        (1.0, 0.0, 0.0),
-        (1.0, 1.0, 0.0),
-        (0.0, 1.0, 0.0),
-        (0.0, 0.0, 1.0),
-        (1.0, 0.0, 1.0),
-        (1.0, 1.0, 1.0),
-        (0.0, 1.0, 1.0),
-    ]
-    # faces creation
-    faces = []
-    v_index = [
-        (0, 1, 2, 3),
-        (5, 4, 7, 6),
-        (0, 4, 5, 1),
-        (1, 5, 6, 2),
-        (2, 6, 7, 3),
-        (3, 7, 4, 0),
-    ]
-    for ind, value in enumerate(v_index):
-        wire = geo.tools.make_polygon(list(itemgetter(*value)(vertexes)), closed=True)
-        faces.append(geo.face.BluemiraFace(wire, "face" + str(ind)))
-    # shell creation
-    shell = geo.shell.BluemiraShell(faces, "shell")
-    # solid creation from shell
-    solid = geo.solid.BluemiraSolid(shell, "solid")
-    print(solid)
-    geo.tools.save_as_STEP([solid], "test_cube")
+# %%
+bmface = geo.face.BluemiraFace(bmwire, "bmface")
+print(f"{bmface=}")
+plot_2d(bmface)
+
+# %%[markdown]
+# ## 5. Scaling a bluemira wire
+#
+# **NOTE**: scale function modifies the original object
+#
+# ### 5.1 Scale a BluemiraWire
+
+# %%
+print(f"Original object: {bmwire}")
+bmwire.scale(2)
+print(f"Scaled object: {bmwire}")
+
+# %%[markdown]
+# **NOTE**: since bmface is connected to bmwire, a scale operation on bmwire also affect
+# bmface
+
+# %%[markdown]
+# ### 5.2 Scale a BluemiraFace
+
+# %%
+print(f"Original object: {bmface}")
+bmface.scale(2)
+print(f"Scaled object: {bmface}")
+
+# %%[markdown]
+# ## 6. Saving as a STEP file
+
+# %%
+shapes = [bmwire._shape, bmface._shape]
+print(shapes)
+cadapi.save_as_STEP(shapes, "geo_shapes")
+
+# %%[markdown]
+# ## 7. Closing a BluemiraWire
+#
+# ### 7.1 When boundary is list(Part.Wire)
+
+# %%
+pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+wire = cadapi.make_polygon(pntslist, closed=False)
+bmwire_nc = geo.wire.BluemiraWire(wire)
+print(f"Before close: {bmwire_nc}")
+print(f"Boundary: {bmwire_nc.boundary}")
+bmwire_nc.close()
+print(f"After close: {bmwire_nc}")
+print(f"Boundary: {bmwire_nc.boundary}")
+
+# %%[markdown]
+# ### 7.2 When boundary is list(BluemiraWire)
+
+# %%
+bmwire_nc = geo.wire.BluemiraWire(geo.wire.BluemiraWire(wire))
+print(bmwire_nc)
+bmwire_nc.close()
+print(bmwire_nc)
+print(bmwire_nc.boundary)
+
+# %%[markdown]
+# ## 8. Translate
+
+# %%
+bmface.translate((5.0, 2.0, 0.0))
+plot_2d(bmface)
+geo.tools.save_as_STEP([bmwire, bmface], "geo_translate")
+
+# %%[markdown]
+# ## 9. Bezier spline curve
+
+# %%
+pntslist = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+bmwire_nc = geo.tools.make_bspline(pntslist, closed=False)
+print(bmwire_nc)
+plot_2d(bmwire_nc)
+
+# %%[markdown]
+# ### Same result using cadapi
+
+# %%
+wire = cadapi.make_bspline(pntslist, closed=False)
+bmwire_nc = geo.wire.BluemiraWire(wire)
+print(bmwire_nc)
+plot_2d(bmwire_nc)
+geo.tools.save_as_STEP([bmwire_nc], "geo_bspline")
+
+# %%[markdown]
+# ## 10. Revolve
+
+# %%
+bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))
+show_cad(bmsolid)
+geo.tools.save_as_STEP([bmsolid], "geo_revolve")
+
+# %%[markdown]
+# ## 11. Face and solid with hole
+
+# %%
+pntslist_out = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)]
+delta = 0.25
+pntslist_in = [
+    (1.0 - delta, 1.0 - delta, 0.0),
+    (0.0 + delta, 1.0 - delta, 0.0),
+    (0.0 + delta, 0.0 + delta, 0.0),
+    (1.0 - delta, 0.0 + delta, 0.0),
+]
+wire_out = geo.tools.make_polygon(pntslist_out, closed=True)
+wire_in = geo.tools.make_polygon(pntslist_in, closed=True)
+bmface = geo.face.BluemiraFace([wire_out, wire_in])
+plot_2d(bmface)
+geo.tools.save_as_STEP([bmface], "geo_face_with_hole")
+
+# %%
+bmsolid = geo.tools.revolve_shape(bmface, direction=(0.0, 1.0, 0.0))
+show_cad(bmsolid)
+geo.tools.save_as_STEP([bmsolid], "geo_solid_with_hole")
+
+# %%[markdown]
+# ## 12. Solid creation from Shell
+
+# %%
+vertexes = [
+    (0.0, 0.0, 0.0),
+    (1.0, 0.0, 0.0),
+    (1.0, 1.0, 0.0),
+    (0.0, 1.0, 0.0),
+    (0.0, 0.0, 1.0),
+    (1.0, 0.0, 1.0),
+    (1.0, 1.0, 1.0),
+    (0.0, 1.0, 1.0),
+]
+
+# faces creation
+faces = []
+v_index = [
+    (0, 1, 2, 3),
+    (5, 4, 7, 6),
+    (0, 4, 5, 1),
+    (1, 5, 6, 2),
+    (2, 6, 7, 3),
+    (3, 7, 4, 0),
+]
+for ind, value in enumerate(v_index):
+    wire = geo.tools.make_polygon(list(itemgetter(*value)(vertexes)), closed=True)
+    faces.append(geo.face.BluemiraFace(wire, "face" + str(ind)))
+
+# shell creation
+shell = geo.shell.BluemiraShell(faces, "shell")
+
+# solid creation from shell
+solid = geo.solid.BluemiraSolid(shell, "solid")
+print(solid)
+show_cad(solid)
+geo.tools.save_as_STEP([solid], "geo_cube")


### PR DESCRIPTION
## Linked Issues

Supersedes #542 

## Description

This PR converts our geometry tutorial to a Jupyter notebook and adds simple plotting functionality into that tutorial.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
