### PR TITLE
Add merge method to Component

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -137,10 +137,9 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        if child.name in [_child.name for _child in self.children]:
-            raise ComponentError(
-                f"Component with name '{child.name}' already exists on '{self}'."
-            )
+        # TODO: Support merge_trees here too.
+        if child in self.children:
+            raise ComponentError(f"Component {child} is already a child of {self}")
         self.children = list(self.children) + [child]
 
         return self

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -146,7 +146,45 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def merge_children(self, other: Component):
         """
-        Merge the children the given component into this component.
+        Merge the children of the given component into this component.
+
+        For example, if this object has structure:
+
+        .. code-block::
+
+            parent_1 (Component)
+            ├── x (Component)
+            │   └── leaf_1_x (Component)
+            └── y (Component)
+                └── leaf_1_y (Component)
+
+        and the other has structure:
+
+        .. code-block::
+
+            parent_2 (Component)
+            ├── x (Component)
+            │   └── leaf_2_x (Component)
+            └── z (Component)
+                └── leaf_1_z (Component)
+
+        the new structure of this object will be:
+
+        .. code-block::
+
+            parent_1 (Component)
+            ├── x (Component)
+            │   └── leaf_1_x (Component)
+            │   └── leaf_2_x (Component)
+            ├── y (Component)
+            │   └── leaf_1_y (Component)
+            └── z (Component)
+                └── leaf_1_z (Component)
+
+        Parameters
+        ----------
+        other: Component
+            The component to merge the children from.
         """
         for other_child in other.children:
             common_child = [ch for ch in self.children if ch.name == other_child.name]

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -207,7 +207,13 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        if not isinstance(children, list) or len(children) == 1:
+        if isinstance(children, list) and len(children) == 0:
+            # I'm not sure what the block of code below this is for, but
+            # I assume it does something useful. However, it will throw
+            # an IndexError on an empty list, avoid that here.
+            return self
+
+        if not isinstance(children, list) or len(children) == 0:
             child = children[0] if isinstance(children, list) else children
             return self.add_child(child)
 

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -207,15 +207,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        if isinstance(children, list) and len(children) == 0:
-            # I'm not sure what the block of code below this is for, but
-            # I assume it does something useful. However, it will throw
-            # an IndexError on an empty list, avoid that here.
-            return self
-
-        if not isinstance(children, list) or len(children) == 0:
-            child = children[0] if isinstance(children, list) else children
-            return self.add_child(child)
+        children = list(children)
 
         duplicates = []
         child: Component

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -182,6 +182,8 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         """
         Merge the children of the given component into this component.
 
+        If common children are leaves, then a ComponentError is raised.
+
         For example, if this object has structure:
 
         .. code-block::
@@ -223,6 +225,12 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         for other_child in other.children:
             common_child = [ch for ch in self.children if ch.name == other_child.name]
             if common_child:
+                if other_child.is_leaf and common_child[0].is_leaf:
+                    raise ComponentError(
+                        f"Cannot merge component '{other_child.name}' from "
+                        f"'{other_child.parent}' into '{self}'. '{other_child.name}' "
+                        "is a leaf component in both."
+                    )
                 common_child[0].add_children(list(other_child.children))
             else:
                 self.add_child(other_child)

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -137,9 +137,10 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        # TODO: Support merge_trees here too.
-        if child in self.children:
-            raise ComponentError(f"Component {child} is already a child of {self}")
+        if child.name in [_child.name for _child in self.children]:
+            raise ComponentError(
+                f"Component with name '{child.name}' already exists on '{self}'."
+            )
         self.children = list(self.children) + [child]
 
         return self

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -144,6 +144,17 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
         return self
 
+    def merge_children(self, other: Component):
+        """
+        Merge the children the given component into this component.
+        """
+        for other_child in other.children:
+            common_child = [ch for ch in self.children if ch.name == other_child.name]
+            if common_child:
+                common_child[0].add_children(list(other_child.children))
+            else:
+                self.add_child(other_child)
+
     def add_children(self, children: List[Component], merge_trees=False):
         """
         Add multiple children to this node
@@ -158,7 +169,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        if not isinstance(children, list) or len(children) == 0:
+        if not isinstance(children, list) or len(children) == 1:
             child = children[0] if isinstance(children, list) else children
             return self.add_child(child)
 

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -152,34 +152,34 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
         .. code-block::
 
-            parent_1 (Component)
-            ├── x (Component)
-            │   └── leaf_1_x (Component)
-            └── y (Component)
-                └── leaf_1_y (Component)
+            parent_1
+            ├── x
+            │   └── leaf_1_x
+            └── y
+                └── leaf_1_y
 
         and the other has structure:
 
         .. code-block::
 
-            parent_2 (Component)
-            ├── x (Component)
-            │   └── leaf_2_x (Component)
-            └── z (Component)
-                └── leaf_1_z (Component)
+            parent_2
+            ├── x
+            │   └── leaf_2_x
+            └── z
+                └── leaf_1_z
 
         the new structure of this object will be:
 
         .. code-block::
 
-            parent_1 (Component)
-            ├── x (Component)
-            │   └── leaf_1_x (Component)
-            │   └── leaf_2_x (Component)
-            ├── y (Component)
-            │   └── leaf_1_y (Component)
-            └── z (Component)
-                └── leaf_1_z (Component)
+            parent_1
+            ├── x
+            │   └── leaf_1_x
+            │   └── leaf_2_x
+            ├── y
+            │   └── leaf_1_y
+            └── z
+                └── leaf_1_z
 
         Parameters
         ----------

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -137,7 +137,6 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        # TODO: Support merge_trees here too.
         if child in self.children:
             raise ComponentError(f"Component {child} is already a child of {self}")
         self.children = list(self.children) + [child]

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -144,6 +144,40 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
         return self
 
+    def add_children(self, children: List[Component], merge_trees=False):
+        """
+        Add multiple children to this node
+
+        Parameters
+        ----------
+        children: List[Component]
+            The children to be added
+
+        Returns
+        -------
+        self: Component
+            This component.
+        """
+        children = list(children)
+
+        duplicates = []
+        child: Component
+        for idx, child in reversed(list(enumerate(children))):
+            existing = self.get_component(child.name)
+            if existing is not None:
+                if merge_trees:
+                    existing.children = list(existing.children) + list(child.children)
+                    children.pop(idx)
+                else:
+                    duplicates += [child]
+        if duplicates != []:
+            raise ComponentError(
+                f"Components {duplicates} are already children of {self}"
+            )
+        self.children = list(self.children) + children
+
+        return self
+
     def merge_children(self, other: Component):
         """
         Merge the children of the given component into this component.
@@ -192,40 +226,6 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
                 common_child[0].add_children(list(other_child.children))
             else:
                 self.add_child(other_child)
-
-    def add_children(self, children: List[Component], merge_trees=False):
-        """
-        Add multiple children to this node
-
-        Parameters
-        ----------
-        children: List[Component]
-            The children to be added
-
-        Returns
-        -------
-        self: Component
-            This component.
-        """
-        children = list(children)
-
-        duplicates = []
-        child: Component
-        for idx, child in reversed(list(enumerate(children))):
-            existing = self.get_component(child.name)
-            if existing is not None:
-                if merge_trees:
-                    existing.children = list(existing.children) + list(child.children)
-                    children.pop(idx)
-                else:
-                    duplicates += [child]
-        if duplicates != []:
-            raise ComponentError(
-                f"Components {duplicates} are already children of {self}"
-            )
-        self.children = list(self.children) + children
-
-        return self
 
     def prune_child(self, name: str):
         """

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -107,25 +107,6 @@ class TestComponentClass:
         with pytest.raises(ComponentError):
             parent.add_child(child)
 
-    def test_fail_add_duplicate_child_with_same_name(self):
-        parent = Component("Parent")
-        Component("Child", parent=parent)
-        child = Component("Child")
-
-        with pytest.raises(ComponentError):
-            parent.add_child(child)
-
-    def test_add_child_given_components_share_name_at_different_level(self):
-        parent = Component("Parent")
-        child_1 = Component("Child1", parent=parent)
-        Component("Child2", parent=parent)
-
-        child_1.add_child(Component("Child2"))
-
-        assert parent.get_component("Child1") is not None
-        assert parent.get_component("Child2") is not None
-        assert child_1.get_component("Child2") is not None
-
     def test_add_children(self):
         parent = Component("Parent")
         child1 = Component("Child1")

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -107,6 +107,25 @@ class TestComponentClass:
         with pytest.raises(ComponentError):
             parent.add_child(child)
 
+    def test_fail_add_duplicate_child_with_same_name(self):
+        parent = Component("Parent")
+        Component("Child", parent=parent)
+        child = Component("Child")
+
+        with pytest.raises(ComponentError):
+            parent.add_child(child)
+
+    def test_add_child_given_components_share_name_at_different_level(self):
+        parent = Component("Parent")
+        child_1 = Component("Child1", parent=parent)
+        Component("Child2", parent=parent)
+
+        child_1.add_child(Component("Child2"))
+
+        assert parent.get_component("Child1") is not None
+        assert parent.get_component("Child2") is not None
+        assert child_1.get_component("Child2") is not None
+
     def test_add_children(self):
         parent = Component("Parent")
         child1 = Component("Child1")

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -187,15 +187,14 @@ class TestComponentClass:
         assert isinstance(y_component.get_component("leaf_1_y"), Component)
         assert isinstance(y_component.get_component("leaf_2_y"), Component)
 
-    def test_merge_children_given_shared_leaf(self):
+    def test_merge_children_ComponentError_given_shared_leaf(self):
         parent_1 = Component("parent_1")
         Component("x", parent=parent_1)
         parent_2 = Component("parent_2")
         Component("x", parent=parent_2)
 
-        parent_1.merge_children(parent_2)
-
-        assert len(parent_1.get_component("x", first=False)) == 1
+        with pytest.raises(ComponentError):
+            parent_1.merge_children(parent_2)
 
     def test_merge_children_ComponentError_given_multiple_common_nodes(self):
         parent_1 = _tree_from_dict({"parent_1": {"x": {"x2": "leaf_1"}}})

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -115,6 +115,14 @@ class TestComponentClass:
         parent.add_children([child1, child2])
         assert parent.children == (child1, child2)
 
+    def test_add_children_given_tuple_of_components(self):
+        parent = Component("Parent")
+        children = (Component("Child1"), Component("Child2"))
+
+        parent.add_children(children)
+
+        assert [ch.name for ch in parent.children] == ["Child1", "Child2"]
+
     def test_add_children_does_nothing_given_empty_list(self):
         parent = Component("parent")
 

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -54,7 +54,7 @@ class TestComponentClass:
     def test_get_component_from_node(self):
         parent = Component("Parent")
         child1 = Component("Child1", parent=parent)
-        child2 = Component("Child2", parent=parent)
+        Component("Child2", parent=parent)
         grandchild = Component("Grandchild", parent=child1)
 
         assert grandchild.get_component("Child2") is None


### PR DESCRIPTION
## Linked Issues

Partially addresses #892.

## Description

Adds a `merge_children` method to components so that we can easily merge component trees within builds/designs.

This can be particularly helpful when building subcomponents of another component in multiple dimensions. This new method can be used when the xy, xz, and xyz components of each subcomponent need to be merged.

## Interface Changes

Added `merge_children` method to `Component`.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
