### PR TITLE
Codes cleanup and finish generic wrapper

### DIFF
--- a/BLUEPRINT/reactor.py
+++ b/BLUEPRINT/reactor.py
@@ -43,7 +43,7 @@ from bluemira.base.look_and_feel import bluemira_print, bluemira_warn, print_ban
 from bluemira.base.parameter import ParameterFrame
 
 # PROCESS imports
-from bluemira.codes import run_systems_code
+from bluemira.codes import systems_code_solver
 
 # Equilibria imports
 from bluemira.equilibria._deprecated_run import AbInitioEquilibriumProblem
@@ -292,12 +292,14 @@ class Reactor(ReactorSystem):
         """
         Runs, reads, or mocks the systems code according to the build config dictionary.
         """
-        PROCESS_solver = run_systems_code(
+        PROCESS_solver = systems_code_solver(
             self.params,
             self.build_config,
             self.file_manager.generated_data_dirs["systems_code"],
             self.file_manager.reference_data_dirs["systems_code"],
         )
+
+        PROCESS_solver.run()
         self.params.update_kw_parameters(PROCESS_solver.params.to_dict())
 
     def estimate_kappa_95(self):

--- a/BLUEPRINT/systems/plotting.py
+++ b/BLUEPRINT/systems/plotting.py
@@ -181,10 +181,9 @@ class ReactorPlotter:
         """
         Plots a 1-D vector of the radial build output from PROCESS
         """
-        # TODO: POSTprocess.py is archaic... need to refactor heavily and bring
-        # into the fold...
-        sys_code_dir = self.reactor.file_manager.generated_data_dirs["systems_code"]
-        codes.plot_radial_build(os.sep.join([sys_code_dir, "OUT.DAT"]), width=width)
+        codes.plot_radial_build(
+            self.reactor.file_manager.generated_data_dirs["systems_code"], width=width
+        )
 
     def plot_xz(self, x=None, z=None, show_eq=False, force=False):
         """

--- a/BLUEPRINT/systems/plotting.py
+++ b/BLUEPRINT/systems/plotting.py
@@ -184,7 +184,7 @@ class ReactorPlotter:
         # TODO: POSTprocess.py is archaic... need to refactor heavily and bring
         # into the fold...
         sys_code_dir = self.reactor.file_manager.generated_data_dirs["systems_code"]
-        codes.plot_PROCESS(os.sep.join([sys_code_dir, "OUT.DAT"]), width=width)
+        codes.plot_radial_build(os.sep.join([sys_code_dir, "OUT.DAT"]), width=width)
 
     def plot_xz(self, x=None, z=None, show_eq=False, force=False):
         """

--- a/BLUEPRINT/systems/plotting.py
+++ b/BLUEPRINT/systems/plotting.py
@@ -22,7 +22,6 @@
 """
 Plotting utilities for ReactorSystem objects
 """
-import os
 from itertools import cycle
 
 import matplotlib.pyplot as plt

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -32,7 +32,7 @@ from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
 from bluemira.builders.EUDEMO.plasma import PlasmaBuilder
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
 from bluemira.builders.thermal_shield import ThermalShieldBuilder
-from bluemira.codes import run_systems_code
+from bluemira.codes import systems_code_solver
 from bluemira.codes.process import NAME as PROCESS
 
 
@@ -79,13 +79,15 @@ class EUDEMOReactor(Reactor):
         # run_systems_code interface is updated to have a more general runmode value.
         config["process_mode"] = config.pop("runmode")
 
-        solver = run_systems_code(
+        solver = systems_code_solver(
             self._params,
             config,
             self._file_manager.generated_data_dirs["systems_code"],
             self._file_manager.reference_data_dirs["systems_code"],
         )
+
         self.register_solver(solver, name)
+        solver.run()
         self._params.update_kw_parameters(solver.params.to_dict())
 
         bluemira_print(f"Completed design stage: {name}")

--- a/bluemira/codes/__init__.py
+++ b/bluemira/codes/__init__.py
@@ -47,13 +47,15 @@ def freecad_message_removal():
 
 freecad_default_path = freecad_message_removal()
 
-# PROCESS systems code imports
-from bluemira.codes.process.teardown import plot_PROCESS
-
 # External codes wrapper imports
-from bluemira.codes.wrapper import run_systems_code
+from bluemira.codes.wrapper import (
+    plot_radial_build,
+    systems_code_solver,
+    transport_code_solver,
+)
 
 __all__ = [
-    "run_systems_code",
-    "plot_PROCESS",
+    "systems_code_solver",
+    "transport_code_solver",
+    "plot_radial_build",
 ]

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -193,12 +193,6 @@ class Teardown(Task):
     def __init__(self, parent, *args, **kwargs):
         super().__init__(parent)
 
-    def get_parameters(self):
-        """
-        TODO?
-        """
-        pass
-
 
 class FileProgramInterface:
     """An external code wrapper"""
@@ -221,7 +215,7 @@ class FileProgramInterface:
         if self._runmode is not RunMode and issubclass(self._runmode, RunMode):
             self._set_runmode(runmode)
         else:
-            raise CodesError("Please define a RunMode child lass")
+            raise CodesError("Please define a RunMode child class")
 
         self._protect_tasks()
 

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -88,13 +88,12 @@ class Task:
 
     def __init__(self, parent):
         self.parent = parent
-        self._run_dir = parent._run_dir
 
     def _run_subprocess(self, command, **kwargs):
         stdout = LogPipe("print")
         stderr = LogPipe("error")
 
-        kwargs["cwd"] = kwargs.get("cwd", self._run_dir)
+        kwargs["cwd"] = kwargs.get("cwd", self.parent.run_dir)
         kwargs.pop("shell", None)  # Protect against user input
 
         with subprocess.Popen(  # noqa :S603
@@ -203,14 +202,24 @@ class FileProgramInterface:
     _runmode = RunMode
 
     def __init__(
-        self, NAME, params, runmode, *args, run_dir=None, mappings=None, **kwargs
+        self,
+        NAME,
+        params,
+        runmode,
+        *args,
+        run_dir=None,
+        read_dir=None,
+        mappings=None,
+        **kwargs,
     ):
         self.NAME = NAME
 
         add_mapping(NAME, params, mappings)
 
-        if not hasattr(self, "__run_dir"):
-            self.__run_dir = "./" if run_dir is None else run_dir
+        if not hasattr(self, "run_dir"):
+            self.run_dir = "./" if run_dir is None else run_dir
+
+        self.read_dir = read_dir
 
         if self._runmode is not RunMode and issubclass(self._runmode, RunMode):
             self._set_runmode(runmode)
@@ -267,30 +276,6 @@ class FileProgramInterface:
         """
         mode = runmode.upper().translate(str.maketrans("", "", string.whitespace))
         self._runner = self._runmode[mode]
-
-    @property
-    def _run_dir(self):
-        """
-        Run directory
-        """
-        return self.__run_dir
-
-    @_run_dir.setter
-    def _run_dir(self, directory: str):
-        """
-        Set run directory
-
-        Parameters
-        ----------
-        directory: str
-            new directory
-        """
-        self.__run_dir = directory
-        self._set_property("_run_dir", directory)
-
-    def _set_property(self, prop, val):
-        for obj in ["setup", "run", "teardown"]:
-            setattr(getattr(self, f"{obj}_obj"), prop, val)
 
     @property
     def params(self) -> bm_base.ParameterFrame:

--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -364,7 +364,7 @@ class Setup(interface.Setup):
         """
         Write input file
         """
-        self.io_manager._write(Path(self._run_dir, self.input_file))
+        self.io_manager._write(Path(self.parent.run_dir, self.input_file))
 
     def _run(self):
         """
@@ -400,9 +400,9 @@ class Run(interface.Run):
         super()._run_subprocess(
             [
                 self._binary,
-                Path(self._run_dir, self.parent.setup_obj.input_file),
-                Path(self._run_dir, self.parent.setup_obj.output_file),
-                Path(self._run_dir, self.parent.setup_obj.profiles_file),
+                Path(self.parent.run_dir, self.parent.setup_obj.input_file),
+                Path(self.parent.run_dir, self.parent.setup_obj.output_file),
+                Path(self.parent.run_dir, self.parent.setup_obj.profiles_file),
             ]
         )
 
@@ -418,8 +418,8 @@ class Teardown(interface.Teardown):
         """
         self.io_manager = Outputs()
         self.io_manager.read_output_files(
-            Path(self._run_dir, self.parent.setup_obj.output_file),
-            Path(self._run_dir, self.parent.setup_obj.profiles_file),
+            Path(self.parent.run_dir, self.parent.setup_obj.output_file),
+            Path(self.parent.run_dir, self.parent.setup_obj.profiles_file),
         )
         self.prepare_outputs()
 
@@ -427,10 +427,17 @@ class Teardown(interface.Teardown):
         """
         Mock plasmod teardown
         """
+        self.io_manager = Outputs(use_defaults=True)
+        self.prepare_outputs()
+
+    def _read(self):
+        """
+        Read plasmod teardown
+        """
         self.io_manager = Outputs()
         self.io_manager.read_output_files(
-            Path(self._run_dir, self.parent.setup_obj.output_file),
-            Path(self._run_dir, self.parent.setup_obj.profiles_file),
+            Path(self.parent.read_dir, self.parent.setup_obj.output_file),
+            Path(self.parent.read_dir, self.parent.setup_obj.profiles_file),
         )
         self.prepare_outputs()
 
@@ -459,6 +466,8 @@ class Solver(interface.FileProgramInterface):
         build configuration dictionary
     run_dir: str
         Plasmod run directory
+    read_dir: str
+        Directory to read in previous run
 
     Notes
     -----
@@ -475,6 +484,7 @@ class Solver(interface.FileProgramInterface):
         params,
         build_config=None,
         run_dir: Optional[str] = None,
+        read_dir: Optional[str] = None,
     ):
         super().__init__(
             PLASMOD,
@@ -482,6 +492,7 @@ class Solver(interface.FileProgramInterface):
             build_config.get("mode", "run"),
             binary=build_config.get("binary", BINARY),
             run_dir=run_dir,
+            read_dir=read_dir,
             mappings=create_mapping(),
             problem_settings=build_config.get("problem_settings", None),
         )

--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -217,8 +217,11 @@ class Inputs(PlasmodParameters):
 class Outputs(PlasmodParameters):
     """Class for Plasmod outputs"""
 
-    def __init__(self):
+    def __init__(self, use_defaults=False):
         self._options = self.get_default_plasmod_outputs()
+        if not use_defaults:
+            for k in self._options.keys():
+                self._options[k] = None
 
     def get_default_plasmod_outputs(self):
         """
@@ -301,7 +304,7 @@ class Outputs(PlasmodParameters):
                 f"{PLASMOD} error: " "Abnormal paramters, possibly dtmax/dtmin too large"
             )
         else:
-            raise CodesError(f"{PLASMOD} error: " f"Unknown error code {exit_flag}")
+            raise CodesError(f"{PLASMOD} error: Unknown error code {exit_flag}")
 
 
 class RunMode(interface.RunMode):
@@ -310,6 +313,7 @@ class RunMode(interface.RunMode):
     """
 
     RUN = auto()
+    READ = auto()
     MOCK = auto()
 
 
@@ -365,13 +369,6 @@ class Setup(interface.Setup):
     def _run(self):
         """
         Run plasmod setup
-        """
-        self.update_inputs()
-        self.write_input()
-
-    def _mock(self):
-        """
-        Mock plasmod setup
         """
         self.update_inputs()
         self.write_input()

--- a/bluemira/codes/plasmod/mapping.py
+++ b/bluemira/codes/plasmod/mapping.py
@@ -300,7 +300,7 @@ PLASMOD_INPUTS = {
     # [-] scaling factor for p_ped scaling formula
     # ###### "BM_INP": "pedscal",
     # ###########################
-    # listlist general inputs: control, confinement, B.C., etc
+    # list general inputs: control, confinement, B.C., etc
     # ############################
     # [-] Greenwald density fraction at pedestal
     # ###### "BM_INP": "f_gw",

--- a/bluemira/codes/process/__init__.py
+++ b/bluemira/codes/process/__init__.py
@@ -23,14 +23,14 @@
 Importer for PROCESS runner constants and functions
 """
 
-from bluemira.codes.process.api import PROCESS_ENABLED
+from bluemira.codes.process.api import ENABLED
 from bluemira.codes.process.constants import NAME
 from bluemira.codes.process.run import Solver
-from bluemira.codes.process.teardown import plot_PROCESS
+from bluemira.codes.process.teardown import plot_radial_build
 
 __all__ = [
-    "PROCESS_ENABLED",
+    "ENABLED",
     "NAME",
     "Solver",
-    "plot_PROCESS",
+    "plot_radial_build",
 ]

--- a/bluemira/codes/process/api.py
+++ b/bluemira/codes/process/api.py
@@ -29,7 +29,7 @@ from bluemira.base.file import get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_print, bluemira_warn
 from bluemira.utilities.tools import flatten_iterable
 
-PROCESS_ENABLED = True
+ENABLED = True
 
 
 # Create dummy PROCESS objects.
@@ -68,11 +68,11 @@ try:
     from process.io.mfile import MFile  # noqa: F811,F401
     from process.io.python_fortran_dicts import get_dicts  # noqa: F811
 except (ModuleNotFoundError, FileNotFoundError):
-    PROCESS_ENABLED = False
+    ENABLED = False
     bluemira_warn("PROCESS not installed on this machine; cannot run PROCESS.")
 
 # Get dict of obsolete vars from PROCESS (if installed)
-if PROCESS_ENABLED:
+if ENABLED:
     try:
         from process.io.obsolete_vars import OBS_VARS
     except (ModuleNotFoundError, FileNotFoundError):
@@ -147,13 +147,6 @@ def _nested_check(process_name):
                 names += [_nested_check(p)]
             return list(flatten_iterable(names))
     return process_name
-
-
-def _pconvert(dictionary, key):
-    key_name = dictionary.get(key, key)
-    if key_name is None:
-        raise ValueError(f'Define a parameter conversion for "{key}"')
-    return key_name
 
 
 def convert_unit_p_to_b(s):

--- a/bluemira/codes/process/run.py
+++ b/bluemira/codes/process/run.py
@@ -91,7 +91,7 @@ class Run(interface.Run):
         Clear the output files from PROCESS run directory.
         """
         for filename in self.parent.output_files:
-            filepath = os.sep.join([self._run_dir, filename])
+            filepath = os.sep.join([self.parent.run_dir, filename])
             if os.path.exists(filepath):
                 os.remove(filepath)
 
@@ -151,9 +151,9 @@ class Solver(interface.FileProgramInterface):
         If PROCESS is not being mocked and is not installed.
     """
 
+    run_dir: str
+    read_dir: str
     _params: bm_base.ParameterFrame
-    _run_dir: str
-    _read_dir: str
     _template_indat: str
     _params_to_update: List[str]
     _parameter_mapping: Dict[str, str]
@@ -204,6 +204,7 @@ class Solver(interface.FileProgramInterface):
             build_config.get("mode", "run"),
             binary=build_config.get("binary", BINARY),
             run_dir=run_dir,
+            read_dir=read_dir,
             mappings=mappings,
         )
 

--- a/bluemira/codes/process/run.py
+++ b/bluemira/codes/process/run.py
@@ -33,7 +33,8 @@ from typing import Dict, List, Optional, Union
 import bluemira.base as bm_base
 import bluemira.codes.interface as interface
 from bluemira.base.look_and_feel import bluemira_print
-from bluemira.codes.process.api import DEFAULT_INDAT
+from bluemira.codes.error import CodesError
+from bluemira.codes.process.api import DEFAULT_INDAT, ENABLED
 from bluemira.codes.process.constants import BINARY
 from bluemira.codes.process.constants import NAME as PROCESS
 from bluemira.codes.process.mapping import mappings
@@ -143,6 +144,11 @@ class Solver(interface.FileProgramInterface):
         testing purposes.
     - "none": Do nothing. Useful when loading results from previous runs of Bluemira,
         when overwriting data with PROCESS output would be undesirable.
+
+    Raises
+    ------
+    CodesError
+        If PROCESS is not being mocked and is not installed.
     """
 
     _params: bm_base.ParameterFrame
@@ -175,8 +181,11 @@ class Solver(interface.FileProgramInterface):
         template_indat: Optional[str] = None,
         params_to_update: Optional[List[str]] = None,
     ):
-        self._read_dir = read_dir
 
+        if (not ENABLED) and (build_config.get("mode", "run").lower() != "mock"):
+            raise CodesError(f"{PROCESS} not (properly) installed")
+
+        self.read_dir = read_dir
         self._params_to_update = (
             build_config.get("params_to_update", None)
             if params_to_update is None

--- a/bluemira/codes/process/run.py
+++ b/bluemira/codes/process/run.py
@@ -182,9 +182,6 @@ class Solver(interface.FileProgramInterface):
         params_to_update: Optional[List[str]] = None,
     ):
 
-        if (not ENABLED) and (build_config.get("mode", "run").lower() != "mock"):
-            raise CodesError(f"{PROCESS} not (properly) installed")
-
         self.read_dir = read_dir
         self._params_to_update = (
             build_config.get("params_to_update", None)
@@ -207,6 +204,13 @@ class Solver(interface.FileProgramInterface):
             read_dir=read_dir,
             mappings=mappings,
         )
+
+        self._enabled_check(build_config.get("mode", "run").lower())
+
+    @staticmethod
+    def _enabled_check(mode):
+        if (not ENABLED) and (mode != "mock"):
+            raise CodesError(f"{PROCESS} not (properly) installed")
 
     def get_process_parameters(self, params: Union[List, str]):
         """

--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -122,5 +122,5 @@ class Setup(interface.Setup):
                     else:
                         writer.add_parameter(new_mapping, param.value)
 
-        filename = os.path.join(self._run_dir, "IN.DAT")
+        filename = os.path.join(self.parent.run_dir, "IN.DAT")
         writer.write_in_dat(output_filename=filename)

--- a/bluemira/codes/process/teardown.py
+++ b/bluemira/codes/process/teardown.py
@@ -576,25 +576,21 @@ def process_RB_fromOUT(f):  # noqa :N802
     return {"Radial Build": rb, "n_TF": n_TF, "R_0": R_0}
 
 
-def plot_radial_build(filename: str, width: float = 1.0, show: bool = True):
+def plot_radial_build(sys_code_dir: str, width: float = 1.0, show: bool = True):
     """
     Plot PROCESS radial build.
 
     Parameters
     ----------
-    filename: str
-        OUT.DAT filename string, the corresponding MFILE.DAT path, or the directory
-        containing the PROCESS run results.
+    sys_code_dir: str
+        OUT.DAT directory location
     width: float
         The relative width of the plot.
     show: bool
         If True then immediately display the plot, else delay displaying the plot until
         the user shows it, by default True.
     """
-    if os.path.isdir(filename):
-        filename = os.path.join(filename, "OUT.DAT")
-    elif filename.endswith("MFILE.DAT"):
-        filename = filename.replace("MFILE.DAT", "OUT.DAT")
+    filename = os.sep.join([sys_code_dir, "OUT.DAT"])
 
     if not os.path.exists(filename):
         raise CodesError(f"Could not find PROCESS OUT.DAT results at {filename}")

--- a/bluemira/codes/process/teardown.py
+++ b/bluemira/codes/process/teardown.py
@@ -269,10 +269,10 @@ class Teardown(interface.Teardown):
         self.load_PROCESS_run(recv_all=True)
 
     def _read(self):
-        self.load_PROCESS_run(path=self.parent._read_dir, recv_all=False)
+        self.load_PROCESS_run(path=self.parent.read_dir, recv_all=False)
 
     def _readall(self):
-        self.load_PROCESS_run(path=self.parent._read_dir, recv_all=True)
+        self.load_PROCESS_run(path=self.parent.read_dir, recv_all=True)
 
     def _mock(self):
         self.mock_PROCESS_run()
@@ -285,7 +285,7 @@ class Teardown(interface.Teardown):
         ----------
             path: str, optional
                 path to PROCESS output file (MFILE.DAT) to load
-                uses `_run_dir` if not provided
+                uses `run_dir` if not provided
             recv_all: bool, optional
                 True - Read all PROCESS output with a mapping,
                 False - reads only PROCESS output with a mapping and recv = True.
@@ -311,8 +311,7 @@ class Teardown(interface.Teardown):
         ----------
             path: str, optional
                 path to PROCESS output file (MFILE.DAT) to load
-                uses `_run_dir` if not provided
-
+                uses `run_dir` if not provided
 
         Returns
         -------
@@ -320,7 +319,7 @@ class Teardown(interface.Teardown):
             The object representation of the output MFILE.DAT.
         """
         m_file = BMFile(
-            self._run_dir if path is None else path, self.parent._parameter_mapping
+            self.parent.run_dir if path is None else path, self.parent._parameter_mapping
         )
         self._check_feasible_solution(m_file)
         return m_file
@@ -332,7 +331,7 @@ class Teardown(interface.Teardown):
         bluemira_print("Mocking PROCESS systems code run")
 
         # Create mock PROCESS file.
-        path = self.parent._read_dir
+        path = self.parent.read_dir
         filename = os.sep.join([path, "mockPROCESS.json"])
         with open(filename, "r") as fh:
             process = json.load(fh)
@@ -349,19 +348,19 @@ class Teardown(interface.Teardown):
             If any resulting output files don't exist or are empty.
         """
         for filename in self.parent.output_files:
-            filepath = os.sep.join([self._run_dir, filename])
+            filepath = os.sep.join([self.parent.run_dir, filename])
             if os.path.exists(filepath):
                 with open(filepath) as fh:
                     if len(fh.readlines()) == 0:
                         message = (
                             f"PROCESS generated an empty {filename} "
-                            f"file in {self._run_dir} - check PROCESS logs."
+                            f"file in {self.parent.run_dir} - check PROCESS logs."
                         )
                         raise CodesError(message)
             else:
                 message = (
                     f"PROCESS run did not generate the {filename} "
-                    f"file in {self._run_dir} - check PROCESS logs."
+                    f"file in {self.parent.run_dir} - check PROCESS logs."
                 )
                 raise CodesError(message)
 

--- a/bluemira/codes/process/teardown.py
+++ b/bluemira/codes/process/teardown.py
@@ -445,7 +445,7 @@ def read_n_line(line):
     return out
 
 
-def plot_radial_build(run, width=1.0):
+def setup_radial_build(run, width=1.0):
     """
     Plots radial and vertical build of a PROCESS run
     Input: Dictionary of PROCESS output
@@ -577,7 +577,7 @@ def process_RB_fromOUT(f):  # noqa :N802
     return {"Radial Build": rb, "n_TF": n_TF, "R_0": R_0}
 
 
-def plot_PROCESS(filename: str, width: float = 1.0, show: bool = True):
+def plot_radial_build(filename: str, width: float = 1.0, show: bool = True):
     """
     Plot PROCESS radial build.
 
@@ -601,6 +601,6 @@ def plot_PROCESS(filename: str, width: float = 1.0, show: bool = True):
         raise CodesError(f"Could not find PROCESS OUT.DAT results at {filename}")
 
     radial_build = process_RB_fromOUT(filename)
-    plot_radial_build(radial_build, width=width)
+    setup_radial_build(radial_build, width=width)
     if show:
         plt.show()

--- a/bluemira/codes/utilities.py
+++ b/bluemira/codes/utilities.py
@@ -35,6 +35,27 @@ from bluemira.base.look_and_feel import (
     bluemira_print_clean,
 )
 from bluemira.codes.error import CodesError
+from bluemira.utilities.tools import get_module
+
+
+def get_code_interface(module):
+    """
+    Dynamically import code interface
+
+    Parameters
+    ----------
+    module: str
+        module to import
+
+    Returns
+    -------
+    code module
+
+    """
+    try:
+        return get_module(f"bluemira.codes.{module.lower()}")
+    except ImportError:
+        return get_module(module)
 
 
 def _get_mapping(

--- a/bluemira/codes/wrapper.py
+++ b/bluemira/codes/wrapper.py
@@ -32,7 +32,6 @@ from bluemira.codes.error import CodesError
 from bluemira.codes.interface import FileProgramInterface
 from bluemira.codes.utilities import get_code_interface
 
-
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
     from bluemira.base.parameter import ParameterFrame

--- a/bluemira/codes/wrapper.py
+++ b/bluemira/codes/wrapper.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
-from bluemira.codes import process
-from bluemira.codes.error import CodesError
 from bluemira.codes.interface import FileProgramInterface
 from bluemira.codes.utilities import get_code_interface
 

--- a/bluemira/codes/wrapper.py
+++ b/bluemira/codes/wrapper.py
@@ -30,53 +30,49 @@ from typing import TYPE_CHECKING, Optional
 from bluemira.codes import process
 from bluemira.codes.error import CodesError
 from bluemira.codes.interface import FileProgramInterface
+from bluemira.codes.utilities import get_code_interface
+
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
     from bluemira.base.parameter import ParameterFrame
 
 
-def run_systems_code(
+def systems_code_solver(
     params: ParameterFrame,
     build_config: BuildConfig,
     run_dir: str,
     read_dir: Optional[str] = None,
     template_indat=None,
     params_to_update=None,
+    module: Optional[str] = "PROCESS",
 ) -> FileProgramInterface:
     """
-    Runs, reads or mocks PROCESS according to the build configuration dictionary.
+    Runs, reads or mocks systems code according to the build configuration dictionary.
 
     Parameters
     ----------
-    reactor: class
-        The instantiated reactor class for the run. Note the run mode is set by
-        reactor.build_config.process_mode (or the build_config.json input file).
-
+    params: ParameterFrame
+        ParameterFrame for code
+    build_config: Dict
+        build configuration dictionary
+    run_dir: str
+        Path to the run directory, where the main executable is located
+        and the input/output files will be written.
+    read_dir: str
+        Path to the read directory, where the output files from a run are
+        read in
+    template_indat: str
+        Path to the template file to be used for the run.
     params_to_update: list
         A list of parameter names compatible with the ParameterFrame class.
         If provided, parameters included in this list will be modified to write their
-        values to PROCESS inputs, while all others will be modified to not be written to
-        the PROCESS inputs. By default, None.
+        values to the inputs, while all others will be modified to not be written to
+        the inputs. By default, None.
 
-    Notes
-    -----
-    - "run": Run PROCESS within a bluemira run to generate an radial build.
-        Creates a new input file from a template IN.DAT modified with updated parameters
-        from the bluemira run mapped with write=True. If params_to_update are provided
-        then these will be modified to have write=True and all other will be modified to
-        have write=False.
-    - "runinput": Run PROCESS from an unmodified input file (IN.DAT), generating the
-        radial build to use as the input to the bluemira run. Overrides the write
-        mapping of all parameters to be False.
-    - "read": Load the radial build from a previous PROCESS run (MFILE.DAT). Loads
-        only the parameters mapped with read=True.
-    - "readall": Load the radial build from a previous PROCESS run (MFILE.DAT). Loads
-        all values with a bluemira mapping regardless of the mapping.read bool.
-        Overrides the read mapping of all parameters to be True.
-    - "mock": Run bluemira without running PROCESS, using the default radial build based
-        on EU-DEMO. This option should not be used if PROCESS is installed, except for
-        testing purposes.
+    Returns
+    -------
+    Solver object: FileProgramInterface
 
     Returns
     -------
@@ -87,16 +83,66 @@ def run_systems_code(
     ------
     CodesError
         If PROCESS is not being mocked and is not installed.
+
     """
     # Remove me, temp compatibility layer
     build_config["mode"] = build_config.get("mode", build_config["process_mode"])
     # #####################################
-    process_mode = build_config.get("mode", "run")
-    if (not process.PROCESS_ENABLED) and (process_mode.lower() != "mock"):
-        raise CodesError("PROCESS not (properly) installed")
+    syscode = get_code_interface(module)
 
-    solver = process.Solver(
+    return syscode.Solver(
         params, build_config, run_dir, read_dir, template_indat, params_to_update
     )
-    solver.run()
-    return solver
+
+
+def plot_radial_build(
+    filename: str, width: float = 1.0, show: bool = True, module="PROCESS"
+):
+    """
+    Systems code radial build
+
+    Parameters
+    ----------
+    filename: str
+        The directory containing the system code run results.
+    width: float
+        The relative width of the plot.
+    show: bool
+        If True then immediately display the plot, else delay displaying the plot until
+        the user shows it, by default True.
+
+    """
+    syscode = get_code_interface(module)
+
+    return syscode.plot_radial_build(filename, width, show)
+
+
+def transport_code_solver(
+    params: ParameterFrame,
+    build_config: BuildConfig,
+    run_dir: str,
+    read_dir: Optional[str] = None,
+    module: Optional[str] = "PLASMOD",
+) -> FileProgramInterface:
+    """
+    Transport solver
+
+    Parameters
+    ----------
+    params: ParameterFrame
+        ParameterFrame for plasmod
+    build_config: Dict
+        build configuration dictionary
+    run_dir: str
+        Plasmod run directory
+    read_dir: str
+        Directory to read in previous run
+
+    Returns
+    -------
+    Solver object: FileProgramInterface
+
+    """
+    transp = get_code_interface(module)
+
+    return transp.Solver(params, build_config, run_dir, read_dir)

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -161,7 +161,7 @@ class SkipAlreadyDocumented:
 
     def __init__(self):
         lis = [
-            "bluemira.codes.process.api.PROCESS_ENABLED",
+            "bluemira.codes.process.api.ENABLED",
             "bluemira.codes.process.api.PROCESS_DICT",
         ]
 

--- a/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
@@ -20,7 +20,7 @@
         "from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder\n",
         "from bluemira.builders.tf_coils import RippleConstrainedLengthOpt\n",
         "from bluemira.builders.thermal_shield import ThermalShieldBuilder\n",
-        "from bluemira.codes import plot_PROCESS\n",
+        "from bluemira.codes import plot_radial_build\n",
         "from bluemira.codes.plasmod.mapping import (  # noqa: N812\n",
         "    create_mapping as create_PLASMOD_mappings,\n",
         ")\n",
@@ -414,7 +414,7 @@
       "metadata": {},
       "source": [
         "if build_config[\"PROCESS\"][\"runmode\"] == \"run\":\n",
-        "    plot_PROCESS(reactor.file_manager.generated_data_dirs[\"systems_code\"])\n",
+        "    plot_radial_build(reactor.file_manager.generated_data_dirs[\"systems_code\"])\n",
         "else:\n",
         "    print(\n",
         "        \"The PROCESS design stage did not have the runmode set to run.\"\n",

--- a/examples/design/EU-DEMO/EUDEMO_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.py
@@ -40,7 +40,7 @@ from bluemira.builders.EUDEMO.reactor import EUDEMOReactor
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
 from bluemira.builders.tf_coils import RippleConstrainedLengthOpt
 from bluemira.builders.thermal_shield import ThermalShieldBuilder
-from bluemira.codes import plot_PROCESS
+from bluemira.codes import plot_radial_build
 from bluemira.codes.plasmod.mapping import (  # noqa: N812
     create_mapping as create_PLASMOD_mappings,
 )
@@ -324,7 +324,7 @@ component = reactor.run()
 
 # %%
 if build_config["PROCESS"]["runmode"] == "run":
-    plot_PROCESS(reactor.file_manager.generated_data_dirs["systems_code"])
+    plot_radial_build(reactor.file_manager.generated_data_dirs["systems_code"])
 else:
     print(
         "The PROCESS design stage did not have the runmode set to run."

--- a/tests/bluemira/codes/process/test_run.py
+++ b/tests/bluemira/codes/process/test_run.py
@@ -28,7 +28,8 @@ from unittest.mock import patch
 import pytest
 
 from bluemira.base.builder import BuildConfig
-from bluemira.codes.process import PROCESS_ENABLED, Solver
+from bluemira.codes.process import ENABLED as PROCESS_ENABLED
+from bluemira.codes.process import Solver
 from bluemira.codes.process.constants import NAME as PROCESS
 from tests.bluemira.codes.process import (
     FRAME_LIST,

--- a/tests/bluemira/codes/process/test_run.py
+++ b/tests/bluemira/codes/process/test_run.py
@@ -131,7 +131,8 @@ class TestRun:
         Test that the PROCESS runner accepts valid runmodes and calls the corresponding
         function.
         """
-        self.run_PROCESS(runmode)
+        with patch("bluemira.codes.process.run.Solver._enabled_check"):
+            self.run_PROCESS(runmode)
 
         # Check correct call was made.
         if runmode.upper() == "RUN":

--- a/tests/bluemira/codes/process/test_setup.py
+++ b/tests/bluemira/codes/process/test_setup.py
@@ -22,7 +22,7 @@
 import pytest
 
 from bluemira.codes.process import setup
-from bluemira.codes.process.api import PROCESS_ENABLED
+from bluemira.codes.process.api import ENABLED as PROCESS_ENABLED
 
 
 @pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")

--- a/tests/bluemira/codes/process/test_teardown.py
+++ b/tests/bluemira/codes/process/test_teardown.py
@@ -22,7 +22,7 @@
 import pytest
 
 from bluemira.codes.process import teardown
-from bluemira.codes.process.api import PROCESS_ENABLED
+from bluemira.codes.process.api import ENABLED as PROCESS_ENABLED
 from bluemira.codes.process.mapping import mappings
 from tests.bluemira.codes.process import INDIR
 


### PR DESCRIPTION
## Description

This does a bit of cleanup of some of codes and does some renaming to enable generic wrappers that came up from discussions and thoughts on Friday. Code interfaces can now be loaded on the fly from anywhere with builtin location in `bluemira.codes` the preference.

## Interface Changes

`plot_PROCESS` has been renamed to `plot_radial_build` and `run_systems_code` to `systems_code_solver`. `systems_code_solver` now returns the solver object which needs to be run externally (allowing flexibility and reruns)

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
