### PR TITLE
🥅 less noisy parameters

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -225,7 +225,7 @@ class Builder(abc.ABC):
 
     def _reset_params(self, params):
         self._validate_params(params)
-        self._params.update_kw_parameters(params)
+        self._params.update_kw_parameters({k: params[k] for k in self._params.keys()})
 
     def _extract_config(self, build_config: BuildConfig):
         has_runmode = (

--- a/bluemira/base/parameter.py
+++ b/bluemira/base/parameter.py
@@ -1335,7 +1335,7 @@ class ParameterFrame:
             and len(value) in [2, 3]
             and isinstance(value[1], (str, type(None)))
         ):
-            bluemira_debug("Consider using a dictionary for ordering safety")
+            # bluemira_debug("Consider using a dictionary for ordering safety")
             unit = value[2] if len(value) == 3 else None
             source = value[1]
             value = value[0]

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -137,7 +137,9 @@ class Setup(Task):
         NAME = self.parent.NAME
         self._parameter_mapping = get_recv_mapping(params, NAME, recv_all=True)
         self._params = type(params).from_template(self._parameter_mapping.values())
-        self._params.update_kw_parameters(params.to_dict(verbose=True))
+        self._params.update_kw_parameters(
+            {k: params.get_param(k) for k in self._params.keys()}
+        )
         self.__recv_mapping = get_recv_mapping(params, NAME)
         self.__send_mapping = get_send_mapping(params, NAME)
 


### PR DESCRIPTION
## Description

Parameters have been quite noisy recently, this makes them less so, up for discussion. I've also considered adding a trace logging that this could go into. Thoughts welcome, will assign someone at some point after a discussion.

To test try running the EUDEMO example with and without this

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
