### PR TITLE
Use configuration for builder params

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -31,6 +31,7 @@ import string
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from bluemira.base.components import Component
+from bluemira.base.config import Configuration
 from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print
 from bluemira.base.parameter import ParameterFrame
@@ -85,7 +86,7 @@ class Builder(abc.ABC):
     _default_runmode: Optional[str] = None
     _required_params: List[str] = []
     _required_config: List[str] = []
-    _params: ParameterFrame
+    _params: Configuration
     _design_problem = None
 
     def __init__(self, params: Dict[str, Any], build_config: BuildConfig, **kwargs):
@@ -93,7 +94,7 @@ class Builder(abc.ABC):
 
         self._validate_config(build_config)
         self._extract_config(build_config)
-        self._params = ParameterFrame.from_template(self._required_params)
+        self._params = Configuration.from_template(self._required_params)
         self.reinitialise(params, **kwargs)
 
     def __call__(self) -> Component:

--- a/bluemira/builders/EUDEMO/pf_coils.py
+++ b/bluemira/builders/EUDEMO/pf_coils.py
@@ -30,9 +30,9 @@ import numpy as np
 import bluemira.utilities.plot_tools as bm_plot_tools
 from bluemira.base.builder import BuildConfig, Builder
 from bluemira.base.components import Component
+from bluemira.base.config import Configuration
 from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.base.parameter import ParameterFrame
 from bluemira.builders.pf_coils import PFCoilBuilder
 from bluemira.equilibria.coils import CoilSet
 from bluemira.geometry.tools import boolean_cut, distance_to, make_bspline
@@ -102,7 +102,7 @@ class PFCoilsBuilder(Builder):
         "r_cs_corner",
     ]
     _required_config: List[str] = []
-    _params: ParameterFrame
+    _params: Configuration
 
     def _extract_config(self, build_config: BuildConfig):
         super()._extract_config(build_config)


### PR DESCRIPTION
## Linked Issues

Closes #884 

## Description

This PR updates the configuration being used for the `ParameterFrame` in the base `Builder` class to be `Configuration` so that it has template values assigned from the start. We could make this more dynamic by passing in the Configuration/ParameterFrame class to use for the builders, but for this bug fix I think the current implementation in this PR should be enough.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
