### PR TITLE
Remove some warning messages from dependencies

### DIFF
--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -24,7 +24,7 @@ Methods for finding O- and X-points and flux surfaces on 2-D arrays.
 """
 
 import operator
-from collections import Iterable
+from collections.abc import Iterable
 
 import numba as nb
 import numpy as np

--- a/bluemira/equilibria/opt_objectives.py
+++ b/bluemira/equilibria/opt_objectives.py
@@ -148,7 +148,7 @@ def regularised_lsq_fom(x, a_mat, b_vec, gamma):
         Residual vector (Ax - b)
     """
     residual = np.dot(a_mat, x) - b_vec
-    number_of_targets = np.float(len(residual))
+    number_of_targets = float(len(residual))
     fom = residual.T @ residual / number_of_targets + gamma * gamma * x.T @ x
 
     if not fom > 0:

--- a/bluemira/equilibria/opt_objectives.py
+++ b/bluemira/equilibria/opt_objectives.py
@@ -104,8 +104,8 @@ def regularised_lsq_objective(vector, grad, scale, a_mat, b_vec, gamma):
     vector = vector * scale
     fom, err = regularised_lsq_fom(vector, a_mat, b_vec, gamma)
     if grad.size > 0:
-        jac = 2 * a_mat.T @ a_mat @ vector / np.float(len(b_vec))
-        jac -= 2 * a_mat.T @ b_vec / np.float(len(b_vec))
+        jac = 2 * a_mat.T @ a_mat @ vector / float(len(b_vec))
+        jac -= 2 * a_mat.T @ b_vec / float(len(b_vec))
         jac += 2 * gamma * gamma * vector
         grad[:] = scale * jac
     if not fom > 0:

--- a/bluemira/utilities/opt_problems.py
+++ b/bluemira/utilities/opt_problems.py
@@ -76,7 +76,7 @@ class OptimisationConstraint:
         """
         # Add optimisation problem to constraint arguments if needed by
         # constraint function
-        if "opt_problem" in inspect.getargspec(self._f_constraint).args:
+        if "opt_problem" in inspect.signature(self._f_constraint).args:
             self._args["opt_problem"] = opt_problem
 
         # Apply constraint to optimiser

--- a/bluemira/utilities/opt_problems.py
+++ b/bluemira/utilities/opt_problems.py
@@ -76,7 +76,7 @@ class OptimisationConstraint:
         """
         # Add optimisation problem to constraint arguments if needed by
         # constraint function
-        if "opt_problem" in inspect.signature(self._f_constraint).args:
+        if "opt_problem" in inspect.getfullargspec(self._f_constraint).args:
             self._args["opt_problem"] = opt_problem
 
         # Apply constraint to optimiser
@@ -117,7 +117,7 @@ class OptimisationObjective:
         """
         # Add optimisation problem to objective arguments if needed by
         # objective function
-        if "opt_problem" in inspect.signature(self._f_objective).args:
+        if "opt_problem" in inspect.getfullargspec(self._f_objective).args:
             self._args["opt_problem"] = opt_problem
 
         # Apply objective to optimiser

--- a/bluemira/utilities/opt_problems.py
+++ b/bluemira/utilities/opt_problems.py
@@ -117,7 +117,7 @@ class OptimisationObjective:
         """
         # Add optimisation problem to objective arguments if needed by
         # objective function
-        if "opt_problem" in inspect.getargspec(self._f_objective).args:
+        if "opt_problem" in inspect.signature(self._f_objective).args:
             self._args["opt_problem"] = opt_problem
 
         # Apply objective to optimiser

--- a/tests/bluemira/equilibria/test_coils.py
+++ b/tests/bluemira/equilibria/test_coils.py
@@ -108,23 +108,24 @@ class TestCoil:
         gbp = np.sqrt(gbx**2 + gbz**2)
         gp = c.control_psi(x, z)
 
-        f, ax = plt.subplots()
-        cc = ax.contourf(x, z, gbx)
+        if tests.PLOTTING:
+            f, ax = plt.subplots()
+            cc = ax.contourf(x, z, gbx)
 
-        plt.colorbar(cc)
-        ax.set_aspect("equal")
-        ax.set_xlim([2, 6])
-        ax.set_ylim([-3, 3])
+            plt.colorbar(cc)
+            ax.set_aspect("equal")
+            ax.set_xlim([2, 6])
+            ax.set_ylim([-3, 3])
 
         c.mesh_coil(0.1)
 
-        f, ax = plt.subplots()
         gbxn = c.control_Bx(x, z)
         gbzn = c.control_Bz(x, z)
         gbpn = np.sqrt(gbx**2 + gbz**2)
         gpn = c.control_psi(x, z)
 
         if tests.PLOTTING:
+            f, ax = plt.subplots()
             c = ax.contourf(x, z, gbxn)
             plt.colorbar(c)
             ax.set_aspect("equal")


### PR DESCRIPTION
## Linked Issues
We are getting some warnings from deprecated behaviour in some of our dependencies

## Description
Fixes these warnings

## Interface Changes

Hopefully none

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
