### PR TITLE
🔥 Remove CommentJSONDecoder

### DIFF
--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -49,7 +49,6 @@ from bluemira.codes.plasmod.mapping import (
     TransportModel,
     mappings,
 )
-from bluemira.utilities.tools import CommentJSONDecoder
 
 
 class PlasmodParameters:
@@ -126,7 +125,7 @@ class PlasmodParameters:
         """
         bluemira_debug(f"Loading default values from json: {filepath}")
         with open(filepath) as jfh:
-            return json.load(jfh, cls=CommentJSONDecoder)
+            return json.load(jfh)
 
     def as_dict(self):
         """

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -24,7 +24,6 @@ A collection of miscellaneous tools.
 """
 
 import operator
-import re
 import string
 from collections.abc import Iterable
 from functools import partial
@@ -32,7 +31,7 @@ from importlib import import_module as imp
 from importlib import machinery as imp_mach
 from importlib import util as imp_u
 from itertools import permutations
-from json import JSONDecoder, JSONEncoder, dumps
+from json import JSONEncoder, dumps
 from json.encoder import _make_iterencode
 from os import listdir
 from types import ModuleType
@@ -48,33 +47,6 @@ from bluemira.base.look_and_feel import bluemira_debug, bluemira_warn
 # =====================================================
 # JSON utilities
 # =====================================================
-
-
-class CommentJSONDecoder(JSONDecoder):
-    """
-    Decode JSON with comments
-
-    Notes
-    -----
-    Regex does the following for comments:
-
-        - starts with // followed by most chr (not ")
-        - if not followed by " and any of (whitespace , }) and \\n
-
-    and removes extra commas from the end of dict like objects
-    """
-
-    comments = re.compile(r'[/]{2}(\s*\w*[#-/:-@{-~!^_`\[\]]*)*(?!["]\s*[,]*[\}]*\n)')
-    comma = re.compile(r"[,](\n*\s*)*[\}]")
-    eof = re.compile(r"[,](\n*\s*)*$")
-
-    def decode(self, s, *args, **kwargs):
-        """Return the Python representation of ``s`` (a ``str`` instance
-        containing a JSON document).
-        """
-        s = self.eof.sub("}", self.comma.sub("}", self.comments.sub("", s)).strip())
-        bluemira_debug("Comment stripped JSON\n" + s)
-        return super().decode(s, *args, **kwargs)
 
 
 class NumpyJSONEncoder(JSONEncoder):

--- a/tests/utilities/test_tools.py
+++ b/tests/utilities/test_tools.py
@@ -21,14 +21,12 @@
 
 import json
 import os
-from io import StringIO
 
 import numpy as np
 import pytest
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.utilities.tools import (
-    CommentJSONDecoder,
     NumpyJSONEncoder,
     asciistr,
     cartesian_to_polar,
@@ -43,36 +41,6 @@ from bluemira.utilities.tools import (
     norm,
     polar_to_cartesian,
 )
-
-
-class TestCommentJSONDecoder:
-    def test_decoder(self):
-        loaded = json.load(
-            StringIO(
-                """{
-                "reference_data_root": "",
-                "generated_data_root": "",
-                "plot_flag": {"abgc": false},
-                "process_mode": "run input",
-                "process_indat": "IN.DAT",
-                "plasma_mode": "mock",  //Thisis a comment @#$%^&*()_+|'
-                // hellloo
-                }
-            """
-            ),
-            cls=CommentJSONDecoder,
-        )
-
-        result = {
-            "reference_data_root": "",
-            "generated_data_root": "",
-            "plot_flag": {"abgc": False},
-            "process_mode": "run input",
-            "process_indat": "IN.DAT",
-            "plasma_mode": "mock",
-        }
-
-        assert loaded == result
 
 
 class TestNumpyJSONEncoder:
@@ -314,7 +282,7 @@ def test_polar_cartesian():
 class TestGetModule:
     test_mod = "bluemira.utilities.tools"
     test_mod_loc = get_bluemira_path("utilities") + "/tools.py"
-    test_class_name = "CommentJSONDecoder"
+    test_class_name = "NumpyJSONEncoder"
 
     def test_getmodule(self):
         for mod in [self.test_mod, self.test_mod_loc]:
@@ -353,13 +321,13 @@ class TestGetModule:
             assert the_class.__name__ == self.test_class_name
 
     def test_get_class_default(self):
-        class_name = "CommentJSONDecoder"
+        class_name = "NumpyJSONEncoder"
         for mod in [self.test_mod, self.test_mod_loc]:
             the_class = get_class_from_module(class_name, default_module=mod)
             assert the_class.__name__ == class_name
 
     def test_get_class_default_override(self):
-        class_name = "CommentJSONDecoder"
+        class_name = "NumpyJSONEncoder"
         for mod in [self.test_mod, self.test_mod_loc]:
             the_class = get_class_from_module(
                 f"{mod}::{self.test_class_name}", default_module="a_module"


### PR DESCRIPTION
## Linked Issues

Closes #932 

## Description

As per discussion remove the CommentJSONDecoder

## Interface Changes

Comments no longer allowed in JSON files

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
