### PR TITLE
Save TF Shape

### DIFF
--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -139,6 +139,7 @@ class EUDEMOReactor(Reactor):
         default_config = {
             "param_class": "PrincetonD",
             "variables_map": default_variables_map,
+            "geom_path": None,
             "runmode": "run",
             "problem_class": "bluemira.builders.tf_coils::RippleConstrainedLengthOpt",
             "problem_settings": {},
@@ -152,6 +153,16 @@ class EUDEMOReactor(Reactor):
         }
 
         config = self._process_design_stage_config(name, default_config)
+
+        if config["geom_path"] is None:
+            if config["runmode"] == "run":
+                default_geom_dir = self._file_manager.generated_data_dirs["geometry"]
+            else:
+                default_geom_dir = self._file_manager.reference_data_dirs["geometry"]
+            geom_name = f"tf_coils_{config['param_class']}_{self._params['n_TF']}.json"
+            geom_path = os.path.join(default_geom_dir, geom_name)
+
+            config["geom_path"] = geom_path
 
         builder = TFCoilsBuilder(self._params.to_dict(), config)
         self.register_builder(builder, name)

--- a/bluemira/builders/EUDEMO/tf_coils.py
+++ b/bluemira/builders/EUDEMO/tf_coils.py
@@ -22,15 +22,18 @@
 """
 EU-DEMO build classes for TF Coils.
 """
+import os
 from copy import deepcopy
 from typing import List, Optional, Type
 
 import numpy as np
 
 import bluemira.utilities.plot_tools as bm_plot_tools
+from bluemira.base.builder import BuildConfig
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.config import Configuration
 from bluemira.base.error import BuilderError
+from bluemira.base.look_and_feel import bluemira_print
 from bluemira.builders.EUDEMO.tools import circular_pattern_component
 from bluemira.builders.shapes import OptimisedShapeBuilder
 from bluemira.display.palettes import BLUE_PALETTE
@@ -131,15 +134,38 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
     _default_runmode: str = "run"
     _design_problem: Optional[GeometryOptimisationProblem] = None
     _centreline: BluemiraWire
+    _geom_path: Optional[str] = None
+
+    @property
+    def geom_path(self) -> str:
+        """
+        The path at which the geometry parameterisation can be written to or read from.
+        """
+        return self._geom_path
+
+    def _extract_config(self, build_config: BuildConfig):
+        super()._extract_config(build_config)
+
+        self._geom_path = build_config.get("geom_path", None)
+        if self._geom_path is None and self._runmode.name.lower() == "read":
+            raise BuilderError(
+                "Must supply geom_path in build_config when using 'read' mode."
+            )
+
+        if self._geom_path is not None and os.path.isdir(self._geom_path):
+            default_file_name = (
+                f"tf_coils_{self._param_class.__name__}_{self._params.n_TF}.json"
+            )
+            self._geom_path = os.sep.join([self._geom_path, default_file_name])
 
     def _derive_shape_params(self):
         shape_params = super()._derive_shape_params()
         # PROCESS doesn't output the radius of the current centroid on the inboard
         r_current_in_board = (
-            self.params.r_tf_in
-            + self.params.tk_tf_nose
-            + self.params.tk_tf_ins
-            + 0.5 * (self.params.tf_wp_width - 2 * self.params.tk_tf_ins)
+            self._params.r_tf_in
+            + self._params.tk_tf_nose
+            + self._params.tk_tf_ins
+            + 0.5 * (self._params.tf_wp_width - 2 * self._params.tk_tf_ins)
         )
         self._params.add_parameter(
             "r_tf_current_ib",
@@ -180,18 +206,28 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         )
         self._centreline = self._design_problem.parameterisation.create_shape()
 
-    def read(self, variables: dict):
+    def read(self, **kwargs):
         """
-        Read in a variable dictionary to set up a specified GeometryParameterisation.
+        Read in a file to set up a specified GeometryParameterisation and extract the
+        current centreline.
         """
-        parameterisation = self._param_class(variables)
-        self._centreline = parameterisation.create_shape()
+        bluemira_print(f"Reading TF Coil centreline shape from file {self._geom_path}")
 
-    def mock(self, centreline):
+        with open(self._geom_path, "r") as fh:
+            self._shape = self._param_class.from_json(fh)
+        self._centreline = self._shape.create_shape()
+
+    def mock(self, **kwargs):
         """
-        Mock a design of TF coils using a specified current centreline.
+        Mock a design of TF coils using the original parameterisation of the current
+        centreline.
         """
-        self._centreline = centreline
+        bluemira_print(
+            "Mocking TF Coil centreline shape from parameterisation "
+            f"{self._shape.variables}"
+        )
+
+        self._centreline = self._shape.create_shape()
 
     def build(self, label: str = "TF Coils", **kwargs) -> TFCoilsComponent:
         """
@@ -548,3 +584,17 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         inner = BluemiraFace([wires[1], wires[0]])
         outer = BluemiraFace([wires[3], wires[2]])
         self._temp_casing = [inner, outer]
+
+    def save_shape(self, filename: str = None, **kwargs):
+        """
+        Save the shape to a json file.
+
+        Parameters
+        ----------
+        filename: str
+            The path to the file that the shape should be written to. By default this
+            will be the geom_path.
+        """
+        if filename is None:
+            filename = self._geom_path
+        super().save_shape(filename, **kwargs)

--- a/bluemira/builders/shapes.py
+++ b/bluemira/builders/shapes.py
@@ -95,6 +95,18 @@ class ParameterisedShapeBuilder(Builder):
         shape = self._param_class(shape_params)
         self._shape = shape
 
+    def save_shape(self, filename: str, **kwargs):
+        """
+        Save the shape to a json file.
+
+        Parameters
+        ----------
+        filename: str
+            The path to the file that the shape should be written to.
+        """
+        self._shape.to_json(file=filename, **kwargs)
+        bluemira_print(f"{self._name} shape saved to {filename}")
+
 
 class OptimisedShapeBuilder(ParameterisedShapeBuilder):
     """

--- a/data/reactors/EU-DEMO/geometry/tf_coils_TripleArc_18.json
+++ b/data/reactors/EU-DEMO/geometry/tf_coils_TripleArc_18.json
@@ -1,0 +1,44 @@
+{
+    "x1": {
+        "value": 3.9904249999999992,
+        "lower_bound": 4,
+        "upper_bound": 5,
+        "fixed": true
+    },
+    "dz": {
+        "value": -0.4446325399393063,
+        "lower_bound": -1,
+        "upper_bound": 1,
+        "fixed": false
+    },
+    "sl": {
+        "value": 5.0,
+        "lower_bound": 5,
+        "upper_bound": 10,
+        "fixed": false
+    },
+    "f1": {
+        "value": 4.508001347631,
+        "lower_bound": 4,
+        "upper_bound": 12,
+        "fixed": false
+    },
+    "f2": {
+        "value": 5.696378478911537,
+        "lower_bound": 4,
+        "upper_bound": 12,
+        "fixed": false
+    },
+    "a1": {
+        "value": 12.29534099554494,
+        "lower_bound": 5,
+        "upper_bound": 120,
+        "fixed": false
+    },
+    "a2": {
+        "value": 103.03025404695109,
+        "lower_bound": 10,
+        "upper_bound": 120,
+        "fixed": false
+    }
+}

--- a/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
@@ -15,6 +15,7 @@
         "from bluemira.base.parameter import ParameterMappingEncoder\n",
         "from bluemira.builders.EUDEMO.plasma import PlasmaComponent\n",
         "from bluemira.builders.EUDEMO.reactor import EUDEMOReactor\n",
+        "from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder\n",
         "from bluemira.builders.tf_coils import RippleConstrainedLengthOpt\n",
         "from bluemira.codes import plot_PROCESS\n",
         "from bluemira.codes.plasmod.mapping import (  # noqa: N812\n",
@@ -249,7 +250,7 @@
         "    \"reference_data_root\": \"!BM_ROOT!/data\",\n",
         "    \"generated_data_root\": \"!BM_ROOT!/generated_data\",\n",
         "    \"PROCESS\": {\n",
-        "        \"runmode\": \"read\",  # [\"run\", \"read\", \"mock\"]\n",
+        "        \"runmode\": \"mock\",  # [\"run\", \"read\", \"mock\"]\n",
         "    },\n",
         "    \"Plasma\": {\n",
         "        \"runmode\": \"read\",  # [\"run\", \"read\", \"mock\"]\n",
@@ -277,9 +278,9 @@
         "            \"nx\": 2,\n",
         "            \"ny\": 2,\n",
         "        },\n",
-        "        \"PF Coils\": {\n",
-        "            \"runmode\": \"read\",\n",
-        "        },\n",
+        "    },\n",
+        "    \"PF Coils\": {\n",
+        "        \"runmode\": \"read\",\n",
         "    },\n",
         "}"
       ],
@@ -454,24 +455,8 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "plasma: PlasmaComponent = component.get_component(\"Plasma\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "tf_coils = component.get_component(\"TF Coils\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
+        "plasma: PlasmaComponent = component.get_component(\"Plasma\")\n",
+        "tf_coils = component.get_component(\"TF Coils\")\n",
         "pf_coils = component.get_component(\"PF Coils\")"
       ],
       "outputs": [],
@@ -636,6 +621,29 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "### Saving the Geometry Parametrisation\n",
+        "\n",
+        "If we've run a design with a build stage in the \"run\" runmode then we may want to save\n",
+        "the resulting geometry parameterisation to a file so that it can be read back in,\n",
+        "saving time in future runs if we are only making downstream changes. This can be done\n",
+        "by using the `save_shape` method on the `TFCoilsBuilder`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "tf_coils_builder: TFCoilsBuilder = reactor.get_builder(\"TF Coils\")\n",
+        "if tf_coils_builder.runmode == \"run\":\n",
+        "    tf_coils_builder.save_shape()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "### Plotting the TF Coils Design Problem\n",
         "\n",
         "In the same way that we got the design problem from our Plasma Builder used in the\n",
@@ -647,10 +655,11 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "design_problem: RippleConstrainedLengthOpt\n",
-        "design_problem = reactor.get_builder(\"TF Coils\").design_problem\n",
-        "design_problem.plot()\n",
-        "plt.show()"
+        "tf_coils_builder: TFCoilsBuilder = reactor.get_builder(\"TF Coils\")\n",
+        "if tf_coils_builder.runmode == \"run\":\n",
+        "    design_problem: RippleConstrainedLengthOpt = tf_coils_builder.design_problem\n",
+        "    design_problem.plot()\n",
+        "    plt.show()"
       ],
       "outputs": [],
       "execution_count": null
@@ -714,7 +723,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.10"
+      "version": "3.8.12"
     }
   },
   "nbformat": 4,

--- a/examples/design/EU-DEMO/EUDEMO_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.py
@@ -35,6 +35,7 @@ from bluemira.base.logs import set_log_level
 from bluemira.base.parameter import ParameterMappingEncoder
 from bluemira.builders.EUDEMO.plasma import PlasmaComponent
 from bluemira.builders.EUDEMO.reactor import EUDEMOReactor
+from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
 from bluemira.builders.tf_coils import RippleConstrainedLengthOpt
 from bluemira.codes import plot_PROCESS
 from bluemira.codes.plasmod.mapping import (  # noqa: N812
@@ -209,7 +210,7 @@ build_config = {
     "reference_data_root": "!BM_ROOT!/data",
     "generated_data_root": "!BM_ROOT!/generated_data",
     "PROCESS": {
-        "runmode": "read",  # ["run", "read", "mock"]
+        "runmode": "mock",  # ["run", "read", "mock"]
     },
     "Plasma": {
         "runmode": "read",  # ["run", "read", "mock"]
@@ -237,9 +238,9 @@ build_config = {
             "nx": 2,
             "ny": 2,
         },
-        "PF Coils": {
-            "runmode": "read",
-        },
+    },
+    "PF Coils": {
+        "runmode": "read",
     },
 }
 
@@ -345,11 +346,7 @@ print(component.tree())
 
 # %%
 plasma: PlasmaComponent = component.get_component("Plasma")
-
-# %%
 tf_coils = component.get_component("TF Coils")
-
-# %%
 pf_coils = component.get_component("PF Coils")
 
 # %%[markdown]
@@ -434,6 +431,19 @@ tf_coils.get_component("xz").plot_2d()
 tf_coils.get_component("xyz").show_cad()
 
 # %%[markdown]
+# ### Saving the Geometry Parametrisation
+#
+# If we've run a design with a build stage in the "run" runmode then we may want to save
+# the resulting geometry parameterisation to a file so that it can be read back in,
+# saving time in future runs if we are only making downstream changes. This can be done
+# by using the `save_shape` method on the `TFCoilsBuilder`.
+
+# %%
+tf_coils_builder: TFCoilsBuilder = reactor.get_builder("TF Coils")
+if tf_coils_builder.runmode == "run":
+    tf_coils_builder.save_shape()
+
+# %%[markdown]
 # ### Plotting the TF Coils Design Problem
 #
 # In the same way that we got the design problem from our Plasma Builder used in the
@@ -441,10 +451,11 @@ tf_coils.get_component("xyz").show_cad()
 # Coils build.
 
 # %%
-design_problem: RippleConstrainedLengthOpt
-design_problem = reactor.get_builder("TF Coils").design_problem
-design_problem.plot()
-plt.show()
+tf_coils_builder: TFCoilsBuilder = reactor.get_builder("TF Coils")
+if tf_coils_builder.runmode == "run":
+    design_problem: RippleConstrainedLengthOpt = tf_coils_builder.design_problem
+    design_problem.plot()
+    plt.show()
 
 # %%[markdown]
 # ### Visualising the Reactor

--- a/tests/bluemira/builders/EUDEMO/test_data/tf_coils_TripleArc_18.json
+++ b/tests/bluemira/builders/EUDEMO/test_data/tf_coils_TripleArc_18.json
@@ -1,0 +1,44 @@
+{
+    "x1": {
+        "value": 3.9904249999999992,
+        "lower_bound": 4,
+        "upper_bound": 5,
+        "fixed": true
+    },
+    "dz": {
+        "value": -0.4446325399393063,
+        "lower_bound": -1,
+        "upper_bound": 1,
+        "fixed": false
+    },
+    "sl": {
+        "value": 5.0,
+        "lower_bound": 5,
+        "upper_bound": 10,
+        "fixed": false
+    },
+    "f1": {
+        "value": 4.508001347631,
+        "lower_bound": 4,
+        "upper_bound": 12,
+        "fixed": false
+    },
+    "f2": {
+        "value": 5.696378478911537,
+        "lower_bound": 4,
+        "upper_bound": 12,
+        "fixed": false
+    },
+    "a1": {
+        "value": 12.29534099554494,
+        "lower_bound": 5,
+        "upper_bound": 120,
+        "fixed": false
+    },
+    "a2": {
+        "value": 103.03025404695109,
+        "lower_bound": 10,
+        "upper_bound": 120,
+        "fixed": false
+    }
+}

--- a/tests/bluemira/builders/EUDEMO/test_tf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_tf_coils.py
@@ -1,0 +1,68 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for EU-DEMO TF Coils build.
+"""
+
+import pytest
+
+from bluemira.base.config import Configuration
+from bluemira.base.error import BuilderError
+from bluemira.base.file import get_bluemira_path
+from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
+
+DATA_PATH = get_bluemira_path("bluemira/builders/EUDEMO/test_data", subfolder="tests")
+"""
+The path to data to be used in these tests.
+"""
+
+
+class TestTFCoils:
+    """
+    Test the EU-DEMO TF Coils build methods.
+    """
+
+    def setup_method(self):
+        self.build_config = {
+            "name": "TF Coils",
+            "param_class": "TripleArc",
+            "runmode": "read",
+            "variables_map": {},
+            "problem_class": "bluemira.builders.tf_coils::RippleConstrainedLengthOpt",
+            "geom_path": DATA_PATH,
+        }
+        self.params = Configuration().to_dict()
+        self.params["n_TF"] = 18
+
+    def test_bad_geom_path(self):
+        self.build_config["geom_path"] = "/a/bad/path/6b04dbec4a955560d59cf1e5e885b8de"
+        with pytest.raises(BuilderError):
+            TFCoilsBuilder(self.params, self.build_config)
+
+    def test_read_from_dir(self):
+        builder = TFCoilsBuilder(self.params, self.build_config)
+        builder(self.params)
+
+    def test_mock(self):
+        self.build_config["runmode"] = "mock"
+        builder = TFCoilsBuilder(self.params, self.build_config)
+        builder(self.params)


### PR DESCRIPTION
## Linked Issues

N/A

## Description

This PR supports saving the TF Coils builder shape (and any other shape builders) to a json file.

## Interface Changes

Adds `save_shape` to `ParameterisedShapeBuilder`.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
