### PR TITLE
🐛 safety factor an array or float not list

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1219,7 +1219,7 @@ class Equilibrium(MHDState):
                     )
                 )
             flux_surfaces.append(f_s)
-        q = [f_s.safety_factor(self) for f_s in flux_surfaces]
+        q = np.array([f_s.safety_factor(self) for f_s in flux_surfaces])
         if len(q) == 1:
             q = q[0]
         return q


### PR DESCRIPTION
## Description

Without this the eqdsk writer sometimes crashes

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
