### PR TITLE
Move arguments to init

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -32,7 +32,7 @@ from typing import Dict, List, Literal, Optional, Union
 
 from bluemira.base.components import Component
 from bluemira.base.error import BuilderError
-from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
+from bluemira.base.look_and_feel import bluemira_debug, bluemira_print
 from bluemira.base.parameter import ParameterFrame
 
 __all__ = ["Builder", "BuildConfig"]
@@ -94,38 +94,22 @@ class Builder(abc.ABC):
         self._validate_config(build_config)
         self._extract_config(build_config)
         self._params = ParameterFrame.from_template(self._required_params)
-        self.reinitialise(params)
+        self.reinitialise(params, **kwargs)
 
-    def __call__(self, params, *args, **kwargs) -> Component:
+    def __call__(self) -> Component:
         """
-        Perform the full build process, including reinitialisation, using the provided
-        parameters.
-
-        Parameters
-        ----------
-        params: Dict[str, Any]
-            The parameterisation containing at least the required params for this
-            Builder.
+        Perform the full build process using the current parameterisation of the builder.
 
         Returns
         -------
         component: Component
             The Component build by this builder.
         """
-        bluemira_print(f"Reinitialising and running full build chain for {self.name}")
-        self.reinitialise(params)
-        run_result = {}
+        bluemira_print(f"Running full build chain for {self.name}")
         if hasattr(self, "_runmode"):
             bluemira_print(f"Designing {self.name} using runmode: {self.runmode}")
-            run_result = self._runmode(self, *args, **kwargs) or {}
-            if not isinstance(run_result, dict):
-                bluemira_warn(
-                    "Result of builder runmode expected to be a dict or None. "
-                    f"Got {run_result} for builder {self.name} "
-                    "- defaulting to an empty dictionary."
-                )
-                run_result = {}
-        return self.build(**run_result)
+            self._runmode(self)
+        return self.build()
 
     @abc.abstractmethod
     def reinitialise(self, params, **kwargs) -> None:
@@ -142,7 +126,7 @@ class Builder(abc.ABC):
         self._reset_params(params)
 
     @abc.abstractmethod
-    def build(self, **kwargs) -> Component:
+    def build(self) -> Component:
         """
         Runs this Builder's build process to populate the required Components.
 
@@ -194,19 +178,19 @@ class Builder(abc.ABC):
         """
         return self._design_problem
 
-    def run(self, *args, **kwargs):
+    def run(self):
         """
         Optional abstract method to run a design problem while building.
         """
         raise NotImplementedError
 
-    def read(self, *args, **kwargs):
+    def read(self):
         """
         Optional abstract method to read the result of a design problem while building.
         """
         raise NotImplementedError
 
-    def mock(self, *args, **kwargs):
+    def mock(self):
         """
         Optional abstract method to mock a design problem while building.
         """

--- a/bluemira/base/design.py
+++ b/bluemira/base/design.py
@@ -134,7 +134,7 @@ class DesignABC(abc.ABC):
         else:
             raise BuilderError(f"Builder {name} already exists in {self}.")
 
-    def _build_stage(self, name: str, **kwargs) -> Component:
+    def _build_stage(self, name: str) -> Component:
         """
         Build the requested stage and update the design's parameters.
 
@@ -148,7 +148,7 @@ class DesignABC(abc.ABC):
         component: Component
             The resulting component from the build.
         """
-        component = self._builders[name](self._params.to_dict(), **kwargs)
+        component = self._builders[name]()
         self._params.update_kw_parameters(self._builders[name].params.to_dict())
 
         return component

--- a/bluemira/builders/EUDEMO/plasma.py
+++ b/bluemira/builders/EUDEMO/plasma.py
@@ -152,7 +152,6 @@ class PlasmaBuilder(Builder):
         bluemira_print("Running Plasma equilibrium design problem")
         eq = self._create_equilibrium()
         self._analyse_equilibrium(eq)
-        self._boundary = make_polygon(eq.get_LCFS().xyz, "LCFS")
 
     def read(self):
         """
@@ -161,7 +160,6 @@ class PlasmaBuilder(Builder):
         bluemira_print("Reading Plasma equilibrium design problem")
         eq = self._read_equilibrium()
         self._analyse_equilibrium(eq)
-        self._boundary = make_polygon(eq.get_LCFS().xyz, "LCFS")
 
     def mock(self):
         """
@@ -296,7 +294,14 @@ class PlasmaBuilder(Builder):
 
     def _analyse_equilibrium(self, eq: Equilibrium):
         """
-        Analyse an equilibrium and store important values in the Plasma parameters.
+        Analyse an equilibrium and store important values in the Plasma parameters. Also
+        updates the equilibrium and boundary to ensure that they are kept synchronised
+        with the parameters.
+
+        Parameters
+        ----------
+        eq: Equilibrium
+            The equilibrium to analyse for use with this builder.
         """
         plasma_dict = eq.analyse_plasma()
 
@@ -316,7 +321,9 @@ class PlasmaBuilder(Builder):
             "shaf_shift": shaf,
         }
         self._params.update_kw_parameters(params, source="equilibria")
+
         self._equilibrium = eq
+        self._boundary = make_polygon(eq.get_LCFS().xyz, "LCFS")
 
     def build(self) -> PlasmaComponent:
         """

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -164,20 +164,20 @@ class EUDEMOReactor(Reactor):
 
             config["geom_path"] = geom_path
 
-        builder = TFCoilsBuilder(self._params.to_dict(), config)
-        self.register_builder(builder, name)
-
         plasma = component_tree.get_component("Plasma")
         sep_comp: PhysicalComponent = plasma.get_component("xz").get_component("LCFS")
         sep_shape = sep_comp.shape.boundary[0]
 
-        component = super()._build_stage(name, separatrix=sep_shape)
+        builder = TFCoilsBuilder(self._params.to_dict(), config, separatrix=sep_shape)
+        self.register_builder(builder, name)
+
+        component = super()._build_stage(name)
 
         bluemira_print(f"Completed design stage: {name}")
 
         return component
 
-    def build_PF_coils(self, component_tree: Component, **kwargs):
+    def build_PF_coils(self, component_tree: Component):
         """
         Run the PF Coils build using the requested mode.
         """

--- a/bluemira/builders/EUDEMO/tf_coils.py
+++ b/bluemira/builders/EUDEMO/tf_coils.py
@@ -135,14 +135,14 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
     _design_problem: Optional[GeometryOptimisationProblem] = None
     _centreline: BluemiraWire
     _geom_path: Optional[str] = None
-    _keep_out_zone: BluemiraWire
-    _separatrix: BluemiraWire
+    _keep_out_zone: Optional[BluemiraWire] = None
+    _separatrix: Optional[BluemiraWire] = None
 
     def __init__(
         self,
         params,
         build_config: BuildConfig,
-        separatrix: BluemiraWire,
+        separatrix: Optional[BluemiraWire] = None,
         keep_out_zone: Optional[BluemiraWire] = None,
     ):
         super().__init__(
@@ -191,7 +191,7 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
     def reinitialise(
         self,
         params,
-        separatrix: BluemiraWire,
+        separatrix: Optional[BluemiraWire] = None,
         keep_out_zone: Optional[BluemiraWire] = None,
     ) -> None:
         """
@@ -202,8 +202,24 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         params: Dict[str, Any]
             The parameterisation containing at least the required params for this
             Builder.
+        separatrix: Optional[BluemiraWire]
+            The separatrix to pass into constrained optimisation routines. Must be
+            provided if this Builder's runmode is set to run. By default, None.
+        keep_out_zone: Optional[BluemiraWire]
+            Exclusion zone, if any to apply to the build. By default None.
+
+        Raises
+        ------
+        BuilderError
+            If the runmode is set to run but a separatrix is not provided.
         """
         super().reinitialise(params)
+
+        if self.runmode == "run" and separatrix is None:
+            raise BuilderError(
+                "A separatrix must be provided as the runmode for this builder is set "
+                "to run"
+            )
 
         self._centreline = None
         self._wp_cross_section = self._make_wp_xs()

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -42,15 +42,17 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
 
     _param_class: Type[GeometryParameterisation]
     _variables_map: Dict[str, str]
+    _label: str
     _segment_angle: float
     _boundary: BluemiraWire
 
     def _extract_config(self, build_config: BuildConfig):
         super()._extract_config(build_config)
 
+        self._label = build_config.get("label", "LCFS")
         self._segment_angle = build_config.get("segment_angle", 360.0)
 
-    def reinitialise(self, params, **kwargs):
+    def reinitialise(self, params):
         """
         Create the GeometryParameterisation from the provided param_class and
         variables_map and extract the resulting shape as the plasma boundary.
@@ -61,45 +63,39 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
             The parameterisation containing at least the required params for this
             Builder.
         """
-        super().reinitialise(params, **kwargs)
+        super().reinitialise(params)
 
         self._boundary = self._shape.create_shape()
 
-    def build(self, label: str = "LCFS", **kwargs):
+    def build(self):
         """
         Build a plasma with a boundary shape defined by the parameterisation.
         """
-        component = super().build(**kwargs)
+        component = super().build()
 
-        component.add_child(self.build_xz(label=label))
-        component.add_child(self.build_xy(label=label))
-        component.add_child(self.build_xyz(label=label))
+        component.add_child(self.build_xz())
+        component.add_child(self.build_xy())
+        component.add_child(self.build_xyz())
 
         return component
 
-    def build_xz(self, *, label: str = "LCFS", **kwargs) -> Component:
+    def build_xz(self) -> Component:
         """
         Build a PhysicalComponent with a BluemiraFace using the provided plasma boundary
         in the xz plane.
 
-        Parameters
-        ----------
-        label: str
-            The label to apply to the resulting component, by default "LCFS".
-
         Returns
         -------
         result: Component
-            The resulting component representing the xz view of the LCFS.
+            The resulting component representing the xz view of the Plasma.
         """
-        # TODO: Specify a palette so that the plotting options are set up here.
-        face = BluemiraFace(self._boundary, label)
-        component = PhysicalComponent("LCFS", face)
+        face = BluemiraFace(self._boundary, self._label)
+        component = PhysicalComponent(self._label, face)
         component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]
 
         return Component("xz").add_child(component)
 
-    def build_xy(self, *, label: str = "LCFS", **kwargs) -> Component:
+    def build_xy(self) -> Component:
         """
         Build a PhysicalComponent with a BluemiraFace using the plasma boundary in the
         xy plane.
@@ -107,44 +103,31 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
         The projection onto the xy plane is taken as the ring bound by the maximum and
         minimum values of the boundary in the radial direction.
 
-        Parameters
-        ----------
-        label: str
-            The label to apply to the resulting component, by default "LCFS".
-
         Returns
         -------
         result: PhysicalComponent
-            The resulting component representing the xy view of the LCFS.
+            The resulting component representing the xy view of the Plasma.
         """
-        # TODO: Specify a palette so that the plotting options are set up here.
         inner = make_circle(self._boundary.bounding_box.x_min, axis=[0, 1, 0])
         outer = make_circle(self._boundary.bounding_box.x_max, axis=[0, 1, 0])
 
-        face = BluemiraFace([outer, inner], label)
-        component = PhysicalComponent(label, face)
+        face = BluemiraFace([outer, inner], self._label)
+        component = PhysicalComponent(self._label, face)
         component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]
 
         return Component("xy").add_child(component)
 
-    def build_xyz(
-        self,
-        *,
-        label: str = "LCFS",
-        segment_angle: Optional[float] = None,
-        **kwargs,
-    ) -> PhysicalComponent:
+    def build_xyz(self, segment_angle: Optional[float] = None) -> PhysicalComponent:
         """
         Build a PhysicalComponent with a BluemiraShell using the plasma boundary in 3D.
 
         The 3D shell is created by revolving the boundary through the provided segment
-        angle.
+        angle. If the segment angle isn't given then the configured value for the Builder
+        is used.
 
         Parameters
         ----------
-        label: str
-            The label to apply to the resulting component, by default "LCFS".
-        segment_angle: float
+        segment_angle: Optional[float]
             The angle [°] around which to revolve the 3D geometry.
 
         Returns
@@ -156,7 +139,7 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
             segment_angle = self._segment_angle
 
         shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=segment_angle)
-        component = PhysicalComponent(label, shell)
+        component = PhysicalComponent(self._label, shell)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
 
         return Component("xyz").add_child(component)

--- a/bluemira/builders/shapes.py
+++ b/bluemira/builders/shapes.py
@@ -78,7 +78,7 @@ class ParameterisedShapeBuilder(Builder):
             shape_params[key] = val
         return shape_params
 
-    def reinitialise(self, params, **kwargs):
+    def reinitialise(self, params):
         """
         Create the GeometryParameterisation from the provided param_class and
         variables_map.
@@ -89,7 +89,7 @@ class ParameterisedShapeBuilder(Builder):
             The parameterisation containing at least the required params for this
             Builder.
         """
-        super().reinitialise(params, **kwargs)
+        super().reinitialise(params)
 
         shape_params = self._derive_shape_params()
         shape = self._param_class(shape_params)
@@ -193,7 +193,7 @@ class SimpleBuilderMixin:
 
         self._label: str = build_config["label"]
 
-    def build(self, **kwargs) -> Component:
+    def build(self) -> Component:
         """
         Build the components from parameterised shapes using the provided configuration
         and parameterisation.
@@ -203,7 +203,7 @@ class SimpleBuilderMixin:
         component: Component
             The Component built by this builder.
         """
-        component = super().build(**kwargs)
+        component = super().build()
 
         component.add_child(
             PhysicalComponent(self._label, self._shape.create_shape(label=self._label))

--- a/examples/design/design_plasma.ipynb
+++ b/examples/design/design_plasma.ipynb
@@ -1,0 +1,194 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from bluemira.base.design import Design\n",
+        "from bluemira.builders.plasma import MakeParameterisedPlasma"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Configuring and Running a Simple Parameterised Design\n",
+        "\n",
+        "This example shows how to set up a parameterised design with a single build stage.\n",
+        "The build stage takes the provided major radius (`R_0`) aspect ratio (`A`) parameters,\n",
+        "maps these onto a parameterised shape, which in this case is a Johner parameterisation\n",
+        "of the last closed flux surface (LCFS).\n",
+        "\n",
+        "## Configuring the design\n",
+        "\n",
+        "First we have to specify a `build_config` for our design. This gives the build stages\n",
+        "that will be run within the design, what `Builder` class will be used for the build\n",
+        "at that stage, and how that `Builder` should be configured. Here we see that we are\n",
+        "specifying a build stage called \"Plasma\", that will use the `MakeParameterisedPlasma`\n",
+        "class of `Builder`. We specify that the parameterisation class to use should be\n",
+        "`JohnerLCFS`, the implementation of which is in the `bluemira.equilibria.shapes`\n",
+        "module. We map the `R_0` and `A` external parameters onto the `r_0` and `a` parameters\n",
+        "for that shape, and give the `PhysicalComponent` that results from the build a label of\n",
+        "LCFS."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "build_config = {\n",
+        "    \"Plasma\": {\n",
+        "        \"class\": \"MakeParameterisedPlasma\",\n",
+        "        \"param_class\": \"bluemira.equilibria.shapes::JohnerLCFS\",\n",
+        "        \"variables_map\": {\n",
+        "            \"r_0\": \"R_0\",\n",
+        "            \"a\": \"A\",\n",
+        "        },\n",
+        "        \"label\": \"LCFS\",\n",
+        "    },\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Parameterising the Design\n",
+        "\n",
+        "Now that we have set up the design to be performed, we need to provide the values to\n",
+        "which to set each of the parameters that are needed for the design. We also need to\n",
+        "provide a `Name` for our design so that it can be identified."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "params = {\n",
+        "    \"Name\": \"A Plasma Design\",\n",
+        "    \"R_0\": (9.0, \"Input\"),\n",
+        "    \"A\": (3.5, \"Input\"),\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Running the Design\n",
+        "\n",
+        "After configuring and parameterising our design, we can now run it as below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "design = Design(params, build_config)\n",
+        "result = design.run()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspecting the Design Results\n",
+        "\n",
+        "Our design has now completed and we have the resulting `Component` available in our\n",
+        "`result` variable. This component gives us a tree of values that we can navigate to\n",
+        "see the shapes produced by our design in different dimensions (or views). In this case\n",
+        "our top level `Component` is what we named our design, then the next level is the\n",
+        "system that has been built as part of our build stages. We then see the representation\n",
+        "of that system in various dimensions, followed by the physical components the define\n",
+        "the shapes that make up that system in the given view."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "print(result.tree())"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can also plot our components in each of the provided dimensions, as well as viewing\n",
+        "the 3D cad for the xyz dimension. Finally we can also access the `Builder` that was\n",
+        "used by the build stage in order to re-run part of the design. In this case we are\n",
+        "able to generate a new 3D component using the same `Builder` but this time we sweep it\n",
+        "through 270 degrees, rather than the full 360."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "color = (0.80078431, 0.54, 0.80078431)\n",
+        "for dims in [\"xz\", \"xy\"]:\n",
+        "    lcfs = result.get_component(\"Plasma\").get_component(dims).get_component(\"LCFS\")\n",
+        "    lcfs.plot_options.face_options[\"color\"] = color\n",
+        "    lcfs.plot_2d()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "lcfs = result.get_component(\"Plasma\").get_component(\"xyz\").get_component(\"LCFS\")\n",
+        "lcfs.display_cad_options.color = color\n",
+        "lcfs.display_cad_options.transparency = 0.2\n",
+        "lcfs.show_cad()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "plasma_builder: MakeParameterisedPlasma = design.get_builder(\"Plasma\")\n",
+        "lcfs = plasma_builder.build_xyz(segment_angle=270.0)\n",
+        "lcfs.display_cad_options.color = color\n",
+        "lcfs.show_cad()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ],
+  "metadata": {
+    "anaconda-cloud": {},
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/examples/design/design_plasma.py
+++ b/examples/design/design_plasma.py
@@ -23,8 +23,31 @@
 A basic tutorial for configuring and running a design with a parameterised plasma.
 """
 
+# %%
 from bluemira.base.design import Design
 from bluemira.builders.plasma import MakeParameterisedPlasma
+
+# %%[markdown]
+# # Configuring and Running a Simple Parameterised Design
+#
+# This example shows how to set up a parameterised design with a single build stage.
+# The build stage takes the provided major radius (`R_0`) aspect ratio (`A`) parameters,
+# maps these onto a parameterised shape, which in this case is a Johner parameterisation
+# of the last closed flux surface (LCFS).
+#
+# ## Configuring the design
+#
+# First we have to specify a `build_config` for our design. This gives the build stages
+# that will be run within the design, what `Builder` class will be used for the build
+# at that stage, and how that `Builder` should be configured. Here we see that we are
+# specifying a build stage called "Plasma", that will use the `MakeParameterisedPlasma`
+# class of `Builder`. We specify that the parameterisation class to use should be
+# `JohnerLCFS`, the implementation of which is in the `bluemira.equilibria.shapes`
+# module. We map the `R_0` and `A` external parameters onto the `r_0` and `a` parameters
+# for that shape, and give the `PhysicalComponent` that results from the build a label of
+# LCFS.
+
+# %%
 
 build_config = {
     "Plasma": {
@@ -34,27 +57,69 @@ build_config = {
             "r_0": "R_0",
             "a": "A",
         },
+        "label": "LCFS",
     },
 }
+
+# %%[markdown]
+# ## Parameterising the Design
+#
+# Now that we have set up the design to be performed, we need to provide the values to
+# which to set each of the parameters that are needed for the design. We also need to
+# provide a `Name` for our design so that it can be identified.
+
+# %%
+
 params = {
     "Name": "A Plasma Design",
     "R_0": (9.0, "Input"),
     "A": (3.5, "Input"),
 }
+
+# %%[markdown]
+# ## Running the Design
+#
+# After configuring and parameterising our design, we can now run it as below.
+
+# %%
 design = Design(params, build_config)
 result = design.run()
 
+# %%[markdown]
+# ## Inspecting the Design Results
+#
+# Our design has now completed and we have the resulting `Component` available in our
+# `result` variable. This component gives us a tree of values that we can navigate to
+# see the shapes produced by our design in different dimensions (or views). In this case
+# our top level `Component` is what we named our design, then the next level is the
+# system that has been built as part of our build stages. We then see the representation
+# of that system in various dimensions, followed by the physical components the define
+# the shapes that make up that system in the given view.
+
+# %%
+print(result.tree())
+
+# %%[markdown]
+# We can also plot our components in each of the provided dimensions, as well as viewing
+# the 3D cad for the xyz dimension. Finally we can also access the `Builder` that was
+# used by the build stage in order to re-run part of the design. In this case we are
+# able to generate a new 3D component using the same `Builder` but this time we sweep it
+# through 270 degrees, rather than the full 360.
+
+# %%
 color = (0.80078431, 0.54, 0.80078431)
 for dims in ["xz", "xy"]:
     lcfs = result.get_component("Plasma").get_component(dims).get_component("LCFS")
     lcfs.plot_options.face_options["color"] = color
     lcfs.plot_2d()
 
+# %%
 lcfs = result.get_component("Plasma").get_component("xyz").get_component("LCFS")
 lcfs.display_cad_options.color = color
 lcfs.display_cad_options.transparency = 0.2
 lcfs.show_cad()
 
+# %%
 plasma_builder: MakeParameterisedPlasma = design.get_builder("Plasma")
 lcfs = plasma_builder.build_xyz(segment_angle=270.0)
 lcfs.display_cad_options.color = color

--- a/tests/bluemira/builders/EUDEMO/test_tf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_tf_coils.py
@@ -60,9 +60,14 @@ class TestTFCoils:
 
     def test_read_from_dir(self):
         builder = TFCoilsBuilder(self.params, self.build_config)
-        builder(self.params)
+        builder()
 
     def test_mock(self):
         self.build_config["runmode"] = "mock"
         builder = TFCoilsBuilder(self.params, self.build_config)
-        builder(self.params)
+        builder()
+
+    def test_run_no_separatrix(self):
+        self.build_config["runmode"] = "run"
+        with pytest.raises(BuilderError):
+            TFCoilsBuilder(self.params, self.build_config)

--- a/tests/bluemira/builders/test_plasma.py
+++ b/tests/bluemira/builders/test_plasma.py
@@ -45,7 +45,7 @@ class TestMakeParameterisedPlasma:
             "segment_angle": 270.0,
         }
         builder = MakeParameterisedPlasma(params, build_config)
-        component = builder(params)
+        component = builder()
         assert component is not None
         assert isinstance(component, Component)
         assert len(component.children) == 3

--- a/tests/bluemira/builders/test_shapes.py
+++ b/tests/bluemira/builders/test_shapes.py
@@ -57,7 +57,7 @@ class TestMakeParameterisedShape:
             "label": "Shape",
         }
         cls.builder = MakeParameterisedShape(cls.params, cls.build_config)
-        cls.component = cls.builder(cls.params)
+        cls.component = cls.builder()
 
     def test_builder_output(self):
         """
@@ -156,7 +156,7 @@ class TestMakeOptimisedShape:
             "label": "Shape",
         }
         builder = MakeOptimisedShape(params, build_config)
-        component = builder(params)
+        component = builder()
 
         assert component is not None
 


### PR DESCRIPTION
## Linked Issues

Related to #629 

## Description

This moves various kwargs usage, which is currently prevalent in many function signatures, to the init function. In this way, each builder can be set up and reinitialised as required, but is always called the same way. The usage of explicit arguments on the implementations of the init functions for concrete classes should also make it easier to follow what arguments need to be passed in.

## Interface Changes

The `Builder` classes now setup everything that they need in `__init__` and `reinitialise`. This means that the `build` and runmodes (`run`/`read`/`mock`) are called consistently without any arguments. The `_build_stage` in `Reactor` is now also called without arguments. `kwargs` are removed from places where they are not longer used.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
