### PR TITLE
Re-add new process parameter mappings

### DIFF
--- a/bluemira/base/config.py
+++ b/bluemira/base/config.py
@@ -107,6 +107,13 @@ class Configuration(ConfigurationSchema, ParameterFrame):
         ['p_ec', 'EC launcher power', 10, 'MW', 'Maximum launcher power per sector', 'Input'],
         ['f_cd_aux', 'Auxiliary current drive fraction', 0.1, 'dimensionless', None, 'Input'],
         ['f_cd_ohm', 'Ohmic current drive fraction', 0.1, 'dimensionless', None, 'Input'],
+        ['TF_res_bus', 'TF Bus resistance', 0, 'm' , None, 'Input'],
+        ['TF_res_tot', 'Total resistance for TF coil set', 0, 'ohm' , None, 'Input'],
+        ['TF_E_stored', 'total stored energy in the toroidal field', 0, 'GJ', None, 'Input'],
+        ['TF_respc_ob', 'TF coil leg resistance', 0, 'ohm', None, 'Input'],
+        ['TF_currpt_ob', 'TF coil current per turn' , 0, 'A', None, 'Input'],
+        ['P_bd_in', 'total auxiliary injected power' , 0, 'MW', None, 'Input'],
+        ['condrad_cryo_heat', "Conduction and radiation heat loads on cryogenic components", 0, 'MW', None, 'Input'],
 
         # First wall profile
         ['fw_psi_n', 'Normalised psi boundary to fit FW to', 1.07, 'dimensionless', None, 'Input'],

--- a/bluemira/base/config_schema.py
+++ b/bluemira/base/config_schema.py
@@ -97,6 +97,13 @@ class ConfigurationSchema:
     p_ec: Parameter
     f_cd_aux: Parameter
     f_cd_ohm: Parameter
+    TF_res_bus: Parameter
+    TF_res_tot: Parameter
+    TF_E_stored: Parameter
+    TF_respc_ob: Parameter
+    TF_currpt_ob: Parameter
+    P_bd_in: Parameter
+    condrad_cryo_heat: Parameter
 
     # First wall profile
     fw_psi_n: Parameter

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -121,8 +121,10 @@ class Setup(Task):
 
     """
 
-    def __init__(self, parent, *args, params=None, **kwargs):
+    def __init__(self, parent, *args, params=None, problem_settings=None, **kwargs):
         super().__init__(parent)
+
+        self._problem_settings = problem_settings if problem_settings is not None else {}
         self.set_parameters(params)
 
     def set_parameters(self, params):
@@ -292,6 +294,7 @@ class FileProgramInterface(ABC):
         run_dir=None,
         read_dir=None,
         mappings=None,
+        problem_settings=None,
         **kwargs,
     ):
         self.NAME = NAME
@@ -310,7 +313,9 @@ class FileProgramInterface(ABC):
 
         self._protect_tasks()
 
-        self.setup_obj = self._setup(self, *args, params=params, **kwargs)
+        self.setup_obj = self._setup(
+            self, *args, params=params, problem_settings=problem_settings, **kwargs
+        )
         self.run_obj = self._run(self, *args, **kwargs)
         self.teardown_obj = self._teardown(self, *args, **kwargs)
 
@@ -386,6 +391,13 @@ class FileProgramInterface(ABC):
         The ParameterFrame corresponding to this run.
         """
         return self.setup_obj._send_mapping
+
+    @property
+    def problem_settings(self):
+        """
+        Get problem settings dictionary
+        """
+        return self.setup_obj._problem_settings
 
     def modify_mappings(self, mappings: Dict[str, Dict[str, bool]]):
         """

--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -336,20 +336,23 @@ class Setup(interface.Setup):
 
     """
 
-    def __init__(self, parent, *args, problem_settings=None, **kwargs):
+    def __init__(self, parent, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
 
-        self._problem_settings = problem_settings if problem_settings is not None else {}
         self.input_file = "plasmod_input.dat"
         self.output_file = "plasmod_outputs.dat"
         self.profiles_file = "plasmod_profiles.dat"
-        self.io_manager = Inputs({**self.get_new_inputs(), **self._problem_settings})
+        self.io_manager = Inputs(
+            {**self._get_new_inputs(), **self.parent.problem_settings}
+        )
 
     def update_inputs(self):
         """
         Update plasmod inputs
         """
-        self.io_manager.modify({**self.get_new_inputs(), **self._problem_settings})
+        self.io_manager.modify(
+            {**self._get_new_inputs(), **self.parent.problem_settings}
+        )
 
     def write_input(self):
         """
@@ -487,13 +490,6 @@ class Solver(interface.FileProgramInterface):
             mappings=mappings,
             problem_settings=build_config.get("problem_settings", None),
         )
-
-    @property
-    def problem_settings(self):
-        """
-        Get problem settings dictionary
-        """
-        return self.setup_obj._problem_settings
 
     def get_raw_variables(self, scalar: Union[List, str]):
         """

--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -343,16 +343,14 @@ class Setup(interface.Setup):
         self.output_file = "plasmod_outputs.dat"
         self.profiles_file = "plasmod_profiles.dat"
         self.io_manager = Inputs(
-            {**self._get_new_inputs(), **self.parent.problem_settings}
+            {**self.get_new_inputs(), **self.parent.problem_settings}
         )
 
     def update_inputs(self):
         """
         Update plasmod inputs
         """
-        self.io_manager.modify(
-            {**self._get_new_inputs(), **self.parent.problem_settings}
-        )
+        self.io_manager.modify({**self.get_new_inputs(), **self.parent.problem_settings})
 
     def write_input(self):
         """

--- a/bluemira/codes/plasmod/mapping.py
+++ b/bluemira/codes/plasmod/mapping.py
@@ -23,6 +23,9 @@
 PLASMOD mappings
 """
 
+from bluemira.codes.utilities import Model, create_mapping
+
+
 class ImpurityModel(Model):
     """
     Impurity Model selector

--- a/bluemira/codes/plasmod/mapping.py
+++ b/bluemira/codes/plasmod/mapping.py
@@ -22,25 +22,6 @@
 """
 PLASMOD mappings
 """
-from enum import Enum
-
-from bluemira.base.look_and_feel import bluemira_print
-from bluemira.codes.utilities import create_mapping
-
-
-class Model(Enum):
-    """
-    Base Model Enum
-    """
-
-    @classmethod
-    def info(cls):
-        """
-        Show Model options
-        """
-        infostr = f"{cls.__doc__}\n" + "\n".join(repr(l_) for l_ in list(cls))
-        bluemira_print(infostr)
-
 
 class ImpurityModel(Model):
     """

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -136,6 +136,7 @@ OUT_mappings = {
     "r_tf_out_centre": ("r_tf_outboard_mid", "m"),
     "g_vv_ts": ("gapds", "m"),
     "TF_res_bus": ("tfbusres", "m"),
+    "TF_res_tot": ("ztot", "ohm"),
     "TF_E_tot": ("estotftgj", "GJ"),
     "TF_respc_ob": ("tflegres", "ohm"),
     "TF_currpt_ob": ("cpttf", "A"),

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -86,6 +86,12 @@ OUT_mappings = {
     "r_vv_ob_in": ("r_vv_ob_in", "m"),
     "r_tf_out_centre": ("r_tf_outboard_mid", "m"),
     "g_vv_ts": ("gapds", "m"),
+    "TF_res_bus": ("tfbusres", "m"),
+    "TF_E_tot": ("estotftgj", "GJ"),
+    "TF_respc_ob": ("tflegres", "ohm"),
+    "TF_currpt_ob": ("cpttf", "A"),
+    "P_bd_in": ("pinjmw", "MW"),
+    "condrad_cryo_heat": ("qss/1.0D6", "MW"),
 }
 
 IO_mappings = {

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -22,7 +22,56 @@
 """
 PROCESS mappings
 """
-from bluemira.codes.utilities import create_mapping
+from bluemira.codes.utilities import Model, create_mapping
+
+
+class CurrentDriveEfficiencyModel(Model):
+    """
+    Switch for current drive efficiency model:
+
+    1 - Fenstermacher Lower Hybrid
+    2 - Ion Cyclotron current drive
+    3 - Fenstermacher ECH
+    4 - Ehst Lower Hybrid
+    5 - ITER Neutral Beam
+    6 - new Culham Lower Hybrid model
+    7 - new Culham ECCD model
+    8 - new Culham Neutral Beam model
+    10 - ECRH user input gamma
+    11 - ECRH "HARE" model (E. Poli, Physics of Plasmas 2019)
+    12 - EBW user scaling input. Scaling (S. Freethy)
+
+    PROCESS variable name: "iefrf"
+    """
+
+    FENSTER_LH = 1
+    ICYCCD = 2
+    FENSTER_ECH = 3
+    EHST_LH = 4
+    ITER_NB = 5
+    CUL_LH = 6
+    CUL_ECCD = 7
+    CUL_NB = 8
+    ECRH_UI_GAM = 10
+    ECRH_HARE = 11
+    EBW_UI = 12
+
+
+class TFCoilConductorTechnology(Model):
+    """
+    Switch for TF coil conductor model:
+
+    0 - copper
+    1 - superconductor
+    2 - Cryogenic aluminium
+
+    PROCESS variable name: i_tf_sup
+    """
+
+    COPPER = 1
+    SC = 2
+    CYRO_AL = 3
+
 
 IN_mappings = {
     "P_el_net": ("pnetelin", "MW"),

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -137,7 +137,7 @@ OUT_mappings = {
     "g_vv_ts": ("gapds", "m"),
     "TF_res_bus": ("tfbusres", "m"),
     "TF_res_tot": ("ztot", "ohm"),
-    "TF_E_tot": ("estotftgj", "GJ"),
+    "TF_E_stored": ("estotftgj", "GJ"),
     "TF_respc_ob": ("tflegres", "ohm"),
     "TF_currpt_ob": ("cpttf", "A"),
     "P_bd_in": ("pinjmw", "MW"),

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -65,7 +65,7 @@ class TFCoilConductorTechnology(Model):
     1 - superconductor
     2 - Cryogenic aluminium
 
-    PROCESS variable name: i_tf_sup
+    PROCESS variable name: "i_tf_sup"
     """
 
     COPPER = 1

--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -68,9 +68,9 @@ class TFCoilConductorTechnology(Model):
     PROCESS variable name: "i_tf_sup"
     """
 
-    COPPER = 1
-    SC = 2
-    CYRO_AL = 3
+    COPPER = 0
+    SC = 1
+    CYRO_AL = 2
 
 
 IN_mappings = {

--- a/bluemira/codes/process/run.py
+++ b/bluemira/codes/process/run.py
@@ -191,6 +191,7 @@ class Solver(interface.FileProgramInterface):
             run_dir=run_dir,
             read_dir=read_dir,
             mappings=mappings,
+            problem_settings=build_config.get("problem_settings", None),
         )
 
         self._enabled_check(build_config.get("mode", "run").lower())

--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -58,11 +58,6 @@ class Setup(interface.Setup):
     Setup Task for process
     """
 
-    def __init__(self, parent, *args, problem_settings=None, **kwargs):
-        super().__init__(parent, *args, **kwargs)
-
-        self._problem_settings = problem_settings if problem_settings is not None else {}
-
     def _run(self):
         """
         Write the IN.DAT file and store in the main PROCESS folder
@@ -112,7 +107,7 @@ class Setup(interface.Setup):
             _inputs = self._get_new_inputs(remapper=update_obsolete_vars)
             for key, value in _inputs.items():
                 writer.add_parameter(key, value)
-            for key, value in self._problem_settings.items():
+            for key, value in self.parent.problem_settings.items():
                 writer.add_parameter(key, value)
 
         self._validate_models(writer)

--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -70,18 +70,17 @@ class Setup(interface.Setup):
         self.write_indat(use_bp_inputs=False)
 
     def _validate_models(self, writer):
-        models = [
-            "iefrf",
-            CurrentDriveEfficiencyModel,
-            "i_tf_sup",
-            TFCoilConductorTechnology,
-        ]
+        models = {
+            "iefrf": CurrentDriveEfficiencyModel,
+            "i_tf_sup": TFCoilConductorTechnology,
+        }
 
-        for name, model_cls in models:
+        for name, model_cls in models.items():
             try:
-                val = writer.data[name].value
+                val = writer.data[name].get_value
             except KeyError:
                 continue
+
             model = model_cls[val] if isinstance(val, str) else model_cls(val)
             writer.add_parameter(name, model.value)
 

--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -104,7 +104,7 @@ class Setup(interface.Setup):
             )
 
         if use_bp_inputs is True:
-            _inputs = self._get_new_inputs(remapper=update_obsolete_vars)
+            _inputs = self.get_new_inputs(remapper=update_obsolete_vars)
             for key, value in _inputs.items():
                 writer.add_parameter(key, value)
             for key, value in self.parent.problem_settings.items():

--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -58,6 +58,11 @@ class Setup(interface.Setup):
     Setup Task for process
     """
 
+    def __init__(self, parent, *args, problem_settings=None, **kwargs):
+        super().__init__(parent, *args, **kwargs)
+
+        self._problem_settings = problem_settings if problem_settings is not None else {}
+
     def _run(self):
         """
         Write the IN.DAT file and store in the main PROCESS folder
@@ -104,8 +109,10 @@ class Setup(interface.Setup):
             )
 
         if use_bp_inputs is True:
-            _inputs = self.get_new_inputs(remapper=update_obsolete_vars)
+            _inputs = self._get_new_inputs(remapper=update_obsolete_vars)
             for key, value in _inputs.items():
+                writer.add_parameter(key, value)
+            for key, value in self._problem_settings.items():
                 writer.add_parameter(key, value)
 
         self._validate_models(writer)

--- a/bluemira/codes/utilities.py
+++ b/bluemira/codes/utilities.py
@@ -26,16 +26,32 @@ Utility functions for interacting with external codes
 
 import os
 import threading
+from enum import Enum
 from typing import Dict, Literal
 
 from bluemira.base.look_and_feel import (
     _bluemira_clean_flush,
     bluemira_error_clean,
+    bluemira_print,
     bluemira_print_clean,
 )
 from bluemira.base.parameter import ParameterFrame, ParameterMapping
 from bluemira.codes.error import CodesError
 from bluemira.utilities.tools import get_module
+
+
+class Model(Enum):
+    """
+    Base Model Enum
+    """
+
+    @classmethod
+    def info(cls):
+        """
+        Show Model options
+        """
+        infostr = f"{cls.__doc__}\n" + "\n".join(repr(l_) for l_ in list(cls))
+        bluemira_print(infostr)
 
 
 def get_code_interface(module):

--- a/data/reactors/EU-DEMO/systems_code/mockPROCESS.json
+++ b/data/reactors/EU-DEMO/systems_code/mockPROCESS.json
@@ -54,5 +54,12 @@
     "tk_tf_wp": 0.70786,
     "tk_ts": 0.05,
     "tk_vv_in": 0.3,
-    "v_burn": 0.044484
+    "v_burn": 0.044484,
+    "TF_res_bus": 0,
+    "TF_res_tot": 0,
+    "TF_E_stored": 0,
+    "TF_respc_ob": 0,
+    "TF_currpt_ob": 0,
+    "P_bd_in": 0,
+    "condrad_cryo_heat": 0
 }

--- a/tests/bluemira/codes/process/test_data/mockPROCESS.json
+++ b/tests/bluemira/codes/process/test_data/mockPROCESS.json
@@ -54,5 +54,12 @@
     "g_ts_tf": 0.05,
     "g_vv_bb": 0.02,
     "tk_fw_in": 0.052,
-    "tk_fw_out": 0.052
+    "tk_fw_out": 0.052,
+    "TF_res_bus": 0,
+    "TF_res_tot": 0,
+    "TF_E_stored": 0,
+    "TF_respc_ob": 0,
+    "TF_currpt_ob": 0,
+    "P_bd_in": 0,
+    "condrad_cryo_heat": 0
 }

--- a/tests/bluemira/codes/process/test_setup.py
+++ b/tests/bluemira/codes/process/test_setup.py
@@ -19,21 +19,54 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from bluemira.codes.process import setup
+from bluemira.base.parameter import ParameterFrame
+from bluemira.codes.error import CodesError
+from bluemira.codes.process import setup as process_setup
+from bluemira.codes.process.api import DEFAULT_INDAT
 from bluemira.codes.process.api import ENABLED as PROCESS_ENABLED
+from tests.bluemira.codes.process import OUTDIR
 
 
 @pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")
 class TestPROCESSInputWriter:
     """Load default PROCESS values"""
 
-    writer = setup.PROCESSInputWriter()
+    writer = process_setup.PROCESSInputWriter()
 
     def test_change_var(self):
         self.writer.add_parameter("vgap2", 0.55)
         assert self.writer.data["vgap2"].get_value == 0.55
+
+
+@pytest.mark.skipif(PROCESS_ENABLED is not True, reason="PROCESS install required")
+class TestSetup:
+    def setup(self):
+        fake_parent = MagicMock()
+        fake_parent._template_indat = DEFAULT_INDAT
+        fake_parent.run_dir = OUTDIR
+        self.setup_writer = process_setup.Setup(fake_parent, params=ParameterFrame())
+
+    def test_raises_CodesError_on_bad_template(self):
+        self.setup_writer.parent._template_indat = "a/file/IN.DAT"
+        with pytest.raises(CodesError):
+            self.setup_writer.write_indat()
+
+    @pytest.mark.parametrize("problem_settings", ({}, {"iefrf": 6, "i_tf_sup": 2}))
+    def test_write_input_file(self, problem_settings):
+        self.setup_writer.parent.problem_settings = problem_settings
+        self.setup_writer.write_indat()
+
+        with open(OUTDIR + "/IN.DAT", "r") as fh:
+            data = fh.readlines()
+
+        for dat in data:
+            for k, v in problem_settings.items():
+                if dat.startswith(k):
+                    assert str(v) in dat
 
 
 if __name__ == "__main__":

--- a/tests/bluemira/codes/process/test_setup.py
+++ b/tests/bluemira/codes/process/test_setup.py
@@ -57,6 +57,11 @@ class TestSetup:
 
     @pytest.mark.parametrize("problem_settings", ({}, {"iefrf": 6, "i_tf_sup": 2}))
     def test_write_input_file(self, problem_settings):
+        """
+        Tests that an input file is written properly (by proxy calls validate models)
+
+        Eventually this should be moved out to PROCESS itself
+        """
         self.setup_writer.parent.problem_settings = problem_settings
         self.setup_writer.write_indat()
 


### PR DESCRIPTION
## Linked Issues

Closes #867 

## Description

Fixes the problem with #848. This exposed that our PROCESS input file needs updating because string with commas dont get converted properly. 

```ipdb
ipdb> writer.data['iefrf'].get_value
*** ValueError: invalid literal for int() with base 10: '5,'
```

I took the second option of waiting for #833 to go in rather than updating our existing default input file. 
I've added a couple of tests to catch some of this.

This needs #833 to be merged 

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
