### PR TITLE
Hotfix set parameter

### DIFF
--- a/bluemira/base/parameter.py
+++ b/bluemira/base/parameter.py
@@ -1055,6 +1055,9 @@ class ParameterFrame:
                 unit = value.unit
             value = value.value
 
+        if unit is None:
+            unit = self.get_param(var).unit
+
         self.__setattr__(var, Parameter(var=var, value=value, unit=unit, source=source))
 
     def update_kw_parameters(self, kwargs, source=None, *, allow_new=False):

--- a/tests/bluemira/base/test_parameter.py
+++ b/tests/bluemira/base/test_parameter.py
@@ -821,6 +821,11 @@ class TestParameterFrame:
         assert params_copy.n_CS.value == 15
         assert params_copy.n_CS.source == "hello2"
 
+        # No unit provided
+        params_copy.set_parameter("n_CS", 10, source="hello")
+        assert params_copy.n_CS.value == 10
+        assert params_copy.n_CS.source == "hello"
+
 
 class TestReactorSystem:
 


### PR DESCRIPTION
## Description

set parameter should be available without providing a unit

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
