### PR TITLE
Fix intermittent failures in `test_shapes.py`

### DIFF
--- a/tests/bluemira/builders/test_shapes.py
+++ b/tests/bluemira/builders/test_shapes.py
@@ -131,6 +131,8 @@ class TestMakeOptimisedShape:
                 "dz": 0.0,
             },
             "problem_class": problem_class,
+            "algorithm_name": "SLSQP",
+            "opt_conditions": {"ftol_rel": 1e-6, "max_eval": 100},
             "label": "Shape",
         }
         builder = MakeOptimisedShape(params, build_config)


### PR DESCRIPTION
## Linked Issues

We are occasionally getting failures in `test_shapes.py` (ranging from 1-2, depending on luck).

## Description
Fixes above failures by adding an `ftol_rel` termination condition to the optimiser. Previously, not setting this was meaning that the optimisation algorithm would terminate after `max_eval` leading to potential round-off error failures.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
