### PR TITLE
Catch no intersection between flux surface and first wall

### DIFF
--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -34,6 +34,7 @@ import numba as nb
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import PSI_NORM_TOL
 from bluemira.equilibria.error import FluxSurfaceError
 from bluemira.equilibria.find import find_flux_surface_through_point
@@ -464,6 +465,11 @@ class PartialOpenFluxSurface(OpenFluxSurface):
         first_wall = first_wall.copy()
 
         args = join_intersect(self.loop, first_wall, get_arg=True)
+
+        if not args:
+            bluemira_warn("No intersection between flux surface and first_wall.")
+            self.alpha = None
+            return
 
         # Because we oriented the loop the "right" way, the first intersection
         # is at the smallest argument

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -467,7 +467,9 @@ class PartialOpenFluxSurface(OpenFluxSurface):
         args = join_intersect(self.loop, first_wall, get_arg=True)
 
         if not args:
-            bluemira_warn("No intersection between flux surface and first_wall.")
+            bluemira_warn(
+                "No intersection detected between flux surface and first_wall."
+            )
             self.alpha = None
             return
 

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -216,7 +216,7 @@ class ChargedParticleSolver:
         self.flux_surfaces_ob_hfs = []
 
         x = self.x_sep_omp + self.dx_mp
-        while x < x_out_omp:
+        while x < x_out_omp - EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ob_lfs.append(lfs)
             self.flux_surfaces_ob_hfs.append(hfs)
@@ -231,7 +231,7 @@ class ChargedParticleSolver:
         self.flux_surfaces_ib_lfs = []
         self.flux_surfaces_ib_hfs = []
         x = self.x_sep_imp - self.dx_mp
-        while x > x_out_imp:
+        while x > x_out_imp + EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ib_lfs.append(lfs)
             self.flux_surfaces_ib_hfs.append(hfs)

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -216,7 +216,7 @@ class ChargedParticleSolver:
         self.flux_surfaces_ob_hfs = []
 
         x = self.x_sep_omp + self.dx_mp
-        while x < x_out_omp - 10 * EPS:
+        while x < x_out_omp - EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ob_lfs.append(lfs)
             self.flux_surfaces_ob_hfs.append(hfs)
@@ -231,7 +231,7 @@ class ChargedParticleSolver:
         self.flux_surfaces_ib_lfs = []
         self.flux_surfaces_ib_hfs = []
         x = self.x_sep_imp - self.dx_mp
-        while x > x_out_imp + 10 * EPS:
+        while x > x_out_imp + EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ib_lfs.append(lfs)
             self.flux_surfaces_ib_hfs.append(hfs)

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -249,9 +249,9 @@ class ChargedParticleSolver:
             self.flux_surfaces_ib_hfs,
         ]:
             if group:
-                for i, f_s in enumerate(group):
-                    f_s.clip(first_wall)
-                    if f_s.alpha is None:
+                for i, flux_surface in enumerate(group):
+                    flux_surface.clip(first_wall)
+                    if flux_surface.alpha is None:
                         # No intersection detected between flux surface and first wall
                         # Drop the flux surface from the group
                         group.pop(i)

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -216,7 +216,7 @@ class ChargedParticleSolver:
         self.flux_surfaces_ob_hfs = []
 
         x = self.x_sep_omp + self.dx_mp
-        while x < x_out_omp - EPS:
+        while x < x_out_omp - 10 * EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ob_lfs.append(lfs)
             self.flux_surfaces_ob_hfs.append(hfs)
@@ -231,11 +231,30 @@ class ChargedParticleSolver:
         self.flux_surfaces_ib_lfs = []
         self.flux_surfaces_ib_hfs = []
         x = self.x_sep_imp - self.dx_mp
-        while x > x_out_imp + EPS:
+        while x > x_out_imp + 10 * EPS:
             lfs, hfs = self._make_flux_surfaces(x, self._o_point.z)
             self.flux_surfaces_ib_lfs.append(lfs)
             self.flux_surfaces_ib_hfs.append(hfs)
             x -= self.dx_mp
+
+    def _clip_flux_surfaces(self, first_wall):
+        """
+        Clip the flux surfaces to a first wall. Catch the cases where no intersections
+        are found.
+        """
+        for group in [
+            self.flux_surfaces_ob_lfs,
+            self.flux_surfaces_ob_hfs,
+            self.flux_surfaces_ib_lfs,
+            self.flux_surfaces_ib_hfs,
+        ]:
+            if group:
+                for i, f_s in enumerate(group):
+                    f_s.clip(first_wall)
+                    if f_s.alpha is None:
+                        # No intersection detected between flux surface and first wall
+                        # Drop the flux surface from the group
+                        group.pop(i)
 
     def analyse(self, first_wall):
         """
@@ -273,8 +292,7 @@ class ChargedParticleSolver:
         self._make_flux_surfaces_ob()
 
         # Find the intersections of the flux surfaces with the first wall
-        for flux_surface in self.flux_surfaces:
-            flux_surface.clip(first_wall)
+        self._clip_flux_surfaces(first_wall)
 
         x_omp, z_omp, x_lfs_inter, z_lfs_inter, alpha_lfs = self._get_arrays(
             self.flux_surfaces_ob_lfs
@@ -322,8 +340,7 @@ class ChargedParticleSolver:
         self._make_flux_surfaces_ib()
 
         # Find the intersections of the flux surfaces with the first wall
-        for flux_surface in self.flux_surfaces:
-            flux_surface.clip(first_wall)
+        self._clip_flux_surfaces(first_wall)
 
         (
             x_omp,

--- a/examples/radiation_transport/heat_flux_calculation_DN.py
+++ b/examples/radiation_transport/heat_flux_calculation_DN.py
@@ -32,26 +32,16 @@ from bluemira.geometry._deprecated_loop import Loop
 from bluemira.radiation_transport.advective_transport import ChargedParticleSolver
 
 read_path = get_bluemira_path("equilibria", subfolder="data")
-
-fw_name = "FW_inner_profile_SKbug.csv"
-fw_name = os.sep.join([read_path, fw_name])
-import pandas
-
-data = pandas.read_csv(fw_name)
-
-eq_name = "STEP_eqref_SKbug.json"
+eq_name = "DN-DEMO_eqref.json"
 eq_name = os.sep.join([read_path, eq_name])
 eq = Equilibrium.from_eqdsk(eq_name, load_large_file=True)
 
-# read_path = get_bluemira_path(
-#     "bluemira/radiation_transport/test_data", subfolder="tests"
-# )
-fw_name = "FW_inner_profile_SKbug.csv"
+read_path = get_bluemira_path(
+    "bluemira/radiation_transport/test_data", subfolder="tests"
+)
+fw_name = "DN_fw_shape.json"
 fw_name = os.sep.join([read_path, fw_name])
-import pandas
-
-data = pandas.read_csv(fw_name)
-fw_shape = Loop.from_array(data.to_numpy().T)
+fw_shape = Loop.from_file(fw_name)
 
 params = ParameterFrame(
     # fmt: off

--- a/examples/radiation_transport/heat_flux_calculation_DN.py
+++ b/examples/radiation_transport/heat_flux_calculation_DN.py
@@ -32,16 +32,26 @@ from bluemira.geometry._deprecated_loop import Loop
 from bluemira.radiation_transport.advective_transport import ChargedParticleSolver
 
 read_path = get_bluemira_path("equilibria", subfolder="data")
-eq_name = "DN-DEMO_eqref.json"
+
+fw_name = "FW_inner_profile_SKbug.csv"
+fw_name = os.sep.join([read_path, fw_name])
+import pandas
+
+data = pandas.read_csv(fw_name)
+
+eq_name = "STEP_eqref_SKbug.json"
 eq_name = os.sep.join([read_path, eq_name])
 eq = Equilibrium.from_eqdsk(eq_name, load_large_file=True)
 
-read_path = get_bluemira_path(
-    "bluemira/radiation_transport/test_data", subfolder="tests"
-)
-fw_name = "DN_fw_shape.json"
+# read_path = get_bluemira_path(
+#     "bluemira/radiation_transport/test_data", subfolder="tests"
+# )
+fw_name = "FW_inner_profile_SKbug.csv"
 fw_name = os.sep.join([read_path, fw_name])
-fw_shape = Loop.from_file(fw_name)
+import pandas
+
+data = pandas.read_csv(fw_name)
+fw_shape = Loop.from_array(data.to_numpy().T)
 
 params = ParameterFrame(
     # fmt: off


### PR DESCRIPTION
## Linked Issues

Closes #859


## Description

In some cases flux surfaces were effectively parallel and coincident with the first wall, likely triggering a linalgerror in `get_intersect` and thus not being registered as intersections. I think this part is fine. What is not fine is that the flux surfaces that lie effectively on top of the first wall were not being removed from the charged particle heat flux calculation.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
