### PR TITLE
Danshort12/register solver

### DIFF
--- a/BLUEPRINT/reactor.py
+++ b/BLUEPRINT/reactor.py
@@ -292,13 +292,13 @@ class Reactor(ReactorSystem):
         """
         Runs, reads, or mocks the systems code according to the build config dictionary.
         """
-        PROCESS_output: ParameterFrame = run_systems_code(
+        PROCESS_solver = run_systems_code(
             self.params,
             self.build_config,
             self.file_manager.generated_data_dirs["systems_code"],
             self.file_manager.reference_data_dirs["systems_code"],
         )
-        self.params.update_kw_parameters(PROCESS_output.to_dict())
+        self.params.update_kw_parameters(PROCESS_solver.params.to_dict())
 
     def estimate_kappa_95(self):
         """

--- a/bluemira/base/design.py
+++ b/bluemira/base/design.py
@@ -23,17 +23,23 @@
 Module containing the bluemira Design class.
 """
 
+from __future__ import annotations
+
 import abc
 import copy
+import typing
 from typing import Dict, Optional, Set, Type, Union
 
 from bluemira.base.builder import BuildConfig, Builder
 from bluemira.base.components import Component
 from bluemira.base.config import Configuration
-from bluemira.base.error import BuilderError
+from bluemira.base.error import DesignError
 from bluemira.base.file import BM_ROOT, FileManager
 from bluemira.base.look_and_feel import bluemira_print, print_banner
 from bluemira.utilities.tools import get_class_from_module
+
+if typing.TYPE_CHECKING:
+    from bluemira.codes.interface import FileProgramInterface
 
 
 class DesignABC(abc.ABC):
@@ -48,6 +54,7 @@ class DesignABC(abc.ABC):
     _params: Configuration
     _build_config: Dict[str, BuildConfig]
     _builders: Dict[str, Builder]
+    _solvers: Dict[str, FileProgramInterface]
 
     def __init__(
         self,
@@ -97,6 +104,43 @@ class DesignABC(abc.ABC):
         component = Component(self._params.Name)
         return component
 
+    def get_solver(self, solver_name: str) -> FileProgramInterface:
+        """
+        Get the solver with the corresponding solver_name.
+
+        Parameters
+        ----------
+        solver_name: str
+            The name of the solver to get.
+
+        Returns
+        -------
+        solver: FileProgramInterface
+            The solver corresponding to the provided name.
+        """
+        return self._solvers[solver_name]
+
+    def register_solver(self, solver: FileProgramInterface, name: str):
+        """
+        Add this solver to the internal solver registry.
+
+        Parameters
+        ----------
+        solver: FileProgramInterface
+            The solver to be registered.
+        name: str
+            The name to register this solver with.
+
+        Raises
+        ------
+        DesignError
+            If name already exists in the registry.
+        """
+        if name not in self._solvers:
+            self._solvers[name] = solver
+        else:
+            raise DesignError(f"Solver {name} already exists in {self}.")
+
     def get_builder(self, builder_name: str) -> Builder:
         """
         Get the builder with the corresponding builder_name.
@@ -126,13 +170,13 @@ class DesignABC(abc.ABC):
 
         Raises
         ------
-        BuilderError
+        DesignError
             If name already exists in the registry.
         """
         if name not in self._builders:
             self._builders[name] = builder
         else:
-            raise BuilderError(f"Builder {name} already exists in {self}.")
+            raise DesignError(f"Builder {name} already exists in {self}.")
 
     def _build_stage(self, name: str) -> Component:
         """
@@ -174,7 +218,7 @@ class DesignABC(abc.ABC):
         }
 
         if len(missing_params) > 0:
-            raise BuilderError(
+            raise DesignError(
                 f"Required parameters {', '.join(sorted(missing_params))} not provided to Design"
             )
 

--- a/bluemira/base/design.py
+++ b/bluemira/base/design.py
@@ -205,6 +205,7 @@ class DesignABC(abc.ABC):
         corresponding options.
         """
         self._builders = {}
+        self._solvers = {}
         self._required_params = {"Name"}
 
     def _validate_params(self, params: Dict[str, Union[int, float, str]]):

--- a/bluemira/base/error.py
+++ b/bluemira/base/error.py
@@ -68,3 +68,11 @@ class ParameterError(BluemiraError):
     """
 
     pass
+
+
+class DesignError(BluemiraError):
+    """
+    Exception class for Designs.
+    """
+
+    pass

--- a/bluemira/builders/EUDEMO/reactor.py
+++ b/bluemira/builders/EUDEMO/reactor.py
@@ -28,7 +28,6 @@ import os
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.design import Reactor
 from bluemira.base.look_and_feel import bluemira_print
-from bluemira.base.parameter import ParameterFrame
 from bluemira.builders.EUDEMO.pf_coils import PFCoilsBuilder
 from bluemira.builders.EUDEMO.plasma import PlasmaBuilder
 from bluemira.builders.EUDEMO.tf_coils import TFCoilsBuilder
@@ -78,13 +77,14 @@ class EUDEMOReactor(Reactor):
         # run_systems_code interface is updated to have a more general runmode value.
         config["process_mode"] = config.pop("runmode")
 
-        output: ParameterFrame = run_systems_code(
+        solver = run_systems_code(
             self._params,
             config,
             self._file_manager.generated_data_dirs["systems_code"],
             self._file_manager.reference_data_dirs["systems_code"],
         )
-        self._params.update_kw_parameters(output.to_dict())
+        self.register_solver(solver, name)
+        self._params.update_kw_parameters(solver.params.to_dict())
 
         bluemira_print(f"Completed design stage: {name}")
 

--- a/bluemira/codes/wrapper.py
+++ b/bluemira/codes/wrapper.py
@@ -25,13 +25,15 @@ Bluemira External Codes Wrapper
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from bluemira.base.builder import BuildConfig
-from bluemira.base.parameter import ParameterFrame
 from bluemira.codes import process
 from bluemira.codes.error import CodesError
 from bluemira.codes.interface import FileProgramInterface
+
+if TYPE_CHECKING:
+    from bluemira.base.builder import BuildConfig
+    from bluemira.base.parameter import ParameterFrame
 
 
 def run_systems_code(

--- a/bluemira/codes/wrapper.py
+++ b/bluemira/codes/wrapper.py
@@ -27,19 +27,21 @@ from __future__ import annotations
 
 from typing import Optional
 
-import bluemira.base as bm_base
+from bluemira.base.builder import BuildConfig
+from bluemira.base.parameter import ParameterFrame
 from bluemira.codes import process
 from bluemira.codes.error import CodesError
+from bluemira.codes.interface import FileProgramInterface
 
 
 def run_systems_code(
-    params: bm_base.ParameterFrame,
-    build_config: bm_base.BuildConfig,
+    params: ParameterFrame,
+    build_config: BuildConfig,
     run_dir: str,
     read_dir: Optional[str] = None,
     template_indat=None,
     params_to_update=None,
-) -> bm_base.ParameterFrame:
+) -> FileProgramInterface:
     """
     Runs, reads or mocks PROCESS according to the build configuration dictionary.
 
@@ -74,6 +76,11 @@ def run_systems_code(
         on EU-DEMO. This option should not be used if PROCESS is installed, except for
         testing purposes.
 
+    Returns
+    -------
+    solver: FileProgramInterface
+        The solver that has been run.
+
     Raises
     ------
     CodesError
@@ -90,4 +97,4 @@ def run_systems_code(
         params, build_config, run_dir, read_dir, template_indat, params_to_update
     )
     solver.run()
-    return solver.params
+    return solver

--- a/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.ipynb
@@ -25,7 +25,7 @@
         ")\n",
         "from bluemira.codes.process.mapping import mappings as PROCESS_mappings  # noqa: N812\n",
         "from bluemira.display.displayer import ComponentDisplayer\n",
-        "from bluemira.equilibria.run import AbInitioEquilibriumProblem\n",
+        "from bluemira.equilibria._deprecated_run import AbInitioEquilibriumProblem\n",
         "from bluemira.utilities.tools import json_writer"
       ],
       "outputs": [],
@@ -741,7 +741,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.10"
     }
   },
   "nbformat": 4,

--- a/examples/design/EU-DEMO/EUDEMO_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_reactor.py
@@ -45,7 +45,7 @@ from bluemira.codes.plasmod.mapping import (  # noqa: N812
 )
 from bluemira.codes.process.mapping import mappings as PROCESS_mappings  # noqa: N812
 from bluemira.display.displayer import ComponentDisplayer
-from bluemira.equilibria.run import AbInitioEquilibriumProblem
+from bluemira.equilibria._deprecated_run import AbInitioEquilibriumProblem
 from bluemira.utilities.tools import json_writer
 
 # %%[markdown]


### PR DESCRIPTION
## Linked Issues

Related to #721

## Description

Introduces minimal changes to support registering a solver with a `Reactor`.

## Interface Changes

run_systems_code now returns the solver used rather than just the parameters.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
