### PR TITLE
Implement "natural order sort" in for coil names in CoilGroup

### DIFF
--- a/bluemira/equilibria/coils.py
+++ b/bluemira/equilibria/coils.py
@@ -24,6 +24,7 @@ Coil and coil grouping objects
 """
 
 from copy import deepcopy
+from re import split
 from typing import Any, Optional
 
 import matplotlib.pyplot as plt
@@ -888,9 +889,15 @@ class CoilGroup:
         cs_coils = [coil for coil in coils if coil.ctype == "CS"]
         other = [coil for coil in coils if coil.ctype not in ["PF", "CS"]]
 
-        pf_coils.sort(key=lambda x: x.name)
-        cs_coils.sort(key=lambda x: x.name)
-        other.sort(key=lambda x: x.name)
+        def sort_function(key):
+            return [
+                int(text) if text.isdigit() else text
+                for text in split(r"(\d+)", key.name)
+            ]
+
+        pf_coils.sort(key=sort_function)
+        cs_coils.sort(key=sort_function)
+        other.sort(key=sort_function)
 
         all_coils = pf_coils + cs_coils + other
 

--- a/tests/bluemira/equilibria/test_coils.py
+++ b/tests/bluemira/equilibria/test_coils.py
@@ -544,5 +544,18 @@ class TestCoilSizing:
             Coil(4, 4, dz=1)
 
 
+class TestCoilSorting:
+    def test_sorting_coilset(self):
+        """Ensure sorting of coils properly handles numbers in the coil name."""
+        coils = [
+            Coil(5, 5, 0, dx=1.0, dz=1.0, name="CS_2"),
+            Coil(5, 5, 0, dx=1.0, dz=1.0, name="CS_10"),
+        ]
+        sorted_coils = CoilGroup.sort_coils(coils)
+        sorted_names = list(sorted_coils)
+        assert sorted_names[0] == "CS_2"
+        assert sorted_names[1] == "CS_10"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Linked Issues

Closes #655.

## Description

This changes the way coils are sorted in the `CoilGroup.sort_coils` method. Previously they were sorted into alphabetical order, which naively meant that numbers in strings were sorted based on their leading digit. This has now been changed so that any numbers present in the string will be sorted according to their numerical value. This is a so-called "natural sort order".

## Interface Changes

None.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
