### PR TITLE
📌 Pin nlopt and conda cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
       - dependency-name: "numpy"  # numba limited
       - dependency-name: "section-properties" # beams needs to be updated
       - dependency-name: "neutronics-material-maker" # incompatible upgrade path
+      - dependency-name: "nlopt"  # numpy limited

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -28,9 +28,7 @@ dependencies:
   - MeshPy=2020.1
   - meshio=4.4.5
   - mshr=2019.1.0
-  - wrapt=1.13.3
   - pythonocc-core=7.5.1
-  - fluids=1.0.19
   - shapely=1.8.0
   - scipy=1.5.3
   - graphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ cycler==0.11.0
 decorator==5.1.1
 defusedxml==0.7.1
 entrypoints==0.4
+fluids==1.0.19
 fortranformat==1.2.0
 gmsh-interop==2021.1.1
 imageio==2.16.1


### PR DESCRIPTION
## Description

nlopt doesnt like running with numpy< 1.22 for whatever reason. This pins nlopt until such time that we update numpy

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
