### PR TITLE
Fix HelmholtzCage and magnetostatics rotation conventions

### DIFF
--- a/bluemira/magnetostatics/baseclass.py
+++ b/bluemira/magnetostatics/baseclass.py
@@ -138,11 +138,11 @@ class RectangularCrossSectionCurrentSource(CurrentSource):
         Parameters
         ----------
         angle: float
-            The rotation degree [rad]
+            The rotation degree [degree]
         axis: Union[np.array(3), str]
             The axis of rotation
         """
-        r = rotation_matrix(angle, axis)
+        r = rotation_matrix(np.deg2rad(angle), axis).T
         self.origin = self.origin @ r
         self.points = np.array([p @ r for p in self.points], dtype=object)
         self.dcm = self.dcm @ r

--- a/bluemira/magnetostatics/biot_savart.py
+++ b/bluemira/magnetostatics/biot_savart.py
@@ -217,11 +217,11 @@ class BiotSavartFilament(CurrentSource):
         Parameters
         ----------
         angle: float
-            The rotation degree [rad]
+            The rotation degree [degree]
         axis: Union[np.array(3), str]
             The axis of rotation
         """
-        r = rotation_matrix(angle, axis)
+        r = rotation_matrix(np.deg2rad(angle), axis).T
         self.points = self.points @ r
         self.d_l = self.d_l @ r
         self.mid_points = self.mid_points @ r

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -163,9 +163,7 @@ class HelmholtzCage(SourceGroup):
         """
         Pattern the CurrentSource axisymmetrically.
         """
-        angles = np.pi / self.n_TF + np.linspace(
-            0, 2 * np.pi, int(self.n_TF), endpoint=False
-        )
+        angles = np.linspace(0, 360, int(self.n_TF), endpoint=False)
         sources = []
         for angle in angles:
             source = circuit.copy()
@@ -195,10 +193,10 @@ class HelmholtzCage(SourceGroup):
         point = np.array([x, y, z])
         ripple_field = np.zeros(2)
         n = np.array([0, 1, 0])
-        planes = [np.pi / self.n_TF, 0]  # rotate (inline, ingap)
+        planes = [0, np.pi / self.n_TF]  # rotate (inline, ingap)
 
         for i, theta in enumerate(planes):
-            r_matrix = rotation_matrix(theta)
+            r_matrix = rotation_matrix(theta).T
             sr = np.dot(point, r_matrix)
             nr = np.dot(n, r_matrix)
             field = self.field(*sr)

--- a/examples/magnetostatics/helmholtz_example.ipynb
+++ b/examples/magnetostatics/helmholtz_example.ipynb
@@ -1,0 +1,281 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Introduction\n",
+        "\n",
+        "In this example we will build some HelmholtzCages with different types of current\n",
+        "sources."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "\n",
+        "from bluemira.geometry._deprecated_loop import Loop\n",
+        "from bluemira.geometry._deprecated_tools import make_circle_arc\n",
+        "from bluemira.magnetostatics.biot_savart import BiotSavartFilament\n",
+        "from bluemira.magnetostatics.circuits import (\n",
+        "    ArbitraryPlanarRectangularXSCircuit,\n",
+        "    HelmholtzCage,\n",
+        ")\n",
+        "from bluemira.magnetostatics.circular_arc import CircularArcCurrentSource\n",
+        "from bluemira.utilities.plot_tools import Plot3D"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Set up some geometry and key parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "n_TF = 6\n",
+        "current = 20e6\n",
+        "breadth = 0.5\n",
+        "depth = 1.0\n",
+        "radius = 6\n",
+        "x_c = 9\n",
+        "z_c = 0\n",
+        "x, z = make_circle_arc(radius, x_c, z_c, n_points=200, start_angle=np.pi)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Make a Biot-Savart filament (which needs to be properly discretised)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "n_filaments_x = 2\n",
+        "n_filaments_y = 3\n",
+        "fil_radius = 0.5 * (breadth + depth) / (n_filaments_x * n_filaments_y)\n",
+        "\n",
+        "loop = Loop(x=x, z=z)\n",
+        "loop.close()\n",
+        "loop.interpolate(50)\n",
+        "\n",
+        "loops = []\n",
+        "filaments = []\n",
+        "dx_offsets = np.linspace(-breadth / 2, breadth / 2, n_filaments_x)\n",
+        "dy_offsets = np.linspace(-depth / 2, depth / 2, n_filaments_y)\n",
+        "\n",
+        "for dx in dx_offsets:\n",
+        "    for dy in dy_offsets:\n",
+        "        new_loop = loop.offset(dx)\n",
+        "        new_loop.translate(vector=[0, dy, 0])\n",
+        "        loops.append(new_loop)\n",
+        "\n",
+        "biotsavart_circuit = BiotSavartFilament(\n",
+        "    loops, radius=fil_radius, current=current / (n_filaments_x * n_filaments_y)\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Make an analytical circuit with a rectangular cross-section comprised\n",
+        "of several trapezoidal prism elements"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "loop.close()\n",
+        "analytical_circuit1 = ArbitraryPlanarRectangularXSCircuit(\n",
+        "    loop, breadth=breadth, depth=depth, current=current\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Make an analytical circuit of a circle arc with a rectangular cross-section"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "analytical_circuit2 = CircularArcCurrentSource(\n",
+        "    [x_c, 0, z_c],\n",
+        "    [-1, 0, 0],\n",
+        "    [0, 0, 1],\n",
+        "    [0, 1, 0],\n",
+        "    breadth=breadth,\n",
+        "    depth=depth,\n",
+        "    radius=radius,\n",
+        "    dtheta=2 * np.pi,\n",
+        "    current=current,\n",
+        ")"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Pattern the three circuits into HelmholtzCages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "biotsavart_tf_cage = HelmholtzCage(biotsavart_circuit, n_TF=n_TF)\n",
+        "analytical_tf_cage1 = HelmholtzCage(analytical_circuit1, n_TF=n_TF)\n",
+        "analytical_tf_cage2 = HelmholtzCage(analytical_circuit2, n_TF=n_TF)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Calculate the fields in the x-y and x-z planes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "nx, ny = 50, 50\n",
+        "x = np.linspace(0, 18, nx)\n",
+        "y = np.linspace(-18, 0, ny)\n",
+        "xx1, yy = np.meshgrid(x, y, indexing=\"ij\")\n",
+        "\n",
+        "biotsavart_xy_fields = biotsavart_tf_cage.field(xx1, yy, np.zeros_like(xx1))\n",
+        "analytical_xy_fields = analytical_tf_cage1.field(xx1, yy, np.zeros_like(xx1))\n",
+        "analytical_xy_fields2 = analytical_tf_cage2.field(xx1, yy, np.zeros_like(xx1))\n",
+        "\n",
+        "biotsavart_xy_fields = np.sqrt(np.sum(biotsavart_xy_fields**2, axis=0))\n",
+        "analytical_xy_fields = np.sqrt(np.sum(analytical_xy_fields**2, axis=0))\n",
+        "analytical_xy_fields2 = np.sqrt(np.sum(analytical_xy_fields2**2, axis=0))\n",
+        "\n",
+        "nx, nz = 50, 50\n",
+        "x = np.linspace(0, 18, nx)\n",
+        "z = np.linspace(0, 14, nz)\n",
+        "xx, zz = np.meshgrid(x, z, indexing=\"ij\")\n",
+        "\n",
+        "biotsavart_xz_fields = biotsavart_tf_cage.field(xx, np.zeros_like(xx), zz)\n",
+        "analytical_xz_fields = analytical_tf_cage1.field(xx, np.zeros_like(xx), zz)\n",
+        "analytical_xz_fields2 = analytical_tf_cage2.field(xx, np.zeros_like(xx), zz)\n",
+        "\n",
+        "biotsavart_xz_fields = np.sqrt(np.sum(biotsavart_xz_fields**2, axis=0))\n",
+        "analytical_xz_fields = np.sqrt(np.sum(analytical_xz_fields**2, axis=0))\n",
+        "analytical_xz_fields2 = np.sqrt(np.sum(analytical_xz_fields2**2, axis=0))"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "Let's visualise the results"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "def plot_cage_results(cage, xz_fields, xy_fields):\n",
+        "    \"\"\"\n",
+        "    Plot utility for contours in 3-D projections in matplotlib.\n",
+        "    \"\"\"\n",
+        "    b_max = max(np.amax(xz_fields), np.amax(xy_fields))\n",
+        "    levels = np.linspace(0, b_max, 20)\n",
+        "\n",
+        "    ax = Plot3D()\n",
+        "\n",
+        "    cm = ax.contourf(\n",
+        "        xx1,\n",
+        "        yy,\n",
+        "        xy_fields,\n",
+        "        zdir=\"z\",\n",
+        "        levels=levels,\n",
+        "        offset=0,\n",
+        "        alpha=0.8,\n",
+        "        zorder=-1,\n",
+        "        cmap=\"magma\",\n",
+        "    )\n",
+        "\n",
+        "    ax.contourf(\n",
+        "        xx,\n",
+        "        xz_fields,\n",
+        "        zz,\n",
+        "        zdir=\"y\",\n",
+        "        levels=levels,\n",
+        "        offset=0,\n",
+        "        alpha=0.8,\n",
+        "        zorder=-1,\n",
+        "        cmap=\"magma\",\n",
+        "    )\n",
+        "    f = plt.gcf()\n",
+        "    cb0 = f.colorbar(cm, shrink=0.46)\n",
+        "    cb0.ax.set_title(\"$B$ [T]\")\n",
+        "    cage.plot(ax=ax)\n",
+        "    ax.set_xlabel(\"x [m]\")\n",
+        "    ax.set_ylabel(\"y [m]\")\n",
+        "    ax.set_ylabel(\"z [m]\")\n",
+        "\n",
+        "\n",
+        "# Plot the two cages and the results in the two planes\n",
+        "plot_cage_results(analytical_tf_cage1, analytical_xz_fields, analytical_xy_fields)\n",
+        "plot_cage_results(analytical_tf_cage2, analytical_xz_fields2, analytical_xy_fields2)\n",
+        "plot_cage_results(biotsavart_tf_cage, biotsavart_xz_fields, biotsavart_xy_fields)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ],
+  "metadata": {
+    "anaconda-cloud": {},
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/examples/magnetostatics/helmholtz_example.py
+++ b/examples/magnetostatics/helmholtz_example.py
@@ -22,6 +22,14 @@
 """
 Simple HelmholzCage example with different current sources.
 """
+
+# %%[markdown]
+# ## Introduction
+
+# In this example we will build some HelmholtzCages with different types of current
+# sources.
+
+# %%
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -35,7 +43,10 @@ from bluemira.magnetostatics.circuits import (
 from bluemira.magnetostatics.circular_arc import CircularArcCurrentSource
 from bluemira.utilities.plot_tools import Plot3D
 
+# %%[markdown]
 # Set up some geometry and key parameters
+
+# %%
 n_TF = 6
 current = 20e6
 breadth = 0.5
@@ -45,7 +56,10 @@ x_c = 9
 z_c = 0
 x, z = make_circle_arc(radius, x_c, z_c, n_points=200, start_angle=np.pi)
 
+# %%[markdown]
 # Make a Biot-Savart filament (which needs to be properly discretised)
+
+# %%
 n_filaments_x = 2
 n_filaments_y = 3
 fil_radius = 0.5 * (breadth + depth) / (n_filaments_x * n_filaments_y)
@@ -69,15 +83,20 @@ biotsavart_circuit = BiotSavartFilament(
     loops, radius=fil_radius, current=current / (n_filaments_x * n_filaments_y)
 )
 
+# %%[markdown]
 # Make an analytical circuit with a rectangular cross-section comprised
 # of several trapezoidal prism elements
+
+# %%
 loop.close()
 analytical_circuit1 = ArbitraryPlanarRectangularXSCircuit(
     loop, breadth=breadth, depth=depth, current=current
 )
 
+# %%[markdown]
 # Make an analytical circuit of a circle arc with a rectangular cross-section
 
+# %%
 analytical_circuit2 = CircularArcCurrentSource(
     [x_c, 0, z_c],
     [-1, 0, 0],
@@ -89,12 +108,19 @@ analytical_circuit2 = CircularArcCurrentSource(
     dtheta=2 * np.pi,
     current=current,
 )
-# Pattern the three circuits
+
+# %%[markdown]
+# Pattern the three circuits into HelmholtzCages
+
+# %%
 biotsavart_tf_cage = HelmholtzCage(biotsavart_circuit, n_TF=n_TF)
 analytical_tf_cage1 = HelmholtzCage(analytical_circuit1, n_TF=n_TF)
 analytical_tf_cage2 = HelmholtzCage(analytical_circuit2, n_TF=n_TF)
 
-# Calculate the fields in the x-y plane
+# %%[markdown]
+# Calculate the fields in the x-y and x-z planes
+
+# %%
 nx, ny = 50, 50
 x = np.linspace(0, 18, nx)
 y = np.linspace(-18, 0, ny)
@@ -108,7 +134,6 @@ biotsavart_xy_fields = np.sqrt(np.sum(biotsavart_xy_fields**2, axis=0))
 analytical_xy_fields = np.sqrt(np.sum(analytical_xy_fields**2, axis=0))
 analytical_xy_fields2 = np.sqrt(np.sum(analytical_xy_fields2**2, axis=0))
 
-# Calculate the fields in the x-z plane
 nx, nz = 50, 50
 x = np.linspace(0, 18, nx)
 z = np.linspace(0, 14, nz)
@@ -122,43 +147,46 @@ biotsavart_xz_fields = np.sqrt(np.sum(biotsavart_xz_fields**2, axis=0))
 analytical_xz_fields = np.sqrt(np.sum(analytical_xz_fields**2, axis=0))
 analytical_xz_fields2 = np.sqrt(np.sum(analytical_xz_fields2**2, axis=0))
 
+# %%[markdown]
 
+# Let's visualise the results
+
+# %%
 def plot_cage_results(cage, xz_fields, xy_fields):
     """
     Plot utility for contours in 3-D projections in matplotlib.
     """
-    b_minmax = min(np.amax(xz_fields), np.amax(xy_fields))
     b_max = max(np.amax(xz_fields), np.amax(xy_fields))
-    levels = np.linspace(0, b_minmax, 20)
-    levels2 = np.linspace(b_minmax, b_max, 10)
+    levels = np.linspace(0, b_max, 20)
 
     ax = Plot3D()
-    # This will make the plot look better once matplotlib PRs are accepted
-    ax.computed_zorder = False
+
     cm = ax.contourf(
-        xx1, yy, xy_fields, zdir="z", levels=levels, offset=0, alpha=0.8, zorder=-1
-    )
-    cm2 = ax.contourf(
         xx1,
         yy,
         xy_fields,
         zdir="z",
-        levels=levels2,
+        levels=levels,
         offset=0,
         alpha=0.8,
         zorder=-1,
-        cmap="plasma_r",
-    )
-    ax.contourf(
-        xx, xz_fields, zz, zdir="y", levels=levels, offset=0, alpha=0.8, zorder=-1
+        cmap="magma",
     )
 
-    #  We need to use 2 colorbars because of 3-D projection shenanigans in matplotlib
+    ax.contourf(
+        xx,
+        xz_fields,
+        zz,
+        zdir="y",
+        levels=levels,
+        offset=0,
+        alpha=0.8,
+        zorder=-1,
+        cmap="magma",
+    )
     f = plt.gcf()
     cb0 = f.colorbar(cm, shrink=0.46)
-    cb = f.colorbar(cm2, shrink=0.46)
     cb0.ax.set_title("$B$ [T]")
-    cb.ax.set_title("$B$ [T]")
     cage.plot(ax=ax)
     ax.set_xlabel("x [m]")
     ax.set_ylabel("y [m]")

--- a/examples/magnetostatics/helmholtz_example.py
+++ b/examples/magnetostatics/helmholtz_example.py
@@ -152,6 +152,8 @@ analytical_xz_fields2 = np.sqrt(np.sum(analytical_xz_fields2**2, axis=0))
 # Let's visualise the results
 
 # %%
+
+
 def plot_cage_results(cage, xz_fields, xy_fields):
     """
     Plot utility for contours in 3-D projections in matplotlib.

--- a/tests/bluemira/magnetostatics/test_circuits.py
+++ b/tests/bluemira/magnetostatics/test_circuits.py
@@ -189,9 +189,6 @@ class TestCariddiBenchmark:
         cls.cage = cage
 
     def test_cariddi(self):
-        # ripple = []
-        # for xr, zr in zip(self.x_rip[1:19], self.z_rip[1:19]):
-        #     ripple.append(self.cage.ripple(xr, 0, zr))
 
         ripple = self.cage.ripple(self.x_rip[1:19], np.zeros(18), self.z_rip[1:19])
 


### PR DESCRIPTION
## Linked Issues

Fixes a couple of problems in magnetostatics related to conventions:
* HelmholtzCage now patterned with the first circuit a theta=0
* CurrentSource rotation now right-handed and in degrees

Converts the magnetostatics example to a Jupyter notebook

## Description
See above

## Interface Changes

Degrees now the interface to magnetostatics rotations

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
