### PR TITLE
Load anything

### DIFF
--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -30,6 +30,7 @@ from collections.abc import Iterable
 from functools import partial
 from importlib import import_module as imp
 from importlib import util as imp_u
+from importlib import machinery as imp_mach
 from itertools import permutations
 from json import JSONDecoder, JSONEncoder, dumps
 from json.encoder import _make_iterencode
@@ -708,14 +709,23 @@ def _loadfromspec(name: str) -> ModuleType:
 
     mod_file = f"{dirname}/{requested}"
 
+    name, ext = requested.rsplit(".", 1) if "." in requested else (requested, "")
+
+    if ext not in imp_mach.SOURCE_SUFFIXES:
+        n_suffix = True
+        imp_mach.SOURCE_SUFFIXES.append(ext)
+    else:
+        n_suffix = False
+
     try:
-        spec = imp_u.spec_from_file_location(
-            mod_file.rsplit("/")[-1].split(".")[0], mod_file
-        )
+        spec = imp_u.spec_from_file_location(name, mod_file)
         module = imp_u.module_from_spec(spec)
         spec.loader.exec_module(module)
-    except (AttributeError, ImportError):
+    except (AttributeError, ImportError, SyntaxError):
         raise ImportError("File '{}' is not a module".format(mod_files[0]))
+
+    if n_suffix:
+        imp_mach.SOURCE_SUFFIXES.pop()
 
     return module
 

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -29,8 +29,8 @@ import string
 from collections.abc import Iterable
 from functools import partial
 from importlib import import_module as imp
-from importlib import util as imp_u
 from importlib import machinery as imp_mach
+from importlib import util as imp_u
 from itertools import permutations
 from json import JSONDecoder, JSONEncoder, dumps
 from json.encoder import _make_iterencode

--- a/tests/bluemira/utilities/test_tools.py
+++ b/tests/bluemira/utilities/test_tools.py
@@ -334,6 +334,18 @@ class TestGetModule:
         with pytest.raises(ImportError):
             get_module(get_bluemira_path() + "../README.md")
 
+    def test_get_weird_ext_python_file(self, tmpdir):
+        path1 = tmpdir.join("file")
+        path2 = tmpdir.join("file.hello")
+        function = """def f():
+    return True"""
+        for path in [path1, path2]:
+            with open(path, "w") as file:
+                file.writelines(function)
+
+            mod = get_module(str(path))
+            assert mod.f()
+
     def test_get_class(self):
         for mod in [self.test_mod, self.test_mod_loc]:
             the_class = get_class_from_module(f"{mod}::{self.test_class_name}")

--- a/tests/bluemira/utilities/test_tools.py
+++ b/tests/bluemira/utilities/test_tools.py
@@ -19,27 +19,28 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import pytest
-import os
-import numpy as np
 import json
+import os
 from io import StringIO
+
+import numpy as np
+import pytest
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.utilities.tools import (
+    CommentJSONDecoder,
+    NumpyJSONEncoder,
     asciistr,
     cartesian_to_polar,
     clip,
-    CommentJSONDecoder,
     compare_dicts,
     cross,
     dot,
-    get_module,
     get_class_from_module,
+    get_module,
     is_num,
     levi_civita_tensor,
     norm,
-    NumpyJSONEncoder,
     polar_to_cartesian,
 )
 


### PR DESCRIPTION
## Description

Our module loader only worked if the file extension was '.py' and a python file, now it works with any extension if python can import it.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
