### PR TITLE
🎨 Dont crash on separatrix plotting failure

### DIFF
--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -33,6 +33,7 @@ from scipy.interpolate import RectBivariateSpline
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import J_TOR_MIN, M_PER_MN
+from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.find import Xpoint, get_contours, grid_2d_contour
 from bluemira.equilibria.physics import calc_psi
 from bluemira.utilities.plot_tools import str_to_latex
@@ -429,6 +430,7 @@ class EquilibriumPlotter(Plotter):
 
         # Do some housework
         self.psi = self.eq.psi()
+
         self.o_points, self.x_points = self.eq.get_OX_points(self.psi, force_update=True)
 
         if self.x_points:
@@ -511,15 +513,22 @@ class EquilibriumPlotter(Plotter):
         increasing values going outwards from plasma core.
         """
         psi = calc_psi(psi_norm, self.op_psi, self.xp_psi)
-        self.ax.contour(
-            self.eq.x, self.eq.z, self.psi, levels=[psi], colors=color, zorder=9
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.ax.contour(
+                self.eq.x, self.eq.z, self.psi, levels=[psi], colors=color, zorder=9
+            )
 
     def plot_separatrix(self):
         """
         Plot the separatrix.
         """
-        separatrix = self.eq.get_separatrix()
+        try:
+            separatrix = self.eq.get_separatrix()
+        except EquilibriaError:
+            bluemira_warn("Unable to plot separatrix")
+            return
+
         if isinstance(separatrix, list):
             loops = separatrix
         else:


### PR DESCRIPTION

## Description

Protects against not being able to plot separatrix, enables merge of #569 

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
