### PR TITLE
🐛 pin bandit in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
       - dependency-name: "numpy"  # numba limited
       - dependency-name: "section-properties" # beams needs to be updated
       - dependency-name: "neutronics-material-maker" # incompatible upgrade path
+      - dependency-name: "bandit" # https://github.com/tylerwince/flake8-bandit/issues/21


### PR DESCRIPTION
## Description

bandit can't be upgraded until flake8-bandit is

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
