### PR TITLE
Make make_circle_arc_3P consistent with make_circle

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -408,6 +408,17 @@ def make_circle_arc_3P(p1, p2, p3):  # noqa: N802
     """
     # TODO: check what happens when the 3 points are in a line
     arc = Part.ArcOfCircle(Base.Vector(p1), Base.Vector(p2), Base.Vector(p3))
+
+    # next steps are made to create an arc of circle that is consistent with that
+    # created by 'make_circle'
+    output = Part.Circle()
+    output.Radius = arc.Radius
+    output.Center = arc.Center
+    output.Axis = arc.Axis
+    arc = Part.ArcOfCircle(
+        output, output.parameter(arc.StartPoint), output.parameter(arc.EndPoint)
+    )
+
     return Part.Wire(Part.Edge(arc))
 
 

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -41,6 +41,7 @@ from bluemira.geometry.tools import (
     interpolate_bspline,
     log_geometry_on_failure,
     make_circle,
+    make_circle_arc_3P,
     make_ellipse,
     make_polygon,
     offset_wire,
@@ -590,3 +591,15 @@ class TestLogFailedGeometryOperationSerialisation:
         assert os.path.basename(call_args[0]).startswith("naughty_function_fallback")
         assert call_args[1] == "w"
         assert result == 42
+
+
+class TestMakeCircle:
+    def test_make_circle_arc_3P(self):
+        p1 = [1, 0, 2]
+        p2 = [2, 0, 3]
+        p3 = [0, 0, 3.2]
+
+        arc = make_circle_arc_3P(p1, p2, p3)
+        points = arc.discretize(2).points
+        np.testing.assert_allclose(np.array(p1), np.array(points[0]), atol=1e-15)
+        np.testing.assert_allclose(np.array(p3), np.array(points[1]), atol=1e-15)

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -30,7 +30,12 @@ from numpy.linalg import norm
 import bluemira.codes._freecadapi as cadapi
 from bluemira.geometry.error import _FallBackError
 from bluemira.geometry.face import BluemiraFace
-from bluemira.geometry.parameterisations import PictureFrame, PolySpline, PrincetonD
+from bluemira.geometry.parameterisations import (
+    PictureFrame,
+    PolySpline,
+    PrincetonD,
+    TripleArc,
+)
 from bluemira.geometry.plane import BluemiraPlane
 from bluemira.geometry.tools import (
     _signed_distance_2D,
@@ -556,8 +561,7 @@ class TestLogFailedGeometryOperationSerialisation:
         PrincetonD().create_shape(),
         PolySpline().create_shape(),
         PictureFrame().create_shape(),
-        # TODO: Fix serialisation for this (origin uncertain)
-        # TripleArc().create_shape(),
+        TripleArc().create_shape(),
     ]
 
     @mock.patch("builtins.open", new_callable=mock.mock_open)

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -28,6 +28,7 @@ import pytest
 from numpy.linalg import norm
 
 import bluemira.codes._freecadapi as cadapi
+from bluemira.base.constants import EPS
 from bluemira.geometry.error import _FallBackError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import (

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -605,5 +605,5 @@ class TestMakeCircle:
 
         arc = make_circle_arc_3P(p1, p2, p3)
         points = arc.discretize(2).points
-        np.testing.assert_allclose(np.array(p1), np.array(points[0]), atol=1e-15)
-        np.testing.assert_allclose(np.array(p3), np.array(points[1]), atol=1e-15)
+        np.testing.assert_allclose(np.array(p1), np.array(points[0]), atol=EPS)
+        np.testing.assert_allclose(np.array(p3), np.array(points[1]), atol=EPS)


### PR DESCRIPTION
## Linked Issues

Closes #965 

## Description

It makes `make_circle_arc_3P` consistent with `make_circle`

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
