### PR TITLE
EUDEMO upper port size optimisation problem

### DIFF
--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -75,7 +75,7 @@ class UpperPortOP(OptimisationProblem):
         params,
         optimiser: Optimiser,
         breeding_blanket_xz: BluemiraFace,
-        constraint_tol: float,
+        constraint_tol: float = 1e6,
     ):
 
         objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -19,22 +19,128 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+from typing import List
+
+import numpy as np
+
+from bluemira.base.constants import EPS
+from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import GeometryParameterisation
-from bluemira.geometry.tools import boolean_cut, make_polygon
+from bluemira.geometry.placement import BluemiraPlacement
+from bluemira.geometry.tools import boolean_cut, make_polygon, slice_shape
 from bluemira.utilities.opt_problems import (
     OptimisationConstraint,
     OptimisationObjective,
     OptimisationProblem,
 )
-
-
-class UpperPortCut(GeometryParameterisation):
-    def __init__(
-        self,
-    ):
-        pass
+from bluemira.utilities.opt_variables import BoundedVariable, OptVariables
+from bluemira.utilities.optimiser import Optimiser, approx_derivative
 
 
 class UpperPortOP(OptimisationProblem):
-    def __init__():
-        pass
+    def __init__(
+        self, parameterisation, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace
+    ):
+
+        objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})
+
+        box = breeding_blanket_xz.bounding_box
+        r_ib_min = box.x_min
+        r_ob_max = box.x_max
+
+        constraints = [
+            OptimisationConstraint(
+                self.constrain_blanket_cut,
+                f_constraint_args={
+                    "bb": breeding_blanket_xz,
+                    "c_rm": 0.02,
+                    "r_ib_min": r_ib_min,
+                    "r_ob_max": r_ob_max,
+                },
+                tolerance=1e-6 * np.ones(3),
+            )
+        ]
+        super().__init__(parameterisation, optimiser, objective, constraints)
+        lower_bounds = [r_ib_min + 0.5, 9, r_ib_min + 1, 0]
+        upper_bounds = [9, r_ob_max - 0.5, r_ob_max - 1, 30]
+        self.set_up_optimiser(4, bounds=[lower_bounds, upper_bounds])
+
+    @staticmethod
+    def minimise_port_size(vector, grad):
+        ri, ro, ci, gamma = vector
+        value = ro - ri
+        if grad.size > 0:
+            grad[0] = -1
+            grad[1] = 1
+            grad[2] = 0
+            grad[3] = 0
+        return value
+
+    @staticmethod
+    def get_outer_cut_point(vector, bb):
+        ri, ro, ci, gamma = vector
+        cut_plane = BluemiraPlacement.from_3_points([ci, 0, 0], [ci, 0, 1], [ci, 1, 1])
+        # Get the first intersection with the vertical inner cut plane
+        intersections = slice_shape(bb.boundary[0], cut_plane)
+        intersections = intersections[intersections[:, -1] > 0.0]
+        intersection = sorted(intersections, key=lambda x: x[-1])[0]
+
+        x, y, z = intersection
+        x2 = x - np.sin(np.deg2rad(gamma))
+        y2 = y
+        z2 = z + np.cos(np.deg2rad(gamma))
+        angled_cut_plane = BluemiraPlacement.from_3_points(
+            intersection, [x2, y2, z2], [x, y + 1, z]
+        )
+        intersections = slice_shape(bb.boundary[0], angled_cut_plane)
+        intersections = intersections[intersections[:, -1] > z + EPS]
+        intersection = sorted(intersections, key=lambda x: x[-1])[0]
+        co, _, _ = intersection
+        return co
+
+    @staticmethod
+    def calculate_constraints(vector, bb, c_rm, r_ib_min, r_ob_max):
+        ri, ro, ci, gamma = vector
+
+        co = UpperPortOP.get_outer_cut_point(vector, bb)
+
+        return [
+            (r_ob_max - ci + 2 * c_rm) - (ro - co),
+            (ci - r_ib_min + 2 * c_rm) - (ro - ri),
+            (ro - ci + 2 * c_rm) - (ci - r_ib_min),
+        ]
+
+    @staticmethod
+    def constrain_blanket_cut(constraint, vector, grad, bb, c_rm, r_ib_min, r_ob_max):
+
+        constraint[0] = UpperPortOP.calculate_constraints(
+            vector, bb, c_rm, r_ib_min, r_ob_max
+        )
+
+        if grad.size > 0:
+            grad[:] = approx_derivative(
+                UpperPortOP.calculate_constraints,
+                vector,
+                f0=constraint,
+                args=(bb, c_rm, r_ib_min, r_ob_max),
+            )
+
+        return constraint
+
+    def optimise(self, x0):
+        return self.opt.optimise(x0)
+
+
+if __name__ == "__main__":
+
+    bb = make_polygon(
+        {"x": [5, 6, 6, 11, 11, 12, 12, 5], "y": 0, "z": [-5, -5, 5, 5, -5, -5, 6, 6]},
+        closed=True,
+    )
+    bb = BluemiraFace(bb)
+    optimiser = Optimiser("SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8})
+
+    parameterisation = np.array([])
+    design_problem = UpperPortOP(parameterisation, optimiser, bb)
+
+    result = design_problem.optimise([7, 10, 9, 0])

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -262,7 +262,7 @@ def build_upper_port_zone(r_up_inner, r_up_outer, z_max=10, z_min=0):
 
 if __name__ == "__main__":
     # TODO: Remove this once threaded into the reactor build via some kind of builder
-
+    # See issues #906, #907
     from bluemira.base.config import Configuration
     from bluemira.display import show_cad
 

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -238,6 +238,22 @@ def segment_blanket_xz(breeding_blanket_xz, r_inner_cut, cut_angle, cut_thicknes
 def build_upper_port_zone(r_up_inner, r_up_outer, z_max=10, z_min=0):
     """
     Make the void geometry for the upper port in the poloidal plane.
+
+    Parameters
+    ----------
+    r_up_inner: radius
+        Inner radius of the upper port void space
+    r_up_outer: radius
+        Outer radius of the upper port void space
+    z_max: float
+        Maximum vertical height of the upper port void space
+    z_min: float
+        Minimum vertical height of the upper port void space
+
+    Returns
+    -------
+    upper_port: BluemiraFace
+        Face representing the upper port void space in the x-z plane
     """
     x = [r_up_inner, r_up_outer, r_up_outer, r_up_inner]
     z = [z_min, z_min, z_max, z_max]

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -234,7 +234,7 @@ def build_upper_port_zone(r_up_inner, r_up_outer, z_max=10, z_min=0):
 
 
 if __name__ == "__main__":
-    # TODO: Remove this once threaded into the reactor build
+    # TODO: Remove this once threaded into the reactor build via some kind of builder
 
     from bluemira.base.config import Configuration
     from bluemira.display import show_cad

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -59,6 +59,8 @@ class UpperPortOP(OptimisationProblem):
 
     Parameters
     ----------
+    params: ParameterFrame
+        Parameter frame for the problem
     optimiser: Optimiser
         Optimiser object to use when solving this problem
     breeding_blanket_xz: BluemiraFace
@@ -98,7 +100,6 @@ class UpperPortOP(OptimisationProblem):
         lower_bounds = [r_ib_min - c_rm, R_0, r_ib_min + tk_bb_ib, 0]
         upper_bounds = [R_0, r_ob_max + c_rm, r_ob_max - tk_bb_ob, bb_min_angle]
         self.set_up_optimiser(n_variables, bounds=[lower_bounds, upper_bounds])
-        self.bb_xz = breeding_blanket_xz
         self.params = params
 
     @staticmethod

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -241,9 +241,9 @@ def build_upper_port_zone(r_up_inner, r_up_outer, z_max=10, z_min=0):
 
     Parameters
     ----------
-    r_up_inner: radius
+    r_up_inner: float
         Inner radius of the upper port void space
-    r_up_outer: radius
+    r_up_outer: float
         Outer radius of the upper port void space
     z_max: float
         Maximum vertical height of the upper port void space

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from bluemira.base.constants import EPS
 from bluemira.geometry.face import BluemiraFace
-from bluemira.geometry.placement import BluemiraPlacement
+from bluemira.geometry.plane import BluemiraPlane
 from bluemira.geometry.tools import make_polygon, slice_shape
 from bluemira.utilities.opt_problems import (
     OptimisationConstraint,
@@ -46,7 +46,7 @@ class UpperPortOP(OptimisationProblem):
     optimiser: Optimiser
         Optimiser object to use when solving this problem
     breeding_blanket_xz: BluemiraFace
-        Unsegmentation breeding blanket x-z geometry
+        Unsegmented breeding blanket x-z geometry
     """
 
     def __init__(self, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace):
@@ -130,7 +130,7 @@ class UpperPortOP(OptimisationProblem):
         Get the outer cut point radius of the cutting plane with the breeding blanket
         geometry.
         """
-        cut_plane = BluemiraPlacement.from_3_points([ci, 0, 0], [ci, 0, 1], [ci, 1, 1])
+        cut_plane = BluemiraPlane.from_3_points([ci, 0, 0], [ci, 0, 1], [ci, 1, 1])
         # Get the first intersection with the vertical inner cut plane
         intersections = slice_shape(bb.boundary[0], cut_plane)
         intersections = intersections[intersections[:, -1] > 0.0]
@@ -140,7 +140,7 @@ class UpperPortOP(OptimisationProblem):
         x2 = x - np.sin(np.deg2rad(gamma))
         y2 = y
         z2 = z + np.cos(np.deg2rad(gamma))
-        angled_cut_plane = BluemiraPlacement.from_3_points(
+        angled_cut_plane = BluemiraPlane.from_3_points(
             intersection, [x2, y2, z2], [x, y + 1, z]
         )
         # Get the last intersection with the angled cut plane and the outer

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -78,6 +78,9 @@ class UpperPortOP(OptimisationProblem):
         tk_bb_ib = params.tk_bb_ib.value
         tk_bb_ob = params.tk_bb_ob.value
 
+        n_variables = 4
+        n_constraints = 3
+
         constraints = [
             OptimisationConstraint(
                 self.constrain_blanket_cut,
@@ -87,14 +90,14 @@ class UpperPortOP(OptimisationProblem):
                     "r_ib_min": r_ib_min,
                     "r_ob_max": r_ob_max,
                 },
-                tolerance=1e-6 * np.ones(3),
+                tolerance=1e-6 * np.ones(n_constraints),
             )
         ]
         super().__init__(np.array([]), optimiser, objective, constraints)
 
         lower_bounds = [r_ib_min - c_rm, R_0, r_ib_min + tk_bb_ib, 0]
         upper_bounds = [R_0, r_ob_max + c_rm, r_ob_max - tk_bb_ob, bb_min_angle]
-        self.set_up_optimiser(4, bounds=[lower_bounds, upper_bounds])
+        self.set_up_optimiser(n_variables, bounds=[lower_bounds, upper_bounds])
         self.bb_xz = breeding_blanket_xz
         self.params = params
 

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -66,9 +66,17 @@ class UpperPortOP(OptimisationProblem):
         Optimiser object to use when solving this problem
     breeding_blanket_xz: BluemiraFace
         Unsegmented breeding blanket x-z geometry
+    constraint_tol: float
+        Constraint tolerance
     """
 
-    def __init__(self, params, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace):
+    def __init__(
+        self,
+        params,
+        optimiser: Optimiser,
+        breeding_blanket_xz: BluemiraFace,
+        constraint_tol: float,
+    ):
 
         objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})
 
@@ -93,7 +101,7 @@ class UpperPortOP(OptimisationProblem):
                     "r_ib_min": r_ib_min,
                     "r_ob_max": r_ob_max,
                 },
-                tolerance=1e-6 * np.ones(n_constraints),
+                tolerance=constraint_tol * np.ones(n_constraints),
             )
         ]
         super().__init__(np.array([]), optimiser, objective, constraints)

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -23,9 +23,13 @@
 Some crude EU-DEMO remote maintenance considerations
 """
 
+from typing import Optional
+
 import numpy as np
 
 from bluemira.base.constants import EPS
+from bluemira.builders.shapes import OptimisedShapeBuilder
+from bluemira.geometry.constants import VERY_BIG
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.plane import BluemiraPlane
 from bluemira.geometry.tools import make_polygon, slice_shape
@@ -49,7 +53,7 @@ class UpperPortOP(OptimisationProblem):
         Unsegmented breeding blanket x-z geometry
     """
 
-    def __init__(self, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace):
+    def __init__(self, params, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace):
 
         objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})
 
@@ -62,17 +66,19 @@ class UpperPortOP(OptimisationProblem):
                 self.constrain_blanket_cut,
                 f_constraint_args={
                     "bb": breeding_blanket_xz,
-                    "c_rm": 0.02,
+                    "c_rm": params.c_rm.value,
                     "r_ib_min": r_ib_min,
                     "r_ob_max": r_ob_max,
                 },
-                tolerance=1e-6 * np.ones(3),
+                tolerance=1e-6 * np.ones(4),
             )
         ]
         super().__init__(np.array([]), optimiser, objective, constraints)
-        lower_bounds = [r_ib_min + 0.5, 9, r_ib_min + 1, 0]
-        upper_bounds = [9, r_ob_max - 0.5, r_ob_max - 1, 30]
+        lower_bounds = [r_ib_min - params.c_rm.value, 9, r_ib_min + 1, 1]
+        upper_bounds = [9, r_ob_max + params.c_rm.value, r_ob_max - 1, 30]
         self.set_up_optimiser(4, bounds=[lower_bounds, upper_bounds])
+        self.bb_xz = breeding_blanket_xz
+        self.params = params
 
     @staticmethod
     def minimise_port_size(vector, grad):
@@ -82,10 +88,10 @@ class UpperPortOP(OptimisationProblem):
         ri, ro, ci, gamma = vector
         # Dual objective: minimise port (ro - ri) and maximise outer radius (-ro)
         # ro - ri - ro
-        value = -ri
+        value = ro - ri
         if grad.size > 0:
             grad[0] = -1
-            grad[1] = 0
+            grad[1] = 1
             grad[2] = 0
             grad[3] = 0
         return value
@@ -116,13 +122,30 @@ class UpperPortOP(OptimisationProblem):
         """
         ri, ro, ci, gamma = vector
 
-        co = UpperPortOP.get_outer_cut_point(bb, ci, gamma)
+        co = UpperPortOP.get_outer_cut_point(bb, ci, gamma)[0]
 
         return [
-            (r_ob_max - ci + 2 * c_rm) - (ro - co),
-            (ci - r_ib_min + 2 * c_rm) - (ro - ri),
-            (ro - ci + 2 * c_rm) - (ci - r_ib_min),
+            # The outboard blanket must fit through the port
+            (r_ob_max - co + c_rm) - (ro - co),
+            # The inboard blanket must fit through the port
+            (ci - r_ib_min + c_rm) - (ro - ri),
+            # The inboard blanket must squeeze past the other inboard blanket
+            (ci - r_ib_min) - (ro - ci + c_rm),
+            # There should be enough vertically accessible space on the inboard blanket
+            (ri + 0.5 * abs(ci - r_ib_min)) - (ci),
         ]
+
+    @staticmethod
+    def get_inner_cut_point(bb, ci):
+        """
+        Get the inner cut point of the breeding blanket geometry.
+        """
+        cut_plane = BluemiraPlane.from_3_points([ci, 0, 0], [ci, 0, 1], [ci, 1, 1])
+        # Get the first intersection with the vertical inner cut plane
+        intersections = slice_shape(bb.boundary[0], cut_plane)
+        intersections = intersections[intersections[:, -1] > 0.0]
+        intersection = sorted(intersections, key=lambda x: x[-1])[0]
+        return intersection
 
     @staticmethod
     def get_outer_cut_point(bb, ci, gamma):
@@ -130,12 +153,7 @@ class UpperPortOP(OptimisationProblem):
         Get the outer cut point radius of the cutting plane with the breeding blanket
         geometry.
         """
-        cut_plane = BluemiraPlane.from_3_points([ci, 0, 0], [ci, 0, 1], [ci, 1, 1])
-        # Get the first intersection with the vertical inner cut plane
-        intersections = slice_shape(bb.boundary[0], cut_plane)
-        intersections = intersections[intersections[:, -1] > 0.0]
-        intersection = sorted(intersections, key=lambda x: x[-1])[0]
-
+        intersection = UpperPortOP.get_inner_cut_point(bb, ci)
         x, y, z = intersection
         x2 = x - np.sin(np.deg2rad(gamma))
         y2 = y
@@ -147,18 +165,52 @@ class UpperPortOP(OptimisationProblem):
         intersections = slice_shape(bb.boundary[0], angled_cut_plane)
         intersections = intersections[intersections[:, -1] > z + EPS]
         intersection = sorted(intersections, key=lambda x: x[-1])[0]
-        co, _, _ = intersection
-        return co
+        return intersection
 
     def optimise(self, x0):
         """
         Solve the optimisation problem.
         """
-        return self.opt.optimise(x0)
+        x0 = self.opt.optimise(x0)
+        print(x0)
+        bb_cut = self._make_bb_cut_geometry(x0)
+        up_zone = self._make_upper_port_zone(x0)
+        return bb_cut, up_zone
+
+    def _make_bb_cut_geometry(self, vector):
+        """
+        Make the void geometry for the BB cut in the poloidal plane.
+        """
+        ri, ro, ci, gamma = vector
+        p0 = self.get_inner_cut_point(self.bb_xz, ci)
+        gamma = np.deg2rad(gamma)
+        d = 10
+        p1x = p0[0] - d * np.sin(gamma)
+        p1z = p0[2] + d * np.cos(gamma)
+        p3z = p0[2] - self.params.c_rm.value / np.sin(gamma)
+        p3 = [p0[0], 0, p3z]
+        p1 = [p1x, 0, p1z]
+        p2x = p3[0] - d * np.sin(gamma)
+        p2z = p3[2] + d * np.cos(gamma)
+        p2 = [p2x, 0, p2z]
+
+        return make_polygon([p0, p1, p2, p3], closed=True)
+
+    @staticmethod
+    def _make_upper_port_zone(vector):
+        """
+        Make the void geometry for the upper port in the poloidal plane.
+        """
+        ri, ro, ci, gamma = vector
+        return make_polygon({"x": [ri, ro, ro, ri], "z": [0, 0, 10, 10]}, closed=True)
 
 
 if __name__ == "__main__":
 
+    from bluemira.base.config import Configuration
+    from bluemira.display import show_cad
+
+    params = Configuration()
     bb = make_polygon(
         {"x": [5, 6, 6, 11, 11, 12, 12, 5], "y": 0, "z": [-5, -5, 5, 5, -5, -5, 6, 6]},
         closed=True,
@@ -166,6 +218,7 @@ if __name__ == "__main__":
     bb = BluemiraFace(bb)
     optimiser = Optimiser("SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8})
 
-    design_problem = UpperPortOP(optimiser, bb)
+    design_problem = UpperPortOP(params, optimiser, bb)
 
-    result = design_problem.optimise([7, 10, 9, 0])
+    bb_cut, up_port = design_problem.optimise([7, 10, 9, 1])
+    show_cad([bb, bb_cut, up_port])

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -113,7 +113,7 @@ class UpperPortOP(OptimisationProblem):
     @staticmethod
     def constrain_blanket_cut(constraint, vector, grad, bb, c_rm, r_ib_min, r_ob_max):
 
-        constraint[0] = UpperPortOP.calculate_constraints(
+        constraint[:] = UpperPortOP.calculate_constraints(
             vector, bb, c_rm, r_ib_min, r_ob_max
         )
 
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         closed=True,
     )
     bb = BluemiraFace(bb)
-    optimiser = Optimiser("SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8})
+    optimiser = Optimiser("COBYLA", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8})
 
     parameterisation = np.array([])
     design_problem = UpperPortOP(parameterisation, optimiser, bb)

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -19,21 +19,17 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-from typing import List
-
 import numpy as np
 
 from bluemira.base.constants import EPS
 from bluemira.geometry.face import BluemiraFace
-from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.placement import BluemiraPlacement
-from bluemira.geometry.tools import boolean_cut, make_polygon, slice_shape
+from bluemira.geometry.tools import make_polygon, slice_shape
 from bluemira.utilities.opt_problems import (
     OptimisationConstraint,
     OptimisationObjective,
     OptimisationProblem,
 )
-from bluemira.utilities.opt_variables import BoundedVariable, OptVariables
 from bluemira.utilities.optimiser import Optimiser, approx_derivative
 
 

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -1,0 +1,40 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2022 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from bluemira.geometry.parameterisations import GeometryParameterisation
+from bluemira.geometry.tools import boolean_cut, make_polygon
+from bluemira.utilities.opt_problems import (
+    OptimisationConstraint,
+    OptimisationObjective,
+    OptimisationProblem,
+)
+
+
+class UpperPortCut(GeometryParameterisation):
+    def __init__(
+        self,
+    ):
+        pass
+
+
+class UpperPortOP(OptimisationProblem):
+    def __init__():
+        pass

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -43,11 +43,13 @@ class UpperPortOP(OptimisationProblem):
 
     Parameters
     ----------
+    optimiser: Optimiser
+        Optimiser object to use when solving this problem
+    breeding_blanket_xz: BluemiraFace
+        Unsegmentation breeding blanket x-z geometry
     """
 
-    def __init__(
-        self, parameterisation, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace
-    ):
+    def __init__(self, optimiser: Optimiser, breeding_blanket_xz: BluemiraFace):
 
         objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})
 
@@ -67,7 +69,7 @@ class UpperPortOP(OptimisationProblem):
                 tolerance=1e-6 * np.ones(3),
             )
         ]
-        super().__init__(parameterisation, optimiser, objective, constraints)
+        super().__init__(np.array([]), optimiser, objective, constraints)
         lower_bounds = [r_ib_min + 0.5, 9, r_ib_min + 1, 0]
         upper_bounds = [9, r_ob_max - 0.5, r_ob_max - 1, 30]
         self.set_up_optimiser(4, bounds=[lower_bounds, upper_bounds])
@@ -164,7 +166,6 @@ if __name__ == "__main__":
     bb = BluemiraFace(bb)
     optimiser = Optimiser("SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8})
 
-    parameterisation = np.array([])
-    design_problem = UpperPortOP(parameterisation, optimiser, bb)
+    design_problem = UpperPortOP(optimiser, bb)
 
     result = design_problem.optimise([7, 10, 9, 0])

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -75,7 +75,7 @@ class UpperPortOP(OptimisationProblem):
         params,
         optimiser: Optimiser,
         breeding_blanket_xz: BluemiraFace,
-        constraint_tol: float = 1e6,
+        constraint_tol: float = 1e-6,
     ):
 
         objective = OptimisationObjective(self.minimise_port_size, f_objective_args={})

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+"""
+Some crude EU-DEMO remote maintenance considerations
+"""
+
 import numpy as np
 
 from bluemira.base.constants import EPS
@@ -86,7 +90,9 @@ class UpperPortOP(OptimisationProblem):
 
     @staticmethod
     def constrain_blanket_cut(constraint, vector, grad, bb, c_rm, r_ib_min, r_ob_max):
-        """ """
+        """
+        Calculate the constraint and grad matrices.
+        """
         constraint[:] = UpperPortOP.calculate_constraints(
             vector, bb, c_rm, r_ib_min, r_ob_max
         )

--- a/bluemira/builders/EUDEMO/maintenance.py
+++ b/bluemira/builders/EUDEMO/maintenance.py
@@ -26,6 +26,7 @@ Some crude EU-DEMO remote maintenance considerations
 import numpy as np
 
 from bluemira.base.constants import EPS
+from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.geometry.constants import VERY_BIG
 from bluemira.geometry.face import BluemiraFace
@@ -220,8 +221,14 @@ def segment_blanket_xz(breeding_blanket_xz, r_inner_cut, cut_angle, cut_thicknes
 
     # Do cut
     cut_result = boolean_cut(breeding_blanket_xz, cut_zone)
-    if len(cut_result) != 2:
-        bluemira_warn("Something strange is going on with the BB poloidal segmentation")
+    if len(cut_result) < 2:
+        raise BuilderError(
+            f"BB poloidal segmentation only returning {len(cut_result)} faces."
+        )
+    if len(cut_result) > 2:
+        bluemira_warn(
+            f"The BB poloidal segmentation operation returned more than 2 faces ({len(cut_result)}); only taking the first two..."
+        )
     ib_silhouette, ob_silhouette = sorted(cut_result, key=lambda x: x.center_of_mass[0])[
         :2
     ]

--- a/bluemira/utilities/optimiser.py
+++ b/bluemira/utilities/optimiser.py
@@ -216,6 +216,16 @@ class Optimiser(NLOPTOptimiser):
     def check_constraints(self, x):
         """
         Check that the constraints have been met.
+
+        Parameters
+        ----------
+        x: np.ndarray
+            Solution vector to check the constraints for
+
+        Returns
+        -------
+        check: bool
+            Whether or not the constraints have been satisfied within the tolerances
         """
         c_values = []
         tolerances = []
@@ -231,3 +241,5 @@ class Optimiser(NLOPTOptimiser):
                 "Some constraints have not been adequately satisfied.\n"
                 f"{pformat(c_values)} !< {pformat(tolerances)}"
             )
+            return False
+        return True

--- a/tests/builders/EUDEMO/test_maintenance.py
+++ b/tests/builders/EUDEMO/test_maintenance.py
@@ -1,0 +1,49 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2022 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from bluemira.base.config import Configuration
+from bluemira.builders.EUDEMO.maintenance import UpperPortOP
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.tools import make_polygon
+from bluemira.utilities.optimiser import Optimiser
+
+
+class TestUpperPortOP:
+    def test_dummy_blanket_port_opt(self):
+        params = Configuration()
+        bb = make_polygon(
+            {
+                "x": [5, 6, 6, 11, 11, 12, 12, 5],
+                "y": 0,
+                "z": [-5, -5, 5, 5, -5, -5, 6, 6],
+            },
+            closed=True,
+        )
+        bb = BluemiraFace(bb)
+        optimiser = Optimiser(
+            "SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-8}
+        )
+
+        design_problem = UpperPortOP(params, optimiser, bb)
+
+        solution = design_problem.optimise()
+
+        assert design_problem.opt.check_constraints(solution)


### PR DESCRIPTION
## Linked Issues

Starting to address #906 

## Description
Adds an optimisation problem for the sizing of the upper port and the segmentation of the breeding blankets in the poloidal plane.

## Interface Changes
None yet, still need to figure out how best to thread this into the reactor build chain. Thought I'd get the brains working first.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
