### PR TITLE
Allow 3D builds through provided angle

### DIFF
--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -185,8 +185,14 @@ class PFCoilsBuilder(Builder):
     def build_xy(self):
         """
         Build the x-y components of the PF coils.
+
+        Returns
+        -------
+        component: Component
+            The component grouping the results in the xy plane.
         """
         xy_comps = []
+        comp: PFCoilBuilder
         for comp in self.sub_components:
             xy_comps.append(comp.build_xy())
         component = Component("xy", children=xy_comps)
@@ -196,21 +202,38 @@ class PFCoilsBuilder(Builder):
     def build_xz(self):
         """
         Build the x-z components of the PF coils.
+
+        Returns
+        -------
+        component: Component
+            The component grouping the results in the xz plane.
         """
         xz_comps = []
+        comp: PFCoilBuilder
         for comp in self.sub_components:
             xz_comps.append(comp.build_xz())
         component = Component("xz", children=xz_comps)
         bm_plot_tools.set_component_plane(component, "xz")
         return component
 
-    def build_xyz(self):
+    def build_xyz(self, degree: float = 360.0):
         """
         Build the x-y-z components of the PF coils.
+
+        Parameters
+        ----------
+        degree: float
+            The angle [°] around which to build the components, by default 360.0.
+
+        Returns
+        -------
+        component: Component
+            The component grouping the results in 3D (xyz).
         """
         xyz_comps = []
+        comp: PFCoilBuilder
         for comp in self.sub_components:
-            xyz_comps.append(comp.build_xyz())
+            xyz_comps.append(comp.build_xyz(degree=degree))
         component = Component("xyz", children=xyz_comps)
         return component
 

--- a/bluemira/builders/EUDEMO/plasma.py
+++ b/bluemira/builders/EUDEMO/plasma.py
@@ -114,7 +114,6 @@ class PlasmaBuilder(Builder):
     _boundary: Optional[BluemiraWire] = None
     _equilibrium: Optional[Equilibrium] = None
     _plot_flag: bool
-    _segment_angle: float
     _eqdsk_path: Optional[str] = None
     _default_runmode: str = "run"
 
@@ -129,7 +128,6 @@ class PlasmaBuilder(Builder):
             self._eqdsk_path = build_config["eqdsk_path"]
 
         self._plot_flag = build_config.get("plot_flag", False)
-        self._segment_angle = build_config.get("segment_angle", 360.0)
 
     def reinitialise(self, params) -> None:
         """
@@ -419,12 +417,17 @@ class PlasmaBuilder(Builder):
 
         return component
 
-    def build_xyz(self, segment_angle: Optional[float] = None) -> Component:
+    def build_xyz(self, degree: float = 360.0) -> Component:
         """
         Build the 3D representation of this plasma.
 
         Generates the LCFS from the _boundary defined on the builder by revolving around
         the z axis.
+
+        Parameters
+        ----------
+        degree: float
+            The angle [°] around which to build the components, by default 360.0.
 
         Returns
         -------
@@ -439,10 +442,7 @@ class PlasmaBuilder(Builder):
         """
         self._ensure_boundary()
 
-        if segment_angle is None:
-            segment_angle = self._segment_angle
-
-        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=segment_angle)
+        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=degree)
         component = PhysicalComponent("LCFS", shell)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
         component.display_cad_options.transparency = 0.5

--- a/bluemira/builders/EUDEMO/tf_coils.py
+++ b/bluemira/builders/EUDEMO/tf_coils.py
@@ -397,17 +397,32 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
 
         return component
 
-    def build_xyz(self) -> Component:
+    def build_xyz(self, degree: float = 360.0) -> Component:
         """
         Build the x-y-z components of the TF coils.
+
+        Parameters
+        ----------
+        degree: float
+            The angle [°] around which to build the components, by default 360.0.
+
+        Returns
+        -------
+        component: Component
+            The component grouping the results in 3D (xyz).
         """
         component = Component("xyz")
+
+        # Minimum angle per TF coil
+        min_tf_deg = 360.0 / self._params.n_TF.value
+        n_tf_draw = min(int(degree // min_tf_deg) + 1, self._params.n_TF.value)
+        degree = min_tf_deg * n_tf_draw
 
         # Winding pack
         wp_solid = sweep_shape(self._wp_cross_section, self._centreline)
         winding_pack = PhysicalComponent("Winding pack", wp_solid)
         winding_pack.display_cad_options.color = BLUE_PALETTE["TF"][1]
-        sectors = circular_pattern_component(winding_pack, self._params.n_TF.value)
+        sectors = circular_pattern_component(winding_pack, n_tf_draw, degree=degree)
         component.add_children(sectors, merge_trees=True)
 
         # Insulation
@@ -417,7 +432,7 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         ins_solid = boolean_cut(solid, wp_solid)[0]
         insulation = PhysicalComponent("Insulation", ins_solid)
         insulation.display_cad_options.color = BLUE_PALETTE["TF"][2]
-        sectors = circular_pattern_component(insulation, self._params.n_TF.value)
+        sectors = circular_pattern_component(insulation, n_tf_draw, degree=degree)
         component.add_children(sectors, merge_trees=True)
 
         # Casing
@@ -509,7 +524,7 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
 
         casing = PhysicalComponent("Casing", case_solid_hollow)
         casing.display_cad_options.color = BLUE_PALETTE["TF"][0]
-        sectors = circular_pattern_component(casing, self._params.n_TF.value)
+        sectors = circular_pattern_component(casing, n_tf_draw, degree=degree)
         component.add_children(sectors, merge_trees=True)
 
         return component

--- a/bluemira/builders/EUDEMO/tf_coils.py
+++ b/bluemira/builders/EUDEMO/tf_coils.py
@@ -413,8 +413,12 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         """
         component = Component("xyz")
 
-        # Minimum angle per TF coil
-        min_tf_deg = 360.0 / self._params.n_TF.value
+        # Minimum angle per TF coil (nudged by a tiny length since we start counting a
+        # sector at theta=0). This means we can draw a sector as 360 / n_TF and get one
+        # TF coil per sector. Python represents floats with 16 significant figures before
+        # getting round off, so adding on 1e-13 works here, in case someone sets n_TF
+        # to be 2.
+        min_tf_deg = (360.0 / self._params.n_TF.value) + 1e-13
         n_tf_draw = min(int(degree // min_tf_deg) + 1, self._params.n_TF.value)
         degree = min_tf_deg * n_tf_draw
 

--- a/bluemira/builders/EUDEMO/tf_coils.py
+++ b/bluemira/builders/EUDEMO/tf_coils.py
@@ -420,7 +420,7 @@ class TFCoilsBuilder(OptimisedShapeBuilder):
         # to be 2.
         min_tf_deg = (360.0 / self._params.n_TF.value) + 1e-13
         n_tf_draw = min(int(degree // min_tf_deg) + 1, self._params.n_TF.value)
-        degree = min_tf_deg * n_tf_draw
+        degree = (360.0 / self._params.n_TF.value) * n_tf_draw
 
         # Winding pack
         wp_solid = sweep_shape(self._wp_cross_section, self._centreline)

--- a/bluemira/builders/pf_coils.py
+++ b/bluemira/builders/pf_coils.py
@@ -120,15 +120,26 @@ class PFCoilBuilder:
         casing.plot_options.face_options["color"] = BLUE_PALETTE["PF"][2]
         return Component(self.coil.name, children=[wp, ins, casing])
 
-    def build_xyz(self):
+    def build_xyz(self, degree: float = 360.0):
         """
         Build the x-y-z representation of a PF coil.
+
+        Parameters
+        ----------
+        degree: float
+            The angle [°] around which to build the components, by default 360.0.
+
+        Returns
+        -------
+        component: Component
+            The component grouping the results in 3D (xyz).
         """
         # I doubt this is floating-point safe to collisions...
         c_xz = self.build_xz()
         components = []
+        c: PhysicalComponent
         for c in c_xz.children:
-            shape = revolve_shape(c.shape, degree=360)
+            shape = revolve_shape(c.shape, degree=degree)
             c_xyz = PhysicalComponent(c.name, shape)
             c_xyz.display_cad_options.color = c.plot_options.face_options["color"]
             components.append(c_xyz)

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -23,7 +23,7 @@
 Built-in build steps for making a parameterised plasma
 """
 
-from typing import Dict, Optional, Type
+from typing import Dict, Type
 
 from bluemira.base.builder import BuildConfig
 from bluemira.base.components import Component, PhysicalComponent
@@ -43,14 +43,12 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
     _param_class: Type[GeometryParameterisation]
     _variables_map: Dict[str, str]
     _label: str
-    _segment_angle: float
     _boundary: BluemiraWire
 
     def _extract_config(self, build_config: BuildConfig):
         super()._extract_config(build_config)
 
         self._label = build_config.get("label", "LCFS")
-        self._segment_angle = build_config.get("segment_angle", 360.0)
 
     def reinitialise(self, params):
         """
@@ -117,28 +115,24 @@ class MakeParameterisedPlasma(ParameterisedShapeBuilder):
 
         return Component("xy").add_child(component)
 
-    def build_xyz(self, segment_angle: Optional[float] = None) -> PhysicalComponent:
+    def build_xyz(self, degree: float = 360.0) -> PhysicalComponent:
         """
         Build a PhysicalComponent with a BluemiraShell using the plasma boundary in 3D.
 
-        The 3D shell is created by revolving the boundary through the provided segment
-        angle. If the segment angle isn't given then the configured value for the Builder
-        is used.
+        The 3D shell is created by revolving the boundary through the angle provided
+        through the degree parameter.
 
         Parameters
         ----------
-        segment_angle: Optional[float]
-            The angle [°] around which to revolve the 3D geometry.
+        degree: float
+            The angle [°] around which to revolve the 3D geometry, by default 360.0.
 
         Returns
         -------
         result: PhysicalComponent
             The resulting component.
         """
-        if segment_angle is None:
-            segment_angle = self._segment_angle
-
-        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=segment_angle)
+        shell = revolve_shape(self._boundary, direction=(0, 0, 1), degree=degree)
         component = PhysicalComponent(self._label, shell)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
 

--- a/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
@@ -8,12 +8,14 @@
         "\n",
         "import matplotlib.pyplot as plt\n",
         "\n",
+        "from bluemira.base.components import Component\n",
         "from bluemira.base.config import Configuration\n",
         "from bluemira.base.error import ParameterError\n",
         "from bluemira.base.file import get_bluemira_root\n",
         "from bluemira.base.logs import set_log_level\n",
         "from bluemira.base.parameter import ParameterMappingEncoder\n",
-        "from bluemira.builders.EUDEMO.plasma import PlasmaComponent\n",
+        "from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder\n",
+        "from bluemira.builders.EUDEMO.plasma import PlasmaBuilder, PlasmaComponent\n",
         "from bluemira.builders.EUDEMO.reactor import EUDEMOReactor\n",
         "from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder\n",
         "from bluemira.builders.tf_coils import RippleConstrainedLengthOpt\n",
@@ -701,6 +703,22 @@
       "metadata": {},
       "source": [
         "ComponentDisplayer().show_cad(component.get_component(\"xyz\", first=False))"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "component = Component(\"Segment View\")\n",
+        "plasma_builder: PlasmaBuilder = reactor.get_builder(\"Plasma\")\n",
+        "tf_coils_builder: TFCoilsBuilder = reactor.get_builder(\"TF Coils\")\n",
+        "pf_coils_builder: PFCoilsBuilder = reactor.get_builder(\"PF Coils\")\n",
+        "component.add_child(plasma_builder.build_xyz(degree=270))\n",
+        "component.add_child(tf_coils_builder.build_xyz(degree=270))\n",
+        "component.add_child(pf_coils_builder.build_xyz(degree=270))\n",
+        "component.show_cad()"
       ],
       "outputs": [],
       "execution_count": null

--- a/examples/design/EU-DEMO/EUDEMO_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.py
@@ -28,12 +28,14 @@ import pprint as pprint
 
 import matplotlib.pyplot as plt
 
+from bluemira.base.components import Component
 from bluemira.base.config import Configuration
 from bluemira.base.error import ParameterError
 from bluemira.base.file import get_bluemira_root
 from bluemira.base.logs import set_log_level
 from bluemira.base.parameter import ParameterMappingEncoder
-from bluemira.builders.EUDEMO.plasma import PlasmaComponent
+from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
+from bluemira.builders.EUDEMO.plasma import PlasmaBuilder, PlasmaComponent
 from bluemira.builders.EUDEMO.reactor import EUDEMOReactor
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
 from bluemira.builders.tf_coils import RippleConstrainedLengthOpt
@@ -476,3 +478,13 @@ pf_coils.get_component("xz").plot_2d(ax=ax)
 
 # %%
 ComponentDisplayer().show_cad(component.get_component("xyz", first=False))
+
+# %%
+component = Component("Segment View")
+plasma_builder: PlasmaBuilder = reactor.get_builder("Plasma")
+tf_coils_builder: TFCoilsBuilder = reactor.get_builder("TF Coils")
+pf_coils_builder: PFCoilsBuilder = reactor.get_builder("PF Coils")
+component.add_child(plasma_builder.build_xyz(degree=270))
+component.add_child(tf_coils_builder.build_xyz(degree=270))
+component.add_child(pf_coils_builder.build_xyz(degree=270))
+component.show_cad()

--- a/examples/design/design_plasma.ipynb
+++ b/examples/design/design_plasma.ipynb
@@ -161,7 +161,7 @@
       "metadata": {},
       "source": [
         "plasma_builder: MakeParameterisedPlasma = design.get_builder(\"Plasma\")\n",
-        "lcfs = plasma_builder.build_xyz(segment_angle=270.0)\n",
+        "lcfs = plasma_builder.build_xyz(degree=270.0)\n",
         "lcfs.display_cad_options.color = color\n",
         "lcfs.show_cad()"
       ],

--- a/examples/design/design_plasma.py
+++ b/examples/design/design_plasma.py
@@ -121,6 +121,6 @@ lcfs.show_cad()
 
 # %%
 plasma_builder: MakeParameterisedPlasma = design.get_builder("Plasma")
-lcfs = plasma_builder.build_xyz(segment_angle=270.0)
+lcfs = plasma_builder.build_xyz(degree=270.0)
 lcfs.display_cad_options.color = color
 lcfs.show_cad()

--- a/tests/bluemira/builders/EUDEMO/test_reactor.py
+++ b/tests/bluemira/builders/EUDEMO/test_reactor.py
@@ -35,7 +35,8 @@ import tests
 from bluemira.base.components import Component
 from bluemira.base.file import get_bluemira_root
 from bluemira.base.logs import get_log_level, set_log_level
-from bluemira.builders.EUDEMO.plasma import PlasmaComponent
+from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
+from bluemira.builders.EUDEMO.plasma import PlasmaBuilder, PlasmaComponent
 from bluemira.builders.EUDEMO.reactor import EUDEMOReactor
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder, TFCoilsComponent
 from bluemira.geometry.coordinates import Coordinates
@@ -169,3 +170,14 @@ class TestEUDEMO:
                 self.component.get_component("TF Coils").get_component("xyz"),
             ],
         ).show_cad()
+
+    def test_show_segment_cad(self):
+        component = Component("Segment View")
+        plasma_builder: PlasmaBuilder = self.reactor.get_builder("Plasma")
+        tf_coils_builder: TFCoilsBuilder = self.reactor.get_builder("TF Coils")
+        pf_coils_builder: PFCoilsBuilder = self.reactor.get_builder("PF Coils")
+        component.add_child(plasma_builder.build_xyz(degree=270))
+        component.add_child(tf_coils_builder.build_xyz(degree=270))
+        component.add_child(pf_coils_builder.build_xyz(degree=270))
+        if tests.PLOTTING:
+            component.show_cad()

--- a/tests/bluemira/builders/EUDEMO/test_tf_coils.py
+++ b/tests/bluemira/builders/EUDEMO/test_tf_coils.py
@@ -71,3 +71,12 @@ class TestTFCoils:
         self.build_config["runmode"] = "run"
         with pytest.raises(BuilderError):
             TFCoilsBuilder(self.params, self.build_config)
+
+    @pytest.mark.parametrize(
+        "degree,n_children", [(360, 18), (20, 1), (21, 2), (270, 14)]
+    )
+    def test_build_xyz(self, degree, n_children):
+        builder = TFCoilsBuilder(self.params, self.build_config)
+        builder.mock()
+        result = builder.build_xyz(degree=degree)
+        assert len(result.children) == n_children

--- a/tests/bluemira/builders/test_plasma.py
+++ b/tests/bluemira/builders/test_plasma.py
@@ -42,7 +42,6 @@ class TestMakeParameterisedPlasma:
                 "r_0": "R_0",
                 "a": "A",
             },
-            "segment_angle": 270.0,
         }
         builder = MakeParameterisedPlasma(params, build_config)
         component = builder()


### PR DESCRIPTION
## Linked Issues

N/A

## Description

This PR allows 3D builds to be created through a specified angle. This is intended to allow components to be visualised without wrapping around the whole reactor, allowing for cut-through views.

## Interface Changes

The `build_xyz` methods are given an optional `degree` parameter, which is 360 by default.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
