### PR TITLE
Add full stops to error class docstrings

### DIFF
--- a/bluemira/utilities/error.py
+++ b/bluemira/utilities/error.py
@@ -36,7 +36,7 @@ class UtilitiesError(BluemiraError):
 
 class PositionerError(UtilitiesError):
     """
-    Error for positioner utilities
+    Error for positioner utilities.
     """
 
     pass
@@ -44,7 +44,7 @@ class PositionerError(UtilitiesError):
 
 class OptUtilitiesError(UtilitiesError):
     """
-    Error for optimisation utilities
+    Error for optimisation utilities.
     """
 
     pass
@@ -52,7 +52,7 @@ class OptUtilitiesError(UtilitiesError):
 
 class OptVariablesError(OptUtilitiesError):
     """
-    Error for optimisation utilities
+    Error for optimisation utilities.
     """
 
     pass


### PR DESCRIPTION
## Description

Add full stops to the end of the docstrings in some error classes.

This is mostly to test code owners changes.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
