### PR TITLE
🐛 fix tests

### DIFF
--- a/bluemira/codes/process/setup.py
+++ b/bluemira/codes/process/setup.py
@@ -109,7 +109,7 @@ class Setup(interface.Setup):
             for key, value in self.parent.problem_settings.items():
                 writer.add_parameter(key, value)
 
-        self._validate_models(writer)
+            self._validate_models(writer)
 
         filename = os.path.join(self.parent.run_dir, "IN.DAT")
         writer.write_in_dat(output_filename=filename)

--- a/tests/codes/process/test_run.py
+++ b/tests/codes/process/test_run.py
@@ -233,7 +233,9 @@ class TestRun:
             if param.mapping is not None and "PROCESS" in param.mapping:
                 if param.mapping["PROCESS"].send:
                     number_of_expected_calls += 1
-        assert mock_add_parameter.call_count == number_of_expected_calls
+        # +1 because models get a validation call if they exist
+        # there is one model in the default input file (of the ones we check)
+        assert mock_add_parameter.call_count == number_of_expected_calls + 1
 
         # Check that the dummy values with send = True were written.
         mock_add_parameter.assert_any_call("dp", 3)


### PR DESCRIPTION
## Description

A couple of the process tests were failing if process is installed. This fixes them

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
