### PR TITLE
Remove all traces of `beams` module from `materials`.

### DIFF
--- a/bluemira/materials/constants.py
+++ b/bluemira/materials/constants.py
@@ -25,13 +25,3 @@ Constants for use in the materials package.
 
 T_DEFAULT = 293.15  # Default temperature for all liquids [K]
 P_DEFAULT = 101325  # Default pressure for all liquids [Pa]
-
-
-# Sigh.. cba to fix
-MATERIAL_BEAM_MAP = {
-    "rho": "rho",
-    "mu": "nu",
-    "CTE": "alpha",
-    "E": "E",
-    "Sy": "sigma_y",
-}

--- a/bluemira/materials/material.py
+++ b/bluemira/materials/material.py
@@ -661,29 +661,6 @@ class MassFractionMaterial(SerialisedMaterial, nmm.Material):
         """
         return self.name
 
-    def make_mat_dict(self, temperature):
-        """
-        Makes a material dictionary for use in simple beam FE solver
-
-        Parameters
-        ----------
-        temperature: float
-            The temperature in Kelvin
-
-        Returns
-        -------
-        mat_dict: dict
-            The simplified dictionary of material properties
-        """
-        mat_dict = {
-            "E": self.E(temperature) * 1e9,
-            "nu": self.mu(temperature),
-            "alpha": self.CTE(temperature),
-            "rho": self.rho(temperature),
-            "sigma_y": self.Sy(temperature),
-        }
-        return mat_dict
-
     def mu(self, temperature):
         """
         Poisson's ratio

--- a/bluemira/materials/mixtures.py
+++ b/bluemira/materials/mixtures.py
@@ -117,48 +117,83 @@ class HomogenisedMixture(SerialisedMaterial, nmm.MultiMaterial):
 
         return value
 
-    def E(self, temperature):
+    def E(self, temperature):  # noqa :N802
         """
+        Young's modulus.
+
         Parameters
         ----------
         temperature: float
-            The temperature in Kelvin
+            The optional temperature [K].
+
+        Returns
+        -------
+        youngs_modulus: float
+            The Young's modulus of the material at the given temperature.
         """
         return self._calc_homogenised_property("E", temperature)
 
     def mu(self, temperature):
         """
+        Poisson's ratio.
+
         Parameters
         ----------
         temperature: float
-            The temperature in Kelvin
+            The optional temperature [K].
+
+        Returns
+        -------
+        poissons_ratio: float
+            Poisson's ratio for the material at the given temperature.
         """
         return self._calc_homogenised_property("mu", temperature)
 
-    def CTE(self, temperature):
+    def CTE(self, temperature):  # noqa :N802
         """
+        Mean coefficient of thermal expansion in 10**-6/T
+
         Parameters
         ----------
         temperature: float
             The temperature in Kelvin
+
+        Returns
+        -------
+        cte: float
+            Mean coefficient of thermal expansion in 10**-6/T at the given temperature.
         """
         return self._calc_homogenised_property("CTE", temperature)
 
     def rho(self, temperature):
         """
+        Density.
+
         Parameters
         ----------
         temperature: float
-            The temperature in Kelvin
+            The optional temperature [K].
+
+        Returns
+        -------
+        density: float
+            The density of the material at the given temperature.
         """
         return self._calc_homogenised_property("rho", temperature)
 
-    def Sy(self, temperature):
+    def Sy(self, temperature):  # noqa :N802
         """
+        Minimum yield stress in MPa
+
         Parameters
         ----------
         temperature: float
             The temperature in Kelvin
+
+        Returns
+        -------
+        sy: float
+            Minimum yield stress in MPa at the given temperature.
         """
         return self._calc_homogenised_property("Sy", temperature)
 

--- a/bluemira/materials/mixtures.py
+++ b/bluemira/materials/mixtures.py
@@ -33,7 +33,7 @@ with warnings.catch_warnings():
     import neutronics_material_maker as nmm
 
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.materials.constants import MATERIAL_BEAM_MAP, T_DEFAULT
+from bluemira.materials.constants import T_DEFAULT
 from bluemira.materials.error import MaterialsError
 from bluemira.materials.material import SerialisedMaterial
 

--- a/tests/bluemira/materials/test_mixtures.py
+++ b/tests/bluemira/materials/test_mixtures.py
@@ -20,20 +20,22 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 import pytest
 
+from tests.bluemira.materials.materials_helpers import MATERIAL_CACHE
+
 # =============================================================================
 # Material mixture utility classes
 # =============================================================================
-from bluemira.materials.constants import MATERIAL_BEAM_MAP
-from tests.bluemira.materials.materials_helpers import MATERIAL_CACHE
 
 
 class TestMatDict:
     def test_wp(self):
         tf = MATERIAL_CACHE.get_material("Toroidal_Field_Coil_2015")
-        mat_dict = tf.make_mat_dict(294)
 
-        for key in MATERIAL_BEAM_MAP.values():
-            assert key in mat_dict
+        assert isinstance(tf.E(294), float)
+        assert isinstance(tf.CTE(294), float)
+        assert isinstance(tf.rho(294), float)
+        assert isinstance(tf.mu(294), float)
+        assert isinstance(tf.Sy(294), float)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Linked Issues

Closes #627 

## Description

Remove the `make_mat_dict` method from `Material` - to be implemented in the new structural module.

## Interface Changes

Remove the `make_mat_dict` method from `Material`

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
