### PR TITLE
Add get legs functionality to `equilibria`

### DIFF
--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -816,7 +816,7 @@ def get_legs(equilibrium, n_layers: int = 1, dx_off: float = 0.0):
         dx_offsets = np.linspace(0, dx_off, n_layers)[1:]
 
     if isinstance(separatrix, Iterable):
-        # Double null (sort in/out top/bottom)
+        # Double null (sort in/out bottom/top)
         separatrix.sort(key=lambda half_sep: np.min(half_sep.x))
         x_points.sort(key=lambda x_point: x_point.z)
         legs = []
@@ -824,7 +824,7 @@ def get_legs(equilibrium, n_layers: int = 1, dx_off: float = 0.0):
             for x_p in x_points:
                 sep_leg = _extract_leg(half_sep, x_p.x, x_p.z, delta, o_point.z)
                 quadrant_legs = [sep_leg]
-                if dx_offsets:
+                if dx_offsets is not None:
                     quadrant_legs.extend(
                         _extract_offsets(
                             equilibrium, dx_offsets, sep_leg, direction, delta, o_point.z
@@ -844,7 +844,7 @@ def get_legs(equilibrium, n_layers: int = 1, dx_off: float = 0.0):
         legs.sort(key=lambda leg: leg.x[0])
         inner_leg, outer_leg = legs
         inner_legs, outer_legs = [inner_leg], [outer_leg]
-        if dx_offsets:
+        if dx_offsets is not None:
             inner_legs.extend(
                 _extract_offsets(
                     equilibrium, dx_offsets, inner_leg, -1, delta, o_point.z

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -24,6 +24,7 @@ Methods for finding O- and X-points and flux surfaces on 2-D arrays.
 """
 
 import operator
+from collections import Iterable
 
 import numba as nb
 import numpy as np
@@ -733,11 +734,27 @@ def get_legs(equilibrium):
 
     Parameters
     ----------
+    equilibrium: Equilibrium
+        Equilibrium for which to find the separatrix legs
 
     Returns
     -------
     legs: List[Loop]
-        Geometries of the legs
+        Geometries of the legs, sorted as:
+            [lower inner,  # if present
+             lower outer,  # if present
+             upper inner,  # if present
+             upper outer,  # if present
+            ]
+
+    Raises
+    ------
+    EquilibriaError: if a strange number of legs would be found for an X-point
+
+    Notes
+    -----
+    Will return two legs in the case of a single null
+    Will return four legs in the case of a double null
     """
 
     def extract_leg(flux_line, x_point):
@@ -779,13 +796,13 @@ def get_legs(equilibrium):
     separatrix = equilibrium.get_separatrix()
     delta = 2 * equilibrium.grid.dx
 
-    if equilibrium.is_double_null:
+    if isinstance(separatrix, Iterable):
+        # Double null
         legs = []
         for half_sep in separatrix:
             for x_p in x_points[:2]:
                 leg = extract_leg(half_sep, x_p)
                 legs.append(leg)
-
     else:
         # Single null
         legs = extract_leg(separatrix, x_points[0])

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -728,7 +728,7 @@ def find_LCFS_separatrix(
     return lcfs, separatrix
 
 
-def get_legs(equilibrium):
+def get_legs(equilibrium, n_layers: int, dx_off: float):
     """
     Get the legs of a separatrix.
 
@@ -736,10 +736,14 @@ def get_legs(equilibrium):
     ----------
     equilibrium: Equilibrium
         Equilibrium for which to find the separatrix legs
+    n_layers: int
+        Number of flux surfaces to extract for each leg
+    dx_off: float
+        Total span in radial space of the flux surfaces to extract
 
     Returns
     -------
-    legs: List[Loop]
+    legs: Dict[str, List[Loop]]
         Geometries of the legs, sorted as:
             [lower inner,  # if present
              lower outer,  # if present

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -800,7 +800,6 @@ def get_legs(equilibrium, n_layers: int = 1, dx_off: float = 0.0):
     -----
     Will return two legs in the case of a single null
     Will return four legs in the case of a double null
-
     We can't rely on the X-point being contained within the two legs, due to
     interpolation and local minimum finding tolerances.
     """

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -800,10 +800,10 @@ def get_legs(equilibrium, n_layers: int = 1, dx_off: float = 0.0):
     -----
     Will return two legs in the case of a single null
     Will return four legs in the case of a double null
+
     We can't rely on the X-point being contained within the two legs, due to
     interpolation and local minimum finding tolerances.
     """
-
     o_points, x_points = equilibrium.get_OX_points()
     o_point = o_points[0]
     x_points = x_points[:2]

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -764,10 +764,10 @@ def get_legs(equilibrium):
         arg_inters = join_intersect(flux_line, radial_line, get_arg=True)
         arg_inters.sort()
         if x_point.z < o_p.z:
-            # Lower single null
+            # Lower null
             func = operator.lt
         else:
-            # Upper single null
+            # Upper null
             func = operator.gt
 
         if len(arg_inters) > 2:

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -755,8 +755,8 @@ def get_legs(equilibrium, n_layers: int, dx_off: float):
     Will return two legs in the case of a single null
     Will return four legs in the case of a double null
 
-    We can't rely on the X-point being contained within the two legs, due to interpolation
-    and local minimum finding tolerances.
+    We can't rely on the X-point being contained within the two legs, due to
+    interpolation and local minimum finding tolerances.
     """
 
     def extract_leg(flux_line, x_cut, z_cut):

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -159,7 +159,6 @@ class TestGetLegs:
     def test_double_null(self, n_layers):
         filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
         eq = Equilibrium.from_eqdsk(filename)
-        n_layers = 5
         legs = get_legs(eq, n_layers, 0.2)
         x_points = eq.get_OX_points()[1][:2]
         x_points.sort(key=lambda xp: xp.z)

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -160,16 +160,16 @@ class TestGetLegs:
                 self.assert_valid_leg(leg, x_point)
                 self.assert_valid_leg(leg, x_point)
 
-    def test_single_single(self):
+    def test_single_one_layer(self):
         legs = get_legs(self.sn_eq, 1, 0.0)
-        assert len(legs) == 1
+        assert len(legs) == 2
         assert "lower_inner" in legs
         assert "lower_outer" in legs
         assert len(legs["lower_inner"]) == 1
         assert len(legs["lower_outer"]) == 1
         x1 = legs["lower_inner"][0].x[0]
         legs = get_legs(self.sn_eq, 1, 1.0)
-        assert len(legs) == 1
+        assert len(legs) == 2
         assert "lower_inner" in legs
         assert "lower_outer" in legs
         assert len(legs["lower_inner"]) == 1
@@ -195,6 +195,23 @@ class TestGetLegs:
                 x_p = x_points[1]
             for leg in leg_group:
                 self.assert_valid_leg(leg, x_p)
+
+    def test_double_one_layer(self):
+        legs = get_legs(self.dn_eq, 1, 0.0)
+        assert len(legs) == 4
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
+        assert len(legs["lower_inner"]) == 1
+        assert len(legs["lower_outer"]) == 1
+        x1 = legs["lower_inner"][0].x[0]
+        legs = get_legs(self.dn_eq, 1, 1.0)
+        assert len(legs) == 4
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
+        assert len(legs["lower_inner"]) == 1
+        assert len(legs["lower_outer"]) == 1
+        x2 = legs["lower_inner"][0].x[0]
+        assert np.isclose(x1, x2)
 
     def assert_valid_leg(self, leg, x_point):
         assert np.isclose(leg.z[0], x_point.z)

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -140,27 +140,47 @@ class TestInPlasma:
 
 
 class TestGetLegs:
+    @classmethod
+    def setup_class(cls):
+        filename = os.sep.join([DATA, "eqref_OOB.json"])
+        cls.sn_eq = Equilibrium.from_eqdsk(filename)
+        filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
+        cls.dn_eq = Equilibrium.from_eqdsk(filename)
+
     @pytest.mark.parametrize("n_layers", [2, 3, 5])
     def test_single_null(self, n_layers):
-        filename = os.sep.join([DATA, "eqref_OOB.json"])
-        eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq, n_layers, 0.2)
+        legs = get_legs(self.sn_eq, n_layers, 0.2)
         assert len(legs) == 2
         assert "lower_inner" in legs
         assert "lower_outer" in legs
-        x_point = eq.get_OX_points()[1][0]
+        x_point = self.sn_eq.get_OX_points()[1][0]
         for leg_group in legs.values():
             assert len(leg_group) == n_layers
             for leg in leg_group:
                 self.assert_valid_leg(leg, x_point)
                 self.assert_valid_leg(leg, x_point)
 
+    def test_single_single(self):
+        legs = get_legs(self.sn_eq, 1, 0.0)
+        assert len(legs) == 1
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
+        assert len(legs["lower_inner"]) == 1
+        assert len(legs["lower_outer"]) == 1
+        x1 = legs["lower_inner"][0].x[0]
+        legs = get_legs(self.sn_eq, 1, 1.0)
+        assert len(legs) == 1
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
+        assert len(legs["lower_inner"]) == 1
+        assert len(legs["lower_outer"]) == 1
+        x2 = legs["lower_inner"][0].x[0]
+        assert np.isclose(x1, x2)
+
     @pytest.mark.parametrize("n_layers", [2, 3, 5])
     def test_double_null(self, n_layers):
-        filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
-        eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq, n_layers, 0.2)
-        x_points = eq.get_OX_points()[1][:2]
+        legs = get_legs(self.dn_eq, n_layers, 0.2)
+        x_points = self.dn_eq.get_OX_points()[1][:2]
         x_points.sort(key=lambda xp: xp.z)
         assert len(legs) == 4
         assert "lower_inner" in legs

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -140,7 +140,7 @@ class TestInPlasma:
 
 
 class TestGetLegs:
-    @pytest.mark.parametrize("n_layers", [1, 3, 5])
+    @pytest.mark.parametrize("n_layers", [2, 3, 5])
     def test_single_null(self, n_layers):
         filename = os.sep.join([DATA, "eqref_OOB.json"])
         eq = Equilibrium.from_eqdsk(filename)
@@ -155,7 +155,7 @@ class TestGetLegs:
                 self.assert_valid_leg(leg, x_point)
                 self.assert_valid_leg(leg, x_point)
 
-    @pytest.mark.parametrize("n_layers", [1, 3, 5])
+    @pytest.mark.parametrize("n_layers", [2, 3, 5])
     def test_double_null(self, n_layers):
         filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
         eq = Equilibrium.from_eqdsk(filename)

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -145,12 +145,24 @@ class TestGetLegs:
         eq = Equilibrium.from_eqdsk(filename)
         legs = get_legs(eq)
         assert len(legs) == 2
+        x_point = eq.get_OX_points()[1][0]
+        self.assert_valid_leg(legs[0], x_point)
+        self.assert_valid_leg(legs[1], x_point)
 
     def test_double_null(self):
         filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
         eq = Equilibrium.from_eqdsk(filename)
         legs = get_legs(eq)
+        x_points = eq.get_OX_points()[1][:2]
+        x_points.sort(key=lambda xp: xp.z)
         assert len(legs) == 4
+        self.assert_valid_leg(legs[0], x_points[0])
+        self.assert_valid_leg(legs[1], x_points[0])
+        self.assert_valid_leg(legs[2], x_points[1])
+        self.assert_valid_leg(legs[3], x_points[1])
+
+    def assert_valid_leg(self, leg, x_point):
+        assert np.isclose(leg.z[0], x_point.z)
 
 
 if __name__ == "__main__":

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -140,27 +140,36 @@ class TestInPlasma:
 
 
 class TestGetLegs:
-    def test_single_null(self):
+    @pytest.mark.parametrize("n_layers", [1, 3, 5])
+    def test_single_null(self, n_layers):
         filename = os.sep.join([DATA, "eqref_OOB.json"])
         eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq, 5, 0.2)
+        legs = get_legs(eq, n_layers, 0.2)
         assert len(legs) == 2
         assert "lower_inner" in legs
         assert "lower_outer" in legs
         x_point = eq.get_OX_points()[1][0]
         for leg_group in legs.values():
+            assert len(leg_group) == n_layers
             for leg in leg_group:
                 self.assert_valid_leg(leg, x_point)
                 self.assert_valid_leg(leg, x_point)
 
-    def test_double_null(self):
+    @pytest.mark.parametrize("n_layers", [1, 3, 5])
+    def test_double_null(self, n_layers):
         filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
         eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq, 5, 0.2)
+        n_layers = 5
+        legs = get_legs(eq, n_layers, 0.2)
         x_points = eq.get_OX_points()[1][:2]
         x_points.sort(key=lambda xp: xp.z)
         assert len(legs) == 4
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
+        assert "upper_inner" in legs
+        assert "upper_outer" in legs
         for name, leg_group in legs.items():
+            assert len(leg_group) == n_layers
             if "lower" in name:
                 x_p = x_points[0]
             else:

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -143,23 +143,30 @@ class TestGetLegs:
     def test_single_null(self):
         filename = os.sep.join([DATA, "eqref_OOB.json"])
         eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq)
+        legs = get_legs(eq, 5, 0.2)
         assert len(legs) == 2
+        assert "lower_inner" in legs
+        assert "lower_outer" in legs
         x_point = eq.get_OX_points()[1][0]
-        self.assert_valid_leg(legs[0], x_point)
-        self.assert_valid_leg(legs[1], x_point)
+        for leg_group in legs.values():
+            for leg in leg_group:
+                self.assert_valid_leg(leg, x_point)
+                self.assert_valid_leg(leg, x_point)
 
     def test_double_null(self):
         filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
         eq = Equilibrium.from_eqdsk(filename)
-        legs = get_legs(eq)
+        legs = get_legs(eq, 5, 0.2)
         x_points = eq.get_OX_points()[1][:2]
         x_points.sort(key=lambda xp: xp.z)
         assert len(legs) == 4
-        self.assert_valid_leg(legs[0], x_points[0])
-        self.assert_valid_leg(legs[1], x_points[0])
-        self.assert_valid_leg(legs[2], x_points[1])
-        self.assert_valid_leg(legs[3], x_points[1])
+        for name, leg_group in legs.items():
+            if "lower" in name:
+                x_p = x_points[0]
+            else:
+                x_p = x_points[1]
+            for leg in leg_group:
+                self.assert_valid_leg(leg, x_p)
 
     def assert_valid_leg(self, leg, x_point):
         assert np.isclose(leg.z[0], x_point.z)

--- a/tests/bluemira/equilibria/test_find.py
+++ b/tests/bluemira/equilibria/test_find.py
@@ -31,6 +31,7 @@ from bluemira.equilibria.find import (
     _in_plasma,
     find_LCFS_separatrix,
     find_local_minima,
+    get_legs,
     inv_2x2_matrix,
 )
 
@@ -136,6 +137,20 @@ class TestInPlasma:
 
         result2 = _in_plasma(x, z, mask, lcfs)
         assert np.allclose(result, result2)
+
+
+class TestGetLegs:
+    def test_single_null(self):
+        filename = os.sep.join([DATA, "eqref_OOB.json"])
+        eq = Equilibrium.from_eqdsk(filename)
+        legs = get_legs(eq)
+        assert len(legs) == 2
+
+    def test_double_null(self):
+        filename = os.sep.join([DATA, "DN-DEMO_eqref.json"])
+        eq = Equilibrium.from_eqdsk(filename)
+        legs = get_legs(eq)
+        assert len(legs) == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Linked Issues
Partially addresses #675 

## Description

Adds a `get_legs` function to `equilibria/find.py` to extract the separatrix legs from an equilibrium. Tested for SN and DN.

## Interface Changes

See above.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
