### PR TITLE
Geometry module  __all__ for some files

### DIFF
--- a/bluemira/geometry/bound_box.py
+++ b/bluemira/geometry/bound_box.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+__all__ = ["BoundingBox"]
+
 
 @dataclass
 class BoundingBox:

--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -38,6 +38,8 @@ from bluemira.geometry.base import BluemiraGeo
 from bluemira.geometry.error import DisjointedFace, NotClosedWire
 from bluemira.geometry.wire import BluemiraWire
 
+__all__ = ["BluemiraFace"]
+
 
 class BluemiraFace(BluemiraGeo):
     """Bluemira Face class."""

--- a/bluemira/geometry/plane.py
+++ b/bluemira/geometry/plane.py
@@ -30,6 +30,8 @@ import numpy as np
 import bluemira.codes._freecadapi as cadapi
 from bluemira.geometry.error import GeometryError
 
+__all__ = ["BluemiraPlane"]
+
 
 class BluemiraPlane:
     """

--- a/bluemira/geometry/shell.py
+++ b/bluemira/geometry/shell.py
@@ -32,6 +32,8 @@ import bluemira.codes._freecadapi as cadapi
 from bluemira.geometry.base import BluemiraGeo
 from bluemira.geometry.face import BluemiraFace
 
+__all__ = ["BluemiraShell"]
+
 
 class BluemiraShell(BluemiraGeo):
     """Bluemira Shell class."""

--- a/bluemira/geometry/solid.py
+++ b/bluemira/geometry/solid.py
@@ -33,6 +33,8 @@ from bluemira.geometry.base import BluemiraGeo
 from bluemira.geometry.error import DisjointedSolid
 from bluemira.geometry.shell import BluemiraShell
 
+__all__ = ["BluemiraSolid"]
+
 
 class BluemiraSolid(BluemiraGeo):
     """Bluemira Solid class."""

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -48,6 +48,8 @@ from bluemira.geometry.coordinates import Coordinates
 # import from error
 from bluemira.geometry.error import MixedOrientationWireError, NotClosedWire
 
+__all__ = ["BluemiraWire"]
+
 
 class BluemiraWire(BluemiraGeo):
     """Bluemira Wire class."""


### PR DESCRIPTION
## Linked Issues

Reduces a bit of namespace noise in IDEs and should protect namespaces better in general

## Description

Adds __all__ to some files in geometry in which only a single class resides. Such that now one should not see `from bluemira.geometry.face import [BluemiraWire] as a suggestion.

## Interface Changes
N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`