### PR TITLE
Create mapping edit helper

### DIFF
--- a/bluemira/base/parameter.py
+++ b/bluemira/base/parameter.py
@@ -94,6 +94,27 @@ class ParameterMapping:
         """
         return repr(self.to_dict())
 
+    def __setattr__(self, attr: str, value: Union[bool, str]):
+        """
+        Protect against additional attributes
+
+        Parameters
+        ----------
+        attr: str
+            Attribute to set (name can only be set on init)
+        value: Union[bool, str]
+            Value of attribute
+
+        """
+        if attr not in ["send", "recv", "name"] or (
+            hasattr(self, "name") and attr not in ["send", "recv"]
+        ):
+            raise KeyError(f"{attr} cannot be set for a {self.__class__.__name__}")
+        elif attr in ["send", "recv"] and not isinstance(value, bool):
+            raise ValueError(f"{attr} must be a bool")
+        else:
+            super().__setattr__(attr, value)
+
 
 class ParameterMappingEncoder(json.JSONEncoder):
     """

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -333,7 +333,14 @@ class FileProgramInterface:
         Parameters
         ----------
         mappings: dict
-            A list of keys wi
+            A dictionary of variables to change mappings.
+
+        Notes
+        -----
+            Only one of send or recv is needed. The mappings dictionary could look like:
+
+               {"var1": {"send": False, "recv": True}, "var2": {"recv": False}}
+
         """
         for key, val in mappings.items():
             try:

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -326,7 +326,7 @@ class FileProgramInterface:
         """
         return self.setup_obj._send_mapping
 
-    def modify_mappings(self, mappings: Dict[str : Dict[str, bool]]):
+    def modify_mappings(self, mappings: Dict[str, Dict[str, bool]]):
         """
         Modify the send/recieve mappings of a key
 

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -326,6 +326,24 @@ class FileProgramInterface:
         """
         return self.setup_obj._send_mapping
 
+    def modify_mappings(self, mappings: Dict[str : Dict[str, bool]]):
+        """
+        Modify the send/recieve mappings of a key
+
+        Parameters
+        ----------
+        mappings: dict
+            A list of keys wi
+        """
+        for key, val in mappings.items():
+            try:
+                p_map = getattr(self.params, key).mapping[self.NAME]
+            except (AttributeError, KeyError):
+                bluemira_warn(f"No mapping known for {key} in {self.NAME}")
+            else:
+                for sr_key, sr_val in val.items():
+                    setattr(p_map, sr_key, sr_val)
+
     def run(self, *args, **kwargs):
         """
         Run the full program interface

--- a/examples/codes/run_plasmod_example.ipynb
+++ b/examples/codes/run_plasmod_example.ipynb
@@ -366,8 +366,8 @@
       "source": [
         "#### Changing the mapping sending or recieving\n",
         "The mapping can be changed on a given parameter or set of parameters.\n",
-        "Notice how the value of `q_95` doesn't change even though its value has\n",
-        "(the previous value of 3.5 is used)."
+        "Notice how the value of `q_95` doesn't change in the output\n",
+        "even though its value has in the parameter (the previous value of 3.5 is used)."
       ]
     },
     {

--- a/examples/codes/run_plasmod_example.ipynb
+++ b/examples/codes/run_plasmod_example.ipynb
@@ -359,6 +359,29 @@
       ],
       "outputs": [],
       "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "#### Changing the mapping sending or recieving\n",
+        "The mapping can be changed on a given parameter or set of parameters.\n",
+        "Notice how the value of `q_95` doesn't change even though its value has\n",
+        "(the previous value of 3.5 is used)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "plasmod_solver.modify_mappings({\"q_95\": {\"send\": False}})\n",
+        "plasmod_solver.params.q_95 = (5, \"input\")\n",
+        "plasmod_solver.run()\n",
+        "print_outputs(plasmod_solver)\n",
+        "print(\"\\nq_95 value history\\n\", plasmod_solver.params.q_95.history())"
+      ],
+      "outputs": [],
+      "execution_count": null
     }
   ],
   "metadata": {

--- a/examples/codes/run_plasmod_example.py
+++ b/examples/codes/run_plasmod_example.py
@@ -249,3 +249,16 @@ print_outputs(plasmod_solver)
 plasmod_solver.problem_settings["qdivt_sup"] = 10.0
 plasmod_solver.run()
 print_outputs(plasmod_solver)
+
+# %%[markdown]
+# #### Changing the mapping sending or recieving
+# The mapping can be changed on a given parameter or set of parameters.
+# Notice how the value of `q_95` doesn't change even though its value has
+# (the previous value of 3.5 is used).
+
+# %%
+plasmod_solver.modify_mappings({"q_95": {"send": False}})
+plasmod_solver.params.q_95 = (5, "input")
+plasmod_solver.run()
+print_outputs(plasmod_solver)
+print("\nq_95 value history\n", plasmod_solver.params.q_95.history())

--- a/examples/codes/run_plasmod_example.py
+++ b/examples/codes/run_plasmod_example.py
@@ -253,8 +253,8 @@ print_outputs(plasmod_solver)
 # %%[markdown]
 # #### Changing the mapping sending or recieving
 # The mapping can be changed on a given parameter or set of parameters.
-# Notice how the value of `q_95` doesn't change even though its value has
-# (the previous value of 3.5 is used).
+# Notice how the value of `q_95` doesn't change in the output
+# even though its value has in the parameter (the previous value of 3.5 is used).
 
 # %%
 plasmod_solver.modify_mappings({"q_95": {"send": False}})

--- a/tests/bluemira/base/test_parameter.py
+++ b/tests/bluemira/base/test_parameter.py
@@ -64,6 +64,25 @@ class DummyPF(ReactorSystem):
         self._init_params(self.inputs)
 
 
+class TestParameterMapping:
+    def test_value_change(self):
+        pm = ParameterMapping("Name", send=True, recv=False)
+
+        with pytest.raises(ValueError):
+            pm.send = "A string"
+
+        with pytest.raises(KeyError):
+            pm.name = "NewName"
+
+        with pytest.raises(KeyError):
+            pm.mynewattr = "Hello"
+
+        pm.send = False
+        pm.recv = True
+        assert not pm.send
+        assert pm.recv
+
+
 class TestParameter:
     p = Parameter(
         "r_0",


### PR DESCRIPTION
## Description

This makes it easier for users to modify the send/recv mappings of a code 

## Interface Changes

Additional `set_mappings` function. `ParameterMapping` now errors if you try to set other attributes to it

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
