### PR TITLE
🎨 add ignore and change time for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "08:00"
+      time: "07:00"
     ignore:
       - dependency-name: "matplotlib" # Issue #234
       - dependency-name: "scipy"  # section-properties and numba-scipy limit
       - dependency-name: "numpy"  # numba limited
       - dependency-name: "section-properties" # beams needs to be updated
+      - dependency-name: "neutronics-material-maker" # incompatible upgrade path


### PR DESCRIPTION
## Description

Adds neutronics-material-maker to upgrades ignores and makes the time slightly earlier so its finished for me starting

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
