### PR TITLE
🐛 further protect subprocess

### DIFF
--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -98,7 +98,7 @@ class Task:
         kwargs.pop("shell", None)  # Protect against user input
 
         with subprocess.Popen(  # noqa (S603)
-            command, stdout=stdout, stderr=stderr, **kwargs
+            command, stdout=stdout, stderr=stderr, shell=False, **kwargs  # noqa (S603)
         ) as s:
             stdout.close()
             stderr.close()

--- a/tests/bluemira/codes/test_interface.py
+++ b/tests/bluemira/codes/test_interface.py
@@ -1,0 +1,47 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import MagicMock
+import pytest
+
+from bluemira.codes import interface
+
+
+class EvilDict(dict):
+    def __init__(self, *arg, **kw):
+        super().__init__(*arg, **kw)
+
+    def pop(self, *args, **kw):
+        pass
+
+
+class TestTask:
+    def test_protected_subprocess(self):
+        parent = MagicMock()
+        parent._run_dir = "./"
+        parent.NAME = "TEST"
+        task = interface.Task(parent)
+        e_dict = EvilDict(shell=True)  # noqa (S604)
+        with pytest.raises((FileNotFoundError, TypeError)):
+            task._run_subprocess("random command", **e_dict)
+        assert e_dict["shell"]
+        with pytest.raises(FileNotFoundError):
+            task._run_subprocess("random command", shell=e_dict["shell"])  # noqa (S604)


### PR DESCRIPTION
## Description

Realised its possible to craft a dict like object that ignores pop. This will now error with two arguments specified if someone tries this. I think we're protected by kwargs anyway but best to be safe.

```python

In [9]: d
Out[9]: {'a': 1}

In [10]: class CustomDict(dict):
    ...:    def __init__(self,*arg,**kw):
    ...:       super().__init__(*arg, **kw)
    ...:    def pop(self, *args, **kw):
    ...:        pass
    ...: 

In [11]: d = CustomDict({'a':1})

In [12]: d.pop('a')

In [13]: d
Out[13]: {'a': 1}
```

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
