### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ incorporates several modules, some of which rely on other codes, to carry out a 
 typical conceptual fusion reactor design activities.
 
 ``Bluemira`` was created from two similar codes: ``BLUEPRINT`` and ``MIRA`` (see
-[publications](#Publications)).
+[publications](#publications)).
 
 ## Work in Progress!
 
@@ -39,7 +39,7 @@ before starting to use any modules, so we can warn you of changes to come.
 * `utilities`: collection of utility toolboxes for file IO, databases,
   machine learning, and misc.
 
-## Publications [](#Publications)
+## Publications
 
 The ``bluemira`` code and its modules are described in the following publications:
 
@@ -63,7 +63,7 @@ The ``MIRA`` code and its modules are described in the following publications:
 
 ## Terms of use
 
-``Bluemira`` is [released under the LGPLv2.1 license](LICENSE.md), but we also ask that
+``Bluemira`` is [released under the LGPLv2.1 license](LICENSE), but we also ask that
 you show professional courtesy when using this code:
 
 1. Since you are benefiting from work on ``bluemira``, we ask that you submit any
@@ -81,7 +81,7 @@ you show professional courtesy when using this code:
    all the authors get the credit they deserve by citing the relevant ``bluemira``,
    ``BLUEPRINT``, and ``MIRA`` papers.
 
-For a full list of existing publications, see [here](#Publications).
+For a full list of existing publications, see [here](#publications).
 
 ## Code of conduct
 
@@ -89,7 +89,7 @@ See [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Installation
 
-See our [getting started guide](documentation/source/started.rst).
+See our [installation guide](https://bluemira.readthedocs.io/en/develop/installation.html).
 
 ## Developing
 


### PR DESCRIPTION
## Linked Issues
Closes #586 

## Description

Fixes a few dead links in the repo's README.

* link to LICENSE fixed.

* internal links to "Publications" header fixed.

* link to installation guide fixed. I've opted to link to the online docs rather than the relative path to the rst. Hopefully that's the correct thing to do here.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
