### PR TITLE
Update definition of Cunningham convergence to be consistent with FIESTA

### DIFF
--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -336,7 +336,7 @@ class CunninghamConvergence(ConvergenceCriterion):
             True if the convergence criterion is met, else False.
         """
         d_j = j_old - j_new
-        conv = np.sum(d_j**2) / np.sum(j_new)
+        conv = np.sum(d_j**2) / np.sum(j_new**2)
         if print_status:
             bluemira_print_flush(
                 f"EQUILIBRIA G-S iter {i}: J_phi source convergence: {conv:e}"


### PR DESCRIPTION
## Description

As identified in discussions with G. Cunningham, the previous definition of the `CunninghamConvergence` criterion used in bluemira for slightly differs from that used in FIESTA. 

This PR makes the convergence parameter consistent (and dimensionless) for easier comparison with FIESTA runs, as intended.