### PR TITLE
Removing the seconf `make_2d_profie` call

### DIFF
--- a/BLUEPRINT/systems/firstwall.py
+++ b/BLUEPRINT/systems/firstwall.py
@@ -1167,7 +1167,6 @@ class FirstWall(ReactorSystem):
         self.profile = self.geom["2D profile"].inner
 
         self.hf_firstwall_params(self.profile)
-        self.make_2d_profile()
 
     # Output and plotting stuff
     def hf_save_as_csv(self, filename="hf_on_the_wall", metadata=""):


### PR DESCRIPTION
## Linked Issues

Closes https://github.com/Fusion-Power-Plant-Framework/bluemira/issues/610

Related STEP issues:
 - STEP Merge request depending on this issue: https://git.ccfe.ac.uk/step-bluemira-reactor-design/step-blueprint-reactor-design/-/merge_requests/84/edit

## Description

Quick-fixes the FW failure. Removing the second call for `make_2d_profile()` in `FirstWall` `build()` function. The failure happening for the second call.

The second call was itended to allow the drawing of the flux line in the divertor region. The FW region flux lines seems not to need this feature anymore to show the dinvertor regions flux line to my amazement.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
- [ ] STEP reactor design passes
