### PR TITLE
Shape design parameter validation and notebook conversion

### DIFF
--- a/bluemira/base/design.py
+++ b/bluemira/base/design.py
@@ -24,6 +24,7 @@ Module containing the bluemira Design class.
 """
 
 import abc
+import copy
 from typing import Dict, List, Optional, Type, Union
 
 from bluemira.base.builder import BuildConfig, Builder
@@ -43,7 +44,7 @@ class DesignABC(abc.ABC):
     the analysis results and reactor components.
     """
 
-    _required_params: List[str] = ["Name"]
+    _required_params: List[str]
     _params: Configuration
     _build_config: Dict[str, BuildConfig]
     _builders: Dict[str, Builder]
@@ -54,10 +55,18 @@ class DesignABC(abc.ABC):
         build_config: Dict[str, BuildConfig],
     ):
         print_banner()
-        self._build_config = build_config
+        self._build_config = copy.deepcopy(build_config)
         self._extract_build_config(params)
+        self._validate_params(params)
         self._params = Configuration.from_template(self._required_params)
         self._params.update_kw_parameters(params)
+
+    @property
+    def required_params(self) -> List[str]:
+        """
+        The names of the parameters that are required to run this design.
+        """
+        return self._required_params
 
     @property
     def params(self) -> Configuration:
@@ -147,10 +156,26 @@ class DesignABC(abc.ABC):
     @abc.abstractmethod
     def _extract_build_config(self, params: Dict[str, Union[int, float, str]]):
         """
-        Extracts the builders from the config, which must be an ordered dictionary
-        mapping the name of the builder to the corresponding options.
+        Extract the builders and associated required parameter names from the config,
+        which must be an ordered dictionary mapping the name of the builder to the
+        corresponding options.
         """
         self._builders = {}
+        self._required_params = ["Name"]
+
+    def _validate_params(self, params: Dict[str, Union[int, float, str]]):
+        """
+        Validate that the provided parameters are as expected.
+        """
+        missing_params = []
+        for param_name in self._required_params:
+            if param_name not in params:
+                missing_params.append(param_name)
+
+        if missing_params != []:
+            raise BuilderError(
+                f"Required parameters {', '.join(missing_params)} not provided to Design"
+            )
 
 
 class Design(DesignABC):
@@ -205,7 +230,7 @@ class Reactor(DesignABC):
     """
     The Reactor class allows a Design to be implemented directly in the code. This can
     simplify some of logic when compared with the configurable Design class, in
-    particularwhen passing around Component information. As such, individual Reactor
+    particular when passing around Component information. As such, individual Reactor
     instances must implement their own `run` method. The Reactor class also provides
     managed output via a FileManager to aid the persistence of input and output data.
     """
@@ -279,3 +304,9 @@ class Reactor(DesignABC):
         Perform a bulk update of the parameters from the given source.
         """
         self._params.update_kw_parameters(params, source=source)
+
+    def _validate_params(self, params: Dict[str, Union[int, float, str]]):
+        """
+        Validation of Reactor parameters is currently not supported.
+        """
+        pass

--- a/examples/design/design_shapes.ipynb
+++ b/examples/design/design_shapes.ipynb
@@ -87,10 +87,12 @@
         "  - uses the `MakeOptimisedShape` Builder class.\n",
         "  - parameterises the TF Coils centerline shape using the `PrincetonD`\n",
         "    GeometryParameterisation class.\n",
-        "  - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 and x2\n",
-        "    shape parameters. The dz shape parameter is set to 0 and fixed. The x1 shape\n",
+        "  - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 (the\n",
+        "    inboard limb radius) and x2 (the outboard limb radius) shape parameters. The dz\n",
+        "    (vertical offset from z=0) shape parameter is set to 0 and fixed. The x1 shape\n",
         "    parameter is also fixed, while the x2 shape parameter is allowed to vary in the\n",
-        "    optimisation, with an adjusted lower bound of 14.\n",
+        "    optimisation, with an adjusted lower bound of 14. This means that only the outboard\n",
+        "    leg radius is free to vary in the optimisation.\n",
         "  - uses the `MaximiseLength` GeometryOptimisationProblem class to define the design\n",
         "    problem that will be solved as part of the TF Coil build stage.\n",
         "  - labels the resulting component as \"Shape\"."
@@ -257,7 +259,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.10"
     }
   },
   "nbformat": 4,

--- a/examples/design/design_shapes.ipynb
+++ b/examples/design/design_shapes.ipynb
@@ -1,0 +1,265 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from bluemira.base.design import Design\n",
+        "from bluemira.geometry.optimisation import GeometryOptimisationProblem"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Configuring and Running a Simple Shape-Based Design\n",
+        "\n",
+        "This example shows how to set up and run a shape-based Design that uses a parameterised\n",
+        "shape as-is to represent a plasma surface, and solves a GeometryOptimisationProblem\n",
+        "to represent a fictitious TF coil centerline.\n",
+        "\n",
+        "## Defining the GeometryOptimisationProblem\n",
+        "\n",
+        "First we have to consider the optimisation problem that we would like to solve as part\n",
+        "of our Design. In this case we would like to optimise the TF Coil centerline by making\n",
+        "it as long as possible. This can be performed by solving an unconstrained\n",
+        "GeometryOptimisationProblem that uses the negative length as the objective function\n",
+        "(since minimising the negative length will maximise the value of the absolute length).\n",
+        "Such an optimisation problem can be defined as below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "class MaximiseLength(GeometryOptimisationProblem):\n",
+        "    \"\"\"\n",
+        "    A simple geometry optimisation problem that minimises length without constraints.\n",
+        "    \"\"\"\n",
+        "\n",
+        "    def calculate_length(self, x):\n",
+        "        \"\"\"\n",
+        "        Calculate the length of the GeometryParameterisation.\n",
+        "\n",
+        "        Result is negative as we're maximising rather than minimising. Note that most\n",
+        "        real life problems will minimise.\n",
+        "        \"\"\"\n",
+        "        self.update_parameterisation(x)\n",
+        "        return -self.parameterisation.create_shape().length\n",
+        "\n",
+        "    def f_objective(self, x, grad):\n",
+        "        \"\"\"\n",
+        "        Objective function is the length of the parameterised shape.\n",
+        "        \"\"\"\n",
+        "        length = self.calculate_length(x)\n",
+        "\n",
+        "        if grad.size > 0:\n",
+        "            # Only called if a gradient-based optimiser is used\n",
+        "            grad[:] = self.optimiser.approx_derivative(\n",
+        "                self.calculate_length, x, f0=length\n",
+        "            )\n",
+        "\n",
+        "        return length"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Configuring the Design\n",
+        "\n",
+        "The Design is configured by passing in a dictionary that provides the build stages to\n",
+        "be run, and the way that each of those build stages should be set up. In particular\n",
+        "in this case we define the following:\n",
+        "\n",
+        "- The Plasma build stage:\n",
+        "  - uses the `MakeParameterisedShape` Builder class.\n",
+        "  - parameterises the plasma shape using the `JohnerLCFS` GeometryParameterisation\n",
+        "    class.\n",
+        "  - maps the R_0 and A Design parameters to the r_0 and a shape parameters.\n",
+        "  - labels the resulting component as \"Shape\".\n",
+        "\n",
+        "- The TF Coils build stage:\n",
+        "  - uses the `MakeOptimisedShape` Builder class.\n",
+        "  - parameterises the TF Coils centerline shape using the `PrincetonD`\n",
+        "    GeometryParameterisation class.\n",
+        "  - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 and x2\n",
+        "    shape parameters. The dz shape parameter is set to 0 and fixed. The x1 shape\n",
+        "    parameter is also fixed, while the x2 shape parameter is allowed to vary in the\n",
+        "    optimisation, with an adjusted lower bound of 14.\n",
+        "  - uses the `MaximiseLength` GeometryOptimisationProblem class to define the design\n",
+        "    problem that will be solved as part of the TF Coil build stage.\n",
+        "  - labels the resulting component as \"Shape\"."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "build_config = {\n",
+        "    \"Plasma\": {\n",
+        "        \"class\": \"MakeParameterisedShape\",\n",
+        "        \"param_class\": \"bluemira.equilibria.shapes::JohnerLCFS\",\n",
+        "        \"variables_map\": {\n",
+        "            \"r_0\": \"R_0\",\n",
+        "            \"a\": \"A\",\n",
+        "        },\n",
+        "        \"label\": \"Shape\",\n",
+        "    },\n",
+        "    \"TF Coils\": {\n",
+        "        \"class\": \"MakeOptimisedShape\",\n",
+        "        \"param_class\": \"PrincetonD\",\n",
+        "        \"variables_map\": {\n",
+        "            \"x1\": {\n",
+        "                \"value\": \"r_tf_in_centre\",\n",
+        "                \"fixed\": True,\n",
+        "            },\n",
+        "            \"x2\": {\n",
+        "                \"value\": \"r_tf_out_centre\",\n",
+        "                \"lower_bound\": 14.0,\n",
+        "            },\n",
+        "            \"dz\": {\n",
+        "                \"value\": 0.0,\n",
+        "                \"fixed\": True,\n",
+        "            },\n",
+        "        },\n",
+        "        \"problem_class\": MaximiseLength,\n",
+        "        \"label\": \"Shape\",\n",
+        "    },\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Parameterising the Design\n",
+        "\n",
+        "The Design is parameterised by mapping the required parameter names to their initial\n",
+        "values. All Designs must have a Name, and in this case the other required parameters\n",
+        "are defined by the mapped variables in the `build_config`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "params = {\n",
+        "    \"Name\": \"Shape Design Example\",\n",
+        "    \"R_0\": (9.0, \"Input\"),\n",
+        "    \"A\": (3.5, \"Input\"),\n",
+        "    \"r_tf_in_centre\": (5.0, \"Input\"),\n",
+        "    \"r_tf_out_centre\": (15.0, \"Input\"),\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Running the Design\n",
+        "\n",
+        "The Design object is defined as run as below:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "design = Design(params, build_config)\n",
+        "component = design.run()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Visualising the Results\n",
+        "\n",
+        "The result of the design is a Component object that represents a tree of outputs from\n",
+        "the different build stages. The resulting Component tree from this Design can be\n",
+        "printed out."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(component.tree())"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "It is also possible to plot the nodes in the tree that are defined with shapes (known\n",
+        "as PhysicalComponents)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "component.plot_2d()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can also inspect the properties of the individual build stages by extracting them\n",
+        "from the Design. This example shows how the resulting parameters from the solution of\n",
+        "the TF Coils design problem can be extracted. Note that we have maximised the value of\n",
+        "x2 without constraint, so it has found the upper bound as defined on that variable.\n",
+        "All other variables have stayed as originally defined as they were set to be fixed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "tf_builder = design.get_builder(\"TF Coils\")\n",
+        "tf_design_problem: GeometryOptimisationProblem = tf_builder.design_problem\n",
+        "print(tf_design_problem.parameterisation.variables)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ],
+  "metadata": {
+    "anaconda-cloud": {},
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/examples/design/design_shapes.py
+++ b/examples/design/design_shapes.py
@@ -43,6 +43,7 @@ from bluemira.geometry.optimisation import GeometryOptimisationProblem
 # (since minimising the negative length will maximise the value of the absolute length).
 # Such an optimisation problem can be defined as below.
 
+
 # %%
 class MaximiseLength(GeometryOptimisationProblem):
     """

--- a/examples/design/design_shapes.py
+++ b/examples/design/design_shapes.py
@@ -23,12 +23,27 @@
 A basic tutorial for configuring and running a design with parameterised shapes.
 """
 
+# %%
 from bluemira.base.design import Design
 from bluemira.geometry.optimisation import GeometryOptimisationProblem
 
-# Make an example optimisation problem to be solved in the design.
+# %%[markdown]
+# # Configuring and Running a Simple Shape-Based Design
+#
+# This example shows how to set up and run a shape-based Design that uses a parameterised
+# shape as-is to represent a plasma surface, and solves a GeometryOptimisationProblem
+# to represent a fictitious TF coil centerline.
+#
+# ## Defining the GeometryOptimisationProblem
+#
+# First we have to consider the optimisation problem that we would like to solve as part
+# of our Design. In this case we would like to optimise the TF Coil centerline by making
+# it as long as possible. This can be performed by solving an unconstrained
+# GeometryOptimisationProblem that uses the negative length as the objective function
+# (since minimising the negative length will maximise the value of the absolute length).
+# Such an optimisation problem can be defined as below.
 
-
+# %%
 class MaximiseLength(GeometryOptimisationProblem):
     """
     A simple geometry optimisation problem that minimises length without constraints.
@@ -59,8 +74,34 @@ class MaximiseLength(GeometryOptimisationProblem):
         return length
 
 
-# Set up the configuration for the design.
+# %%[markdown]
+# ## Configuring the Design
+#
+# The Design is configured by passing in a dictionary that provides the build stages to
+# be run, and the way that each of those build stages should be set up. In particular
+# in this case we define the following:
+#
+# - The Plasma build stage:
+#   - uses the `MakeParameterisedShape` Builder class.
+#   - parameterises the plasma shape using the `JohnerLCFS` GeometryParameterisation
+#     class.
+#   - maps the R_0 and A Design parameters to the r_0 and a shape parameters.
+#   - labels the resulting component as "Shape".
+#
+# - The TF Coils build stage:
+#   - uses the `MakeOptimisedShape` Builder class.
+#   - parameterises the TF Coils centerline shape using the `PrincetonD`
+#     GeometryParameterisation class.
+#   - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 and x2
+#     shape parameters. The dz shape parameter is set to 0 and fixed. The x1 shape
+#     parameter is also fixed, while the x2 shape parameter is allowed to vary in the
+#     optimisation, with an adjusted lower bound of 14.
+#   - uses the `MaximiseLength` GeometryOptimisationProblem class to define the design
+#     problem that will be solved as part of the TF Coil build stage.
+#   - labels the resulting component as "Shape".
 
+
+# %%
 build_config = {
     "Plasma": {
         "class": "MakeParameterisedShape",
@@ -92,24 +133,58 @@ build_config = {
         "label": "Shape",
     },
 }
+
+
+# %%[markdown]
+# ## Parameterising the Design
+#
+# The Design is parameterised by mapping the required parameter names to their initial
+# values. All Designs must have a Name, and in this case the other required parameters
+# are defined by the mapped variables in the `build_config`.
+
+# %%
 params = {
+    "Name": "Shape Design Example",
     "R_0": (9.0, "Input"),
     "A": (3.5, "Input"),
     "r_tf_in_centre": (5.0, "Input"),
     "r_tf_out_centre": (15.0, "Input"),
 }
 
-# Create our design object and run it to get the resulting component.
+# %%[markdown]
+# ## Running the Design
+#
+# The Design object is defined as run as below:
 
+# %%
 design = Design(params, build_config)
 component = design.run()
 
-# Plot our resulting component.
+# %%[markdown]
+# ## Visualising the Results
+#
+# The result of the design is a Component object that represents a tree of outputs from
+# the different build stages. The resulting Component tree from this Design can be
+# printed out.
 
+# %%
+print(component.tree())
+
+# %%[markdown]
+# It is also possible to plot the nodes in the tree that are defined with shapes (known
+# as PhysicalComponents).
+
+# %%
 component.plot_2d()
 
-# Get the TF design problem and print out the resulting parameterisation
+# %%[markdown]
+# We can also inspect the properties of the individual build stages by extracting them
+# from the Design. This example shows how the resulting parameters from the solution of
+# the TF Coils design problem can be extracted. Note that we have maximised the value of
+# x2 without constraint, so it has found the upper bound as defined on that variable.
+# All other variables have stayed as originally defined as they were set to be fixed.
 
+# %%
 tf_builder = design.get_builder("TF Coils")
 tf_design_problem: GeometryOptimisationProblem = tf_builder.design_problem
 print(tf_design_problem.parameterisation.variables)

--- a/examples/design/design_shapes.py
+++ b/examples/design/design_shapes.py
@@ -93,10 +93,12 @@ class MaximiseLength(GeometryOptimisationProblem):
 #   - uses the `MakeOptimisedShape` Builder class.
 #   - parameterises the TF Coils centerline shape using the `PrincetonD`
 #     GeometryParameterisation class.
-#   - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 and x2
-#     shape parameters. The dz shape parameter is set to 0 and fixed. The x1 shape
+#   - maps the r_tf_in_centre and r_tf_out_centre Design parameters to the x1 (the
+#     inboard limb radius) and x2 (the outboard limb radius) shape parameters. The dz
+#     (vertical offset from z=0) shape parameter is set to 0 and fixed. The x1 shape
 #     parameter is also fixed, while the x2 shape parameter is allowed to vary in the
-#     optimisation, with an adjusted lower bound of 14.
+#     optimisation, with an adjusted lower bound of 14. This means that only the outboard
+#     leg radius is free to vary in the optimisation.
 #   - uses the `MaximiseLength` GeometryOptimisationProblem class to define the design
 #     problem that will be solved as part of the TF Coil build stage.
 #   - labels the resulting component as "Shape".

--- a/tests/bluemira/base/test_design.py
+++ b/tests/bluemira/base/test_design.py
@@ -23,43 +23,50 @@
 Tests for the design module.
 """
 
+import copy
+
+import pytest
+
 import tests
 from bluemira.base.design import Design
+from bluemira.base.error import BuilderError
 
 
 class TestDesign:
+    build_config = {
+        "Plasma": {
+            "class": "MakeParameterisedShape",
+            "param_class": "bluemira.equilibria.shapes::JohnerLCFS",
+            "variables_map": {
+                "r_0": "R_0",
+                "a": "A",
+            },
+            "label": "Shape",
+        },
+        "TF Coils": {
+            "class": "MakeParameterisedShape",
+            "param_class": "PrincetonD",
+            "variables_map": {
+                "x1": "r_tf_in_centre",
+                "x2": {
+                    "value": "r_tf_out_centre",
+                    "lower_bound": 8.0,
+                },
+                "dz": 0.0,
+            },
+            "label": "Shape",
+        },
+    }
+    params = {
+        "Name": "Test Design",
+        "R_0": (9.0, "Input"),
+        "A": (3.5, "Input"),
+        "r_tf_in_centre": (5.0, "Input"),
+        "r_tf_out_centre": (15.0, "Input"),
+    }
+
     def test_builders(self):
-        build_config = {
-            "Plasma": {
-                "class": "MakeParameterisedShape",
-                "param_class": "bluemira.equilibria.shapes::JohnerLCFS",
-                "variables_map": {
-                    "r_0": "R_0",
-                    "a": "A",
-                },
-                "label": "Shape",
-            },
-            "TF Coils": {
-                "class": "MakeParameterisedShape",
-                "param_class": "PrincetonD",
-                "variables_map": {
-                    "x1": "r_tf_in_centre",
-                    "x2": {
-                        "value": "r_tf_out_centre",
-                        "lower_bound": 8.0,
-                    },
-                    "dz": 0.0,
-                },
-                "label": "Shape",
-            },
-        }
-        params = {
-            "R_0": (9.0, "Input"),
-            "A": (3.5, "Input"),
-            "r_tf_in_centre": (5.0, "Input"),
-            "r_tf_out_centre": (15.0, "Input"),
-        }
-        design = Design(params, build_config)
+        design = Design(self.params, self.build_config)
         component = design.run()
 
         assert component is not None
@@ -74,3 +81,9 @@ class TestDesign:
 
         if tests.PLOTTING:
             component.plot_2d()
+
+    def test_params_validation(self):
+        bad_params = copy.deepcopy(self.params)
+        bad_params.pop("Name")
+        with pytest.raises(BuilderError):
+            Design(bad_params, self.build_config)


### PR DESCRIPTION
## Linked Issues

N/A

## Description

The component tree for the design_shape example was failing as the Design was being defined without a name. This PR looks to ensure that generic Designs are defined with all of the required parameters in place (most are handled by the validation on the resulting Builder classes). It adds the Name parameter to the example design, and converts the example to a Jupyter notebook.

## Interface Changes

Validation added to ensure required parameters are provided to a design.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
