### PR TITLE
Add PROCESS build dependencies to installation guide

### DIFF
--- a/documentation/source/installation.rst
+++ b/documentation/source/installation.rst
@@ -62,16 +62,17 @@ inquire about access can be found `here <https://ccfe.ukaea.uk/resources/process
 
 .. note::
 
-    ``PROCESS`` requires gfortran-9, which is not the default version on Ubuntu 18.04. In
-    order to make this more recent gfortran version available, if you are using Ubuntu
-    18.04 you then must first run:
+    The ``PROCESS`` build requires gfortran-9, gcc and make.
+    gfortran-9 is not the default version on Ubuntu 18.04.
+    In order to install the dependencies and make this more recent gfortran version available,
+    if you are using Ubuntu 18.04, you must first run:
 
     .. code-block:: bash
 
         sudo apt-get update
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get update && sudo apt-get install -y gfortran-9
+        sudo apt-get update && sudo apt-get install -y gfortran-9 gcc make
         sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-9 30
 
 In order install ``PROCESS`` in your ``bluemira`` environment, run the following:


### PR DESCRIPTION
## Linked Issues

Closes #604 

## Description

Adds installation of `gcc` and `make` to the PROCESS installation documentation. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
