### PR TITLE
Refactor and clean-up `beta_p` calculations in `equilibria`

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1187,12 +1187,18 @@ class Equilibrium(MHDState):
         """
         Get plasma pressure map.
         """
-        o_points, x_points = self.get_OX_points()
-        mask = in_plasma(
-            self.x, self.z, self.psi(), o_points=o_points, x_points=x_points
-        )
+        mask = self._get_core_mask()
         p = self.pressure(np.clip(self.psi_norm(), 0, 1))
         return p * mask
+
+    def _get_core_mask(self):
+        """
+        Get a 2-D masking array for the plasma core.
+        """
+        o_points, x_points = self.get_OX_points()
+        return in_plasma(
+            self.x, self.z, self.psi(), o_points=o_points, x_points=x_points
+        )
 
     def q(self, psinorm, o_points=None, x_points=None):
         """

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -401,13 +401,6 @@ def beta(pressure, field):
     return np.mean(pressure) / (field**2 / 2 * MU_0)
 
 
-def beta_p(pressure, Bp):
-    """
-    The ratio of plasma pressure to poloidal magnetic pressure
-    """
-    return beta(pressure, Bp)
-
-
 def normalise_beta(beta, a, b_tor, Ip):
     """
     Converts beta to normalised beta

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -314,9 +314,9 @@ def calc_beta_t(eq):
     return 2 * MU_0 * p_avg / eq._B_0**2
 
 
-def calc_betap(eq):
+def calc_beta_p(eq):
     """
-    Calculate the ratio of plasma pressure to magnetic pressure
+    Calculate the ratio of plasma pressure to poloidal magnetic pressure
 
     \t:math:`\\beta_p = \\dfrac{2\\mu_0\\langle p \\rangle}{B_p^2}`
 
@@ -338,7 +338,7 @@ def calc_betap(eq):
     return 2 * MU_0 * p_int / Bp2_int
 
 
-def calc_beta_p(eq):
+def calc_beta_p_approx(eq):
     """
     Calculate the ratio of plasma pressure to magnetic pressure. This is
     following the definitions of Friedberg, Ideal MHD, pp. 68-69.
@@ -373,7 +373,7 @@ def calc_summary(eq):
     li = 2 * li_true / (MU_0 * eq._R_0)
     li3 = 2 * bpavg / (eq._R_0 * (MU_0 * eq._Ip) ** 2)
     volume = calc_volume(eq)
-    beta_p = calc_betap(eq)
+    beta_p = calc_beta_p(eq)
     return {
         "W": energy,
         "Li": li_true,

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -294,26 +294,6 @@ def calc_p_average(eq):
     return volume_integral(p, eq.x, eq.dx, eq.dz) / v_plasma
 
 
-def calc_betap(eq):
-    """
-    Calculate the ratio of plasma pressure to magnetic pressure
-
-    \t:math:`\\beta_p = \\dfrac{2\\mu_0\\langle p \\rangle}{B_p^2}`
-
-    Parameters
-    ----------
-    eq: Equilibrium
-        The Equilibrium object for which to calculate beta_p
-
-    Returns
-    -------
-    beta: float
-        Ratio of plasma to magnetic pressure
-    """
-    p = eq.pressure_map()
-    return 4 / (MU_0 * eq._R_0 * eq._Ip**2) * volume_integral(p, eq.x, eq.dx, eq.dz)
-
-
 def calc_beta_t(eq):
     """
     Calculate the ratio of plasma pressure to toroidal magnetic pressure.
@@ -332,6 +312,30 @@ def calc_beta_t(eq):
     """
     p_avg = calc_p_average(eq)
     return 2 * MU_0 * p_avg / eq._B_0**2
+
+
+def calc_betap(eq):
+    """
+    Calculate the ratio of plasma pressure to magnetic pressure
+
+    \t:math:`\\beta_p = \\dfrac{2\\mu_0\\langle p \\rangle}{B_p^2}`
+
+    Parameters
+    ----------
+    eq: Equilibrium
+        The Equilibrium object for which to calculate beta_p
+
+    Returns
+    -------
+    beta: float
+        Ratio of plasma to magnetic pressure
+    """
+    p = eq.pressure_map()
+    mask = eq._get_core_mask()
+    Bp = mask * eq.Bp()
+    p_int = volume_integral(p, eq.x, eq.dx, eq.dz)
+    Bp2_int = volume_integral(Bp**2, eq.x, eq.dx, eq.dz)
+    return 2 * MU_0 * p_int / Bp2_int
 
 
 def calc_beta_p(eq):

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -341,7 +341,8 @@ def calc_beta_p(eq):
 def calc_beta_p_approx(eq):
     """
     Calculate the ratio of plasma pressure to magnetic pressure. This is
-    following the definitions of Friedberg, Ideal MHD, pp. 68-69.
+    following the definitions of Friedberg, Ideal MHD, pp. 68-69, which is an
+    approximation.
 
     \t:math:`\\beta_p = \\dfrac{2\\mu_0\\langle p \\rangle}{B_p^2}`
 

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -548,6 +548,7 @@ class BetaIpProfile(Profile):
 
         if x_points != []:  # NOTE: Necessary unpythonic formulation
             # More accurate beta_p constraint calculation
+            # This is the Freidberg approximation
             lcfs, _ = find_LCFS_separatrix(
                 x, z, psi, o_points=o_points, x_points=x_points
             )

--- a/examples/equilibria/eudemo_2017.ipynb
+++ b/examples/equilibria/eudemo_2017.ipynb
@@ -28,7 +28,7 @@
         "from bluemira.equilibria.equilibrium import Breakdown, Equilibrium\n",
         "from bluemira.equilibria.grid import Grid\n",
         "from bluemira.equilibria.optimiser import BreakdownOptimiser, FBIOptimiser\n",
-        "from bluemira.equilibria.physics import calc_beta_p, calc_li, calc_psib\n",
+        "from bluemira.equilibria.physics import calc_beta_p_approx, calc_li, calc_psib\n",
         "from bluemira.equilibria.profiles import BetaIpProfile, CustomProfile, DoublePowerFunc\n",
         "from bluemira.equilibria.solve import PicardAbsIterator, PicardLiAbsIterator"
       ],
@@ -353,7 +353,9 @@
         "ax[2].set_title(\"$\\\\psi_{b}$ = \" + f\"{eof_psi:.2f} V.s\")\n",
         "\n",
         "\n",
-        "bluemira_print(\"SOF:\\n\" f\"beta_p: {calc_beta_p(sof):.2f}\\n\" f\"l_i: {calc_li(sof):.2f}\")\n",
+        "bluemira_print(\n",
+        "    \"SOF:\\n\" f\"beta_p: {calc_beta_p_approx(sof):.2f}\\n\" f\"l_i: {calc_li(sof):.2f}\"\n",
+        ")\n",
         "\n",
         "# TODO: Fix this example...\n",
         "# bluemira_print(\"EOF:\\n\" f\"beta_p: {calc_beta_p(eof):.2f}\\n\" f\"l_i: {calc_li(sof):.2f}\")"

--- a/examples/equilibria/eudemo_2017.py
+++ b/examples/equilibria/eudemo_2017.py
@@ -45,7 +45,7 @@ from bluemira.equilibria.eq_constraints import AutoConstraints
 from bluemira.equilibria.equilibrium import Breakdown, Equilibrium
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.optimiser import BreakdownOptimiser, FBIOptimiser
-from bluemira.equilibria.physics import calc_beta_p, calc_li, calc_psib
+from bluemira.equilibria.physics import calc_beta_p_approx, calc_li, calc_psib
 from bluemira.equilibria.profiles import BetaIpProfile, CustomProfile, DoublePowerFunc
 from bluemira.equilibria.solve import PicardAbsIterator, PicardLiAbsIterator
 
@@ -286,7 +286,9 @@ ax[1].set_title("$\\psi_{b}$ = " + f"{sof_psi:.2f} V.s")
 ax[2].set_title("$\\psi_{b}$ = " + f"{eof_psi:.2f} V.s")
 
 
-bluemira_print("SOF:\n" f"beta_p: {calc_beta_p(sof):.2f}\n" f"l_i: {calc_li(sof):.2f}")
+bluemira_print(
+    "SOF:\n" f"beta_p: {calc_beta_p_approx(sof):.2f}\n" f"l_i: {calc_li(sof):.2f}"
+)
 
 # TODO: Fix this example...
 # bluemira_print("EOF:\n" f"beta_p: {calc_beta_p(eof):.2f}\n" f"l_i: {calc_li(sof):.2f}")


### PR DESCRIPTION
## Linked Issues

Addresses some of #675 
## Description

We had one too many functions claiming to calculate beta_p. There are two valid calculations for this now, one which is a Friedberg approximation, and the other which uses the full integrals.

## Interface Changes

Some function refactors to `calc_beta_p` and `calc_beta_p_approx`

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
