### PR TITLE
GS operator possible speedups

### DIFF
--- a/bluemira/equilibria/grad_shafranov.py
+++ b/bluemira/equilibria/grad_shafranov.py
@@ -23,7 +23,7 @@
 Grad-Shafranov operator classes
 """
 import numpy as np
-from numpy import linspace, ones, reshape
+from numpy import linspace, reshape
 from scipy.sparse import lil_matrix
 from scipy.sparse.linalg import factorized
 


### PR DESCRIPTION
## Description

This aims to speedup the current GS operator, I was spurred on by the numba doesnt work comment. I've done a bit of profiling and below is currently v3 and v3_f on the below figure. As you can see if the grid is large enough this is definitely faster. There are also some minor improvements in v2 that are across the board faster

The different versions and profiling code can be seen in this gist: https://gist.github.com/je-cook/54d4a13b6f26afa03adf9dcf339a9fe0

![GS_op_prof](https://user-images.githubusercontent.com/81617086/150767982-a09ee195-f85e-46cd-9045-59d96169f828.png)


## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
