### PR TITLE
Modify `Teardown` to warn if values were not found in the output.

### DIFF
--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -269,8 +269,12 @@ class Teardown(Task):
                 )
             except AttributeError as exc:
                 raise AttributeError(f"No mapping found for {bm_key}") from exc
-            if code_unit is not None:
-                outputs[bm_key] = {"value": value, "unit": code_unit}
+
+            if value is None:
+                bluemira_warn(f"No value for {bm_key} found in output.")
+            else:
+                if code_unit is not None:
+                    outputs[bm_key] = {"value": value, "unit": code_unit}
 
         self.parent.params.update_kw_parameters(
             outputs, source=source if source is not None else f"{self.parent.NAME}"


### PR DESCRIPTION
## Linked Issues

This can happen for old output files where mappings may not exist or be up to date.

e.g. Closes #{ID}

## Description

What is your PR trying to achieve? How did you go about achieving it?

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
