### PR TITLE
Serialisation for GeometryParameterisations

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -23,7 +23,11 @@
 Geometry parameterisations
 """
 
+from __future__ import annotations
+
 import abc
+import json
+from typing import TextIO, Union
 
 import numpy as np
 from scipy.special import iv as bessel
@@ -64,7 +68,7 @@ class GeometryParameterisation(abc.ABC):
 
     __slots__ = ("name", "variables", "n_ineq_constraints")
 
-    def __init__(self, variables):
+    def __init__(self, variables: OptVariables):
         """
         Parameters
         ----------
@@ -196,6 +200,34 @@ class GeometryParameterisation(abc.ABC):
             CAD Wire of the geometry
         """
         pass
+
+    def to_json(self, file: str):
+        """
+        Write the json representation of the GeometryParameterisation to a file.
+
+        Parameters
+        ----------
+        file: str
+            The path to the file.
+        """
+        self.variables.to_json(file)
+
+    @classmethod
+    def from_json(cls, file: Union[str, TextIO]) -> GeometryParameterisation:
+        """
+        Create the GeometryParameterisation from a json file.
+
+        Parameters
+        ----------
+        file: Union[str, TextIO]
+            The path to the file, or an open file handle that supports reading.
+        """
+        if isinstance(file, str):
+            with open(file, "r") as fh:
+                return cls.from_json(fh)
+
+        var_dict = json.load(file)
+        return cls(var_dict)
 
 
 class PrincetonD(GeometryParameterisation):

--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -23,7 +23,11 @@
 Optimisation variable class.
 """
 
+from __future__ import annotations
+
+import json
 from operator import attrgetter
+from typing import Dict, TextIO, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +37,7 @@ from tabulate import tabulate
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.display.palettes import BLUEMIRA_PALETTE
 from bluemira.utilities.error import OptVariablesError
+from bluemira.utilities.tools import json_writer
 
 
 def normalise_value(value, lower_bound, upper_bound):
@@ -75,6 +80,26 @@ def denormalise_value(v_norm, lower_bound, upper_bound):
         Denormalised value w.r.t. bounds
     """
     return lower_bound + v_norm * (upper_bound - lower_bound)
+
+
+class BoundedVariableEncoder(json.JSONEncoder):
+    """
+    A JSONEncoder for serialising BoundedVariable instances.
+    """
+
+    def default(self, obj):
+        """
+        Serialises a Bounded Variable by extracting the value, lower_bound, upper_bound,
+        and fixed properties.
+        """
+        if isinstance(obj, BoundedVariable):
+            return {
+                "value": obj.value,
+                "lower_bound": obj.lower_bound,
+                "upper_bound": obj.upper_bound,
+                "fixed": obj.fixed,
+            }
+        return super().default(obj)
 
 
 class BoundedVariable:
@@ -477,7 +502,7 @@ class OptVariables:
         if name not in self._var_dict.keys():
             raise OptVariablesError(f"Variable {name} not in OptVariables instance.")
 
-    def __getitem__(self, name):
+    def __getitem__(self, name) -> BoundedVariable:
         """
         Dictionary-like access to variables.
 
@@ -581,6 +606,38 @@ class OptVariables:
             + "\n    ".join([repr(var) for var in self._var_dict.values()])
             + "\n)"
         )
+
+    def to_json(self, file: str, **kwargs):
+        """
+        Write the json representation of these OptVariables to a file.
+
+        Parameters
+        ----------
+        file: str
+            The path to the file.
+        """
+        cls = kwargs.pop("cls", None)
+        if cls is None:
+            cls = BoundedVariableEncoder
+        json_writer(self._var_dict, file, cls=cls, **kwargs)
+
+    @classmethod
+    def from_json(cls, file: Union[str, TextIO], frozen=False) -> OptVariables:
+        """
+        Create an OptVariables instance from a json file.
+
+        Parameters
+        ----------
+        file: Union[str, TextIO]
+            The path to the file, or an open file handle that supports reading.
+        """
+        if isinstance(file, str):
+            with open(file, "r") as fh:
+                return cls.from_json(fh)
+
+        var_dict: Dict = json.load(file)
+        new_vars = [BoundedVariable(key, **val) for key, val in var_dict.items()]
+        return cls(new_vars, frozen=frozen)
 
     def plot(self):
         """

--- a/tests/bluemira/geometry/test_parameterisations.py
+++ b/tests/bluemira/geometry/test_parameterisations.py
@@ -19,6 +19,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+import os
+import shutil
+import tempfile
+from typing import Type
+
 import numpy as np
 import pytest
 
@@ -36,6 +41,33 @@ from bluemira.geometry.tools import make_polygon
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.utilities.error import OptVariablesError
 from bluemira.utilities.opt_variables import BoundedVariable, OptVariables
+
+
+@pytest.mark.parametrize(
+    "param_class",
+    [
+        PictureFrame,
+        PolySpline,
+        PrincetonD,
+        SextupleArc,
+        TaperedPictureFrame,
+        TripleArc,
+    ],
+)
+def test_read_write(param_class: Type[GeometryParameterisation]):
+    tempdir = tempfile.mkdtemp()
+    try:
+        the_path = os.sep.join([tempdir, f"{param_class.__name__}.json"])
+        param = param_class()
+        param.to_json(the_path)
+        new_param = param_class.from_json(the_path)
+        for attr in GeometryParameterisation.__slots__:
+            if attr == "variables":
+                assert new_param.variables._to_records() == param.variables._to_records()
+            else:
+                assert getattr(new_param, attr) == getattr(param, attr)
+    finally:
+        shutil.rmtree(tempdir)
 
 
 class TestGeometryParameterisation:

--- a/tests/bluemira/utilities/test_opt_variables.py
+++ b/tests/bluemira/utilities/test_opt_variables.py
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+import os
+import shutil
+import tempfile
+
 import numpy as np
 import pytest
 
@@ -80,16 +84,15 @@ class TestBoundedVariable:
 
 
 class TestOptVariables:
-    @classmethod
-    def setup_class(cls):
+    def setup_method(self):
         v1 = BoundedVariable("a", 2, 0, 3)
         v2 = BoundedVariable("b", 0, -1, 1)
         v3 = BoundedVariable("c", -1, -10, 10)
-        cls.vars = OptVariables([v1, v2, v3])
+        self.vars = OptVariables([v1, v2, v3])
         v1 = BoundedVariable("a", 2, 0, 3)
         v2 = BoundedVariable("b", 0, -1, 1)
         v3 = BoundedVariable("c", -1, -10, 10)
-        cls.vars_frozen = OptVariables([v1, v2, v3], frozen=True)
+        self.vars_frozen = OptVariables([v1, v2, v3], frozen=True)
 
     def test_init(self):
         assert self.vars.n_free_variables == 3
@@ -107,15 +110,14 @@ class TestOptVariables:
 
     def test_remove(self):
         self.vars.remove_variable("c")
-        assert self.vars.n_free_variables == 3
-        assert len(self.vars.values) == 4
-        assert np.allclose(self.vars.values, np.array([2, 0, 4, 1]))
+        assert len(self.vars.values) == 2
+        assert np.allclose(self.vars.values, np.array([2, 0]))
 
     def test_fix(self):
         self.vars.fix_variable("a", value=100)
         assert self.vars.values[0] == 100
         assert self.vars.n_free_variables == 2
-        assert np.allclose(self.vars.values, np.array([100, 0, 4, 1]))
+        assert np.allclose(self.vars.values, np.array([100, 0, -1]))
 
     def test_getitem(self):
         assert self.vars["a"] == self.vars._var_dict["a"]
@@ -161,6 +163,16 @@ class TestOptVariables:
                 {"a": {"value": -2, "lower_bound": -1, "upper_bound": -3}},
                 strict_bounds=False,
             )
+
+    def test_read_write(self):
+        tempdir = tempfile.mkdtemp()
+        try:
+            the_path = os.sep.join([tempdir, "opt_var_test.json"])
+            self.vars.to_json(the_path)
+            new_vars = OptVariables.from_json(the_path)
+            new_vars._to_records() == self.vars._to_records()
+        finally:
+            shutil.rmtree(tempdir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Linked Issues

Closes #621 

## Description

Implements serialisation for `OptVariables` and applies it to `GeometryParameterisation` classes.

## Interface Changes

Adds `to_json` and `from_json` to `OptVariables` and `GeometryParameterisation` classes.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
