### PR TITLE
🎨 uplift process mfile interface

### DIFF
--- a/bluemira/codes/process/run.py
+++ b/bluemira/codes/process/run.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import os
 import subprocess  # noqa :S404
 from enum import auto
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import bluemira.base as bm_base
 import bluemira.codes.interface as interface
@@ -194,3 +194,19 @@ class Solver(interface.FileProgramInterface):
             run_dir=run_dir,
             mappings=mappings,
         )
+
+    def get_process_parameters(self, params: Union[List, str]):
+        """
+        Get raw parameters from an MFILE
+        (mapped bluemira parameters will have bluemira names)
+
+        Parameters
+        ----------
+        params: Union[List, str]
+            parameter names to access
+
+        Returns
+        -------
+        values list
+        """
+        return self.teardown_obj.bm_file.extract_outputs(params)

--- a/tests/bluemira/codes/process/test_run.py
+++ b/tests/bluemira/codes/process/test_run.py
@@ -177,17 +177,15 @@ class TestRun:
         assert "PROCESS" not in param.mapping and param.mapping["FAKE_CODE"].recv is True
         assert "gp" not in runner._recv_mapping
 
-    @patch("bluemira.codes.process.teardown.Teardown._load_PROCESS")
-    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output")
+    @patch("bluemira.codes.process.teardown.Teardown.load_PROCESS_run")
+    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output_files")
     @patch("bluemira.codes.process.run.Run._run_subprocess")
     @patch("bluemira.codes.process.run.Run._clear_PROCESS_output")
-    @patch("bluemira.codes.process.teardown.Teardown.read_mfile")
     @patch("bluemira.codes.process.setup.PROCESSInputWriter.add_parameter")
     @pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")
     def test_runinput(
         self,
         mock_add_parameter,
-        mock_read_mfile,
         mock_clear,
         mock_run,
         mock_check,
@@ -204,23 +202,20 @@ class TestRun:
         assert mock_add_parameter.call_count == 0
 
         # Check that correct run calls were made.
-        assert mock_read_mfile.call_count == 1
         assert mock_clear.call_count == 1
         assert mock_run.call_count == 1
         assert mock_check.call_count == 1
         assert mock_load.call_count == 1
 
-    @patch("bluemira.codes.process.teardown.Teardown._load_PROCESS")
-    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output")
+    @patch("bluemira.codes.process.teardown.Teardown.load_PROCESS_run")
+    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output_files")
     @patch("bluemira.codes.process.run.Run._run_subprocess")
     @patch("bluemira.codes.process.run.Run._clear_PROCESS_output")
-    @patch("bluemira.codes.process.teardown.Teardown.read_mfile")
     @patch("bluemira.codes.process.setup.PROCESSInputWriter.add_parameter")
     @pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")
     def test_run_with_params_to_update(
         self,
         mock_add_parameter,
-        mock_read_mfile,
         mock_clear,
         mock_run,
         mock_check,
@@ -243,23 +238,20 @@ class TestRun:
         mock_add_parameter.assert_any_call("fp", 5)
 
         # Check that correct run calls were made.
-        assert mock_read_mfile.call_count == 1
         assert mock_clear.call_count == 1
         assert mock_run.call_count == 1
         assert mock_check.call_count == 1
         assert mock_load.call_count == 1
 
-    @patch("bluemira.codes.process.teardown.Teardown._load_PROCESS")
-    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output")
+    @patch("bluemira.codes.process.teardown.Teardown.load_PROCESS_run")
+    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output_files")
     @patch("bluemira.codes.process.run.Run._run_subprocess")
     @patch("bluemira.codes.process.run.Run._clear_PROCESS_output")
-    @patch("bluemira.codes.process.teardown.Teardown.read_mfile")
     @patch("bluemira.codes.process.setup.PROCESSInputWriter.add_parameter")
     @pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")
     def test_run_without_params_to_update(
         self,
         mock_add_parameter,
-        mock_read_mfile,
         mock_clear,
         mock_run,
         mock_check,
@@ -288,14 +280,13 @@ class TestRun:
         mock_add_parameter.assert_any_call("fp", 5)
 
         # Check that correct run calls were made.
-        assert mock_read_mfile.call_count == 1
         assert mock_clear.call_count == 1
         assert mock_run.call_count == 1
         assert mock_check.call_count == 1
         assert mock_load.call_count == 1
 
-    @patch("bluemira.codes.process.teardown.Teardown._load_PROCESS")
-    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output")
+    @patch("bluemira.codes.process.teardown.Teardown.load_PROCESS_run")
+    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output_files")
     @patch("bluemira.codes.process.run.Run._run_subprocess")
     @patch("bluemira.codes.process.run.Run._clear_PROCESS_output")
     @patch("bluemira.codes.process.setup.PROCESSInputWriter.add_parameter")
@@ -314,8 +305,8 @@ class TestRun:
         assert mock_load.call_count == 1
         assert mock_add_parameter.call_count == 0
 
-    @patch("bluemira.codes.process.teardown.Teardown._load_PROCESS")
-    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output")
+    @patch("bluemira.codes.process.teardown.Teardown.load_PROCESS_run")
+    @patch("bluemira.codes.process.teardown.Teardown._check_PROCESS_output_files")
     @patch("bluemira.codes.process.run.Run._run_subprocess")
     @patch("bluemira.codes.process.run.Run._clear_PROCESS_output")
     @patch("bluemira.codes.process.setup.PROCESSInputWriter.add_parameter")


### PR DESCRIPTION
## Description

This allows access directly to the mfile data from the process solver object if parameters are not mapped. 
At the same time I've simplified a bit of logic for loading mfiles contents

## Interface Changes

All mfile variables are now accessible

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
