### PR TITLE
Add track tool for PF coil positioning

### DIFF
--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -288,16 +288,11 @@ def make_segments(track, exclusion_zones, coils):
             split_values = l_values[:-1] + 0.5 * np.diff(l_values)
             # Sub-divide into BSplines for now...
             # TODO: Actual primitive sub-division less fun...
-            split_values = np.append(split_values, 1.0)
+            split_values = np.concatenate([[0.0], split_values, [1.0]])
             sub_segs = []
-            for i, split in enumerate(split_values):
-                if i == 0:
-                    start = 0.0
-                    stop = split
-                else:
-                    start = split_values[i - 1]
-                    stop = split
-
+            for i in range(len(split_values) - 1):
+                start = split_values[i]
+                stop = split_values[i + 1]
                 l_range = np.linspace(start, stop, 1000)
                 x, z = segment.to_xz(l_range)
                 y = np.zeros_like(x)

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -233,3 +233,17 @@ class PFCoilsBuilder(Builder):
 
         field_solver = SourceGroup(sources)
         return field_solver
+
+
+from bluemira.geometry.tools import boolean_cut, point_inside_shape
+
+
+def make_segments(track, exclusion_zones, coils):
+    track = track
+    exclusion_zones = exclusion_zones
+    segments = boolean_cut(track, exclusion_zones)
+
+    for i, coil in enumerate(coils):
+        for zone in exclusion_zones:
+            if point_inside_shape([coil.x, 0, coil.z], zone):
+                pass

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -35,8 +35,10 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.base.parameter import ParameterFrame
 from bluemira.builders.pf_coils import PFCoilBuilder
 from bluemira.equilibria.coils import CoilSet
+from bluemira.geometry.tools import boolean_cut, distance_to, make_bspline
 from bluemira.magnetostatics.baseclass import SourceGroup
 from bluemira.magnetostatics.circular_arc import CircularArcCurrentSource
+from bluemira.utilities.positioning import PathInterpolator, PositionMapper
 
 
 class PFCoilsComponent(Component):
@@ -234,15 +236,6 @@ class PFCoilsBuilder(Builder):
 
         field_solver = SourceGroup(sources)
         return field_solver
-
-
-from bluemira.geometry.tools import (
-    boolean_cut,
-    distance_to,
-    make_bspline,
-    point_inside_shape,
-)
-from bluemira.utilities.positioning import PathInterpolator, PositionMapper
 
 
 def make_coil_mapper(track, exclusion_zones, coils):

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -293,4 +293,4 @@ def make_coil_mapper(track, exclusion_zones, coils):
                 sub_segs.append(PathInterpolator(make_bspline([x, y, z])))
             new_segments.extend(sub_segs)
 
-    return PositionMapper([segment for segment in new_segments])
+    return PositionMapper(new_segments)

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -257,8 +257,6 @@ def make_coil_mapper(track, exclusion_zones, coils):
     mapper: PositionMapper
         Position mapper for coil position interpolation
     """
-    track = track
-    exclusion_zones = exclusion_zones
     # Break down the track into subsegments
     segments = boolean_cut(track, exclusion_zones)
 

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -289,7 +289,7 @@ def make_coil_mapper(track, exclusion_zones, coils):
             for i in range(len(split_values) - 1):
                 start = split_values[i]
                 stop = split_values[i + 1]
-                l_range = np.linspace(start, stop, 1000)
+                l_range = np.linspace(start, stop, 500)
                 x, z = segment.to_xz(l_range)
                 y = np.zeros_like(x)
                 sub_segs.append(PathInterpolator(make_bspline([x, y, z])))

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -235,7 +235,7 @@ class PFCoilsBuilder(Builder):
         return field_solver
 
 
-from bluemira.geometry.tools import boolean_cut, point_inside_shape
+from bluemira.geometry.tools import boolean_cut, make_circle, point_inside_shape
 
 
 def make_segments(track, exclusion_zones, coils):
@@ -243,7 +243,23 @@ def make_segments(track, exclusion_zones, coils):
     exclusion_zones = exclusion_zones
     segments = boolean_cut(track, exclusion_zones)
 
+    links = []
     for i, coil in enumerate(coils):
         for zone in exclusion_zones:
             if point_inside_shape([coil.x, 0, coil.z], zone):
+                # Coil is inside an exclusion zone
                 pass
+            else:
+                # Coil can be mapped to a segment already
+                for j, segment in enumerate(segments):
+                    l_value = segment.to_L(coil.x, coil.z)
+                    if l_value == 0.0:
+                        pass
+                    elif l_value == 1.0:
+                        pass
+                    else:
+                        links.append(i, j)
+
+    # Check if multiple coils are on the same segment and split the segments
+
+    return

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -235,7 +235,8 @@ class PFCoilsBuilder(Builder):
         return field_solver
 
 
-from bluemira.geometry.tools import boolean_cut, make_circle, point_inside_shape
+from bluemira.geometry.tools import boolean_cut, distance_to, point_inside_shape
+from bluemira.utilities.positioning import PathInterpolator
 
 
 def make_segments(track, exclusion_zones, coils):
@@ -248,7 +249,10 @@ def make_segments(track, exclusion_zones, coils):
         for zone in exclusion_zones:
             if point_inside_shape([coil.x, 0, coil.z], zone):
                 # Coil is inside an exclusion zone
-                pass
+                for j, segment in enumerate(segments):
+                    # Find out which segment the coil is nearest to
+                    pass
+
             else:
                 # Coil can be mapped to a segment already
                 for j, segment in enumerate(segments):
@@ -262,4 +266,5 @@ def make_segments(track, exclusion_zones, coils):
 
     # Check if multiple coils are on the same segment and split the segments
 
+    # Make a PathInterpolator for each PF coil
     return

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -58,6 +58,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import MINIMUM_LENGTH
 
+apiVertex = Part.Vertex  # noqa :N816
 apiVector = Base.Vector  # noqa :N816
 apiWire = Part.Wire  # noqa :N816
 apiFace = Part.Face  # noqa :N816
@@ -1097,8 +1098,8 @@ def point_inside_shape(point, shape):
     inside: bool
         Whether or not the point is inside the shape
     """
-    vertex = apiVector(*point)
-    return shape.isInside(vertex, EPS, True)
+    vector = apiVector(*point)
+    return shape.isInside(vector, EPS, True)
 
 
 # ======================================================================================

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -58,6 +58,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import MINIMUM_LENGTH
 
+apiVector = Base.Vector  # noqa :N816
 apiWire = Part.Wire  # noqa :N816
 apiFace = Part.Face  # noqa :N816
 apiShell = Part.Shell  # noqa :N816
@@ -1078,6 +1079,26 @@ def boolean_cut(shape, tools, split=True):
     else:
         raise ValueError(f"Cut function not implemented for {_type} objects.")
     return output
+
+
+def point_inside_shape(point, shape):
+    """
+    Whether or not a point is inside a shape.
+
+    Parameters
+    ----------
+    point: Iterable(3)
+        Coordinates of the point
+    shape: BluemiraGeo
+        Geometry to check with
+
+    Returns
+    -------
+    inside: bool
+        Whether or not the point is inside the shape
+    """
+    vertex = apiVector(*point)
+    return shape.isInside(vertex, EPS, True)
 
 
 # ======================================================================================

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -756,3 +756,22 @@ def boolean_cut(shape, tools):
         return [convert(obj, shape.label) for obj in cut_shape]
 
     return convert(cut_shape, shape.label)
+
+
+def point_inside_shape(point, shape):
+    """
+    Whether or not a point is inside a shape.
+
+    Parameters
+    ----------
+    point: Iterable(3)
+        Coordinates of the point
+    shape: BluemiraGeo
+        Geometry to check with
+
+    Returns
+    -------
+    inside: bool
+        Whether or not the point is inside the shape
+    """
+    return cadapi.point_inside_shape(point, shape._shape)

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -58,10 +58,31 @@ def convert(apiobj, label=""):
 # # =============================================================================
 # # Geometry creation
 # # =============================================================================
+def _make_vertex(point):
+    """
+    Make a vertex.
+
+    Parameters
+    ----------
+    point: Iterable
+        Coordinates of the point
+
+    Returns
+    -------
+    vertex: apiVertex
+        Vertex at the point
+    """
+    if not len(point) == 3:
+        raise GeometryError("Points must be of dimension 3.")
+
+    return cadapi.apiVertex(*point)
+
+
 def make_polygon(
     points: Union[list, np.ndarray], label: str = "", closed: bool = False
 ) -> BluemiraWire:
-    """Make a polygon from a set of points.
+    """
+    Make a polygon from a set of points.
 
     Parameters
     ----------
@@ -429,8 +450,15 @@ def distance_to(geo1: BluemiraGeo, geo2: BluemiraGeo):
         between geo1 and geo2. The distance between those points
         is the minimum distance given by dist.
     """
-    shape1 = geo1._shape
-    shape2 = geo2._shape
+    # Check geometry for vertices
+    if isinstance(geo1, Iterable):
+        shape1 = _make_vertex(geo1)
+    else:
+        shape1 = geo1._shape
+    if isinstance(geo2, Iterable):
+        shape2 = _make_vertex(geo2)
+    else:
+        shape2 = geo2._shape
     return cadapi.dist_to_shape(shape1, shape2)
 
 

--- a/bluemira/utilities/positioning.py
+++ b/bluemira/utilities/positioning.py
@@ -107,7 +107,7 @@ class PathInterpolator(XZGeometryInterpolator):
         Convert parametric-space 'L' values to physical x-z space.
         """
         l_value = np.clip(l_value, 0.0, 1.0)
-        return float(self.x_ius(l_value)), float(self.z_ius(l_value))
+        return self.x_ius(l_value), self.z_ius(l_value)
 
     def to_L(self, x, z):
         """

--- a/tests/bluemira/builders/EUDEMO/test_pf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_pf_coils.py
@@ -35,7 +35,11 @@ from bluemira.geometry.tools import boolean_cut, make_polygon
 class TestMakeCoilMapper:
     @classmethod
     def setup_class(cls):
-        cls.track = PrincetonD().create_shape()
+        cls.tracks = [
+            PrincetonD().create_shape(),
+            TaperedPictureFrame().create_shape(),
+            TripleArc().create_shape(),
+        ]
         exclusion1 = BluemiraFace(
             make_polygon([[6, 9, 9, 6], [0, 0, 0, 0], [0, 0, 20, 20]], closed=True)
         )
@@ -52,12 +56,15 @@ class TestMakeCoilMapper:
         ]
 
     def test_cuts(self):
-        segments = boolean_cut(self.track, self.exclusions)
-        actual_length = sum([seg.length for seg in segments])
-        mapper = make_coil_mapper(self.track, self.exclusions, self.coils)
-        interp_length = sum([tool.geometry.length for tool in mapper.interpolators])
-        assert np.isclose(actual_length, interp_length, rtol=1e-2)
+        for track in self.tracks:
+            segments = boolean_cut(track, self.exclusions)
+            actual_length = sum([seg.length for seg in segments])
+            mapper = make_coil_mapper(track, self.exclusions, self.coils)
+            interp_length = sum([tool.geometry.length for tool in mapper.interpolators])
+            assert np.isclose(actual_length, interp_length, rtol=1e-2)
 
     def test_simple(self):
-        mapper = make_coil_mapper(self.track, self.exclusions, self.coils)
-        assert len(mapper.interpolators) == len(self.coils)
+        for track in self.tracks:
+
+            mapper = make_coil_mapper(track, self.exclusions, self.coils)
+            assert len(mapper.interpolators) == len(self.coils)

--- a/tests/bluemira/builders/EUDEMO/test_pf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_pf_coils.py
@@ -56,7 +56,7 @@ class TestMakeCoilMapper:
         actual_length = sum([seg.length for seg in segments])
         mapper = make_coil_mapper(self.track, self.exclusions, self.coils)
         interp_length = sum([tool.geometry.length for tool in mapper.interpolators])
-        assert np.isclose(actual_length, interp_length)
+        assert np.isclose(actual_length, interp_length, rtol=1e-2)
 
     def test_simple(self):
         mapper = make_coil_mapper(self.track, self.exclusions, self.coils)

--- a/tests/bluemira/builders/EUDEMO/test_pf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_pf_coils.py
@@ -1,0 +1,44 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from bluemira.builders.EUDEMO.pf_coils import make_coil_mapper
+from bluemira.equilibria.coils import Coil
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.parameterisations import (
+    PrincetonD,
+    TaperedPictureFrame,
+    TripleArc,
+)
+from bluemira.geometry.tools import make_polygon
+
+
+class TestMakeCoilMapper:
+    @classmethod
+    def setup_class(cls):
+        track = PrincetonD().create_shape()
+        exclusion = BluemiraFace(
+            make_polygon([[6, 9, 9, 6], [0, 0, 0, 0], [0, 0, 20, 20]], closed=True)
+        )
+        coil1 = Coil(4, 9, current=1, j_max=1)
+        coil2 = Coil(9, -9, current=1, j_max=1)
+
+    def test_simple(self):
+        mapper = make_coil_mapper(track, [exclusion], [coil1, coil2])

--- a/tests/bluemira/builders/EUDEMO/test_pf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_pf_coils.py
@@ -43,13 +43,15 @@ class TestMakeCoilMapper:
             make_polygon([[9, 9, 20, 20], [0, 0, 0, 0], [-1, -1, 1, 1]], closed=True)
         )
         cls.exclusions = [exclusion1, exclusion2]
-        coil1 = Coil(4, 9, current=1, j_max=1)
-        coil2 = Coil(9, -9, current=1, j_max=1)
-        coil3 = Coil(0, 12, current=1, j_max=1)
-        cls.coils = [coil1, coil2, coil3]
+
+        cls.coils = [
+            Coil(4, 9, current=1, j_max=1),
+            Coil(9, -9, current=1, j_max=1),
+            Coil(0, 12, current=1, j_max=1),
+            Coil(9, -10, current=1, j_max=1),
+        ]
 
     def test_cuts(self):
-        total_length = self.track.length
         segments = boolean_cut(self.track, self.exclusions)
         actual_length = sum([seg.length for seg in segments])
         mapper = make_coil_mapper(self.track, self.exclusions, self.coils)

--- a/tests/bluemira/geometry/test_tools.py
+++ b/tests/bluemira/geometry/test_tools.py
@@ -31,6 +31,7 @@ from bluemira.geometry.tools import (
     make_circle,
     make_polygon,
     offset_wire,
+    point_inside_shape,
     revolve_shape,
     signed_distance,
     signed_distance_2D_polygon,
@@ -332,3 +333,40 @@ class TestSolidFacePlaneIntersect:
         solid = extrude_shape(face, (1, 2, 3))
         _slice_solid = slice_shape(solid, BluemiraPlane(axis=[3, 2, 1]))
         assert len(_slice_solid) == 1
+
+
+class TestPointInside:
+    def test_simple(self):
+        polygon = BluemiraFace(
+            make_polygon({"x": [-2, 2, 2, -2, -2, -2], "z": [-2, -2, 2, 2, 1.5, -2]})
+        )
+        in_points = [
+            [-1, 0, -1],
+            [-1, 0, 0],
+            [-1, 0, 1],
+            [0, 0, -1],
+            [0, 0, 0],
+            [0, 0, 1],
+            [1, 0, -1],
+            [1, 0, 0],
+            [1, 0, 1],
+        ]
+        for point in in_points:
+            assert point_inside_shape(point, polygon)
+
+        out_points = [
+            [-3, 0, -3],
+            [-3, 0, 0],
+            [-3, 0, 3],
+            [0, 0, -3],
+            [3, 0, 3],
+            [3, 0, -3],
+            [2.005, 0, 0],
+            [2.001, 0, -1.9999],
+            # TODO: This is not very good FreeCAD..
+            # [2.00000009, 0, 0],
+            # [-2.0000000001, 0, -1.999999999999],
+        ]
+
+        for point in out_points:
+            assert not point_inside_shape(point, polygon)


### PR DESCRIPTION
## Description
Adds a track decomposition tool for placing PF coils along a wire based on exclusion zones and a set of coils.

Adds support to `distance_to` to handle points
Adds `point_inside_shape` because I thought I needed it for this... Note that the FreeCAD version seems much less accurate on a 2-D shape than previous discretised methods.

## Interface Changes

`distance_to` can now handle iterables of length 3 and treat them as points

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
