### PR TITLE
Fix a warning in geometry tests

### DIFF
--- a/tests/bluemira/geometry/test_optimisation.py
+++ b/tests/bluemira/geometry/test_optimisation.py
@@ -26,7 +26,7 @@ from bluemira.geometry.parameterisations import TripleArc
 from bluemira.utilities.optimiser import Optimiser
 
 
-class TestOptimisationProblem(GeometryOptimisationProblem):
+class DummyOptimisationProblem(GeometryOptimisationProblem):
     def calculate_length(self, x):
         self.update_parameterisation(x)
         return self.parameterisation.create_shape().length
@@ -65,7 +65,7 @@ class TestGeometryOptimisationProblem:
             "SLSQP",
             opt_conditions=cls.opt_conditions,
         )
-        problem = TestOptimisationProblem(parameterisation, optimiser)
+        problem = DummyOptimisationProblem(parameterisation, optimiser)
         problem.apply_shape_constraints()
         problem.solve()
         cls.ref_length = parameterisation.create_shape().length
@@ -86,7 +86,7 @@ class TestGeometryOptimisationProblem:
             "SLSQP",
             opt_conditions=self.opt_conditions,
         )
-        problem = TestOptimisationProblem(parameterisation, optimiser)
+        problem = DummyOptimisationProblem(parameterisation, optimiser)
         problem.apply_shape_constraints()
         assert problem.parameterisation.variables.n_free_variables == 7
         assert problem.parameterisation.variables._fixed_variable_indices == []
@@ -111,7 +111,7 @@ class TestGeometryOptimisationProblem:
             "SLSQP",
             opt_conditions=self.opt_conditions,
         )
-        problem = TestOptimisationProblem(parameterisation, optimiser)
+        problem = DummyOptimisationProblem(parameterisation, optimiser)
         problem.apply_shape_constraints()
         assert problem.parameterisation.variables.n_free_variables == 6
         assert problem.parameterisation.variables._fixed_variable_indices == [0]
@@ -137,7 +137,7 @@ class TestGeometryOptimisationProblem:
             "SLSQP",
             opt_conditions=self.opt_conditions,
         )
-        problem = TestOptimisationProblem(parameterisation, optimiser)
+        problem = DummyOptimisationProblem(parameterisation, optimiser)
 
         assert problem.parameterisation.variables.n_free_variables == 5
         assert problem.parameterisation.variables._fixed_variable_indices == [0, 5]


### PR DESCRIPTION
## Linked Issues

We were getting this warning because of pytest class naming conventions (which makes sense):
```python
tests/bluemira/geometry/test_optimisation.py:29
  /home/matti/code/bluemira/tests/bluemira/geometry/test_optimisation.py:29: PytestCollectionWarning: cannot collect test class 'TestOptimisationProblem' because it has a __init__ constructor (from: tests/bluemira/geometry/test_optimisation.py)
```

## Description
Renames this class so that it doesn't start with `Test`

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
