### PR TITLE
Creates a register of plotting classes

### DIFF
--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
 import matplotlib.colors as colors
 
-from bluemira.codes import _freecadapi as cadapi
 from bluemira.display.error import DisplayError
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.display.plotter import DisplayOptions
@@ -154,6 +153,8 @@ def show_cad(
     options: Optional[Union[_PlotCADOptions, List[_PlotCADOptions]]]
         The options to use to display the parts.
     """
+    from bluemira.codes import _freecadapi as cadapi
+
     parts, options = _validate_display_inputs(parts, options)
 
     new_options = []

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -475,8 +475,7 @@ class PointsPlotter(BasePlotter):
 
 class _PlotterRegistry:
     """
-    This class provides a registry of plotters that are associated with other bluemira
-    classes.
+    Provides a registry of plotters that are associated with other bluemira classes.
     """
 
     _registry: Dict[Type[Any], Type[BasePlotter]] = {}

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -35,9 +35,6 @@ import numpy as np
 
 from bluemira.display.error import DisplayError
 from bluemira.display.palettes import BLUE_PALETTE
-from bluemira.geometry import bound_box
-from bluemira.geometry import plane as _plane
-from bluemira.geometry.coordinates import Coordinates, _parse_to_xyz_array
 
 if TYPE_CHECKING:
     from bluemira.geometry.base import BluemiraGeo
@@ -69,6 +66,8 @@ def get_default_options():
     """
     Returns the instance as a dictionary.
     """
+    from bluemira.geometry import plane as _plane
+
     output_dict = {}
     for k, v in DEFAULT_PLOT_OPTIONS.items():
         # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
@@ -150,6 +149,8 @@ class PlotOptions(DisplayOptions):
         """
         Returns the instance as a dictionary.
         """
+        from bluemira.geometry import plane as _plane
+
         output_dict = {}
         for k, v in self._options.items():
             # FreeCAD Plane that is contained in BluemiraPlane cannot be deepcopied by
@@ -285,6 +286,8 @@ class BasePlotter(ABC):
 
     def set_plane(self, plane):
         """Set the plotting plane"""
+        from bluemira.geometry import plane as _plane
+
         if plane == "xy":
             # Base.Placement(origin, axis, angle)
             self.options._options["plane"] = _plane.BluemiraPlane()
@@ -366,6 +369,8 @@ class BasePlotter(ABC):
             self.ax.set_ylabel(UNIT_LABEL)
 
     def _set_aspect_3d(self):
+        from bluemira.geometry import bound_box
+
         # This was the only way I found to get 3-D plots to look right in matplotlib
         x_bb, y_bb, z_bb = bound_box.BoundingBox.from_xyz(*self._data.T).get_box_arrays()
         for x, y, z in zip(x_bb, y_bb, z_bb):
@@ -454,6 +459,8 @@ class PointsPlotter(BasePlotter):
         return True
 
     def _populate_data(self, points):
+        from bluemira.geometry.coordinates import _parse_to_xyz_array
+
         points = _parse_to_xyz_array(points).T
         self._data = points
         # apply rotation matrix given by options['plane']
@@ -722,4 +729,3 @@ class Plottable:
 
 register_plotter(list, PointsPlotter)
 register_plotter(np.ndarray, PointsPlotter)
-register_plotter(Coordinates, PointsPlotter)

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -31,6 +31,7 @@ from pyquaternion import Quaternion
 
 from bluemira.base.constants import EPS
 from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.display.plotter import PointsPlotter, register_plotter
 from bluemira.geometry.error import CoordinatesError
 
 # =============================================================================
@@ -929,3 +930,6 @@ class Coordinates:
         Array-like unpacking.
         """
         return self._array.__iter__()
+
+
+register_plotter(Coordinates, PointsPlotter)

--- a/examples/geometry/plotting_tutorial.ipynb
+++ b/examples/geometry/plotting_tutorial.ipynb
@@ -9,9 +9,9 @@
         "import bluemira.display as display\n",
         "import bluemira.geometry.tools\n",
         "from bluemira.base.components import Component, PhysicalComponent\n",
-        "from bluemira.display.plotter import FacePlotter, WirePlotter\n",
-        "from bluemira.geometry.face import BluemiraFace\n",
-        "from bluemira.geometry.parameterisations import PrincetonD"
+        "from bluemira.geometry.face import BluemiraFace, FacePlotter\n",
+        "from bluemira.geometry.parameterisations import PrincetonD\n",
+        "from bluemira.geometry.wire import WirePlotter"
       ],
       "outputs": [],
       "execution_count": null
@@ -729,7 +729,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.10"
     }
   },
   "nbformat": 4,

--- a/examples/geometry/plotting_tutorial.py
+++ b/examples/geometry/plotting_tutorial.py
@@ -28,9 +28,9 @@ import matplotlib.pyplot as plt
 import bluemira.display as display
 import bluemira.geometry.tools
 from bluemira.base.components import Component, PhysicalComponent
-from bluemira.display.plotter import FacePlotter, WirePlotter
-from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.face import BluemiraFace, FacePlotter
 from bluemira.geometry.parameterisations import PrincetonD
+from bluemira.geometry.wire import WirePlotter
 
 # %%[markdown]
 # ## Setup

--- a/tests/bluemira/display/test_plotter.py
+++ b/tests/bluemira/display/test_plotter.py
@@ -24,9 +24,10 @@ Tests for the plotter module.
 """
 
 import numpy as np
+import pytest
 
 import bluemira.geometry as geo
-from bluemira.base.components import Component, PhysicalComponent
+from bluemira.base.components import Component, ComponentPlotter, PhysicalComponent
 from bluemira.display import plot_3d, plotter
 from bluemira.utilities.plot_tools import Plot3D
 
@@ -134,6 +135,30 @@ class TestPlot3d:
         assert ax_2 is not ax_orig
 
 
+class TestPlottingRegister:
+    def test_default_classes(self):
+        assert plotter.get_plotter(list) is plotter.PointsPlotter
+        assert plotter.get_plotter(np.ndarray) is plotter.PointsPlotter
+        assert plotter.get_plotter(geo.coordinates.Coordinates) is plotter.PointsPlotter
+        assert plotter.get_plotter(geo.wire.BluemiraWire) is geo.wire.WirePlotter
+        assert plotter.get_plotter(geo.face.BluemiraFace) is geo.face.FacePlotter
+        assert plotter.get_plotter(Component) is ComponentPlotter
+        assert plotter.get_plotter(PhysicalComponent) is ComponentPlotter
+
+    def test_no_plotter(self):
+        class Thing:
+            pass
+
+        with pytest.raises(ValueError):
+            plotter.get_plotter(Thing)
+
+    def test_register_existing(self):
+        with pytest.raises(ValueError):
+            plotter.register_plotter(list, None)
+
+        assert plotter.get_plotter(list) is plotter.PointsPlotter
+
+
 class TestPointsPlotter:
     def test_plotting_2d(self):
         plotter.PointsPlotter().plot_2d(SQUARE_POINTS)
@@ -147,16 +172,16 @@ class TestWirePlotter:
         self.wire = geo.tools.make_polygon(SQUARE_POINTS)
 
     def test_plotting_2d(self):
-        plotter.WirePlotter().plot_2d(self.wire)
+        geo.wire.WirePlotter().plot_2d(self.wire)
 
     def test_plotting_2d_with_points(self):
-        plotter.WirePlotter(show_points=True).plot_2d(self.wire)
+        geo.wire.WirePlotter(show_points=True).plot_2d(self.wire)
 
     def test_plotting_3d(self):
-        plotter.WirePlotter().plot_3d(self.wire)
+        geo.wire.WirePlotter().plot_3d(self.wire)
 
     def test_plotting_3d_with_points(self):
-        plotter.WirePlotter(show_points=True).plot_3d(self.wire)
+        geo.wire.WirePlotter(show_points=True).plot_3d(self.wire)
 
 
 class TestFacePlotter:
@@ -166,16 +191,16 @@ class TestFacePlotter:
         self.face = geo.face.BluemiraFace(wire)
 
     def test_plotting_2d(self):
-        plotter.FacePlotter().plot_2d(self.face)
+        geo.face.FacePlotter().plot_2d(self.face)
 
     def test_plotting_2d_with_wire(self):
-        plotter.FacePlotter(show_wires=True).plot_2d(self.face)
+        geo.face.FacePlotter(show_wires=True).plot_2d(self.face)
 
     def test_plotting_3d(self):
-        plotter.FacePlotter().plot_3d(self.face)
+        geo.face.FacePlotter().plot_3d(self.face)
 
     def test_plotting_3d_with_wire_and_points(self):
-        plotter.FacePlotter(show_wires=True, show_points=True).plot_3d(self.face)
+        geo.face.FacePlotter(show_wires=True, show_points=True).plot_3d(self.face)
 
 
 class TestComponentPlotter:
@@ -190,13 +215,13 @@ class TestComponentPlotter:
         self.child2 = PhysicalComponent("Child2", shape=face2, parent=self.group)
 
     def test_plotting_2d(self):
-        plotter.ComponentPlotter().plot_2d(self.group)
+        ComponentPlotter().plot_2d(self.group)
 
     def test_plotting_2d_no_wires(self):
-        plotter.ComponentPlotter(show_wires=True).plot_2d(self.group)
+        ComponentPlotter(show_wires=True).plot_2d(self.group)
 
     def test_plotting_3d(self):
-        plotter.ComponentPlotter().plot_3d(self.group)
+        ComponentPlotter().plot_3d(self.group)
 
     def test_plotting_3d_with_wires_and_points(self):
-        plotter.ComponentPlotter(show_wires=True, show_points=True).plot_3d(self.group)
+        ComponentPlotter(show_wires=True, show_points=True).plot_3d(self.group)


### PR DESCRIPTION
## Linked Issues

Closes #531 

## Description

Looks to make plotters more closely associated with their corresponding classes via the following changes:

- Creates a registry class to store mapping between class and plotter
- Helper methods to avoid exposing registry
- Move plotting classes to be along side corresponding geometry / component classes
- Register plotting classes within module

## Interface Changes

No external changes. Will allow users to associate their own plotters with their own classes (e.g. for specific components).

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
