### PR TITLE
EquilibriaError to Exception

### DIFF
--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -525,7 +525,7 @@ class EquilibriumPlotter(Plotter):
         """
         try:
             separatrix = self.eq.get_separatrix()
-        except EquilibriaError:
+        except Exception:
             bluemira_warn("Unable to plot separatrix")
             return
 

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -33,7 +33,6 @@ from scipy.interpolate import RectBivariateSpline
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import J_TOR_MIN, M_PER_MN
-from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.find import Xpoint, get_contours, grid_2d_contour
 from bluemira.equilibria.physics import calc_psi
 from bluemira.utilities.plot_tools import str_to_latex

--- a/scripts/install-process.sh
+++ b/scripts/install-process.sh
@@ -16,7 +16,7 @@ fi
 if [ ! -d process ]; then
   git clone git@git.ccfe.ac.uk:process/process.git
   cd process
-  git checkout develop
+  git checkout v2.2.0
   cd ..
 fi
 

--- a/scripts/install-process.sh
+++ b/scripts/install-process.sh
@@ -16,7 +16,7 @@ fi
 if [ ! -d process ]; then
   git clone git@git.ccfe.ac.uk:process/process.git
   cd process
-  git checkout v2.2.0
+  git checkout develop
   cd ..
 fi
 


### PR DESCRIPTION
The error occurred during **build_EQ**  on the first iteration when running `step_reactor`  likely cause was the warning under failed to plot separatrix.  Changed the `EquilibriaError` to `Exception` to catch all errors in `def plot_separatrix`
