### PR TITLE
Return numpy array on freecad center_of_mass

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -468,7 +468,7 @@ def volume(obj) -> float:
 
 def center_of_mass(obj) -> np.ndarray:
     """Object's center of mass"""
-    return _get_api_attr(obj, "CenterOfMass")
+    return vector_to_numpy(_get_api_attr(obj, "CenterOfMass"))
 
 
 def is_null(obj):

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import math
 
 # import typing
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import freecad  # noqa: F401
 import FreeCAD
@@ -471,22 +471,22 @@ def center_of_mass(obj) -> np.ndarray:
     return vector_to_numpy(_get_api_attr(obj, "CenterOfMass"))
 
 
-def is_null(obj):
+def is_null(obj) -> bool:
     """True if obj is null"""
     return _get_api_attr(obj, "isNull")()
 
 
-def is_closed(obj):
+def is_closed(obj) -> bool:
     """True if obj is closed"""
     return _get_api_attr(obj, "isClosed")()
 
 
-def is_valid(obj):
+def is_valid(obj) -> bool:
     """True if obj is valid"""
     return _get_api_attr(obj, "isValid")()
 
 
-def bounding_box(obj):
+def bounding_box(obj) -> Tuple[float, float, float, float, float, float]:
     """Object's bounding box"""
     box = _get_api_attr(obj, "BoundBox")
     return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax

--- a/tests/bluemira/codes/test_freecadapi.py
+++ b/tests/bluemira/codes/test_freecadapi.py
@@ -128,7 +128,9 @@ class TestFreecadapi:
     def test_center_of_mass(self):
         wire: Part.Wire = cadapi.make_polygon(self.square_points, True)
         face: Part.Face = Part.Face(wire)
-        comparison = cadapi.center_of_mass(wire) == np.array((0.5, 0.5, 0.0))
+        com = cadapi.center_of_mass(wire)
+        comparison = com == np.array((0.5, 0.5, 0.0))
+        assert isinstance(com, np.ndarray)
         assert comparison.all()
 
     def test_scale_shape(self):

--- a/tests/bluemira/geometry/test_deprecated_tools.py
+++ b/tests/bluemira/geometry/test_deprecated_tools.py
@@ -760,7 +760,7 @@ class TestCoordsConversion:
         face, converted_face = method(self, *loop.xyz)
         assert face.area == converted_face.area
         assert face.volume == converted_face.volume
-        assert face.center_of_mass == converted_face.center_of_mass
+        np.testing.assert_equal(face.center_of_mass, converted_face.center_of_mass)
 
     @pytest.mark.parametrize(
         "filename,method",


### PR DESCRIPTION
## Linked Issues

Closes #769 

## Description

Makes the return type of `bluemira.codes._freecadapi.center_or_mass` to a `np.ndarray`.

## Interface Changes

`BluemiraWire.center_of_mass` now returns a numpy array instead of a `FreeCAD.Base.Vector`. I think this was the original intent, and the behaviour of the two is not hugely different.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
