### PR TITLE
Bugfix for CoilsetPositionCOP and NestedCoilsetPositionCOP

### DIFF
--- a/bluemira/equilibria/opt_problems.py
+++ b/bluemira/equilibria/opt_problems.py
@@ -570,7 +570,7 @@ class CoilsetPositionCOP(CoilsetOP):
         # to set coilset.
         # Necessary as optimised state may not always be the final
         # one evaluated by optimiser.
-        self.get_state_figure_of_merit(state)
+        self._objective(state, np.empty(shape=(0, 0)))
         return self.coilset
 
     @staticmethod
@@ -748,7 +748,7 @@ class NestedCoilsetPositionCOP(CoilsetOP):
         # to set coilset.
         # Necessary as optimised state may not always be the final
         # one evaluated by optimiser.
-        self.get_state_figure_of_merit(positions)
+        self._objective(positions, np.empty(shape=(0, 0)))
         return self.coilset
 
     @staticmethod


### PR DESCRIPTION
## Description

Quick bugfix for `CoilsetPositionCOP` and `NestedCoilsetPositionCOP.` 

Previously, at the end of an optimisation using these `OptimisationProblem`s, the objective function used to set the CoilSet to its optimal state was being called with the wrong set of arguments; this update fixes this by calling the `OptimisationProblem` objective directly.