### PR TITLE
Circular imports

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -25,14 +25,14 @@ Module containing the base Component class.
 
 from __future__ import annotations
 
-import anytree
-from anytree import NodeMixin, RenderTree
 from typing import Any, List, Optional, Union
 
-from bluemira.display.plotter import Plottable
-from bluemira.display.displayer import DisplayableCAD
+import anytree
+from anytree import NodeMixin, RenderTree
 
 from bluemira.base.error import ComponentError
+from bluemira.display.displayer import DisplayableCAD
+from bluemira.display.plotter import Plottable
 
 
 class Component(NodeMixin, Plottable, DisplayableCAD):

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -25,7 +25,7 @@ Module containing the base Component class.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import anytree
 from anytree import NodeMixin, RenderTree
@@ -33,6 +33,9 @@ from anytree import NodeMixin, RenderTree
 from bluemira.base.error import ComponentError
 from bluemira.display.displayer import DisplayableCAD
 from bluemira.display.plotter import Plottable
+
+if TYPE_CHECKING:
+    from bluemira.geometry.base import BluemiraGeo
 
 
 class Component(NodeMixin, Plottable, DisplayableCAD):

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -32,9 +32,7 @@ from typing import Any, List, Optional, Union
 from bluemira.display.plotter import Plottable
 from bluemira.display.displayer import DisplayableCAD
 
-import bluemira.geometry as geo
-
-from .error import ComponentError
+from bluemira.base.error import ComponentError
 
 
 class Component(NodeMixin, Plottable, DisplayableCAD):
@@ -188,7 +186,7 @@ class PhysicalComponent(Component):
     def __init__(
         self,
         name: str,
-        shape: geo.base.BluemiraGeo,
+        shape: BluemiraGeo,
         material: Any = None,
         parent: Component = None,
         children: Component = None,
@@ -198,14 +196,14 @@ class PhysicalComponent(Component):
         self.material = material
 
     @property
-    def shape(self) -> geo.base.BluemiraGeo:
+    def shape(self) -> BluemiraGeo:
         """
         The geometric shape of the Component.
         """
         return self._shape
 
     @shape.setter
-    def shape(self, value: geo.base.BluemiraGeo):
+    def shape(self, value: BluemiraGeo):
         self._shape = value
 
     @property
@@ -228,7 +226,7 @@ class MagneticComponent(PhysicalComponent):
     def __init__(
         self,
         name: str,
-        shape: geo.base.BluemiraGeo,
+        shape: BluemiraGeo,
         material: Any = None,
         conductor: Any = None,
         parent: Component = None,

--- a/bluemira/builders/EUDEMO/plasma.py
+++ b/bluemira/builders/EUDEMO/plasma.py
@@ -25,29 +25,36 @@ A builder for Plasma properties and geometry
 
 from __future__ import annotations
 
-import numpy as np
 from typing import List, Optional
 
-from bluemira.base.builder import Builder, BuildConfig
+import numpy as np
+
+import bluemira.utilities.plot_tools as bm_plot_tools
+from bluemira.base.builder import BuildConfig, Builder
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.config import Configuration
 from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_print
-
 from bluemira.display.palettes import BLUE_PALETTE
-from bluemira.equilibria.constants import (
-    NBTI_J_MAX,
-    NBTI_B_MAX,
-    NB3SN_J_MAX,
-    NB3SN_B_MAX,
-)
 from bluemira.equilibria import AbInitioEquilibriumProblem
+from bluemira.equilibria.constants import (
+    NB3SN_B_MAX,
+    NB3SN_J_MAX,
+    NBTI_B_MAX,
+    NBTI_J_MAX,
+)
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.shapes import JohnerLCFS
-import bluemira.geometry as geo
 from bluemira.geometry._deprecated_loop import Loop
+from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import PrincetonD
-import bluemira.utilities.plot_tools as bm_plot_tools
+from bluemira.geometry.tools import (
+    make_circle,
+    make_polygon,
+    offset_wire,
+    revolve_shape,
+)
+from bluemira.geometry.wire import BluemiraWire
 
 
 class PlasmaComponent(Component):
@@ -113,7 +120,7 @@ class PlasmaBuilder(Builder):
     ]
 
     _params: Configuration
-    _boundary: geo.wire.BluemiraWire
+    _boundary: BluemiraWire
     _plot_flag: bool
     _segment_angle: float
     _eqdsk_path: Optional[str] = None
@@ -152,7 +159,7 @@ class PlasmaBuilder(Builder):
         bluemira_print("Running Plasma equilibrium design problem")
         eq = self._create_equilibrium()
         self._analyse_equilibrium(eq)
-        self._boundary = geo.tools.make_polygon(eq.get_LCFS().xyz.T, "LCFS")
+        self._boundary = make_polygon(eq.get_LCFS().xyz.T, "LCFS")
         return {"equilibrium": eq}
 
     def read(self):
@@ -162,7 +169,7 @@ class PlasmaBuilder(Builder):
         bluemira_print("Reading Plasma equilibrium design problem")
         eq = self._read_equilibrium()
         self._analyse_equilibrium(eq)
-        self._boundary = geo.tools.make_polygon(eq.get_LCFS().xyz.T, "LCFS")
+        self._boundary = make_polygon(eq.get_LCFS().xyz.T, "LCFS")
         return {"equilibrium": eq}
 
     def mock(self):
@@ -234,7 +241,7 @@ class PlasmaBuilder(Builder):
             tf_boundary.rotate(
                 tf_boundary.center_of_mass, direction=(0, 1, 0), degree=180
             )
-        tf_boundary = geo.tools.offset_wire(tf_boundary, -0.5)
+        tf_boundary = offset_wire(tf_boundary, -0.5)
 
         # TODO: Avoid converting to (deprecated) Loop
         # TODO: Agree on numpy array dimensionality
@@ -372,12 +379,12 @@ class PlasmaBuilder(Builder):
 
         if equilibrium is not None:
             sep_loop = equilibrium.get_separatrix()
-            sep_wire = geo.tools.make_polygon(sep_loop.xyz.T, label="Separatrix")
+            sep_wire = make_polygon(sep_loop.xyz.T, label="Separatrix")
             sep_component = PhysicalComponent("Separatrix", sep_wire)
             sep_component.plot_options.wire_options["color"] = BLUE_PALETTE["PL"]
             component.add_child(sep_component)
 
-        lcfs_face = geo.face.BluemiraFace(self._boundary, label="LCFS")
+        lcfs_face = BluemiraFace(self._boundary, label="LCFS")
         lcfs_component = PhysicalComponent("LCFS", lcfs_face)
         lcfs_component.plot_options.wire_options["color"] = BLUE_PALETTE["PL"]
         lcfs_component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]
@@ -409,10 +416,10 @@ class PlasmaBuilder(Builder):
 
         component = Component("xy")
 
-        inner = geo.tools.make_circle(self._boundary.bounding_box.x_min, axis=[0, 0, 1])
-        outer = geo.tools.make_circle(self._boundary.bounding_box.x_max, axis=[0, 0, 1])
+        inner = make_circle(self._boundary.bounding_box.x_min, axis=[0, 0, 1])
+        outer = make_circle(self._boundary.bounding_box.x_max, axis=[0, 0, 1])
 
-        lcfs_face = geo.face.BluemiraFace([outer, inner], label="LCFS")
+        lcfs_face = BluemiraFace([outer, inner], label="LCFS")
         lcfs_component = PhysicalComponent("LCFS", lcfs_face)
         lcfs_component.plot_options.wire_options["color"] = BLUE_PALETTE["PL"]
         lcfs_component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]
@@ -446,9 +453,7 @@ class PlasmaBuilder(Builder):
         if segment_angle is None:
             segment_angle = self._segment_angle
 
-        shell = geo.tools.revolve_shape(
-            self._boundary, direction=(0, 0, 1), degree=segment_angle
-        )
+        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=segment_angle)
         component = PhysicalComponent("LCFS", shell)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
         component.display_cad_options.transparency = 0.5

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -27,12 +27,11 @@ from typing import Dict, Optional, Type
 
 from bluemira.base.builder import BuildConfig
 from bluemira.base.components import Component, PhysicalComponent
-from bluemira.geometry.parameterisations import GeometryParameterisation
-
 from bluemira.builders.shapes import ParameterisedShapeBuilder
-from bluemira.geometry.wire import BluemiraWire
 from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.tools import make_circle, revolve_shape
+from bluemira.geometry.wire import BluemiraWire
 
 
 class MakeParameterisedPlasma(ParameterisedShapeBuilder):

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -27,11 +27,12 @@ from typing import Dict, Optional, Type
 
 from bluemira.base.builder import BuildConfig
 from bluemira.base.components import Component, PhysicalComponent
-import bluemira.geometry as geo
 from bluemira.geometry.parameterisations import GeometryParameterisation
 
 from bluemira.builders.shapes import ParameterisedShapeBuilder
 from bluemira.geometry.wire import BluemiraWire
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.tools import make_circle, revolve_shape
 
 
 class MakeParameterisedPlasma(ParameterisedShapeBuilder):
@@ -92,7 +93,7 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
             The resulting component representing the xz view of the LCFS.
         """
         # TODO: Specify a palette so that the plotting options are set up here.
-        face = geo.face.BluemiraFace(self._boundary, label)
+        face = BluemiraFace(self._boundary, label)
         component = PhysicalComponent("LCFS", face)
 
         return Component("xz").add_child(component)
@@ -116,10 +117,10 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
             The resulting component representing the xy view of the LCFS.
         """
         # TODO: Specify a palette so that the plotting options are set up here.
-        inner = geo.tools.make_circle(self._boundary.bounding_box.x_min, axis=[0, 1, 0])
-        outer = geo.tools.make_circle(self._boundary.bounding_box.x_max, axis=[0, 1, 0])
+        inner = make_circle(self._boundary.bounding_box.x_min, axis=[0, 1, 0])
+        outer = make_circle(self._boundary.bounding_box.x_max, axis=[0, 1, 0])
 
-        face = geo.face.BluemiraFace([outer, inner], label)
+        face = BluemiraFace([outer, inner], label)
         component = PhysicalComponent(label, face)
 
         return Component("xy").add_child(component)
@@ -153,9 +154,7 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
         if segment_angle is None:
             segment_angle = self._segment_angle
 
-        shell = geo.tools.revolve_shape(
-            self._boundary, direction=(0, 0, 1), degree=segment_angle
-        )
+        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=segment_angle)
         component = PhysicalComponent(label, shell)
 
         return Component("xyz").add_child(component)

--- a/bluemira/display/__init__.py
+++ b/bluemira/display/__init__.py
@@ -23,7 +23,7 @@
 Display and plotting module
 """
 
-from bluemira.display import displayer, plotter
+from . import plotter, displayer
 from bluemira.display.auto_config import plot_defaults
 
 plot_defaults()

--- a/bluemira/display/__init__.py
+++ b/bluemira/display/__init__.py
@@ -24,7 +24,7 @@ Display and plotting module
 """
 
 from bluemira.display import plotter, displayer
-from bluemira.disply.auto_config import plot_defaults
+from bluemira.display.auto_config import plot_defaults
 
 plot_defaults()
 

--- a/bluemira/display/__init__.py
+++ b/bluemira/display/__init__.py
@@ -23,8 +23,8 @@
 Display and plotting module
 """
 
-from . import plotter, displayer
-from .auto_config import plot_defaults
+from bluemira.display import plotter, displayer
+from bluemira.disply.auto_config import plot_defaults
 
 plot_defaults()
 

--- a/bluemira/display/__init__.py
+++ b/bluemira/display/__init__.py
@@ -23,7 +23,7 @@
 Display and plotting module
 """
 
-from bluemira.display import plotter, displayer
+from bluemira.display import displayer, plotter
 from bluemira.display.auto_config import plot_defaults
 
 plot_defaults()

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -24,17 +24,16 @@ api for plotting using freecad
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import copy
+from abc import ABC, abstractmethod
 from typing import Iterable, List, Optional, Tuple, Union
+
 import matplotlib.colors as colors
 
 from bluemira.codes import _freecadapi as cadapi
-
 from bluemira.display.error import DisplayError
-from bluemira.display.plotter import DisplayOptions
 from bluemira.display.palettes import BLUE_PALETTE
-
+from bluemira.display.plotter import DisplayOptions
 
 DEFAULT_DISPLAY_OPTIONS = {
     "color": (0.5, 0.5, 0.5),

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
 import matplotlib.colors as colors
 
@@ -34,6 +34,9 @@ from bluemira.codes import _freecadapi as cadapi
 from bluemira.display.error import DisplayError
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.display.plotter import DisplayOptions
+
+if TYPE_CHECKING:
+    from bluemira.geometry.base import BluemiraGeo
 
 DEFAULT_DISPLAY_OPTIONS = {
     "color": (0.5, 0.5, 0.5),

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -29,12 +29,11 @@ import copy
 from typing import Iterable, List, Optional, Tuple, Union
 import matplotlib.colors as colors
 
-import bluemira.geometry as geo
 from bluemira.codes import _freecadapi as cadapi
 
-from .error import DisplayError
-from .plotter import DisplayOptions
-from .palettes import BLUE_PALETTE
+from bluemira.display.error import DisplayError
+from bluemira.display.plotter import DisplayOptions
+from bluemira.display.palettes import BLUE_PALETTE
 
 
 DEFAULT_DISPLAY_OPTIONS = {
@@ -139,7 +138,7 @@ def _validate_display_inputs(parts, options):
 
 
 def show_cad(
-    parts: Union[geo.base.BluemiraGeo, List[geo.base.BluemiraGeo]],
+    parts: Union[BluemiraGeo, List[BluemiraGeo]],
     options: Optional[Union[DisplayCADOptions, List[DisplayCADOptions]]] = None,
     **kwargs,
 ):
@@ -148,7 +147,7 @@ def show_cad(
 
     Parameters
     ----------
-    parts: Union[geo.base.BluemiraGeo, List[geo.base.BluemiraGeo]]
+    parts: Union[BluemiraGeo, List[BluemiraGeo]]
         The parts to display.
     options: Optional[Union[_PlotCADOptions, List[_PlotCADOptions]]]
         The options to use to display the parts.

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -24,19 +24,21 @@ api for plotting using matplotlib
 """
 from __future__ import annotations
 
-from abc import abstractmethod, ABC
 import copy
-import numpy as np
+import pprint
+from abc import ABC, abstractmethod
+from typing import List, Optional, Union
+
 import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d as a3
-import pprint
-from typing import Optional, Union, List
+import numpy as np
 
-from bluemira.geometry import plane as _plane, bound_box, wire, face
+from bluemira.geometry import bound_box, face
+from bluemira.geometry import plane as _plane
+from bluemira.geometry import wire
 
 from .error import DisplayError
 from .palettes import BLUE_PALETTE
-
 
 DEFAULT_PLOT_OPTIONS = {
     # flags to enable points, wires, and faces plot

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -32,7 +32,7 @@ import mpl_toolkits.mplot3d as a3
 import pprint
 from typing import Optional, Union, List
 
-from bluemira.geometry import plane, bound_box, wire, face
+from bluemira.geometry import plane as _plane, bound_box, wire, face
 
 from .error import DisplayError
 from .palettes import BLUE_PALETTE
@@ -70,7 +70,7 @@ def get_default_options():
         # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
         # copy.deepcopy. For this reason, its deepcopy method must be used in
         # this case.
-        if isinstance(v, plane.BluemiraPlane):
+        if isinstance(v, _plane.BluemiraPlane):
             output_dict[k] = v.deepcopy()
         else:
             output_dict[k] = copy.deepcopy(v)
@@ -151,7 +151,7 @@ class PlotOptions(DisplayOptions):
             # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
             # copy.deepcopy. For this reason, its deepcopy method must to be used in
             # this case.
-            if isinstance(v, plane.BluemiraPlane):
+            if isinstance(v, _plane.BluemiraPlane):
                 output_dict[k] = v.deepcopy()
             else:
                 output_dict[k] = copy.deepcopy(v)
@@ -283,18 +283,18 @@ class BasePlotter(ABC):
         """Set the plotting plane"""
         if plane == "xy":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = plane.BluemiraPlane()
+            self.options._options["plane"] = _plane.BluemiraPlane()
         elif plane == "xz":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = plane.BluemiraPlane(
+            self.options._options["plane"] = _plane.BluemiraPlane(
                 axis=(1.0, 0.0, 0.0), angle=-90.0
             )
         elif plane == "zy":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = plane.BluemiraPlane(
+            self.options._options["plane"] = _plane.BluemiraPlane(
                 axis=(0.0, 1.0, 0.0), angle=90.0
             )
-        elif isinstance(plane, plane.BluemiraPlane):
+        elif isinstance(plane, _plane.BluemiraPlane):
             self.options._options["plane"] = plane
         else:
             DisplayError(f"{plane} is not a valid plane")

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -27,18 +27,20 @@ from __future__ import annotations
 import copy
 import pprint
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d as a3
 import numpy as np
 
+from bluemira.display.error import DisplayError
+from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry import bound_box, face
 from bluemira.geometry import plane as _plane
 from bluemira.geometry import wire
 
-from .error import DisplayError
-from .palettes import BLUE_PALETTE
+if TYPE_CHECKING:
+    from bluemira.geometry.base import BluemiraGeo
 
 DEFAULT_PLOT_OPTIONS = {
     # flags to enable points, wires, and faces plot

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -22,6 +22,8 @@
 """
 api for plotting using matplotlib
 """
+from __future__ import annotations
+
 from abc import abstractmethod, ABC
 import copy
 import numpy as np
@@ -30,7 +32,7 @@ import mpl_toolkits.mplot3d as a3
 import pprint
 from typing import Optional, Union, List
 
-import bluemira.geometry as geo
+from bluemira.geometry import plane, bound_box, wire, face
 
 from .error import DisplayError
 from .palettes import BLUE_PALETTE
@@ -68,7 +70,7 @@ def get_default_options():
         # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
         # copy.deepcopy. For this reason, its deepcopy method must be used in
         # this case.
-        if isinstance(v, geo.plane.BluemiraPlane):
+        if isinstance(v, plane.BluemiraPlane):
             output_dict[k] = v.deepcopy()
         else:
             output_dict[k] = copy.deepcopy(v)
@@ -149,7 +151,7 @@ class PlotOptions(DisplayOptions):
             # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
             # copy.deepcopy. For this reason, its deepcopy method must to be used in
             # this case.
-            if isinstance(v, geo.plane.BluemiraPlane):
+            if isinstance(v, plane.BluemiraPlane):
                 output_dict[k] = v.deepcopy()
             else:
                 output_dict[k] = copy.deepcopy(v)
@@ -281,18 +283,18 @@ class BasePlotter(ABC):
         """Set the plotting plane"""
         if plane == "xy":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = geo.plane.BluemiraPlane()
+            self.options._options["plane"] = plane.BluemiraPlane()
         elif plane == "xz":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = geo.plane.BluemiraPlane(
+            self.options._options["plane"] = plane.BluemiraPlane(
                 axis=(1.0, 0.0, 0.0), angle=-90.0
             )
         elif plane == "zy":
             # Base.Placement(origin, axis, angle)
-            self.options._options["plane"] = geo.plane.BluemiraPlane(
+            self.options._options["plane"] = plane.BluemiraPlane(
                 axis=(0.0, 1.0, 0.0), angle=90.0
             )
-        elif isinstance(plane, geo.plane.BluemiraPlane):
+        elif isinstance(plane, plane.BluemiraPlane):
             self.options._options["plane"] = plane
         else:
             DisplayError(f"{plane} is not a valid plane")
@@ -361,9 +363,7 @@ class BasePlotter(ABC):
 
     def _set_aspect_3d(self):
         # This was the only way I found to get 3-D plots to look right in matplotlib
-        x_bb, y_bb, z_bb = geo.bound_box.BoundingBox.from_xyz(
-            *self._data.T
-        ).get_box_arrays()
+        x_bb, y_bb, z_bb = bound_box.BoundingBox.from_xyz(*self._data.T).get_box_arrays()
         for x, y, z in zip(x_bb, y_bb, z_bb):
             self.ax.plot([x], [y], [z], color="w")
 
@@ -476,7 +476,7 @@ class WirePlotter(BasePlotter):
     _CLASS_PLOT_OPTIONS = {"show_points": False}
 
     def _check_obj(self, obj):
-        if not isinstance(obj, geo.wire.BluemiraWire):
+        if not isinstance(obj, wire.BluemiraWire):
             raise ValueError(f"{obj} must be a BluemiraWire")
         return True
 
@@ -525,7 +525,7 @@ class FacePlotter(BasePlotter):
     _CLASS_PLOT_OPTIONS = {"show_points": False, "show_wires": False}
 
     def _check_obj(self, obj):
-        if not isinstance(obj, geo.face.BluemiraFace):
+        if not isinstance(obj, face.BluemiraFace):
             raise ValueError(f"{obj} must be a BluemiraFace")
         return True
 
@@ -547,7 +547,7 @@ class FacePlotter(BasePlotter):
         #  re-orient the Wires in the correct way for display. Find another way to do
         #  it (maybe adding this function to the freecadapi.
         for w in face._shape.Wires:
-            boundary = geo.wire.BluemiraWire(w)
+            boundary = wire.BluemiraWire(w)
             wplotter = WirePlotter(self.options)
             self._wplotters.append(wplotter)
             wplotter._populate_data(boundary)
@@ -666,9 +666,9 @@ def _get_plotter_class(part):
 
     if isinstance(part, (list, np.ndarray)):
         plot_class = PointsPlotter
-    elif isinstance(part, geo.wire.BluemiraWire):
+    elif isinstance(part, wire.BluemiraWire):
         plot_class = WirePlotter
-    elif isinstance(part, geo.face.BluemiraFace):
+    elif isinstance(part, face.BluemiraFace):
         plot_class = FacePlotter
     elif isinstance(part, bluemira.base.components.Component):
         plot_class = ComponentPlotter
@@ -680,7 +680,7 @@ def _get_plotter_class(part):
 
 
 def plot_2d(
-    parts: Union[geo.base.BluemiraGeo, List[geo.base.BluemiraGeo]],
+    parts: Union[BluemiraGeo, List[BluemiraGeo]],
     options: Optional[Union[PlotOptions, List[PlotOptions]]] = None,
     ax=None,
     show: bool = True,
@@ -715,7 +715,7 @@ def plot_2d(
 
 
 def plot_3d(
-    parts: Union[geo.base.BluemiraGeo, List[geo.base.BluemiraGeo]],
+    parts: Union[BluemiraGeo, List[BluemiraGeo]],
     options: Optional[Union[PlotOptions, List[PlotOptions]]] = None,
     ax=None,
     show: bool = True,

--- a/bluemira/geometry/__init__.py
+++ b/bluemira/geometry/__init__.py
@@ -23,13 +23,13 @@
 Methods and classes for geometry creation and manipulation.
 """
 
-from . import base
-from . import wire
-from . import face
-from . import shell
-from . import solid
-from . import constants
-from . import error
-from . import tools
-from . import plane
-from . import bound_box
+# from . import base
+# from . import wire
+# from . import face
+# from . import shell
+# from . import solid
+# from . import constants
+# from . import error
+# from . import tools
+# from . import plane
+# from . import bound_box

--- a/bluemira/geometry/__init__.py
+++ b/bluemira/geometry/__init__.py
@@ -22,14 +22,3 @@
 """
 Methods and classes for geometry creation and manipulation.
 """
-
-# from . import base
-# from . import wire
-# from . import face
-# from . import shell
-# from . import solid
-# from . import constants
-# from . import error
-# from . import tools
-# from . import plane
-# from . import bound_box

--- a/bluemira/geometry/plotting.py
+++ b/bluemira/geometry/plotting.py
@@ -28,8 +28,8 @@ WARNING: This module is only drafted. It must be updated.
 import matplotlib.pyplot as plt
 
 # import bluemira lib
-from .wire import BluemiraWire
-from .face import BluemiraFace
+from bluemira.geometry.wire import BluemiraWire
+from bluemira.geometry.face import BluemiraFace
 
 from bluemira.utilities.plot_tools import Plot3D
 

--- a/bluemira/geometry/plotting.py
+++ b/bluemira/geometry/plotting.py
@@ -27,10 +27,10 @@ WARNING: This module is only drafted. It must be updated.
 # import graphical lib
 import matplotlib.pyplot as plt
 
-# import bluemira lib
-from bluemira.geometry.wire import BluemiraWire
 from bluemira.geometry.face import BluemiraFace
 
+# import bluemira lib
+from bluemira.geometry.wire import BluemiraWire
 from bluemira.utilities.plot_tools import Plot3D
 
 DEFAULT = {}

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -32,11 +32,11 @@ from typing import List, Union, Iterable
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.geometry.base import BluemiraGeo
 from bluemira.codes import _freecadapi as cadapi
-from .wire import BluemiraWire
-from .face import BluemiraFace
-from .shell import BluemiraShell
-from .solid import BluemiraSolid
-from .error import GeometryError
+from bluemira.geometry.wire import BluemiraWire
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.shell import BluemiraShell
+from bluemira.geometry.solid import BluemiraSolid
+from bluemira.geometry.error import GeometryError
 
 
 def convert(apiobj, label=""):

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -23,20 +23,20 @@
 Useful functions for bluemira geometries.
 """
 
-import numpy as np
-import numba as nb
 from copy import deepcopy
-from typing import List, Union, Iterable
+from typing import Iterable, List, Union
 
+import numba as nb
+import numpy as np
 
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.geometry.base import BluemiraGeo
 from bluemira.codes import _freecadapi as cadapi
-from bluemira.geometry.wire import BluemiraWire
+from bluemira.geometry.base import BluemiraGeo
+from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.shell import BluemiraShell
 from bluemira.geometry.solid import BluemiraSolid
-from bluemira.geometry.error import GeometryError
+from bluemira.geometry.wire import BluemiraWire
 
 
 def convert(apiobj, label=""):

--- a/bluemira/materials/__init__.py
+++ b/bluemira/materials/__init__.py
@@ -37,7 +37,6 @@ from bluemira.materials.material import (
 )
 from bluemira.materials.mixtures import HomogenisedMixture
 
-
 __all__ = [
     "BePebbleBed",
     "HomogenisedMixture",

--- a/bluemira/materials/__init__.py
+++ b/bluemira/materials/__init__.py
@@ -24,8 +24,8 @@
 Module-level functionality for materials.
 """
 
-from .cache import MaterialCache
-from .material import (
+from bluemira.materials.cache import MaterialCache
+from bluemira.materials.material import (
     BePebbleBed,
     Liquid,
     MassFractionMaterial,
@@ -35,7 +35,7 @@ from .material import (
     UnitCellCompound,
     Void,
 )
-from .mixtures import HomogenisedMixture
+from bluemira.materials.mixtures import HomogenisedMixture
 
 
 __all__ = [

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -27,15 +27,15 @@ import copy
 import json
 
 from bluemira.materials.material import (
-    MaterialsError,
-    Void,
-    MassFractionMaterial,
-    NbTiSuperconductor,
-    NbSnSuperconductor,
-    Liquid,
-    UnitCellCompound,
     BePebbleBed,
+    Liquid,
+    MassFractionMaterial,
+    MaterialsError,
+    NbSnSuperconductor,
+    NbTiSuperconductor,
     Plasma,
+    UnitCellCompound,
+    Void,
 )
 from bluemira.materials.mixtures import HomogenisedMixture
 

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -26,7 +26,7 @@ Classes and methods to load, store, and retrieve materials.
 import copy
 import json
 
-from .material import (
+from bluemira.materials.material import (
     MaterialsError,
     Void,
     MassFractionMaterial,
@@ -37,7 +37,7 @@ from .material import (
     BePebbleBed,
     Plasma,
 )
-from .mixtures import HomogenisedMixture
+from bluemira.materials.mixtures import HomogenisedMixture
 
 
 class MaterialCache:

--- a/bluemira/materials/error.py
+++ b/bluemira/materials/error.py
@@ -23,7 +23,7 @@
 Error classes for the materials module.
 """
 
-from ..base.error import BluemiraError
+from bluemira.base.error import BluemiraError
 
 
 class MaterialsError(BluemiraError):

--- a/bluemira/materials/material.py
+++ b/bluemira/materials/material.py
@@ -36,18 +36,18 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=UserWarning)
     import neutronics_material_maker as nmm
 
-from bluemira.utilities.tools import is_num, json_writer
-
 from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.materials.constants import P_DEFAULT, T_DEFAULT
+from bluemira.materials.error import MaterialsError
 from bluemira.utilities.tools import (
     array_or_num,
     gcm3_to_kgm3,
+    is_num,
+    json_writer,
     list_array,
     to_celsius,
     to_kelvin,
 )
-from bluemira.materials.constants import P_DEFAULT, T_DEFAULT
-from bluemira.materials.error import MaterialsError
 
 # Set any custom symbols for use in asteval
 asteval_user_symbols = {

--- a/bluemira/materials/material.py
+++ b/bluemira/materials/material.py
@@ -38,16 +38,16 @@ with warnings.catch_warnings():
 
 from bluemira.utilities.tools import is_num, json_writer
 
-from ..base.look_and_feel import bluemira_warn
-from ..utilities.tools import (
+from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.utilities.tools import (
     array_or_num,
     gcm3_to_kgm3,
     list_array,
     to_celsius,
     to_kelvin,
 )
-from .constants import P_DEFAULT, T_DEFAULT
-from .error import MaterialsError
+from bluemira.materials.constants import P_DEFAULT, T_DEFAULT
+from bluemira.materials.error import MaterialsError
 
 # Set any custom symbols for use in asteval
 asteval_user_symbols = {

--- a/bluemira/materials/mixtures.py
+++ b/bluemira/materials/mixtures.py
@@ -31,11 +31,11 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=UserWarning)
     import neutronics_material_maker as nmm
 
-from ..base.look_and_feel import bluemira_warn
+from bluemira.base.look_and_feel import bluemira_warn
 
-from .constants import MATERIAL_BEAM_MAP, T_DEFAULT
-from .error import MaterialsError
-from .material import SerialisedMaterial
+from bluemira.materials.constants import MATERIAL_BEAM_MAP, T_DEFAULT
+from bluemira.materials.error import MaterialsError
+from bluemira.materials.material import SerialisedMaterial
 
 
 class HomogenisedMixture(SerialisedMaterial, nmm.MultiMaterial):

--- a/bluemira/materials/mixtures.py
+++ b/bluemira/materials/mixtures.py
@@ -23,16 +23,16 @@
 Material mixture utility classes
 """
 import copy
-import numpy as np
 import typing
 import warnings
+
+import numpy as np
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=UserWarning)
     import neutronics_material_maker as nmm
 
 from bluemira.base.look_and_feel import bluemira_warn
-
 from bluemira.materials.constants import MATERIAL_BEAM_MAP, T_DEFAULT
 from bluemira.materials.error import MaterialsError
 from bluemira.materials.material import SerialisedMaterial

--- a/bluemira/radiation_transport/__init__.py
+++ b/bluemira/radiation_transport/__init__.py
@@ -23,4 +23,4 @@
 The bluemira radiation transport module.
 """
 
-from .advective_transport import ChargedParticleSolver
+from bluemira.radiation_transport.advective_transport import ChargedParticleSolver


### PR DESCRIPTION
## Linked Issues

Hopefully Closes #533 

## Description

Attempt to deal with circular imports

flake8 fails because it cant find some annotations as imports

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
