### PR TITLE
Hotfix: Equilibrium from a FIESTA eqdsk

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -227,7 +227,7 @@ class MHDState:
             psi = e["psi"]
             e["dxc"] = e["dxc"] / 2
             e["dzc"] = e["dzc"] / 2
-        elif "Fiesta" in e["name"]:
+        elif "fiesta" in e["name"].lower():
             psi = e["psi"]
         else:  # CREATE
             psi = e["psi"] / (2 * np.pi)  # V.s as opposed to V.s/rad

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -227,7 +227,7 @@ class MHDState:
             psi = e["psi"]
             e["dxc"] = e["dxc"] / 2
             e["dzc"] = e["dzc"] / 2
-        elif "FIESTA" in e["name"]:
+        elif "Fiesta" in e["name"]:
             psi = e["psi"]
         else:  # CREATE
             psi = e["psi"] / (2 * np.pi)  # V.s as opposed to V.s/rad

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -227,6 +227,8 @@ class MHDState:
             psi = e["psi"]
             e["dxc"] = e["dxc"] / 2
             e["dzc"] = e["dzc"] / 2
+        elif "FIESTA" in e["name"]:
+            psi = e["psi"]
         else:  # CREATE
             psi = e["psi"] / (2 * np.pi)  # V.s as opposed to V.s/rad
             e["dxc"] = e["dxc"] / 2

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -233,7 +233,7 @@ class MHDState:
             psi = e["psi"] / (2 * np.pi)  # V.s as opposed to V.s/rad
             e["dxc"] = e["dxc"] / 2
             e["dzc"] = e["dzc"] / 2
-            e["cplasma"] = abs(e["cplasma"])  # Stupid current direction
+            e["cplasma"] = abs(e["cplasma"])
 
         coilset = CoilSet.from_group_vecs(e)
         if force_symmetry:


### PR DESCRIPTION
## Linked Issues

Closes #896

## Description

Adds a hotfix for loading FIESTA geqdsk files, in anticipation of future refactors addressing #318 properly.

As suspected, this is a simple case of different eqdsk conventions.

Note that the q profiles do not match up _exactly_, probably due to some previously mentioned discrepancies, and due to some "lacunes" of our q profile calculations on axis and at the separatrix.
![image](https://user-images.githubusercontent.com/26097289/162033069-b8e36ce4-5fd9-4bbb-ad47-94e053530084.png)


## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
