### PR TITLE
🐛 Fix weird circular import

### DIFF
--- a/bluemira/base/__init__.py
+++ b/bluemira/base/__init__.py
@@ -24,7 +24,7 @@ Base classes and functionality for the bluemira code.
 """
 
 # from .builder import *
-from .parameter import *
+from bluemira.base.parameter import Parameter, ParameterFrame, ParameterMapping
 
 """
 from .components import (


### PR DESCRIPTION
## Description

When in ipython and trying to directly import `bluemira.utilities.tools` it moans about circular imports. If I import `bluemira.base` first it doesnt moan. This makes it so the import always works. In my head the imports are the same (and locals tells me that). Don't really get it...

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
