### PR TITLE
Fix typos in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/eu_demo_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/eu_demo_feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea already is already being discussed.
+Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
 
 ## Description of issue / requirement to address
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea already is already being discussed.
+Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
 
 ## Description of issue / requirement to address
 

--- a/.github/ISSUE_TEMPLATE/step_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/step_feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea already is already being discussed.
+Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
 
 ## Description of issue / requirement to address
 


### PR DESCRIPTION
## Linked Issues

N/A

## Description

Fixes typos in the GitHub issue templates.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
