### PR TITLE
"cwol" is output as well as input

### DIFF
--- a/bluemira/codes/plasmod/PLASMOD_DEFAULT_OUT.json
+++ b/bluemira/codes/plasmod/PLASMOD_DEFAULT_OUT.json
@@ -51,6 +51,7 @@
     "psep_r": null,
     "psepb_q95AR": null,
     "cprotium": null,
+    "cwol": null,
     "che": null,
     "che3": null,
     "cxe": null,

--- a/bluemira/codes/plasmod/api.py
+++ b/bluemira/codes/plasmod/api.py
@@ -114,7 +114,9 @@ class PlasmodParameters:
                 if n_o in self._options:
                     self._options[n_o] = new_options[n_o]
                 else:
-                    bluemira_warn(f"{n_o} not known in input file")
+                    bluemira_warn(
+                        f"{n_o} not known in {self.__class__.__name__[:-1].lower()} file"
+                    )
 
     @staticmethod
     def _load_default_from_json(filepath: str):

--- a/bluemira/codes/plasmod/mapping.py
+++ b/bluemira/codes/plasmod/mapping.py
@@ -279,8 +279,6 @@ PLASMOD_INPUTS = {
     # ###### "BM_INP": ("globtau_xe", "dimensionless"),
     # [-] tauparticle / tauE for Ar
     # ###### "BM_INP": ("globtau_ar", "dimensionless"),
-    # [-] Tungsten concentration
-    # ##### "BM_INP": ("cwol": 0.0,
     # [-] min P_sep/P_LH. if Psep/PLH < Psep/PLH_max -> use heating
     # ###### "BM_INP": ("psepplh_inf", "dimensionless"),
     # [-] max P_sep/P_LH. if Psep/PLH > Psep/PLH_max -> use Xe
@@ -586,6 +584,8 @@ PLASMOD_INOUTS = {
     # ###### "BM_IO": ("car", # TODO
     # [-] Xenon concentration
     # #### "BM_IO": ("cxe", # TODO
+    # [-] Tungsten concentration
+    # ##### "BM_IO": ("cwol": 0.0,
     # ###########################
     # Pedestal properties
     # ############################


### PR DESCRIPTION
## Description

cwol has been moved to IO also fixed bug where every modification failure said it came from the output

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
