### PR TITLE
⬆️ flake8-bandit upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,3 @@ updates:
       - dependency-name: "numpy"  # numba limited
       - dependency-name: "section-properties" # beams needs to be updated
       - dependency-name: "neutronics-material-maker" # incompatible upgrade path
-      - dependency-name: "bandit" # https://github.com/tylerwince/flake8-bandit/issues/21

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
     - id: flake8
       verbose: True
-      additional_dependencies: [flake8-docstrings,  pep8-naming, flake8-bandit, bandit==1.7.2]
+      additional_dependencies: [flake8-docstrings,  pep8-naming, flake8-bandit]
       args: [--exit-zero]
 
 -   repo: local

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -1,8 +1,8 @@
-bandit==1.7.2
+bandit==1.7.4
 black==22.1.0
 coverage[toml]==6.3.2
 flake8==4.0.1
-flake8-bandit==2.1.2
+flake8-bandit==3.0.0
 flake8-docstrings==1.6.0
 flake8-absolute-import==1.0.0.1
 pep8-naming==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -14,36 +14,36 @@ short = "An integrated inter-disciplinary design tool for future fusion "
 with open("README.md", "r") as f:
     long = f.read()
 
-install_requires = [  # PYL = Version limited by python version
-    "asteval",  # 0.9.25
+install_requires = [
+    "asteval",
     "Babel",
-    "click",  # 8.0.3
-    "CoolProp",  # 6.4.1
-    "fortranformat",  # 1.1.1
-    "imageio",  # 2.13.5
-    "ipykernel",  # 6.6.1
-    "matplotlib",  # 3.3.4   PYL
-    "natsort",  # 8.0.2
+    "click",
+    "CoolProp",
+    "fortranformat",
+    "imageio",
+    "ipykernel",
+    "matplotlib==3.3.4",  # upgrade on BP removal
+    "natsort",
     "neutronics-material-maker==0.1.11",  # Crash on upgrade
-    "nlopt",  # 2.7.0
-    "numba",  # 0.53.1
-    "numba-scipy",  # 0.3.0
-    "numpy",  # 1.19.5   PYL
-    "pandas",  # 1.3.5    PYL
+    "nlopt",
+    "numba",
+    "numba-scipy",
+    "numpy==1.21.5",  # numba's highest numpy
+    "pandas",
     "pint",
     "periodictable",
-    "pyclipper",  # 1.2.1
-    "pypet",  # 0.6.0
-    "pyquaternion",  # 0.9.9
-    "scikit-learn",  # 1.0.2
-    "seaborn",  # 0.11.2
-    "sectionproperties",  # 1.0.8 (with scipy <= 1.5)
-    "Shapely",  # 1.8.0
-    "tables",  # 3.7.0
-    "tabulate",  # 0.8.9
-    "trimesh",  # 3.9.42
-    "scipy",  # 1.4.1 Last OK version
-    "wrapt",  # 1.13.3
+    "pyclipper",
+    "pypet",
+    "pyquaternion",
+    "scikit-learn",
+    "seaborn",
+    "sectionproperties",  # 1.0.8dev (with scipy < 1.6)
+    "Shapely",
+    "tables",
+    "tabulate",
+    "trimesh",
+    "scipy==1.5.3",
+    "wrapt",
 ]
 
 openmoc = [
@@ -66,25 +66,25 @@ process = [
 ]
 
 dev_requires = [
-    "black",  # 21.12b0
-    "flake8",  # 4.0.1
-    "flake8-bandit",  # 2.1.2
-    "flake8-docstrings",  # 1.6.0
+    "black",
+    "flake8",
+    "flake8-bandit",
+    "flake8-docstrings",
     "flake8-absolute-import",
-    "pep8-naming",  # 0.12.1
-    "pre-commit",  # 2.16.0
-    "pytest",  # 6.2.5
-    "pytest-cov",  # 3.0.0
-    "pytest-html",  # 3.1.1
-    "pytest-metadata",  # 1.11.0
-    "sphinx",  # 4.3.2
-    "sphinx-autoapi",  # 1.8.4
-    "sphinx-rtd-theme",  # 1.0.0
-    "versioneer",  # 0.21
+    "pep8-naming",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "pytest-html",
+    "pytest-metadata",
+    "sphinx",
+    "sphinx-autoapi",
+    "sphinx-rtd-theme",
+    "versioneer",
 ]
 
 examples = [
-    "notebook",  # 6.4.6
+    "notebook",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,13 @@ install_requires = [
     "fortranformat",
     "imageio",
     "ipykernel",
-    "matplotlib==3.3.4",  # upgrade on BP removal
+    "matplotlib<=3.3.4",  # upgrade on BP removal
     "natsort",
     "neutronics-material-maker==0.1.11",  # Crash on upgrade
     "nlopt",
     "numba",
     "numba-scipy",
-    "numpy==1.21.5",  # numba's highest numpy
+    "numpy<=1.21.5",  # numba's highest numpy
     "pandas",
     "pint",
     "periodictable",
@@ -42,7 +42,7 @@ install_requires = [
     "tables",
     "tabulate",
     "trimesh",
-    "scipy==1.5.3",
+    "scipy<=1.5.3",
     "wrapt",
 ]
 


### PR DESCRIPTION
## Description

flake8-bandit has had a new release allowing us to upgrade bandit too

Additionally pinning versions implicitly is not possible in pre-commit at the moment: 
https://github.com/pre-commit/pre-commit    issue 582
## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
