### PR TITLE
Pass axis to plot_3d if specified

### DIFF
--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -420,7 +420,7 @@ class BasePlotter(ABC):
         if not self._check_options():
             self.ax = ax
         else:
-            self.initialize_plot_3d()
+            self.initialize_plot_3d(ax=ax)
             # this function can be common to 2D and 3D plot
             # self._data is used for 3D plot
             # self._data_to_plot is used for 2D plot

--- a/tests/bluemira/display/test_plotter.py
+++ b/tests/bluemira/display/test_plotter.py
@@ -27,7 +27,8 @@ import numpy as np
 
 import bluemira.geometry as geo
 from bluemira.base.components import Component, PhysicalComponent
-from bluemira.display import plotter
+from bluemira.display import plot_3d, plotter
+from bluemira.utilities.plot_tools import Plot3D
 
 SQUARE_POINTS = np.array(
     [
@@ -108,6 +109,29 @@ class TestPlotOptions:
 
         for key, val in plotter.DEFAULT_PLOT_OPTIONS.items():
             assert getattr(the_options, key) != val
+
+
+class TestPlot3d:
+    """
+    Generic 3D plotting tests.
+    """
+
+    def test_plot_3d_same_axis(self):
+        ax_orig = Plot3D()
+        ax_1 = plot_3d(geo.tools.make_circle(), show=False, ax=ax_orig)
+        ax_2 = plot_3d(geo.tools.make_circle(radius=2), show=False, ax=ax_1)
+
+        assert ax_1 is ax_orig
+        assert ax_2 is ax_orig
+
+    def test_plot_3d_new_axis(self):
+        ax_orig = Plot3D()
+        ax_1 = plot_3d(geo.tools.make_circle(), show=False)
+        ax_2 = plot_3d(geo.tools.make_circle(radius=2), show=False)
+
+        assert ax_1 is not ax_2
+        assert ax_1 is not ax_orig
+        assert ax_2 is not ax_orig
 
 
 class TestPointsPlotter:


### PR DESCRIPTION
## Linked Issues

N/A

## Description

When providing an axis to `plot_3d`, this wasn't being passed through into the initialisation of the plot. This PR ensures that the axis is always provided to `initialize_plot_3d`.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
