### PR TITLE
Add squareness calculation to `ClosedFluxSurface`

### DIFF
--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -235,6 +235,14 @@ class ClosedFluxSurface(FluxSurface):
 
     @property
     @lru_cache(1)
+    def zeta(self):
+        """
+        Average squareness of the ClosedFluxSurface.
+        """
+        return 0.5 * (self.zeta_upper + self.zeta_lower)
+
+    @property
+    @lru_cache(1)
     def zeta_upper(self):
         """
         Outer upper squareness of the ClosedFluxSurface.
@@ -284,7 +292,7 @@ class ClosedFluxSurface(FluxSurface):
         d_ab = np.hypot(xb - xa, zb - za)
         d_ac = np.hypot(xc - xa, zc - za)
         d_cd = np.hypot(xd - xc, zd - zc)
-        return (d_ab - d_ac) / d_cd
+        return float((d_ab - d_ac) / d_cd)
 
     @property
     @lru_cache(1)
@@ -509,7 +517,11 @@ def analyse_plasma_core(eq, n_points=50):
     psi_n = np.append(psi_n, 1.0)
     flux_surfaces = [ClosedFluxSurface(loop) for loop in loops]
     vars = ["major_radius", "minor_radius", "aspect_ratio", "area", "volume"]
-    vars += [f"{v}{end}" for end in ["", "_upper", "_lower"] for v in ["kappa", "delta"]]
+    vars += [
+        f"{v}{end}"
+        for end in ["", "_upper", "_lower"]
+        for v in ["kappa", "delta", "zeta"]
+    ]
     return CoreResults(
         psi_n,
         *[[getattr(fs, var) for fs in flux_surfaces] for var in vars],
@@ -531,11 +543,14 @@ class CoreResults:
     area: Iterable
     V: Iterable
     kappa: Iterable
-    kappa_upper: Iterable
-    kappa_lower: Iterable
     delta: Iterable
-    delta_lower: Iterable
+    zeta: Iterable
+    kappa_upper: Iterable
     delta_upper: Iterable
+    zeta_upper: Iterable
+    kappa_lower: Iterable
+    delta_lower: Iterable
+    zeta_lower: Iterable
     q: Iterable
     Delta_shaf: Iterable
 

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -249,9 +249,11 @@ class ClosedFluxSurface(FluxSurface):
         a = z_max - z_x_max
         b = x_max - x_z_max
         alpha = np.arctan(a / b)
-        x_ellipse_inter, z_ellipse_inter = x_z_max + b * np.cos(
-            alpha
-        ), z_x_max + a * np.sin(alpha)
+        u = np.arctan(0.5 * a / b)
+        cost_lahire = 1 - u ** 2 / (u ** 2 + 1)
+        sint_lahire = 2 * u / (u ** 2 + 1)
+        x_ellipse_inter = x_z_max + b * cost_lahire  # np.cos(alpha)
+        z_ellipse_inter = z_x_max + a * sint_lahire  # np.sin(alpha)
         line = Loop([x_z_max, x_max], z=[z_x_max, z_max])
         fs_inter = get_intersect(self.loop, line)
         d_ab = np.hypot(fs_inter[0] - x_z_max, fs_inter[1] - z_x_max)
@@ -267,7 +269,7 @@ class ClosedFluxSurface(FluxSurface):
         self.plot()
         ax = plt.gca()
         ax.plot([x_z_max, x_max], [z_x_max, z_max], marker="o")
-        ax.plot(x_ellipse_inter, z_ellipse_inter, "s", marker="x")
+        ax.plot(x_ellipse_inter, z_ellipse_inter, "s", marker="X")
         ax.plot(*fs_inter, marker="*")
 
         return (d_ab - d_ac) / d_cd

--- a/tests/bluemira/equilibria/test_flux_surfaces.py
+++ b/tests/bluemira/equilibria/test_flux_surfaces.py
@@ -34,6 +34,7 @@ from bluemira.equilibria.flux_surfaces import (
     OpenFluxSurface,
     PartialOpenFluxSurface,
 )
+from bluemira.equilibria.shapes import flux_surface_cunningham, flux_surface_johner
 from bluemira.geometry._deprecated_loop import Loop
 
 TEST_PATH = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
@@ -101,6 +102,37 @@ class TestClosedFluxSurface:
         open_loop = Loop(x=[0, 4, 5, 8], z=[1, 2, 3, 4])
         with pytest.raises(FluxSurfaceError):
             _ = ClosedFluxSurface(open_loop)
+
+    def test_symmetric(self):
+        kappa = 1.5
+        delta = 0.4
+        fs = flux_surface_cunningham(7, 0, 1, kappa, delta, n=1000)
+        fs.close()
+        fs = ClosedFluxSurface(fs)
+        assert np.isclose(fs.kappa, kappa)
+        assert np.isclose(fs.kappa_lower, kappa)
+        assert np.isclose(fs.kappa_upper, kappa)
+        assert np.isclose(fs.delta_lower, fs.delta_upper)
+        assert np.isclose(fs.zeta_lower, fs.zeta_upper)
+
+    def test_asymmetric(self):
+
+        kappa_u, kappa_l, delta_u, delta_l, a1, a2, a3, a4 = (
+            1.9,
+            1.6,
+            0.4,
+            0.33,
+            60,
+            30,
+            -20,
+            5,
+        )
+        fs = flux_surface_johner(
+            7, 0, 2, kappa_u, kappa_l, delta_u, delta_l, a1, a2, a3, a4, n=1000
+        )
+        fs.close()
+        fs = ClosedFluxSurface(fs)
+        assert not np.isclose(fs.zeta_upper, fs.zeta_lower)
 
 
 class TestFieldLine:


### PR DESCRIPTION
## Linked Issues

c.f. STEP teams chat

## Description

Adds a calculation for the outer upper and lower squareness of a closed flux surface, following Holcomb et al.'s definition of it, see: DOI:10.1063/1.3125934

## Interface Changes

`eq.analyse_core` now returns `CoreResults` in which the squareness is also included

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
