### PR TITLE
Write initial first wall builder

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -48,6 +48,8 @@ per-file-ignores =
         D404,
         D406,
         D409,
+        # It can be useful to have class names in test names e.g., test_raises_SomeException
+        N802,
     __init__.py:
         # Allow unused imports in __init__.py, so we can expose at parent module level
         F401,

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import abc
 import enum
 import string
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from bluemira.base.components import Component
 from bluemira.base.error import BuilderError
@@ -88,7 +88,7 @@ class Builder(abc.ABC):
     _params: ParameterFrame
     _design_problem = None
 
-    def __init__(self, params, build_config: BuildConfig, **kwargs):
+    def __init__(self, params: Dict[str, Any], build_config: BuildConfig, **kwargs):
         self._name = build_config["name"]
 
         self._validate_config(build_config)

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -96,7 +96,7 @@ class Builder(abc.ABC):
         self._params = ParameterFrame.from_template(self._required_params)
         self.reinitialise(params, **kwargs)
 
-    def __call__(self, **kwargs) -> Component:
+    def __call__(self) -> Component:
         """
         Perform the full build process using the current parameterisation of the builder.
 
@@ -109,7 +109,7 @@ class Builder(abc.ABC):
         if hasattr(self, "_runmode"):
             bluemira_print(f"Designing {self.name} using runmode: {self.runmode}")
             self._runmode(self)
-        return self.build(**kwargs)
+        return self.build()
 
     @abc.abstractmethod
     def reinitialise(self, params, **kwargs) -> None:

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -96,7 +96,7 @@ class Builder(abc.ABC):
         self._params = ParameterFrame.from_template(self._required_params)
         self.reinitialise(params, **kwargs)
 
-    def __call__(self) -> Component:
+    def __call__(self, **kwargs) -> Component:
         """
         Perform the full build process using the current parameterisation of the builder.
 
@@ -109,7 +109,7 @@ class Builder(abc.ABC):
         if hasattr(self, "_runmode"):
             bluemira_print(f"Designing {self.name} using runmode: {self.runmode}")
             self._runmode(self)
-        return self.build()
+        return self.build(**kwargs)
 
     @abc.abstractmethod
     def reinitialise(self, params, **kwargs) -> None:

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -85,7 +85,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def get_component(
         self, name: str, first: bool = True, full_tree: bool = False
-    ) -> Union["Component", List[Component]]:
+    ) -> Union["Component", List[Component], None]:
         """
         Find the components with the specified name.
 
@@ -179,6 +179,16 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self.children = list(self.children) + children
 
         return self
+
+    def prune_child(self, name: str):
+        """
+        Remove the child with the given name, and all its children.
+        """
+        found_component = anytree.search.find_by_attr(self, name)
+        if found_component:
+            # Method of deleting a node suggested by library author
+            # https://github.com/c0fec0de/anytree/issues/152
+            found_component.parent = None
 
 
 class PhysicalComponent(Component):

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -174,7 +174,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
                     duplicates += [child]
         if duplicates != []:
             raise ComponentError(
-                f"Components {duplicates} are already a children of {self}"
+                f"Components {duplicates} are already children of {self}"
             )
         self.children = list(self.children) + children
 

--- a/bluemira/base/config.py
+++ b/bluemira/base/config.py
@@ -31,7 +31,7 @@ class Configuration(ConfigurationSchema, ParameterFrame):
     The base object for all variable names and metadata in bluemira.
     Variables specified here should be physical in some way, and not represent
     how the code is being run.
-    Defaults are also specified here, and overidden later.
+    Defaults are also specified here, and overridden later.
     New variables should be defined here, with a corresponding entry in the
     ConfigurationSchema, and passed onwards as Parameter objects.
     """

--- a/bluemira/builders/EUDEMO/first_wall/__init__.py
+++ b/bluemira/builders/EUDEMO/first_wall/__init__.py
@@ -18,7 +18,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
-
+"""
+Module containing builders for the EUDEMO first wall components
+"""
 from .divertor import DivertorBuilder
 from .first_wall import FirstWallBuilder
 from .wall import WallBuilder, WallPolySpline

--- a/bluemira/builders/EUDEMO/first_wall/__init__.py
+++ b/bluemira/builders/EUDEMO/first_wall/__init__.py
@@ -23,4 +23,4 @@ Module containing builders for the EUDEMO first wall components
 """
 from .divertor import DivertorBuilder
 from .first_wall import FirstWallBuilder
-from .wall import WallBuilder, WallPolySpline
+from .wall import WallBuilder, WallPolySpline, WallPrincetonD

--- a/bluemira/builders/EUDEMO/first_wall/__init__.py
+++ b/bluemira/builders/EUDEMO/first_wall/__init__.py
@@ -21,6 +21,10 @@
 """
 Module containing builders for the EUDEMO first wall components
 """
-from .divertor import DivertorBuilder
-from .first_wall import FirstWallBuilder
-from .wall import WallBuilder, WallPolySpline, WallPrincetonD
+from bluemira.builders.EUDEMO.first_wall.divertor import DivertorBuilder
+from bluemira.builders.EUDEMO.first_wall.first_wall import FirstWallBuilder
+from bluemira.builders.EUDEMO.first_wall.wall import (
+    WallBuilder,
+    WallPolySpline,
+    WallPrincetonD,
+)

--- a/bluemira/builders/EUDEMO/first_wall/__init__.py
+++ b/bluemira/builders/EUDEMO/first_wall/__init__.py
@@ -19,6 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-from .closed import ClosedFirstWallBuilder, FirstWallPolySpline
 from .divertor import DivertorBuilder
 from .first_wall import FirstWallBuilder
+from .wall import FirstWallPolySpline, WallBuilder

--- a/bluemira/builders/EUDEMO/first_wall/__init__.py
+++ b/bluemira/builders/EUDEMO/first_wall/__init__.py
@@ -21,4 +21,4 @@
 
 from .divertor import DivertorBuilder
 from .first_wall import FirstWallBuilder
-from .wall import FirstWallPolySpline, WallBuilder
+from .wall import WallBuilder, WallPolySpline

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -163,7 +163,7 @@ class DivertorBuilder(Builder):
         sols = self._get_sols_for_leg(leg)
         leg_length = self._get_length_for_leg(leg)
         # Just use the first scrape-off layer for now
-        point, _ = find_point_along_wire_at_length(sols[0], leg_length)
+        point = find_point_along_wire_at_length(sols[0], leg_length)
 
         # Create some vertical targets for now. Eventually the target
         # angle will be derived from the grazing-angle parameter

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -220,11 +220,13 @@ class DivertorBuilder(Builder):
         """
         Make a baffle.
 
+        The baffle shape is a straight line between the given start and
+        end points.
+
         Parameters
         ----------
-        leg: LegPosition
-            The position of the leg the baffle should join to (e.g.,
-            inner).
+        label: str
+            The label to give the returned Component.
         start: Sequence
             The position (in x-z) to start drawing the baffle from,
             e.g., the outside end of a target.
@@ -232,7 +234,6 @@ class DivertorBuilder(Builder):
             The position (in x-z) to stop drawing the baffle, e.g., the
             postion to the upper part of the first wall.
         """
-        # Just generate the most basic baffle: a straight line
         coords = np.array([[start[0], end[0]], [0, 0], [start[1], end[1]]])
         return PhysicalComponent(label, make_polygon(coords))
 

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -153,10 +153,10 @@ class DivertorBuilder(Builder):
             outer_target_outside_end = self._get_wire_end_with_largest(
                 outer_target.shape, "x"
             )
-        inner_baffle = self.make_baffle(
-            "inner_baffle", self.outer_end_point, outer_target_outside_end, None
+        outer_baffle = self.make_baffle(
+            "outer_baffle", self.outer_end_point, outer_target_outside_end, None
         )
-        component.add_child(inner_baffle)
+        component.add_child(outer_baffle)
 
         return component
 

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -167,6 +167,10 @@ class DivertorBuilder(Builder):
     def make_dome(self, start: Sequence[float], end: Sequence[float], label: str):
         """
         Make a dome between the two given points
+
+        The dome shape follows a constant line of flux that is closest
+        to the input start coordinate. Finally, the nearset point on the
+        flux surface to the end point and the end point are joined.
         """
         # Get the flux surface that crosses the through the start point
         # We can use this surface to guide the shape of the dome

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -62,6 +62,12 @@ class DivertorBuilder(Builder):
     Build an EUDEMO divertor.
     """
 
+    COMPONENT_INNER_BAFFLE = "inner_baffle"
+    COMPONENT_OUTER_BAFFLE = "outer_baffle"
+    COMPONENT_DOME = "dome"
+    COMPONENT_INNER_TARGET = "inner_target"
+    COMPONENT_OUTER_TARGET = "outer_target"
+
     _required_params = [
         "div_L2D_ib",
         "div_L2D_ob",
@@ -119,19 +125,17 @@ class DivertorBuilder(Builder):
         component = Component("xz")
 
         # Build the targets for each separatrix leg
-        inner_target = self.make_target(
-            LegPosition.INNER, self._make_target_name(LegPosition.INNER)
-        )
-        outer_target = self.make_target(
-            LegPosition.OUTER, self._make_target_name(LegPosition.OUTER)
-        )
+        inner_target = self.make_target(LegPosition.INNER, self.COMPONENT_INNER_TARGET)
+        outer_target = self.make_target(LegPosition.OUTER, self.COMPONENT_OUTER_TARGET)
         for target in [inner_target, outer_target]:
             component.add_child(target)
 
         # Build the dome based on target positions
         inner_target_end = self._get_wire_end_with_smallest(inner_target.shape, "z")
         outer_target_start = self._get_wire_end_with_smallest(outer_target.shape, "z")
-        dome = self.make_dome(inner_target_end, outer_target_start, label="dome")
+        dome = self.make_dome(
+            inner_target_end, outer_target_start, label=self.COMPONENT_DOME
+        )
         component.add_child(dome)
 
         # Build the inner baffle
@@ -142,7 +146,10 @@ class DivertorBuilder(Builder):
                 inner_target.shape, "x"
             )
         inner_baffle = self.make_baffle(
-            "inner_baffle", self.inner_start_point, inner_target_outside_end, None
+            self.COMPONENT_INNER_BAFFLE,
+            self.inner_start_point,
+            inner_target_outside_end,
+            None,
         )
         component.add_child(inner_baffle)
 
@@ -154,7 +161,10 @@ class DivertorBuilder(Builder):
                 outer_target.shape, "x"
             )
         outer_baffle = self.make_baffle(
-            "outer_baffle", self.outer_end_point, outer_target_outside_end, None
+            self.COMPONENT_OUTER_BAFFLE,
+            self.outer_end_point,
+            outer_target_outside_end,
+            None,
         )
         component.add_child(outer_baffle)
 
@@ -286,13 +296,6 @@ class DivertorBuilder(Builder):
         for layer in layers:
             sol.append(self.separatrix_legs[leg][layer])
         return sol
-
-    @staticmethod
-    def _make_target_name(leg: LegPosition) -> str:
-        """
-        Make the name (or label) for a target based on the given leg.
-        """
-        return f"target {leg}"
 
     @staticmethod
     def _get_wire_end_with_smallest(wire: BluemiraWire, axis: str) -> np.ndarray:

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -33,7 +33,6 @@ from bluemira.base.components import PhysicalComponent
 from bluemira.base.config import Configuration
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.find import find_flux_surface_through_point, get_legs
-from bluemira.geometry._deprecated_loop import Loop
 from bluemira.geometry.tools import find_point_along_wire_at_length, make_polygon
 from bluemira.geometry.wire import BluemiraWire
 
@@ -340,60 +339,3 @@ class DivertorBuilder(Builder):
         if comp(start_point[axis_idx], end_point[axis_idx]):
             return start_point[[0, -1]]
         return end_point[[0, -1]]
-
-
-if __name__ == "__main__":
-    import os
-
-    import matplotlib.pyplot as plt
-
-    from bluemira.base.file import get_bluemira_path, get_bluemira_root
-    from bluemira.display.plotter import plot_2d
-
-    DATA = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
-    eq_filename = os.path.join(DATA, "eqref_OOB.json")
-    eq = Equilibrium.from_eqdsk(eq_filename)
-    # eq.plot()  # throws exception
-
-    _, x_points = eq.get_OX_points()
-    # # print(ox_points)
-
-    fig, ax = plt.subplots()
-    # o_points_x = [p.x for p in ox_points[0]]
-    # o_points_y = [p.z for p in ox_points[0]]
-    # x_points_x = [p.x for p in ox_points[1]]
-    # x_points_y = [p.z for p in ox_points[1]]
-    # ax.plot(o_points_x, o_points_y, color="blue", marker="o", linestyle="none")
-    # ax.plot(x_points_x, x_points_y, color="g", marker="x", linestyle="none")
-
-    separatrix = eq.get_separatrix()
-    separatrix.plot(ax=ax, linestyle="--", linewidth=0.3)
-    # separatrix[0].plot(ax=ax, linestyle="--", linewidth=0.3)
-    # separatrix[1].plot(ax=ax, linestyle="--", linewidth=0.3)
-    # # plt.show()
-
-    params = {
-        "Name": "Divertor example",
-        "div_L2D_ib": (1.1, "Input"),
-        "div_L2D_ob": (1.45, "Input"),
-        "div_Ltarg": (0.5, "Input"),
-        "div_open": (False, "Input"),
-    }
-    build_config = {"name": "divertor", "runmode": "mock"}
-
-    div = DivertorBuilder(
-        params,
-        build_config=build_config,
-        equilibrium=eq,
-        x_lims=[x_points[0].x - 4, x_points[0].x + 4],
-    )
-    component = div()
-    component.plot_2d(ax=ax)
-
-    # for leg_set in div.separatrix_legs.values():
-    #     plot_2d(leg_set[0], ax=ax, show=False)
-    # plot_2d(leg_set[1], ax=ax, show=False, color="g")
-
-    plt.show()
-
-    # div.make_target(LegPosition.INNER)

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -24,7 +24,7 @@ Define builder for divertor
 
 import enum
 import operator
-from typing import Any, Callable, Dict, Iterable, List, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Sequence
 
 import numpy as np
 

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -106,9 +106,15 @@ class DivertorBuilder(Builder):
         """
         return super().reinitialise(params, **kwargs)
 
-    def mock(self) -> Component:
+    def mock(self):
         """
-        Create a basic shape for the wall's boundary.
+        Mock a solution to the builder's design problem.
+        """
+        pass
+
+    def run(self):
+        """
+        Run the builder's design problem.
         """
         pass
 

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -182,7 +182,7 @@ class DivertorBuilder(Builder):
         """
         Make a divertor target for a the given leg.
         """
-        sol = self._get_sol_for_leg(leg)
+        sols = self._get_sol_for_leg(leg)
         try:
             leg_length = self._get_length_for_leg(leg)
         except ValueError as exc:

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -68,6 +68,8 @@ class DivertorBuilder(Builder):
 
     The builder outputs a component with the structure:
 
+    .. code-block::
+
         divertor (Component)
         └── xz (Component)
             ├── inner_target (PhysicalComponent)

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -329,8 +329,8 @@ class DivertorBuilder(Builder):
         """
         allowed_axes = ["x", "z"]
         if axis not in allowed_axes:
-            raise ValueError("Unrecognised axis '{}'. Must be one of '{}'.").format(
-                axis, "', '".join(allowed_axes)
+            raise ValueError(
+                f"Unrecognised axis '{axis}'. Must be one of: {allowed_axes}."
             )
 
         start_point = wire.start_point()

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -65,6 +65,16 @@ def get_separatrix_legs(
 class DivertorBuilder(Builder):
     """
     Build an EUDEMO divertor.
+
+    The builder outputs a component with the structure:
+
+        divertor (Component)
+        └── xz (Component)
+            ├── inner_target (PhysicalComponent)
+            ├── outer_target (PhysicalComponent)
+            ├── dome (PhysicalComponent)
+            ├── inner_baffle (PhysicalComponent)
+            └── outer_baffle (PhysicalComponent)
     """
 
     COMPONENT_INNER_BAFFLE = "inner_baffle"

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -155,7 +155,7 @@ class DivertorBuilder(Builder):
 
         # Build the outer baffle
         if self.params.div_open:
-            pass
+            outer_target_end = self._get_wire_end_with_smallest(outer_target.shape, "x")
         else:
             outer_target_end = self._get_wire_end_with_largest(outer_target.shape, "x")
         outer_baffle = self.make_baffle(
@@ -329,3 +329,60 @@ class DivertorBuilder(Builder):
         if comp(start_point[axis_idx], end_point[axis_idx]):
             return start_point[[0, -1]]
         return end_point[[0, -1]]
+
+
+if __name__ == "__main__":
+    import os
+
+    import matplotlib.pyplot as plt
+
+    from bluemira.base.file import get_bluemira_path, get_bluemira_root
+    from bluemira.display.plotter import plot_2d
+
+    DATA = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
+    eq_filename = os.path.join(DATA, "eqref_OOB.json")
+    eq = Equilibrium.from_eqdsk(eq_filename)
+    # eq.plot()  # throws exception
+
+    _, x_points = eq.get_OX_points()
+    # # print(ox_points)
+
+    fig, ax = plt.subplots()
+    # o_points_x = [p.x for p in ox_points[0]]
+    # o_points_y = [p.z for p in ox_points[0]]
+    # x_points_x = [p.x for p in ox_points[1]]
+    # x_points_y = [p.z for p in ox_points[1]]
+    # ax.plot(o_points_x, o_points_y, color="blue", marker="o", linestyle="none")
+    # ax.plot(x_points_x, x_points_y, color="g", marker="x", linestyle="none")
+
+    separatrix = eq.get_separatrix()
+    separatrix.plot(ax=ax, linestyle="--", linewidth=0.3)
+    # separatrix[0].plot(ax=ax, linestyle="--", linewidth=0.3)
+    # separatrix[1].plot(ax=ax, linestyle="--", linewidth=0.3)
+    # # plt.show()
+
+    params = {
+        "Name": "Divertor example",
+        "div_L2D_ib": (1.1, "Input"),
+        "div_L2D_ob": (1.45, "Input"),
+        "div_Ltarg": (0.5, "Input"),
+        "div_open": (False, "Input"),
+    }
+    build_config = {"name": "divertor", "runmode": "mock"}
+
+    div = DivertorBuilder(
+        params,
+        build_config=build_config,
+        equilibrium=eq,
+        x_lims=[x_points[0].x - 4, x_points[0].x + 4],
+    )
+    component = div()
+    component.plot_2d(ax=ax)
+
+    # for leg_set in div.separatrix_legs.values():
+    #     plot_2d(leg_set[0], ax=ax, show=False)
+    # plot_2d(leg_set[1], ax=ax, show=False, color="g")
+
+    plt.show()
+
+    # div.make_target(LegPosition.INNER)

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -81,7 +81,6 @@ class DivertorBuilder(Builder):
     ]
     _required_config: List[str] = []
     _params: Configuration
-    _default_runmode: str = "mock"
 
     def __init__(
         self,
@@ -109,18 +108,6 @@ class DivertorBuilder(Builder):
         Initialise the state of this builder ready for a new run.
         """
         return super().reinitialise(params, **kwargs)
-
-    def mock(self):
-        """
-        Mock a solution to the builder's design problem.
-        """
-        pass
-
-    def run(self):
-        """
-        Run the builder's design problem.
-        """
-        pass
 
     def build(self, **kwargs) -> Component:
         """

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -31,7 +31,7 @@ from bluemira.base.builder import BuildConfig, Builder, Component
 from bluemira.base.components import PhysicalComponent
 from bluemira.base.config import Configuration
 from bluemira.equilibria.equilibrium import Equilibrium
-from bluemira.geometry.tools import make_polygon
+from bluemira.geometry.tools import find_point_along_wire_at_length, make_polygon
 from bluemira.geometry.wire import BluemiraWire
 from BLUEPRINT.nova.stream import StreamFlow
 
@@ -182,7 +182,7 @@ class DivertorBuilder(Builder):
         """
         component = Component("xz")
         for leg in [Leg.INNER, Leg.OUTER]:
-            component.add_child(self.make_target(leg, str(leg)))
+            component.add_child(self.make_target(leg, f"target {leg}"))
         return component
 
     def make_target(self, leg: Leg, label: str) -> Component:
@@ -199,7 +199,7 @@ class DivertorBuilder(Builder):
             ) from exc
 
         # We need to work out which SOL to use here
-        point, _ = point_along_wire_at_length(sol[0], leg_length)
+        point, _ = find_point_along_wire_at_length(sol[0], leg_length)
 
         # Just create some vertical targets for now. Eventually the
         # target angle will be set using a grazing-angle parameter

--- a/bluemira/builders/EUDEMO/first_wall/divertor.py
+++ b/bluemira/builders/EUDEMO/first_wall/divertor.py
@@ -337,7 +337,6 @@ class DivertorBuilder(Builder):
 
         start_point = wire.start_point()
         end_point = wire.end_point()
-        axis_idx = 0 if axis == "x" else -1
-        if comp(start_point[axis_idx], end_point[axis_idx]):
-            return start_point[[0, -1]]
-        return end_point[[0, -1]]
+        if comp(getattr(start_point, axis), getattr(end_point, axis)):
+            return start_point.xz.flatten()
+        return end_point.xz.flatten()

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -34,7 +34,6 @@ from bluemira.builders.EUDEMO.first_wall.wall import WallBuilder
 from bluemira.builders.shapes import Builder
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.find import find_OX_points
-from bluemira.geometry.base import BluemiraGeo
 from bluemira.geometry.tools import boolean_cut, make_polygon
 from bluemira.geometry.wire import BluemiraWire
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -28,8 +28,8 @@ import numpy as np
 
 from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent
-from bluemira.builders.EUDEMO.first_wall import ClosedFirstWallBuilder
 from bluemira.builders.EUDEMO.first_wall.divertor import DivertorBuilder
+from bluemira.builders.EUDEMO.first_wall.wall import WallBuilder
 from bluemira.builders.shapes import Builder
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.find import find_OX_points
@@ -96,7 +96,7 @@ class FirstWallBuilder(Builder):
         """
         Build the component for the wall, excluding the divertor.
         """
-        builder = ClosedFirstWallBuilder(params, build_config=build_config)
+        builder = WallBuilder(params, build_config=build_config)
         wall = builder()
 
         wall_shape: BluemiraGeo = wall.get_component("first_wall").shape

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent
+from bluemira.base.error import BuilderError
 from bluemira.builders.EUDEMO.first_wall.divertor import DivertorBuilder
 from bluemira.builders.EUDEMO.first_wall.wall import WallBuilder
 from bluemira.builders.shapes import Builder
@@ -194,7 +195,11 @@ class FirstWallBuilder(Builder):
         wall_xz = wall.get_component("xz")
         wall_boundary = wall_xz.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY)
         x_point_z = self.x_points[0].z
-        cut_shape = _cut_shape_in_z(wall_boundary.shape, x_point_z)
+        if wall_boundary.shape.bounding_box.z_min >= x_point_z:
+            raise BuilderError(
+                "First wall boundary does not inclose separatrix x-point."
+            )
+        cut_shape = _cut_wall_below_x_point(wall_boundary.shape, x_point_z)
 
         # Replace the "uncut" wall boundary with the new shape
         wall_xz.prune_child(WallBuilder.COMPONENT_WALL_BOUNDARY)

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -106,16 +106,14 @@ class FirstWallBuilder(Builder):
     ):
         super().__init__(params, build_config, **kwargs)
 
+        self.wall: Component
+        self.divertor: Component
+
+        self._init_params = params
+        self._build_config = build_config
         self.equilibrium = equilibrium
         _, self.x_points = find_OX_points(
             self.equilibrium.x, self.equilibrium.z, self.equilibrium.psi()
-        )
-        self.wall: Component = self._build_wall(params, build_config)
-        wall_shape = self.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
-        self.divertor: Component = self._build_divertor(
-            params,
-            build_config,
-            [wall_shape.start_point()[0], wall_shape.end_point()[0]],
         )
 
     def reinitialise(self, params, **kwargs) -> None:
@@ -138,6 +136,14 @@ class FirstWallBuilder(Builder):
         """
         Build the component.
         """
+        self.wall = self._build_wall(self._init_params, self._build_config)
+        wall_shape = self.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
+        self.divertor = self._build_divertor(
+            self._init_params,
+            self._build_config,
+            [wall_shape.start_point()[0], wall_shape.end_point()[0]],
+        )
+
         first_wall = Component(self.name)
         first_wall.add_child(self.build_xz())
         return first_wall

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -146,8 +146,8 @@ class FirstWallBuilder(Builder):
         self.wall = self._build_wall()
         wall_shape = self.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
         self._divertor_builder.x_limits = [
-            wall_shape.start_point()[0],
-            wall_shape.end_point()[0],
+            wall_shape.start_point().x[0],
+            wall_shape.end_point().x[0],
         ]
         self.divertor = self._divertor_builder()
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -221,6 +221,7 @@ class FirstWallBuilder(Builder):
         # here when we start supporting double-null plasmas
         build_config = deepcopy(build_config)
         build_config.update({"name": self.COMPONENT_DIVERTOR})
+        build_config.pop("runmode", None)
         builder = DivertorBuilder(params, build_config, self.equilibrium, x_lims)
         return builder()
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -140,9 +140,11 @@ class FirstWallBuilder(Builder):
         """
         self.wall = self._build_wall()
         wall_shape = self.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
-        self.divertor = self._divertor_builder(
-            x_lims=[wall_shape.start_point()[0], wall_shape.end_point()[0]],
-        )
+        self._divertor_builder.x_limits = [
+            wall_shape.start_point()[0],
+            wall_shape.end_point()[0],
+        ]
+        self.divertor = self._divertor_builder()
 
         first_wall = Component(self.name)
         first_wall.add_child(self.build_xz())
@@ -193,7 +195,14 @@ class FirstWallBuilder(Builder):
         build_config = deepcopy(build_config)
         build_config.update({"name": self.COMPONENT_DIVERTOR})
         build_config.pop("runmode", None)
-        return DivertorBuilder(params, build_config, self.equilibrium)
+        return DivertorBuilder(
+            params,
+            build_config,
+            equilibrium=self.equilibrium,
+            # no limits for now, we need to build the wall shape before
+            # we know them
+            x_limits=[],
+        )
 
     def _build_wall(self):
         """

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -216,8 +216,8 @@ class FirstWallBuilder(Builder):
         Create a "keep-out-zone" to be used as a constraint in the
         shape optimiser
         """
-        # The keep-out-zone is generated from the flux surface of the
-        # separatrix above the x-point
-        coords = self.equilibrium.get_separatrix().xyz
+        # Generate keep-out-zone from the last close flux surface
+        lcfs = self.equilibrium.get_LCFS().xyz
+        return make_polygon(lcfs, closed=True)
         coords = coords[:, coords[2] > self.x_points[0].z]
         return make_polygon(coords, closed=True)

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -81,7 +81,7 @@ class FirstWallBuilder(ParameterisedShapeBuilder):
         Build the component for the wall, excluding the divertor.
         """
         builder = ClosedFirstWallBuilder(params, build_config=build_config)
-        wall = builder(params)
+        wall = builder()
 
         wall_shape: BluemiraGeo = wall.get_component("first_wall").shape
         z_max = self.x_point[1]

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -23,7 +23,7 @@ Builders for the first wall of the reactor, including divertor
 """
 
 from copy import deepcopy
-from typing import Any, Dict, Iterable, Sequence
+from typing import Any, Dict, Iterable
 
 import numpy as np
 from scipy.spatial import ConvexHull

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -71,15 +71,16 @@ class FirstWallBuilder(Builder):
     For a single-null plasma, the builder outputs a Component with the
     structure:
 
-    first_wall (Component)
-    └── xz (Component)
-        ├── wall (PhysicalComponent)
-        └── divertor (Component)
-            ├── inner_target (PhysicalComponent)
-            ├── outer_target (PhysicalComponent)
-            ├── dome (PhysicalComponent)
-            ├── inner_baffle (PhysicalComponent)
-            └── outer_baffle (PhysicalComponent)
+        first_wall (Component)
+        └── xz (Component)
+            └── wall (Component)
+                └── wall_boundary (PhysicalComponent)
+            └── divertor (Component)
+                ├── inner_target (PhysicalComponent)
+                ├── outer_target (PhysicalComponent)
+                ├── dome (PhysicalComponent)
+                ├── inner_baffle (PhysicalComponent)
+                └── outer_baffle (PhysicalComponent)
     """
 
     COMPONENT_DIVERTOR = "divertor"

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -22,7 +22,7 @@
 Builders for the first wall of the reactor, including divertor
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 import numpy as np
 
@@ -68,8 +68,7 @@ class FirstWallBuilder(Builder):
         self.divertor: Component = self._build_divertor(
             params,
             build_config,
-            wall_shape.start_point()[[0, 2]],
-            wall_shape.end_point()[[0, 2]],
+            [wall_shape.start_point()[0], wall_shape.end_point()[0]],
         )
 
     def reinitialise(self, params, **kwargs) -> None:
@@ -115,15 +114,12 @@ class FirstWallBuilder(Builder):
         return PhysicalComponent(FirstWallBuilder.COMPONENT_FIRST_WALL, cut_shape)
 
     def _build_divertor(
-        self,
-        params: Dict[str, Any],
-        build_config,
-        start_coord: np.ndarray,
-        end_coord: np.ndarray,
+        self, params: Dict[str, Any], build_config, x_lims: Iterable[float]
     ) -> Component:
-        builder = DivertorBuilder(
-            params, build_config, self.equilibrium, start_coord, end_coord
-        )
+        """
+        Build the divertor component.
+        """
+        builder = DivertorBuilder(params, build_config, self.equilibrium, x_lims)
         return builder()
 
     def _cut_shape_in_z(self, shape: BluemiraWire, z_max: float):

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -88,6 +88,14 @@ class FirstWallBuilder(Builder):
         """
         Build the component.
         """
+        first_wall = Component(FirstWallBuilder.COMPONENT_FIRST_WALL)
+        first_wall.add_child(self.build_xz())
+        return first_wall
+
+    def build_xz(self) -> Component:
+        """
+        Build the component in the xz-plane.
+        """
         parent_component = Component("xz")
         components = [self.wall_part, self.divertor]
         for component in components:

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -173,13 +173,7 @@ class FirstWallBuilder(Builder):
         equilibrium's x-point, to make space for a divertor.
         """
         build_config = deepcopy(build_config)
-
-        build_config.update(
-            {
-                "label": self.COMPONENT_WALL,
-                "name": self.COMPONENT_WALL,
-            }
-        )
+        build_config.update({"label": self.COMPONENT_WALL, "name": self.COMPONENT_WALL})
 
         # Keep-out zone to constrain the wall around the plasma
         keep_out_zones = self._make_wall_keep_out_zones(geom_offset=0.2, psi_n=1.05)

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -171,6 +171,12 @@ class FirstWallBuilder(Builder):
                 "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
                 "label": self.COMPONENT_WALL,
                 "name": self.COMPONENT_WALL,
+                "opt_conditions": {
+                    "ftol_rel": 1e-6,
+                    "xtol_rel": 1e-8,
+                    "xtol_abs": 1e-8,
+                    "max_eval": 100,
+                },
             }
         )
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -37,8 +37,6 @@ from bluemira.equilibria.find import find_OX_points
 from bluemira.geometry.tools import boolean_cut, make_polygon, offset_wire
 from bluemira.geometry.wire import BluemiraWire
 
-_WALL_MODULE_REF = "bluemira.builders.EUDEMO.first_wall.wall"
-
 
 def _cut_wall_below_x_point(shape: BluemiraWire, x_point_z: float) -> BluemiraWire:
     """
@@ -174,20 +172,11 @@ class FirstWallBuilder(Builder):
         equilibrium's x-point, to make space for a divertor.
         """
         build_config = deepcopy(build_config)
+
         build_config.update(
             {
-                "algorithm_name": "SLSQP",
-                "class": f"{_WALL_MODULE_REF}::WallBuilder",
                 "label": self.COMPONENT_WALL,
                 "name": self.COMPONENT_WALL,
-                "opt_conditions": {
-                    "ftol_rel": 1e-6,
-                    "xtol_rel": 1e-8,
-                    "xtol_abs": 1e-8,
-                    "max_eval": 100,
-                },
-                "param_class": f"{_WALL_MODULE_REF}::WallPrincetonD",
-                "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
             }
         )
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -42,9 +42,11 @@ class FirstWallBuilder(Builder):
     """
     Build a first wall with a divertor.
 
-    This class runs the builders for the first wall shape and the
-    divertor, then combines the two.
+    This class runs the builders for the wall shape and the divertor,
+    then combines the two.
     """
+
+    COMPONENT_FIRST_WALL = "first_wall"
 
     def __init__(
         self,
@@ -98,12 +100,11 @@ class FirstWallBuilder(Builder):
         """
         builder = WallBuilder(params, build_config=build_config)
         wall = builder()
-
-        wall_shape: BluemiraGeo = wall.get_component("first_wall").shape
+        wall_shape: BluemiraGeo = wall.get_component(WallBuilder.COMPONENT_WALL).shape
         z_max = self.x_points[0][1]
 
         cut_shape = self._cut_shape_in_z(wall_shape, z_max)
-        return PhysicalComponent("first_wall", cut_shape)
+        return PhysicalComponent(FirstWallBuilder.COMPONENT_FIRST_WALL, cut_shape)
 
     def _build_divertor(
         self,

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -81,6 +81,8 @@ class FirstWallBuilder(Builder):
     For a single-null plasma, the builder outputs a Component with the
     structure:
 
+    .. code-block::
+
         first_wall (Component)
         └── xz (Component)
             └── wall (Component)

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -176,9 +176,8 @@ class FirstWallBuilder(Builder):
         build_config = deepcopy(build_config)
         build_config.update(
             {
+                "algorithm_name": "SLSQP",
                 "class": f"{_WALL_MODULE_REF}::WallBuilder",
-                "param_class": f"{_WALL_MODULE_REF}::WallPolySpline",
-                "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
                 "label": self.COMPONENT_WALL,
                 "name": self.COMPONENT_WALL,
                 "opt_conditions": {
@@ -187,6 +186,8 @@ class FirstWallBuilder(Builder):
                     "xtol_abs": 1e-8,
                     "max_eval": 100,
                 },
+                "param_class": f"{_WALL_MODULE_REF}::WallPrincetonD",
+                "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
             }
         )
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -23,10 +23,9 @@ Builders for the first wall of the reactor, including divertor
 """
 
 from copy import deepcopy
-from typing import Any, Dict, Iterable
+from typing import Any, Dict
 
 import numpy as np
-from scipy.spatial import ConvexHull
 
 from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -128,7 +128,7 @@ class FirstWallBuilder(Builder):
         """
         Build the component.
         """
-        first_wall = Component(FirstWallBuilder.COMPONENT_FIRST_WALL)
+        first_wall = Component(self.name)
         first_wall.add_child(self.build_xz())
         return first_wall
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -23,7 +23,7 @@ Builders for the first wall of the reactor, including divertor
 """
 
 from copy import deepcopy
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Iterable, Sequence
 
 import numpy as np
 from scipy.spatial import ConvexHull
@@ -227,14 +227,22 @@ class FirstWallBuilder(Builder):
     def _make_wall_keep_out_zone(self, geom_offset, psi_n) -> BluemiraWire:
         """
         Create a "keep-out zone" to be used as a constraint in the
-        shape optimiser.
+        wall shape optimiser.
         """
         geom_offset_zone = self._make_geometric_keep_out_zone(geom_offset)
         flux_surface_zone = self._make_flux_surface_keep_out_zone(psi_n)
+        return self._convex_hull_wires([geom_offset_zone, flux_surface_zone])
 
+    def _convex_hull_wires(
+        self, wires: Iterable[BluemiraWire], ndiscr=200
+    ) -> BluemiraWire:
+        """
+        Perform a convex hull around the given wires and return the hull
+        as a new wire.
+        """
         shape_discretizations = []
-        for zone in [geom_offset_zone, flux_surface_zone]:
-            d = zone.discretize(byedges=True, ndiscr=200).xz
+        for wire in wires:
+            d = wire.discretize(byedges=True, ndiscr=ndiscr).xz
             shape_discretizations.append(d)
         coords = np.hstack(shape_discretizations)
 

--- a/bluemira/builders/EUDEMO/first_wall/first_wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/first_wall.py
@@ -30,7 +30,7 @@ from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent
 from bluemira.builders.EUDEMO.first_wall import ClosedFirstWallBuilder
 from bluemira.builders.EUDEMO.first_wall.divertor import DivertorBuilder
-from bluemira.builders.shapes import ParameterisedShapeBuilder
+from bluemira.builders.shapes import Builder
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.find import find_OX_points
 from bluemira.geometry.base import BluemiraGeo
@@ -38,7 +38,7 @@ from bluemira.geometry.tools import boolean_cut, make_polygon
 from bluemira.geometry.wire import BluemiraWire
 
 
-class FirstWallBuilder(ParameterisedShapeBuilder):
+class FirstWallBuilder(Builder):
     """
     Build a first wall with a divertor.
 
@@ -80,17 +80,17 @@ class FirstWallBuilder(ParameterisedShapeBuilder):
         """
         Create a basic shape for the wall's boundary.
         """
-        self.boundary = self._shape.create_shape()
+        pass
 
-    def build(self, **kwargs) -> Component:
+    def build(self) -> Component:
         """
         Build the component.
         """
+        parent_component = Component("xz")
         components = [self.wall_part, self.divertor]
-        component = Component("xz")
-        for comp in components:
-            component.add_child(comp)
-        return component
+        for component in components:
+            parent_component.add_child(component)
+        return parent_component
 
     def _build_wall_no_divertor(self, params: Dict[str, Any], build_config: BuildConfig):
         """

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -214,8 +214,6 @@ class WallBuilder(OptimisedShapeBuilder):
         bm_plot_tools.set_component_plane(component, "xz")
         return component
 
-    # TODO(hsaunders1904): 'height' is not a parameter for all shapes.
-    # Does it make sense to derive it within this class?
     def _derive_shape_params(self):
         """
         Calculate derived parameters for the GeometryParameterisation.

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -136,6 +136,12 @@ class WallBuilder(OptimisedShapeBuilder):
     """
     Builder class for the wall of the reactor, this does not include the
     divertor.
+
+    The builder outputs a component with the structure:
+
+        wall (Component)
+        └── xz (Component)
+            └── wall_boundary (PhysicalComponent)
     """
 
     COMPONENT_WALL_BOUNDARY = "wall_boundary"

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -139,6 +139,8 @@ class WallBuilder(OptimisedShapeBuilder):
 
     The builder outputs a component with the structure:
 
+    .. code-block::
+
         wall (Component)
         └── xz (Component)
             └── wall_boundary (PhysicalComponent)

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -37,7 +37,7 @@ from bluemira.geometry.wire import BluemiraWire
 class WallPolySpline(PolySpline):
     """
     Defines the geometry for reactor first wall, without a divertor,
-    based on a PolySpline
+    based on the PolySpline parameterisation.
     """
 
     _defaults = {
@@ -101,6 +101,10 @@ class WallPolySpline(PolySpline):
 
 
 class WallPrincetonD(PrincetonD):
+    """
+    Defines the geometry for reactor first wall, without a divertor,
+    based on the PrincetonD parameterisation.
+    """
 
     _defaults = {
         "x1": {"value": 5.8},

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -20,25 +20,33 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import copy
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
+
+import numpy as np
+from scipy.spatial import ConvexHull
 
 import bluemira.utilities.plot_tools as bm_plot_tools
+from bluemira import equilibria
 from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent
 from bluemira.base.config import Configuration
-from bluemira.builders.shapes import ParameterisedShapeBuilder
+from bluemira.builders.shapes import OptimisedShapeBuilder
 from bluemira.display.palettes import BLUE_PALETTE
-from bluemira.geometry.parameterisations import PolySpline
+from bluemira.display.plotter import plot_2d
+from bluemira.geometry.optimisation import GeometryOptimisationProblem
+from bluemira.geometry.parameterisations import GeometryParameterisation, PolySpline
+from bluemira.geometry.tools import make_polygon, signed_distance_2D_polygon
 from bluemira.geometry.wire import BluemiraWire
+from bluemira.utilities.optimiser import Optimiser
 
 
-class FirstWallPolySpline(PolySpline):
+class WallPolySpline(PolySpline):
     """
     Defines the geometry for reactor first wall, without a divertor,
     based on a PolySpline
     """
 
-    _default_dict = {
+    _defaults = {
         "x1": {"value": 5.8},
         "x2": {"value": 12.1},
         "z2": {"value": 0},
@@ -54,15 +62,121 @@ class FirstWallPolySpline(PolySpline):
     def __init__(self, var_dict=None):
         if var_dict is None:
             var_dict = {}
-        defaults = copy.deepcopy(self._default_dict)
+        defaults = copy.deepcopy(self._defaults)
         defaults.update(var_dict)
         super().__init__(defaults)
 
+        ib_radius = self.variables["x1"].value
+        ob_radius = self.variables["x2"].value
+        height = self.variables["height"].value
+        self.adjust_variable(
+            "x1",
+            ib_radius,
+            lower_bound=ib_radius - 0.1,
+            upper_bound=ib_radius * 1.1,
+        )
+        self.adjust_variable(
+            "x2",
+            value=ob_radius,
+            lower_bound=ob_radius - 0.001,
+            upper_bound=ob_radius * 1.1,
+        )
+        self.adjust_variable("z2", 0, lower_bound=-0.9, upper_bound=0.9)
+        self.adjust_variable(
+            "height", height + 0.001, lower_bound=height, upper_bound=50
+        )
+        self.adjust_variable("top", 0.5, lower_bound=0.05, upper_bound=0.75)
+        self.adjust_variable("upper", 0.5, lower_bound=0.2, upper_bound=0.7)
+        self.adjust_variable("lower", lower_bound=0.2, upper_bound=0.7)
+        self.adjust_variable("bottom", lower_bound=0.05, upper_bound=0.75)
+        self.adjust_variable("dz", 0, lower_bound=-5, upper_bound=5)
+        self.adjust_variable("tilt", 0, lower_bound=-25, upper_bound=25)
 
-class WallBuilder(ParameterisedShapeBuilder):
+        # Fix 'flat' to avoid drawing the PolySpline's outer straight.
+        # The straight is often optimised to near-zero length, which
+        # causes an error when CAD tries to draw it
+        self.fix_variable("flat", 0)
+
+
+class MinimiseLength(GeometryOptimisationProblem):
     """
-    Builder class for the first wall of the reactor, closed with
-    no divertor.
+    Optimiser to minimize the length of a geometry parameterisation.
+    """
+
+    n_iter = 0
+
+    def __init__(
+        self,
+        parameterisation: GeometryParameterisation,
+        optimiser: Optimiser,
+        keep_out_zones=None,
+        n_koz_points=100,
+        koz_con_tol=1e-3,
+    ):
+        super().__init__(parameterisation, optimiser)
+
+        self.n_koz_points = n_koz_points
+
+        self.keep_out_zones = keep_out_zones
+        if self.keep_out_zones is not None:
+            self.koz_points = self._make_koz_points(keep_out_zones)
+            self.optimiser.add_ineq_constraints(
+                self.f_constrain_koz,
+                koz_con_tol * np.ones(n_koz_points),
+            )
+
+    def _make_koz_points(self, keep_out_zones: Iterable[BluemiraWire]):
+        """
+        Make a set of points at which to evaluate the KOZ constraint
+        """
+        shape_discretizations = []
+        for zone in keep_out_zones:
+            d = zone.discretize(byedges=True, dl=zone.length / 200).xz
+            shape_discretizations.append(d)
+
+        coords = np.concatenate(shape_discretizations)
+
+        hull = ConvexHull(coords.T)
+        return coords[:, hull.vertices]
+
+    def f_constrain_koz(self, constraint, x, grad):
+        """
+        Geometry constraint function to the keep-out-zone
+        """
+        constraint[:] = self.calculate_signed_distance(x)
+
+        if grad.size > 0:
+            grad[:] = self.optimiser.approx_derivative(
+                self.calculate_signed_distance, x, constraint
+            )
+        return constraint
+
+    def calculate_signed_distance(self, x):
+        """
+        Calculate the signed distances from the parameterised shape to
+        the keep-out zone.
+        """
+        self.update_parameterisation(x)
+
+        shape = self.parameterisation.create_shape()
+        s = shape.discretize(ndiscr=self.n_koz_points).xz
+        return signed_distance_2D_polygon(s.T, self.koz_points.T).T
+
+    def calculate_length(self, x):
+        self.update_parameterisation(x)
+        return self.parameterisation.create_shape().length
+
+    def f_objective(self, x, grad):
+        length = self.calculate_length(x)
+        if grad.size > 0:
+            self.optimiser.approx_derivative(self.calculate_length, x, f0=length)
+        return length
+
+
+class WallBuilder(OptimisedShapeBuilder):
+    """
+    Builder class for the wall of the reactor, this does not include the
+    divertor.
     """
 
     COMPONENT_WALL = "wall"
@@ -79,17 +193,37 @@ class WallBuilder(ParameterisedShapeBuilder):
     _params: Configuration
     _default_runmode: str = "mock"
 
-    def __init__(self, params: Dict[str, Any], build_config: BuildConfig, **kwargs):
-        super().__init__(params, build_config, **kwargs)
-
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        build_config: BuildConfig,
+        keep_out_zones: Iterable[BluemiraWire] = None,
+    ):
         # boundary should be set by run/mock/read, it is used by the build methods
         self.boundary: BluemiraWire = None
+        # _keep_out_zones should be set by reinitialize
+        self._keep_out_zones: Iterable[BluemiraWire] = []
 
-    def reinitialise(self, params, **kwargs) -> None:
+        super().__init__(params, build_config, keep_out_zones=keep_out_zones)
+
+    def reinitialise(
+        self, params: Dict[str, Any], keep_out_zones: Iterable[BluemiraWire] = None
+    ) -> None:
         """
         Initialise the state of this builder ready for a new run.
         """
-        return super().reinitialise(params, **kwargs)
+        super().reinitialise(params)
+        self._keep_out_zones = keep_out_zones
+
+    def read(self):
+        raise NotImplementedError()
+
+    def run(self):
+        """
+        Run the design problem for wall builder.
+        """
+        super().run(keep_out_zones=self._keep_out_zones)
+        self.boundary = self._shape.create_shape()
 
     def mock(self):
         """
@@ -105,7 +239,7 @@ class WallBuilder(ParameterisedShapeBuilder):
         component.add_child(self.build_xz())
         return component
 
-    def build_xz(self, **kwargs) -> Component:
+    def build_xz(self) -> Component:
         """
         Build the components in the xz plane.
         """
@@ -125,7 +259,9 @@ class WallBuilder(ParameterisedShapeBuilder):
         Calculate derived parameters for the GeometryParameterisation.
         """
         params = super()._derive_shape_params()
-        r_minor = self._params.R_0 / self._params.A
-        height = (self._params.kappa_95 * r_minor) * 2
-        params["height"] = {"value": height}
+        params["height"] = {"value": self._derive_height()}
         return params
+
+    def _derive_height(self) -> float:
+        r_minor = self._params.R_0 / self._params.A
+        return (self._params.kappa_95 * r_minor) * 2

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -59,7 +59,7 @@ class FirstWallPolySpline(PolySpline):
         super().__init__(defaults)
 
 
-class ClosedFirstWallBuilder(ParameterisedShapeBuilder):
+class WallBuilder(ParameterisedShapeBuilder):
     """
     Builder class for the first wall of the reactor, closed with
     no divertor.

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -174,7 +174,7 @@ class WallBuilder(OptimisedShapeBuilder):
     divertor.
     """
 
-    COMPONENT_WALL = "wall"
+    COMPONENT_WALL_BOUNDARY = "wall_boundary"
 
     _required_params: List[str] = [
         "plasma_type",
@@ -241,8 +241,8 @@ class WallBuilder(OptimisedShapeBuilder):
         component = Component("xz")
         component.add_child(
             PhysicalComponent(
-                self.COMPONENT_WALL,
-                BluemiraWire(self.boundary, label=self.COMPONENT_WALL),
+                self.COMPONENT_WALL_BOUNDARY,
+                BluemiraWire(self.boundary, label=self.COMPONENT_WALL_BOUNDARY),
             )
         )
         component.plot_options.wire_options["color"] = BLUE_PALETTE["DIV"]

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -140,7 +140,8 @@ class WallPrincetonD(PrincetonD):
 
 class MinimiseLength(GeometryOptimisationProblem):
     """
-    Optimiser to minimize the length of a geometry parameterisation.
+    Optimiser to minimise the length of a geometry parameterisation with
+    constraints in the form of a "keep-out zone".
     """
 
     def __init__(
@@ -178,7 +179,7 @@ class MinimiseLength(GeometryOptimisationProblem):
         """
         shape_discretizations = []
         for zone in keep_out_zones:
-            d = zone.discretize(byedges=True, dl=zone.length / 200).xz
+            d = zone.discretize(byedges=True, ndiscr=n_points).xz
             shape_discretizations.append(d)
         coords = np.hstack(shape_discretizations)
         hull = ConvexHull(coords.T)

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -65,6 +65,8 @@ class WallBuilder(ParameterisedShapeBuilder):
     no divertor.
     """
 
+    COMPONENT_WALL = "wall"
+
     _required_params: List[str] = [
         "plasma_type",
         "R_0",  # major radius
@@ -110,7 +112,8 @@ class WallBuilder(ParameterisedShapeBuilder):
         component = Component("xz")
         component.add_child(
             PhysicalComponent(
-                "first_wall", BluemiraWire(self.boundary, label="first_wall")
+                self.COMPONENT_WALL,
+                BluemiraWire(self.boundary, label=self.COMPONENT_WALL),
             )
         )
         component.plot_options.wire_options["color"] = BLUE_PALETTE["DIV"]

--- a/bluemira/builders/EUDEMO/first_wall/wall.py
+++ b/bluemira/builders/EUDEMO/first_wall/wall.py
@@ -26,16 +26,14 @@ import numpy as np
 from scipy.spatial import ConvexHull
 
 import bluemira.utilities.plot_tools as bm_plot_tools
-from bluemira import equilibria
 from bluemira.base.builder import BuildConfig, Component
 from bluemira.base.components import PhysicalComponent
 from bluemira.base.config import Configuration
 from bluemira.builders.shapes import OptimisedShapeBuilder
 from bluemira.display.palettes import BLUE_PALETTE
-from bluemira.display.plotter import plot_2d
 from bluemira.geometry.optimisation import GeometryOptimisationProblem
 from bluemira.geometry.parameterisations import GeometryParameterisation, PolySpline
-from bluemira.geometry.tools import make_polygon, signed_distance_2D_polygon
+from bluemira.geometry.tools import signed_distance_2D_polygon
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.utilities.optimiser import Optimiser
 
@@ -103,8 +101,6 @@ class MinimiseLength(GeometryOptimisationProblem):
     Optimiser to minimize the length of a geometry parameterisation.
     """
 
-    n_iter = 0
-
     def __init__(
         self,
         parameterisation: GeometryParameterisation,
@@ -116,7 +112,6 @@ class MinimiseLength(GeometryOptimisationProblem):
         super().__init__(parameterisation, optimiser)
 
         self.n_koz_points = n_koz_points
-
         self.keep_out_zones = keep_out_zones
         if self.keep_out_zones is not None:
             self.koz_points = self._make_koz_points(keep_out_zones)

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -262,10 +262,18 @@ class EUDEMOReactor(Reactor):
         }
 
         default_config = {
+            "algorithm_name": "SLSQP",
             "name": self.FIRST_WALL,
-            "param_class": "bluemira.builders.EUDEMO.first_wall::WallPolySpline",
+            "opt_conditions": {
+                "ftol_rel": 1e-6,
+                "max_eval": 100,
+                "xtol_abs": 1e-8,
+                "xtol_rel": 1e-8,
+            },
+            "param_class": "bluemira.builders.EUDEMO.first_wall::WallPrincetonD",
+            "problem_class": "bluemira.geometry.optimisation::MinimiseLength",
+            "runmode": "run",
             "variables_map": default_variables_map,
-            "runmode": "mock",
         }
 
         config = self._process_design_stage_config(name, default_config)

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -46,6 +46,7 @@ class EUDEMOReactor(Reactor):
     PLASMA = "Plasma"
     TF_COILS = "TF Coils"
     PF_COILS = "PF Coils"
+    THERMAL_SHIELD = "Thermal Shield"
     FIRST_WALL = "First Wall"
 
     def run(self) -> Component:
@@ -219,7 +220,7 @@ class EUDEMOReactor(Reactor):
         """
         Run the thermal shield build.
         """
-        name = "Thermal Shield"
+        name = self.THERMAL_SHIELD
 
         bluemira_print(f"Starting design stage: {name}")
 
@@ -247,6 +248,8 @@ class EUDEMOReactor(Reactor):
         component = super()._build_stage(name)
 
         bluemira_print(f"Completed design stage: {name}")
+
+        return component
 
     def build_first_wall(self, component_tree: Component, **kwargs):
         """

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -28,7 +28,7 @@ import os
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.design import Reactor
 from bluemira.base.look_and_feel import bluemira_print
-from bluemira.builders.EUDEMO.first_wall import WallBuilder
+from bluemira.builders.EUDEMO.first_wall import FirstWallBuilder
 from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
 from bluemira.builders.EUDEMO.plasma import PlasmaBuilder
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
@@ -262,14 +262,18 @@ class EUDEMOReactor(Reactor):
         }
 
         default_config = {
-            "param_class": "bluemira.builders.EUDEMO.first_wall::FirstWallPolySpline",
+            "name": self.FIRST_WALL,
+            "param_class": "bluemira.builders.EUDEMO.first_wall::WallPolySpline",
             "variables_map": default_variables_map,
             "runmode": "mock",
         }
 
         config = self._process_design_stage_config(name, default_config)
 
-        builder = WallBuilder(self._params.to_dict(), build_config=config)
+        plasma = component_tree.get_component(self.PLASMA)
+        builder = FirstWallBuilder(
+            self._params.to_dict(), build_config=config, equilibrium=plasma.equilibrium
+        )
         self.register_builder(builder, name)
 
         component = super()._build_stage(name)

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -28,7 +28,7 @@ import os
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.design import Reactor
 from bluemira.base.look_and_feel import bluemira_print
-from bluemira.builders.EUDEMO.first_wall import ClosedFirstWallBuilder
+from bluemira.builders.EUDEMO.first_wall import WallBuilder
 from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
 from bluemira.builders.EUDEMO.plasma import PlasmaBuilder
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
@@ -269,7 +269,7 @@ class EUDEMOReactor(Reactor):
 
         config = self._process_design_stage_config(name, default_config)
 
-        builder = ClosedFirstWallBuilder(self._params.to_dict(), build_config=config)
+        builder = WallBuilder(self._params.to_dict(), build_config=config)
         self.register_builder(builder, name)
 
         component = super()._build_stage(name)

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -51,13 +51,7 @@ class EUDEMOReactor(Reactor):
 
     def run(self) -> Component:
         """
-        Run the EU-DEMO reactor build process. Performs the following tasks:
-
-        - Run the (PROCESS) systems code
-        - Build the 'Plasma'
-        - Build the 'TF Coils'
-        - Build the 'PF Coils'
-        - Build the 'First Wall'
+        Run the EU-DEMO reactor build process.
         """
         component = super().run()
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -492,6 +492,18 @@ def bounding_box(obj):
     return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax
 
 
+def start_point(obj) -> np.ndarray:
+    """The start point of the object"""
+    point = obj.Edges[0].firstVertex().Point
+    return vector_to_numpy(point)
+
+
+def end_point(obj) -> np.ndarray:
+    """The end point of the object"""
+    point = obj.Edges[-1].lastVertex().Point
+    return vector_to_numpy(point)
+
+
 # ======================================================================================
 # Wire manipulation
 # ======================================================================================

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -119,7 +119,9 @@ class MinimiseLength(GeometryOptimisationProblem):
         """The objective function for the optimiser."""
         length = self.calculate_length(x)
         if grad.size > 0:
-            self.optimiser.approx_derivative(self.calculate_length, x, f0=length)
+            grad[:] = self.optimiser.approx_derivative(
+                self.calculate_length, x, f0=length
+            )
         return length
 
     def calculate_length(self, x):

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -29,6 +29,8 @@ import numpy as np
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.geometry.parameterisations import GeometryParameterisation
+from bluemira.geometry.tools import signed_distance_2D_polygon
+from bluemira.geometry.wire import BluemiraWire
 from bluemira.utilities.optimiser import Optimiser
 
 
@@ -73,8 +75,6 @@ class GeometryOptimisationProblem(abc.ABC):
         """
         self.parameterisation.variables.set_values_from_norm(x)
 
-    # is there a reason this is not an abstract method?
-    # how do we know what form f_objective needs to take?
     f_objective = None
 
     def solve(self, x0=None):
@@ -85,3 +85,78 @@ class GeometryOptimisationProblem(abc.ABC):
             x0 = self.parameterisation.variables.get_normalised_values()
         x_star = self.optimiser.optimise(x0)
         self.update_parameterisation(x_star)
+
+
+class MinimiseLength(GeometryOptimisationProblem):
+    """
+    Optimiser to minimise the length of a geometry 2D parameterisation
+    in the xz-plane, with optional constraints in the form of a
+    "keep-out zone".
+    """
+
+    def __init__(
+        self,
+        parameterisation: GeometryParameterisation,
+        optimiser: Optimiser,
+        keep_out_zone: BluemiraWire = None,
+        n_koz_points: int = 100,
+        koz_con_tol: float = 1e-3,
+    ):
+        super().__init__(parameterisation, optimiser)
+
+        self.n_koz_points = n_koz_points
+        self.keep_out_zone = keep_out_zone
+        if self.keep_out_zone is not None:
+            self.koz_points = self._make_koz_points(
+                self.keep_out_zone, self.n_koz_points
+            )
+            self.optimiser.add_ineq_constraints(
+                self.f_constrain_koz,
+                koz_con_tol * np.ones(self.n_koz_points),
+            )
+
+    def f_objective(self, x, grad):
+        """The objective function for the optimiser."""
+        length = self.calculate_length(x)
+        if grad.size > 0:
+            self.optimiser.approx_derivative(self.calculate_length, x, f0=length)
+        return length
+
+    def calculate_length(self, x):
+        """Calculate the length of the shape being optimised."""
+        self.update_parameterisation(x)
+        return self.parameterisation.create_shape().length
+
+    def f_constrain_koz(self, constraint, x, grad):
+        """
+        Geometry constraint function to the keep-out-zone.
+        """
+        constraint[:] = self.calculate_signed_distance(x)
+        if grad.size > 0:
+            grad[:] = self.optimiser.approx_derivative(
+                self.calculate_signed_distance, x, constraint
+            )
+        return constraint
+
+    def calculate_signed_distance(self, x):
+        """
+        Calculate the signed distances from the parameterised shape to
+        the keep-out zone.
+        """
+        self.update_parameterisation(x)
+
+        shape = self.parameterisation.create_shape()
+        s = shape.discretize(ndiscr=self.n_koz_points).xz
+        return signed_distance_2D_polygon(s.T, self.koz_points.T).T
+
+    def _make_koz_points(self, keep_out_zone: BluemiraWire, n_points: int) -> np.ndarray:
+        """
+        Generate a set of points that combine the given keep-out-zones,
+        to use as constraints in the optimisation problem.
+
+        Returns
+        -------
+        coords: np.ndarray[2, n_points]
+            Coordinates of the keep-out-zone points in the xz plane.
+        """
+        return keep_out_zone.discretize(byedges=True, ndiscr=n_points).xz

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -73,6 +73,8 @@ class GeometryOptimisationProblem(abc.ABC):
         """
         self.parameterisation.variables.set_values_from_norm(x)
 
+    # is there a reason this is not an abstract method?
+    # how do we know what form f_objective needs to take?
     f_objective = None
 
     def solve(self, x0=None):

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -377,7 +377,7 @@ class PrincetonD(GeometryParameterisation):
         """  # noqa :W505
         if x2 <= x1:
             raise GeometryParameterisationError(
-                "Princeton D parameterisation requires an x2 value"
+                "Princeton D parameterisation requires an x2 value "
                 f"greater than x1: {x1} >= {x2}"
             )
 

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -332,8 +332,8 @@ def convex_hull_wires_2d(
 
     The operation performs discretisations on the input wires.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     wires: Sequence[BluemiraWire]
         The wires to draw a hull around.
     ndiscr: int
@@ -342,8 +342,8 @@ def convex_hull_wires_2d(
         The plane to perform the hull in. One of: 'xz', 'xy', 'yz'.
         Default is 'xz'.
 
-    Returns:
-    --------
+    Returns
+    -------
     hull: BluemiraWire
         A wire forming a convex hull around the input wires in the given
         plane.

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -924,18 +924,32 @@ def get_shape_by_name(shape: BluemiraGeo, name: str):
 # ======================================================================================
 # Find operations
 # ======================================================================================
-def find_point_along_wire_at_length(wire: BluemiraWire, length: float):
+def find_point_along_wire_at_length(
+    wire: BluemiraWire, length: float, ndiscr: int = 2000
+) -> np.ndarray:
     """
-    Find the point that is a given length along a wire, and the
-    unit tanget vector along that point and its neighbour.
+    Find the coordinates of the point that is, from the start of the
+    wire, a given length along the wire.
 
     This method discretizes the wire in order to find the desired point.
     Hence, the error in this calculation will depend on the
     discretization's step size.
+
+    Parameters
+    ----------
+    wire: BluemiraWire
+        The wire to find the point along the length of.
+    length: float
+        The length along the wire to find the coordinates of.
+    ndiscr: int
+        The number of points to discretize the wire into.
+
+    Returns
+    -------
+    coords: np.ndarray[float, (3,)]
+        The coordinate of the point at the given length along the wire.
     """
-    # TODO(hsaunders1904): re-write this using primitives
-    # TODO(hsaunders1904): magic number here needs justification
-    coords = wire.discretize(ndiscr=2000)
+    coords = wire.discretize(ndiscr=ndiscr)
     segment_lengths = np.linalg.norm(np.diff(coords, axis=1), axis=0)
     cumulative_lengths = np.cumsum(segment_lengths)
     if length > cumulative_lengths[-1]:
@@ -944,11 +958,7 @@ def find_point_along_wire_at_length(wire: BluemiraWire, length: float):
         )
     index = np.searchsorted(cumulative_lengths, length)
 
-    tangent_vec = coords[:, index] - coords[:, index - 1]
-    unit_tangent_vec = tangent_vec / np.linalg.norm(tangent_vec)
-
     # Could potentially use the calculated coordinate as the starting
     # point for some sort of optimization/root finder if this needs to
     # be more accurate in the future
-
-    return coords[:, index], unit_tangent_vec
+    return coords[:, index]

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -149,7 +149,7 @@ class BluemiraWire(BluemiraGeo):
 
     def discretize(
         self, ndiscr: int = 100, byedges: bool = False, dl: float = None
-    ) -> np.ndarray:
+    ) -> Coordinates:
         """
         Discretize the wire in ndiscr equidistant points or with a reference dl
         segment step.

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -221,16 +221,16 @@ class BluemiraWire(BluemiraGeo):
             else:
                 o.change_placement(placement)
 
-    def start_point(self) -> np.ndarray:
+    def start_point(self) -> Coordinates:
         """
         Get the coordinates of the start of the wire.
         """
         point = self.boundary[0].Vertexes[0].Point
-        return np.array([point.x, point.y, point.z])
+        return Coordinates([point.x, point.y, point.z])
 
-    def end_point(self) -> np.ndarray:
+    def end_point(self) -> Coordinates:
         """
         Get the coordinates at the end of the wire.
         """
         point = self.boundary[0].Vertexes[-1].Point
-        return np.array([point.x, point.y, point.z])
+        return Coordinates([point.x, point.y, point.z])

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -34,13 +34,14 @@ from bluemira.codes._freecadapi import (
     change_placement,
     discretize,
     discretize_by_edges,
+    end_point,
     rotate_shape,
     scale_shape,
+    start_point,
     translate_shape,
     wire_closure,
 )
 
-# import from bluemira
 # import from bluemira
 from bluemira.geometry.base import BluemiraGeo, _Orientation
 from bluemira.geometry.coordinates import Coordinates
@@ -225,12 +226,10 @@ class BluemiraWire(BluemiraGeo):
         """
         Get the coordinates of the start of the wire.
         """
-        point = self.boundary[0].Vertexes[0].Point
-        return Coordinates([point.x, point.y, point.z])
+        return Coordinates(start_point(self._shape))
 
     def end_point(self) -> Coordinates:
         """
-        Get the coordinates at the end of the wire.
+        Get the coordinates of the end of the wire.
         """
-        point = self.boundary[0].Vertexes[-1].Point
-        return Coordinates([point.x, point.y, point.z])
+        return Coordinates(end_point(self._shape))

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 
 from typing import List
 
-import numpy as np
-
 from bluemira.codes._freecadapi import (
     apiWire,
     change_placement,

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from typing import List
 
-import numpy
+import numpy as np
 
 from bluemira.codes._freecadapi import (
     apiWire,
@@ -149,7 +149,7 @@ class BluemiraWire(BluemiraGeo):
 
     def discretize(
         self, ndiscr: int = 100, byedges: bool = False, dl: float = None
-    ) -> numpy.ndarray:
+    ) -> np.ndarray:
         """
         Discretize the wire in ndiscr equidistant points or with a reference dl
         segment step.
@@ -159,7 +159,7 @@ class BluemiraWire(BluemiraGeo):
         Returns
         -------
         points: Coordinates
-            a numpy array with the x,y,z coordinates of the discretized points.
+            a np array with the x,y,z coordinates of the discretized points.
         """
         if byedges:
             points = discretize_by_edges(self._shape, ndiscr=ndiscr, dl=dl)
@@ -220,3 +220,17 @@ class BluemiraWire(BluemiraGeo):
                 change_placement(o, placement._shape)
             else:
                 o.change_placement(placement)
+
+    def start_point(self) -> np.ndarray:
+        """
+        Get the coordinates of the start of the wire.
+        """
+        point = self.boundary[0].Vertexes[0].Point
+        return np.array([point.x, point.y, point.z])
+
+    def end_point(self) -> np.ndarray:
+        """
+        Get the coordinates at the end of the wire.
+        """
+        point = self.boundary[0].Vertexes[-1].Point
+        return np.array([point.x, point.y, point.z])

--- a/scripts/install-msh2xdmf.sh
+++ b/scripts/install-msh2xdmf.sh
@@ -3,6 +3,8 @@
 # not have a setup.py or pyproject.toml, so cannot be installed as a normal python
 # project.
 
+set -e
+
 if [[ $(basename $PWD) == *"bluemira"* ]]; then
   cd ..
 fi

--- a/tests/bluemira/base/test_components.py
+++ b/tests/bluemira/base/test_components.py
@@ -123,6 +123,24 @@ class TestComponentClass:
         with pytest.raises(ComponentError):
             parent.add_children([child1, child2])
 
+    def test_prune_child_removes_node_with_given_name(self):
+        parent = Component("Parent")
+        Component("Child1", parent=parent)
+        Component("Child2", parent=parent)
+
+        parent.prune_child("Child1")
+
+        assert parent.get_component("Child1") is None
+        assert parent.get_component("Child2") is not None
+
+    def test_prune_child_does_nothing_if_node_does_not_exist(self):
+        parent = Component("Parent")
+        Component("Child1", parent=parent)
+
+        parent.prune_child("not_a_child")
+
+        assert parent.get_component("Child1") is not None
+
 
 class TestPhysicalComponent:
     """

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_closed_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_closed_first_wall.py
@@ -66,7 +66,7 @@ class TestClosedFirstWallBuilder:
     def test_built_component_contains_physical_component_in_xz(self):
         builder = ClosedFirstWallBuilder(self._params, build_config=self._default_config)
 
-        component = builder(self._params)
+        component = builder()
 
         xy_component = component.get_component("xz", first=False)
         assert len(xy_component) == 1
@@ -75,7 +75,7 @@ class TestClosedFirstWallBuilder:
     def test_physical_component_shape_is_closed(self):
         builder = ClosedFirstWallBuilder(self._params, build_config=self._default_config)
 
-        component = builder(self._params)
+        component = builder()
 
         assert component.get_component("first_wall").shape.is_closed()
 
@@ -85,8 +85,8 @@ class TestClosedFirstWallBuilder:
             {"R_0": (10.0, "Input"), "kappa_95": (2.0, "Input"), "A": (2.0, "Input")}
         )
 
-        builder = ClosedFirstWallBuilder(self._params, build_config=self._default_config)
-        component = builder(params)
+        builder = ClosedFirstWallBuilder(params, build_config=self._default_config)
+        component = builder()
 
         bounding_box = component.get_component("first_wall").shape.bounding_box
         # expected_height = 2*(R_0/A)*kappa_95 = 20

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -1,0 +1,93 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+"""
+Tests for divertor builder classes
+"""
+import copy
+import os
+
+import pytest
+
+from bluemira.base.error import BuilderError
+from bluemira.base.file import get_bluemira_path
+from bluemira.builders.EUDEMO.first_wall import DivertorBuilder
+from bluemira.builders.EUDEMO.first_wall.divertor import Leg
+from bluemira.equilibria import Equilibrium
+from bluemira.geometry.tools import make_polygon, signed_distance
+
+DATA = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
+
+
+class TestDivertorBuilder:
+
+    _default_params = {
+        "div_L2D_ib": (1.1, "Input"),
+        "div_L2D_ob": (1.45, "Input"),
+        "div_Ltarg": (0.5, "Input"),
+    }
+
+    @classmethod
+    def setup_class(cls):
+        cls.eq = Equilibrium.from_eqdsk(os.path.join(DATA, "eqref_OOB.json"))
+
+    def setup_method(self):
+        self.params = copy.deepcopy(self._default_params)
+
+    def test_no_BuilderError_on_init_given_valid_params(self):
+        try:
+            DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+        except BuilderError:
+            pytest.fail(str(BuilderError))
+
+    @pytest.mark.parametrize("required_param", DivertorBuilder._required_params)
+    def test_BuilderError_given_required_param_missing(self, required_param):
+        self.params.pop(required_param)
+
+        with pytest.raises(BuilderError):
+            DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+
+    def test_new_builder_sets_leg_lengths(self):
+        self.params.update({"div_L2D_ib": 5, "div_L2D_ob": 10})
+
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+
+        assert builder.leg_length[Leg.INNER] == 5
+        assert builder.leg_length[Leg.OUTER] == 10
+
+    def test_targets_intersect_separatrix(self):
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+        separatrix = make_polygon(self.eq.get_separatrix().xyz.T)
+
+        divertor = builder(self._default_params)
+
+        for leg in [Leg.INNER, Leg.OUTER]:
+            target = divertor.get_component(f"target {leg}")
+            assert signed_distance(target.shape, separatrix) == 0
+
+    def test_div_Ltarg_sets_target_length(self):
+        self.params.update({"div_Ltarg": 1.5})
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+
+        divertor = builder(self.params)
+
+        for leg in [Leg.INNER, Leg.OUTER]:
+            target = divertor.get_component(f"target {leg}")
+            assert target.shape.length == 1.5

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -51,6 +51,10 @@ class TestDivertorBuilder:
         "div_Ltarg": (0.5, "Input"),
         "div_open": (False, "Input"),
     }
+    targets = [
+        DivertorBuilder.COMPONENT_INNER_TARGET,
+        DivertorBuilder.COMPONENT_OUTER_TARGET,
+    ]
 
     @classmethod
     def setup_class(cls):
@@ -105,8 +109,8 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        for leg in [LegPosition.INNER, LegPosition.OUTER]:
-            target = divertor.get_component(f"target {leg}")
+        for leg in self.targets:
+            target = divertor.get_component(leg)
             assert signed_distance(target.shape, self.separatrix) == 0
 
     def test_div_Ltarg_sets_target_length(self):
@@ -117,8 +121,8 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        for leg in [LegPosition.INNER, LegPosition.OUTER]:
-            target = divertor.get_component(f"target {leg}")
+        for leg in self.targets:
+            target = divertor.get_component(leg)
             assert target.shape.length == 1.5
 
     def test_dome_added_to_divertor(self):
@@ -128,7 +132,7 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        assert divertor.get_component("dome") is not None
+        assert divertor.get_component(DivertorBuilder.COMPONENT_DOME) is not None
 
     def test_dome_intersects_targets(self):
         builder = DivertorBuilder(
@@ -137,11 +141,8 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        dome = divertor.get_component("dome")
-        targets = [
-            divertor.get_component(f"target {leg}")
-            for leg in [LegPosition.INNER, LegPosition.OUTER]
-        ]
+        dome = divertor.get_component(DivertorBuilder.COMPONENT_DOME)
+        targets = [divertor.get_component(leg) for leg in self.targets]
         assert signed_distance(dome.shape, targets[0].shape) == 0
         assert signed_distance(dome.shape, targets[1].shape) == 0
 
@@ -152,7 +153,7 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        dome = divertor.get_component("dome")
+        dome = divertor.get_component(DivertorBuilder.COMPONENT_DOME)
         assert signed_distance(dome.shape, self.separatrix) < 0
 
     def test_dome_has_turning_point_below_x_point(self):
@@ -165,7 +166,9 @@ class TestDivertorBuilder:
 
         divertor = builder()
 
-        dome_coords = divertor.get_component("dome").shape.discretize()
+        dome_coords = divertor.get_component(
+            DivertorBuilder.COMPONENT_DOME
+        ).shape.discretize()
         turning_points = get_turning_point_idxs(dome_coords[2, :])
         assert len(turning_points) == 1
         assert dome_coords[2, turning_points[0]] < x_points[0].z

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -30,7 +30,7 @@ import pytest
 from bluemira.base.error import BuilderError
 from bluemira.base.file import get_bluemira_path
 from bluemira.builders.EUDEMO.first_wall import DivertorBuilder
-from bluemira.builders.EUDEMO.first_wall.divertor import Leg
+from bluemira.builders.EUDEMO.first_wall.divertor import LegPosition
 from bluemira.equilibria import Equilibrium
 from bluemira.geometry.tools import make_polygon, signed_distance
 
@@ -76,15 +76,15 @@ class TestDivertorBuilder:
 
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        assert builder.leg_length[Leg.INNER] == 5
-        assert builder.leg_length[Leg.OUTER] == 10
+        assert builder.leg_length[LegPosition.INNER] == 5
+        assert builder.leg_length[LegPosition.OUTER] == 10
 
     def test_targets_intersect_separatrix(self):
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
         divertor = builder(self._default_params)
 
-        for leg in [Leg.INNER, Leg.OUTER]:
+        for leg in [LegPosition.INNER, LegPosition.OUTER]:
             target = divertor.get_component(f"target {leg}")
             assert signed_distance(target.shape, self.separatrix) == 0
 
@@ -94,7 +94,7 @@ class TestDivertorBuilder:
 
         divertor = builder(self.params)
 
-        for leg in [Leg.INNER, Leg.OUTER]:
+        for leg in [LegPosition.INNER, LegPosition.OUTER]:
             target = divertor.get_component(f"target {leg}")
             assert target.shape.length == 1.5
 
@@ -112,7 +112,8 @@ class TestDivertorBuilder:
 
         dome = divertor.get_component("dome")
         targets = [
-            divertor.get_component(f"target {leg}") for leg in [Leg.INNER, Leg.OUTER]
+            divertor.get_component(f"target {leg}")
+            for leg in [LegPosition.INNER, LegPosition.OUTER]
         ]
         assert signed_distance(dome.shape, targets[0].shape) == 0
         assert signed_distance(dome.shape, targets[1].shape) == 0

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -72,34 +72,29 @@ class TestDivertorBuilder:
                 self.params,
                 {"name": "some_name"},
                 self.eq,
-                self.x_lims,
             )
-        except BuilderError:
-            pytest.fail(str(BuilderError))
+        except BuilderError as exc:
+            pytest.fail(str(exc))
 
     @pytest.mark.parametrize("required_param", DivertorBuilder._required_params)
     def test_BuilderError_given_required_param_missing(self, required_param):
         self.params.pop(required_param)
 
         with pytest.raises(BuilderError):
-            DivertorBuilder(self.params, {"name": "some_name"}, self.eq, self.x_lims)
+            DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
     def test_new_builder_sets_leg_lengths(self):
         self.params.update({"div_L2D_ib": 5, "div_L2D_ob": 10})
 
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
         assert builder.leg_length[LegPosition.INNER] == 5
         assert builder.leg_length[LegPosition.OUTER] == 10
 
     def test_targets_intersect_separatrix(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         for leg in self.targets:
             target = divertor.get_component(leg)
@@ -107,31 +102,25 @@ class TestDivertorBuilder:
 
     def test_target_length_set_by_parameter(self):
         self.params.update({"div_Ltarg": 1.5})
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         for leg in self.targets:
             target = divertor.get_component(leg)
             assert target.shape.length == 1.5
 
     def test_dome_added_to_divertor(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         assert divertor.get_component(DivertorBuilder.COMPONENT_DOME) is not None
 
     def test_dome_intersects_targets(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         dome = divertor.get_component(DivertorBuilder.COMPONENT_DOME)
         targets = [divertor.get_component(leg) for leg in self.targets]
@@ -139,22 +128,18 @@ class TestDivertorBuilder:
         assert signed_distance(dome.shape, targets[1].shape) == 0
 
     def test_dome_does_not_intersect_separatrix(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         dome = divertor.get_component(DivertorBuilder.COMPONENT_DOME)
         assert signed_distance(dome.shape, self.separatrix) < 0
 
     def test_SN_lower_dome_has_turning_point_below_x_point(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
         x_points, _ = self.eq.get_OX_points()
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         dome_coords = divertor.get_component(
             DivertorBuilder.COMPONENT_DOME
@@ -164,22 +149,18 @@ class TestDivertorBuilder:
         assert dome_coords[2, turning_points[0]] < x_points[0].z
 
     def test_inner_baffle_has_end_at_lower_x_limit(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         inner_baffle = divertor.get_component(DivertorBuilder.COMPONENT_INNER_BAFFLE)
         assert inner_baffle is not None
         assert inner_baffle.shape.start_point()[0] == min(self.x_lims)
 
     def test_outer_baffle_has_end_at_upper_x_limit(self):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         inner_baffle = divertor.get_component(DivertorBuilder.COMPONENT_OUTER_BAFFLE)
         assert inner_baffle is not None
@@ -187,11 +168,9 @@ class TestDivertorBuilder:
 
     @pytest.mark.parametrize("side", ("INNER", "OUTER"))
     def test_baffle_and_target_intersect(self, side):
-        builder = DivertorBuilder(
-            self.params, {"name": "some_name"}, self.eq, self.x_lims
-        )
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder()
+        divertor = builder(x_lims=self.x_lims)
 
         target = divertor.get_component(
             getattr(DivertorBuilder, f"COMPONENT_{side}_TARGET")
@@ -200,3 +179,9 @@ class TestDivertorBuilder:
             getattr(DivertorBuilder, f"COMPONENT_{side}_BAFFLE")
         )
         assert signed_distance(target.shape, baffle.shape) == 0
+
+    def test_TypeError_if_x_lim_not_passed_to_call(self):
+        builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
+
+        with pytest.raises(TypeError):
+            builder()

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -82,7 +82,7 @@ class TestDivertorBuilder:
     def test_targets_intersect_separatrix(self):
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder(self._default_params)
+        divertor = builder()
 
         for leg in [LegPosition.INNER, LegPosition.OUTER]:
             target = divertor.get_component(f"target {leg}")
@@ -92,7 +92,7 @@ class TestDivertorBuilder:
         self.params.update({"div_Ltarg": 1.5})
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder(self.params)
+        divertor = builder()
 
         for leg in [LegPosition.INNER, LegPosition.OUTER]:
             target = divertor.get_component(f"target {leg}")
@@ -101,14 +101,14 @@ class TestDivertorBuilder:
     def test_dome_added_to_divertor(self):
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder(self.params)
+        divertor = builder()
 
         assert divertor.get_component("dome") is not None
 
     def test_dome_intersects_targets(self):
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder(self.params)
+        divertor = builder()
 
         dome = divertor.get_component("dome")
         targets = [
@@ -121,7 +121,7 @@ class TestDivertorBuilder:
     def test_dome_does_not_intersect_separatrix(self):
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
 
-        divertor = builder(self.params)
+        divertor = builder()
 
         dome = divertor.get_component("dome")
         assert signed_distance(dome.shape, self.separatrix) < 0
@@ -132,7 +132,7 @@ class TestDivertorBuilder:
         builder = DivertorBuilder(self.params, {"name": "some_name"}, self.eq)
         x_points, _ = self.eq.get_OX_points()
 
-        divertor = builder(self.params)
+        divertor = builder()
 
         dome_coords = divertor.get_component("dome").shape.discretize()
         turning_points = get_turning_point_idxs(dome_coords[2, :])

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -148,9 +148,7 @@ class TestDivertorBuilder:
         dome = divertor.get_component(DivertorBuilder.COMPONENT_DOME)
         assert signed_distance(dome.shape, self.separatrix) < 0
 
-    def test_dome_has_turning_point_below_x_point(self):
-        # TODO(hsaunders): not sure about this test, what if the x-point
-        # is at the top of the plasma?
+    def test_SN_lower_dome_has_turning_point_below_x_point(self):
         builder = DivertorBuilder(
             self.params, {"name": "some_name"}, self.eq, self.x_lims
         )
@@ -202,5 +200,3 @@ class TestDivertorBuilder:
             getattr(DivertorBuilder, f"COMPONENT_{side}_BAFFLE")
         )
         assert signed_distance(target.shape, baffle.shape) == 0
-
-    # TODO(hsaunders1904): tests for plasma with x-point on upper side

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_divertor.py
@@ -105,7 +105,7 @@ class TestDivertorBuilder:
             target = divertor.get_component(leg)
             assert signed_distance(target.shape, self.separatrix) == 0
 
-    def test_div_Ltarg_sets_target_length(self):
+    def test_target_length_set_by_parameter(self):
         self.params.update({"div_Ltarg": 1.5})
         builder = DivertorBuilder(
             self.params, {"name": "some_name"}, self.eq, self.x_lims

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -105,3 +105,20 @@ class TestFirstWallBuilder:
 
         walls = wall.get_component(FirstWallBuilder.COMPONENT_WALL, first=False)
         assert len(walls) == 1
+
+    def test_component_tree_structure(self):
+        builder = FirstWallBuilder(
+            self._params, build_config=self._default_config, equilibrium=self.eq
+        )
+
+        first_wall = builder()
+
+        assert first_wall.is_root
+        xz = first_wall.get_component("xz")
+        assert xz is not None
+        assert xz.depth == 1
+        divertor_xz = xz.get_component(FirstWallBuilder.COMPONENT_DIVERTOR)
+        assert divertor_xz.depth == 2
+        wall_xz = xz.get_component(FirstWallBuilder.COMPONENT_WALL)
+        assert wall_xz is not None
+        assert wall_xz.depth == 2

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -30,7 +30,6 @@ from bluemira.base.file import get_bluemira_path
 from bluemira.builders.EUDEMO.first_wall import FirstWallBuilder
 from bluemira.equilibria import Equilibrium
 from bluemira.equilibria.find import find_OX_points
-from bluemira.geometry.tools import make_polygon
 
 DATA = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
 

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.builders.EUDEMO.first_wall import FirstWallBuilder
+from bluemira.builders.EUDEMO.first_wall.wall import WallBuilder
 from bluemira.equilibria import Equilibrium
 from bluemira.equilibria.find import find_OX_points
 
@@ -73,12 +74,12 @@ class TestFirstWallBuilder:
         cls.eq = Equilibrium.from_eqdsk(os.path.join(DATA, "eqref_OOB.json"))
         _, cls.x_points = find_OX_points(cls.eq.x, cls.eq.z, cls.eq.psi())
 
-    def test_wall_part_is_cut_below_x_point_in_z_axis(self):
-        wall = FirstWallBuilder(
+    def test_wall_boundary_is_cut_below_x_point_in_z_axis(self):
+        first_wall = FirstWallBuilder(
             self._params, build_config=self._default_config, equilibrium=self.eq
         )
 
-        shape = wall.wall_part.get_component(FirstWallBuilder.COMPONENT_WALL).shape
+        shape = first_wall.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
         assert not shape.is_closed()
         # significant delta in assertion as the wire is discrete, so cut is not exact
         np.testing.assert_almost_equal(

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -36,6 +36,7 @@ from bluemira.equilibria import Equilibrium
 from bluemira.equilibria.find import find_OX_points
 
 DATA = get_bluemira_path("bluemira/equilibria/test_data", subfolder="tests")
+OPTIMISER_MODULE_REF = "bluemira.geometry.optimisation"
 WALL_MODULE_REF = "bluemira.builders.EUDEMO.first_wall.wall"
 
 
@@ -53,7 +54,7 @@ class TestFirstWallBuilder:
     _default_config = {
         "name": "First Wall",
         "param_class": f"{WALL_MODULE_REF}::WallPrincetonD",
-        "problem_class": f"{WALL_MODULE_REF}::MinimiseLength",
+        "problem_class": f"{OPTIMISER_MODULE_REF}::MinimiseLength",
         "runmode": "mock",
         "variables_map": _default_variables_map,
     }

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -46,7 +46,7 @@ class TestFirstWallBuilder:
     }
 
     _default_config = {
-        "param_class": "bluemira.builders.EUDEMO.first_wall::FirstWallPolySpline",
+        "param_class": "bluemira.builders.EUDEMO.first_wall::WallPolySpline",
         "variables_map": _default_variables_map,
         "runmode": "mock",
         "name": "First Wall",
@@ -78,9 +78,29 @@ class TestFirstWallBuilder:
             self._params, build_config=self._default_config, equilibrium=self.eq
         )
 
-        shape = wall.wall_part.get_component("first_wall").shape
+        shape = wall.wall_part.get_component(FirstWallBuilder.COMPONENT_WALL).shape
         assert not shape.is_closed()
         # significant delta in assertion as the wire is discrete, so cut is not exact
         np.testing.assert_almost_equal(
             shape.bounding_box.z_min, self.x_points[0][1], decimal=1
         )
+
+    def test_contains_one_divertor_component_given_SN_plasma(self):
+        builder = FirstWallBuilder(
+            self._params, build_config=self._default_config, equilibrium=self.eq
+        )
+
+        wall = builder()
+
+        divertors = wall.get_component(FirstWallBuilder.COMPONENT_DIVERTOR, first=False)
+        assert len(divertors) == 1
+
+    def test_contains_one_wall_component(self):
+        builder = FirstWallBuilder(
+            self._params, build_config=self._default_config, equilibrium=self.eq
+        )
+
+        wall = builder()
+
+        walls = wall.get_component(FirstWallBuilder.COMPONENT_WALL, first=False)
+        assert len(walls) == 1

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_first_wall.py
@@ -81,11 +81,13 @@ class TestFirstWallBuilder:
         _, cls.x_points = find_OX_points(cls.eq.x, cls.eq.z, cls.eq.psi())
 
     def test_wall_boundary_is_cut_below_x_point_in_z_axis(self):
-        first_wall = FirstWallBuilder(
+        builder = FirstWallBuilder(
             self._params, build_config=self._default_config, equilibrium=self.eq
         )
 
-        shape = first_wall.wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
+        first_wall = builder()
+
+        shape = first_wall.get_component(WallBuilder.COMPONENT_WALL_BOUNDARY).shape
         assert not shape.is_closed()
         # significant delta in assertion as the wire is discrete, so cut is not exact
         np.testing.assert_almost_equal(
@@ -132,8 +134,9 @@ class TestFirstWallBuilder:
     def test_BuilderError_if_wall_does_not_enclose_x_point(self):
         params = copy.deepcopy(self._params)
         params.update({"r_fw_ib_in": 7, "r_fw_ob_in": 9})
+        builder = FirstWallBuilder(
+            params, build_config=self._default_config, equilibrium=self.eq
+        )
 
         with pytest.raises(BuilderError):
-            FirstWallBuilder(
-                params, build_config=self._default_config, equilibrium=self.eq
-            )
+            builder()

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -70,14 +70,17 @@ class TestWall:
 
         xy_component = component.get_component("xz", first=False)
         assert len(xy_component) == 1
-        assert len(xy_component[0].get_component("first_wall", first=False)) == 1
+        wall_components = xy_component[0].get_component(
+            WallBuilder.COMPONENT_WALL, first=False
+        )
+        assert len(wall_components) == 1
 
     def test_physical_component_shape_is_closed(self):
         builder = WallBuilder(self._params, build_config=self._default_config)
 
         component = builder()
 
-        assert component.get_component("first_wall").shape.is_closed()
+        assert component.get_component(WallBuilder.COMPONENT_WALL).shape.is_closed()
 
     def test_component_height_derived_from_params(self):
         params = copy.deepcopy(self._params)
@@ -88,6 +91,8 @@ class TestWall:
         builder = WallBuilder(params, build_config=self._default_config)
         component = builder()
 
-        bounding_box = component.get_component("first_wall").shape.bounding_box
+        bounding_box = component.get_component(
+            WallBuilder.COMPONENT_WALL
+        ).shape.bounding_box
         # expected_height = 2*(R_0/A)*kappa_95 = 20
         assert bounding_box.z_max - bounding_box.z_min == 20.0

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -25,7 +25,8 @@ Test for the closed first wall, without a divertor.
 import copy
 
 from bluemira.builders.EUDEMO.first_wall import WallBuilder
-from bluemira.builders.EUDEMO.first_wall.first_wall import _WALL_MODULE_REF
+
+WALL_MODULE_REF = "bluemira.builders.EUDEMO.first_wall.wall"
 
 
 class TestWall:
@@ -40,11 +41,11 @@ class TestWall:
     }
 
     _default_config = {
-        "param_class": f"{_WALL_MODULE_REF}::WallPolySpline",
+        "param_class": f"{WALL_MODULE_REF}::WallPolySpline",
         "variables_map": _default_variables_map,
         "runmode": "mock",
         "name": "First Wall",
-        "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
+        "problem_class": f"{WALL_MODULE_REF}::MinimiseLength",
     }
 
     _params = {
@@ -86,7 +87,7 @@ class TestWall:
             WallBuilder.COMPONENT_WALL_BOUNDARY
         ).shape.is_closed()
 
-    def test_component_height_derived_from_params_in_mock_mode(self):
+    def test_component_height_derived_from_params_given_mock_mode_with_PolySpline(self):
         params = copy.deepcopy(self._params)
         params.update(
             {"R_0": (10.0, "Input"), "kappa_95": (2.0, "Input"), "A": (2.0, "Input")}

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -24,10 +24,10 @@ Test for the closed first wall, without a divertor.
 
 import copy
 
-from bluemira.builders.EUDEMO.first_wall import ClosedFirstWallBuilder
+from bluemira.builders.EUDEMO.first_wall import WallBuilder
 
 
-class TestClosedFirstWallBuilder:
+class TestWall:
 
     _default_variables_map = {
         "x1": {  # ib radius
@@ -59,12 +59,12 @@ class TestClosedFirstWallBuilder:
         config = copy.deepcopy(self._default_config)
         config["name"] = "New name"
 
-        builder = ClosedFirstWallBuilder(self._params, build_config=config)
+        builder = WallBuilder(self._params, build_config=config)
 
         assert builder.name == "New name"
 
     def test_built_component_contains_physical_component_in_xz(self):
-        builder = ClosedFirstWallBuilder(self._params, build_config=self._default_config)
+        builder = WallBuilder(self._params, build_config=self._default_config)
 
         component = builder()
 
@@ -73,7 +73,7 @@ class TestClosedFirstWallBuilder:
         assert len(xy_component[0].get_component("first_wall", first=False)) == 1
 
     def test_physical_component_shape_is_closed(self):
-        builder = ClosedFirstWallBuilder(self._params, build_config=self._default_config)
+        builder = WallBuilder(self._params, build_config=self._default_config)
 
         component = builder()
 
@@ -85,7 +85,7 @@ class TestClosedFirstWallBuilder:
             {"R_0": (10.0, "Input"), "kappa_95": (2.0, "Input"), "A": (2.0, "Input")}
         )
 
-        builder = ClosedFirstWallBuilder(params, build_config=self._default_config)
+        builder = WallBuilder(params, build_config=self._default_config)
         component = builder()
 
         bounding_box = component.get_component("first_wall").shape.bounding_box

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -86,7 +86,7 @@ class TestWall:
             WallBuilder.COMPONENT_WALL_BOUNDARY
         ).shape.is_closed()
 
-    def test_component_height_derived_from_params(self):
+    def test_component_height_derived_from_params_in_mock_mode(self):
         params = copy.deepcopy(self._params)
         params.update(
             {"R_0": (10.0, "Input"), "kappa_95": (2.0, "Input"), "A": (2.0, "Input")}

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -28,6 +28,7 @@ import pytest
 
 from bluemira.builders.EUDEMO.first_wall import WallBuilder
 
+OPTIMISER_MODULE_REF = "bluemira.geometry.optimisation"
 WALL_MODULE_REF = "bluemira.builders.EUDEMO.first_wall.wall"
 
 CONFIG = {
@@ -42,7 +43,7 @@ CONFIG = {
     },
     "runmode": "mock",
     "name": "First Wall",
-    "problem_class": f"{WALL_MODULE_REF}::MinimiseLength",
+    "problem_class": f"{OPTIMISER_MODULE_REF}::MinimiseLength",
 }
 PARAMS = {
     "Name": "First Wall Example",

--- a/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
+++ b/tests/bluemira/builders/EUDEMO/first_wall/test_wall.py
@@ -25,6 +25,7 @@ Test for the closed first wall, without a divertor.
 import copy
 
 from bluemira.builders.EUDEMO.first_wall import WallBuilder
+from bluemira.builders.EUDEMO.first_wall.first_wall import _WALL_MODULE_REF
 
 
 class TestWall:
@@ -39,10 +40,11 @@ class TestWall:
     }
 
     _default_config = {
-        "param_class": "bluemira.builders.EUDEMO.first_wall::FirstWallPolySpline",
+        "param_class": f"{_WALL_MODULE_REF}::WallPolySpline",
         "variables_map": _default_variables_map,
         "runmode": "mock",
         "name": "First Wall",
+        "problem_class": f"{_WALL_MODULE_REF}::MinimiseLength",
     }
 
     _params = {
@@ -71,7 +73,7 @@ class TestWall:
         xy_component = component.get_component("xz", first=False)
         assert len(xy_component) == 1
         wall_components = xy_component[0].get_component(
-            WallBuilder.COMPONENT_WALL, first=False
+            WallBuilder.COMPONENT_WALL_BOUNDARY, first=False
         )
         assert len(wall_components) == 1
 
@@ -80,7 +82,9 @@ class TestWall:
 
         component = builder()
 
-        assert component.get_component(WallBuilder.COMPONENT_WALL).shape.is_closed()
+        assert component.get_component(
+            WallBuilder.COMPONENT_WALL_BOUNDARY
+        ).shape.is_closed()
 
     def test_component_height_derived_from_params(self):
         params = copy.deepcopy(self._params)
@@ -92,7 +96,7 @@ class TestWall:
         component = builder()
 
         bounding_box = component.get_component(
-            WallBuilder.COMPONENT_WALL
+            WallBuilder.COMPONENT_WALL_BOUNDARY
         ).shape.bounding_box
         # expected_height = 2*(R_0/A)*kappa_95 = 20
         assert bounding_box.z_max - bounding_box.z_min == 20.0

--- a/tests/bluemira/codes/test_freecadapi.py
+++ b/tests/bluemira/codes/test_freecadapi.py
@@ -184,7 +184,7 @@ class TestFreecadapi:
 
         start_point = cadapi.start_point(wire)
 
-        isinstance(start_point, np.ndarray)
+        assert isinstance(start_point, np.ndarray)
         np.testing.assert_equal(start_point, np.array([0, 0, 0]))
 
     def test_end_point_given_polygon(self):
@@ -192,5 +192,5 @@ class TestFreecadapi:
 
         end_point = cadapi.end_point(wire)
 
-        isinstance(end_point, np.ndarray)
+        assert isinstance(end_point, np.ndarray)
         np.testing.assert_equal(end_point, np.array([1, 1, 0]))

--- a/tests/bluemira/codes/test_freecadapi.py
+++ b/tests/bluemira/codes/test_freecadapi.py
@@ -178,3 +178,19 @@ class TestFreecadapi:
 
         # assert that points1 and points2 are the same
         assert np.allclose(points1 - points2, 0, atol=D_TOLERANCE)
+
+    def test_start_point_given_polygon(self):
+        wire = cadapi.make_polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0]])
+
+        start_point = cadapi.start_point(wire)
+
+        isinstance(start_point, np.ndarray)
+        np.testing.assert_equal(start_point, np.array([0, 0, 0]))
+
+    def test_end_point_given_polygon(self):
+        wire = cadapi.make_polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0]])
+
+        end_point = cadapi.end_point(wire)
+
+        isinstance(end_point, np.ndarray)
+        np.testing.assert_equal(end_point, np.array([1, 1, 0]))

--- a/tests/bluemira/geometry/test_optimisation.py
+++ b/tests/bluemira/geometry/test_optimisation.py
@@ -22,7 +22,6 @@
 import numpy as np
 import pytest
 
-from bluemira.display.plotter import PlotOptions
 from bluemira.geometry.optimisation import GeometryOptimisationProblem, MinimiseLength
 from bluemira.geometry.parameterisations import PictureFrame, TripleArc
 from bluemira.geometry.tools import make_circle

--- a/tests/bluemira/geometry/test_optimisation.py
+++ b/tests/bluemira/geometry/test_optimisation.py
@@ -20,9 +20,12 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
-from bluemira.geometry.optimisation import GeometryOptimisationProblem
-from bluemira.geometry.parameterisations import TripleArc
+from bluemira.display.plotter import PlotOptions
+from bluemira.geometry.optimisation import GeometryOptimisationProblem, MinimiseLength
+from bluemira.geometry.parameterisations import PictureFrame, TripleArc
+from bluemira.geometry.tools import make_circle
 from bluemira.utilities.optimiser import Optimiser
 
 
@@ -145,3 +148,49 @@ class TestGeometryOptimisationProblem:
         problem.solve()
 
         assert problem.parameterisation.variables["a1"].value == 100
+
+
+class TestMinimiseLength:
+    def test_minimise_with_keep_out_zone(self):
+        # Create a PictureFrame with un-rounded edges (a rectangle) and
+        # a circular keep-out zone within it.
+        # We expect the rectangle to contract such that the distance
+        # between the parallel edges is equal to the diameter of the
+        # keep-out zone.
+        koz_radius = 4.5
+        koz_center = [10, 0, 0]
+        keep_out_zone = make_circle(radius=koz_radius, center=koz_center, axis=[0, 1, 0])
+        parameterisation = PictureFrame(
+            {
+                # Make sure bounds are set within the keep-out zone so
+                # we know it's doing some work
+                "x1": {"value": 4.5, "upper_bound": 6, "lower_bound": 3},
+                "x2": {"value": 16, "upper_bound": 17.5, "lower_bound": 14.5},
+                "z1": {"value": 8, "upper_bound": 15, "lower_bound": 2.5},
+                "z2": {"value": -6, "upper_bound": -2.5, "lower_bound": -15},
+                "ri": {"value": 0, "fixed": True},
+                "ro": {"value": 0, "fixed": True},
+            }
+        )
+        optimiser = Optimiser(
+            "SLSQP",
+            opt_conditions={
+                "max_eval": 100,
+                "ftol_rel": 1e-4,
+                "xtol_rel": 1e-8,
+                "xtol_abs": 1e-8,
+            },
+        )
+        problem = MinimiseLength(
+            parameterisation, optimiser, keep_out_zone=keep_out_zone
+        )
+
+        problem.solve()
+
+        optimised_shape = problem.parameterisation.create_shape()
+        np.testing.assert_array_almost_equal(
+            list(optimised_shape.center_of_mass), koz_center, decimal=2
+        )
+        bounds = optimised_shape.bounding_box
+        assert bounds.x_max - bounds.x_min == pytest.approx(2 * koz_radius, rel=0.01)
+        assert bounds.z_max - bounds.z_min == pytest.approx(2 * koz_radius, rel=0.01)

--- a/tests/bluemira/geometry/test_tools.py
+++ b/tests/bluemira/geometry/test_tools.py
@@ -393,7 +393,7 @@ class TestPointAlongWire:
 
         point = find_point_along_wire_at_length(circle, np.pi)
 
-        np.testing.assert_almost_equal(point, semi_circle.end_point(), decimal=2)
+        np.testing.assert_almost_equal(point, semi_circle.end_point().T[0], decimal=2)
 
     @pytest.mark.parametrize("len_offset", [0.1, 1, 10, 200])
     def test_ValueError_given_length_gt_wire_length(self, len_offset):
@@ -406,7 +406,7 @@ class TestPointAlongWire:
 
 
 class TestConvexHullWires2d:
-    def test_ValueError_given_no_wires_empty(self):
+    def test_ValueError_given_wires_empty(self):
         with pytest.raises(ValueError):
             convex_hull_wires_2d([], 10)
 

--- a/tests/bluemira/geometry/test_tools.py
+++ b/tests/bluemira/geometry/test_tools.py
@@ -382,7 +382,23 @@ class TestPointAlongWire:
         wire = make_polygon(coords)
         desired_len = np.sqrt(2.5)
 
-        point, tangent_vec = find_point_along_wire_at_length(wire, desired_len)
+        point = find_point_along_wire_at_length(wire, desired_len)
 
         np.testing.assert_almost_equal(point, [1.5, 0, 0.5], decimal=2)
-        np.testing.assert_allclose(tangent_vec, np.array([1, 0, 3]) / np.sqrt(10))
+
+    def test_point_along_wire_at_length_3d(self):
+        circle = make_circle(radius=1, axis=[1, 1, 1])
+        semi_circle = make_circle(radius=1, axis=[1, 1, 1], end_angle=180)
+
+        point = find_point_along_wire_at_length(circle, np.pi)
+
+        np.testing.assert_almost_equal(point, semi_circle.end_point(), decimal=2)
+
+    @pytest.mark.parametrize("len_offset", [0.1, 1, 10, 200])
+    def test_ValueError_if_length_gt_wire_length(self, len_offset):
+        coords = np.array([[1, 2, 3, 4, 5], [0, 0, 0, 0, 0], [-1, 2, 5, 8, 11]])
+        wire = make_polygon(coords)
+        wire_length = wire.length
+
+        with pytest.raises(ValueError):
+            find_point_along_wire_at_length(wire, wire_length + len_offset)

--- a/tests/bluemira/geometry/test_tools.py
+++ b/tests/bluemira/geometry/test_tools.py
@@ -28,6 +28,7 @@ from bluemira.geometry.placement import BluemiraPlacement
 from bluemira.geometry.tools import (
     _signed_distance_2D,
     extrude_shape,
+    find_point_along_wire_at_length,
     make_circle,
     make_polygon,
     offset_wire,
@@ -372,3 +373,16 @@ class TestPointInside:
 
         for point in out_points:
             assert not point_inside_shape(point, polygon)
+
+
+class TestPointAlongWire:
+    def test_point_along_wire_at_length_2d(self):
+        # Line in 2d: z = 3x - 4
+        coords = np.array([[1, 2, 3, 4, 5], [0, 0, 0, 0, 0], [-1, 2, 5, 8, 11]])
+        wire = make_polygon(coords)
+        desired_len = np.sqrt(2.5)
+
+        point, tangent_vec = find_point_along_wire_at_length(wire, desired_len)
+
+        np.testing.assert_almost_equal(point, [1.5, 0, 0.5], decimal=2)
+        np.testing.assert_allclose(tangent_vec, np.array([1, 0, 3]) / np.sqrt(10))

--- a/tests/bluemira/geometry/test_wire.py
+++ b/tests/bluemira/geometry/test_wire.py
@@ -1,0 +1,47 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+import numpy as np
+
+from bluemira.geometry.tools import make_polygon
+
+
+class TestWire:
+    def test_start_point(self):
+        n_coords = 10
+        coords = np.zeros((3, n_coords))
+        coords[0, :] = np.linspace(0, 2, n_coords)
+        coords[2, :] = np.linspace(-5, 0, n_coords)
+        wire = make_polygon(coords)
+
+        start_point = wire.start_point()
+
+        np.testing.assert_equal(start_point, np.array([0, 0, -5]))
+
+    def test_end_point(self):
+        n_coords = 10
+        coords = np.zeros((3, n_coords))
+        coords[0, :] = np.linspace(0, 2, n_coords)
+        coords[2, :] = np.linspace(-5, 0, n_coords)
+        wire = make_polygon(coords)
+
+        end_point = wire.end_point()
+
+        np.testing.assert_equal(end_point, np.array([2, 0, 0]))

--- a/tests/bluemira/geometry/test_wire.py
+++ b/tests/bluemira/geometry/test_wire.py
@@ -33,7 +33,7 @@ class TestWire:
 
         start_point = wire.start_point()
 
-        np.testing.assert_equal(start_point, np.array([0, 0, -5]))
+        np.testing.assert_equal(start_point, np.array([[0], [0], [-5]]))
 
     def test_end_point(self):
         n_coords = 10
@@ -44,4 +44,4 @@ class TestWire:
 
         end_point = wire.end_point()
 
-        np.testing.assert_equal(end_point, np.array([2, 0, 0]))
+        np.testing.assert_equal(end_point, np.array([[2], [0], [0]]))

--- a/tests/bluemira/geometry/test_wire.py
+++ b/tests/bluemira/geometry/test_wire.py
@@ -20,11 +20,12 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 import numpy as np
 
-from bluemira.geometry.tools import make_polygon
+from bluemira.geometry.coordinates import Coordinates
+from bluemira.geometry.tools import make_bezier, make_circle, make_polygon
 
 
 class TestWire:
-    def test_start_point(self):
+    def test_start_point_given_polygon(self):
         n_coords = 10
         coords = np.zeros((3, n_coords))
         coords[0, :] = np.linspace(0, 2, n_coords)
@@ -33,9 +34,10 @@ class TestWire:
 
         start_point = wire.start_point()
 
+        assert isinstance(start_point, Coordinates)
         np.testing.assert_equal(start_point, np.array([[0], [0], [-5]]))
 
-    def test_end_point(self):
+    def test_end_point_given_polygon(self):
         n_coords = 10
         coords = np.zeros((3, n_coords))
         coords[0, :] = np.linspace(0, 2, n_coords)
@@ -44,4 +46,37 @@ class TestWire:
 
         end_point = wire.end_point()
 
+        assert isinstance(end_point, Coordinates)
         np.testing.assert_equal(end_point, np.array([[2], [0], [0]]))
+
+    def test_start_point_eq_end_point_given_circle(self):
+        wire = make_circle(radius=2, center=(0, 0, 0))
+
+        start_point = wire.start_point()
+        end_point = wire.end_point()
+
+        assert start_point == end_point
+
+    def test_start_point_given_bezier(self):
+        n_coords = 11
+        coords = np.zeros((3, n_coords))
+        coords[0, :] = np.linspace(-5, 5, n_coords)
+        coords[1, :] = np.linspace(0.1, 0.2, n_coords)
+        coords[2, :] = np.linspace(100, 90, n_coords)
+        wire = make_bezier(coords)
+
+        start_point = wire.start_point()
+
+        np.testing.assert_equal(start_point, np.array([[-5], [0.1], [100]]))
+
+    def test_end_point_given_bezier(self):
+        n_coords = 11
+        coords = np.zeros((3, n_coords))
+        coords[0, :] = np.linspace(-5, 5, n_coords)
+        coords[1, :] = np.linspace(0.1, 0.2, n_coords)
+        coords[2, :] = np.linspace(100, 90, n_coords)
+        wire = make_bezier(coords)
+
+        start_point = wire.end_point()
+
+        np.testing.assert_equal(start_point, np.array([[5], [0.2], [90]]))


### PR DESCRIPTION
## Linked Issues
#642

## Description

Implements `FirstWallBuilder` class and adds the "First wall" component to the `EUDEMOReactor`.

Three builder classes have been implemented:
- `WallBuilder`: builds a closed wall shape, independent of divertor
- `DivertorBuilder`: builds the divertor components
- `FirstWallBuilder`: runs `WallBuilder`, cuts it off below the x-point, and uses `DivertorBuilder` to make a divertor in the gap.

Also added is the `MinimiseLength` geometry optimisation class, which minimises the length of a shape parameterisation with some constraints.

Some incomplete parts:
- Divertor targets are currently always vertical
- Divertor baffles are currently straight lines
- Only single-null plasmas with x-point at lower end are supported

Another note for reviewers, the function `bluemira.geometry.tools.find_point_along_wire_at_length` is currently implemented using discretisation. Is there a way to do this using primitives?


## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
