### PR TITLE
🐛 replace old geo import

### DIFF
--- a/documentation/source/geometry/geometry.rst
+++ b/documentation/source/geometry/geometry.rst
@@ -61,6 +61,9 @@ A basic example for the creation of the geometrical objects:
 
     .. code-block:: pycon
 
+        >>> from bluemira.geometry.tools import make_polygon
+        >>> from bluemira.geometry.face import BluemiraFace
+
         >>> pntslist_out = [(1.0, 1.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0,0.0)]
         >>> delta = 0.25
         >>> pntslist_in = [ (1.0 - delta, 1.0 - delta, 0.0),
@@ -68,11 +71,11 @@ A basic example for the creation of the geometrical objects:
                             (0.0 + delta, 0.0 + delta, 0.0),
                             (1.0 - delta, 0.0 + delta, 0.0),
                           ]
-        >>> wire_out = geo.tools.make_polygon(pntslist_out, label="wire_out",closed=True)
-        >>> bmface = geo.face.BluemiraFace(wire_out)
+        >>> wire_out = make_polygon(pntslist_out, label="wire_out",closed=True)
+        >>> bmface = BluemiraFace(wire_out)
         Out: ([BluemiraFace] = Label: wire_out,  length: 4.0,  area: 1.0,  volume: 0.0, )
-        >>> wire_in = geo.tools.make_polygon(pntslist_in, label="wire_in", closed=True)
-        >>> bmface_with_hole = geo.face.BluemiraFace([wire_out, wire_in],label="face_with_hole")
+        >>> wire_in = make_polygon(pntslist_in, label="wire_in", closed=True)
+        >>> bmface_with_hole = BluemiraFace([wire_out, wire_in],label="face_with_hole")
         Out: ([BluemiraFace] = Label: face_with_hole,  length: 6.0,  area: 0.75,volume: 0.0, )
 
     .. note:: the length of the face is equal to the total length of the boundary.

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -25,7 +25,9 @@ Tests for the plotter module.
 
 import numpy as np
 
-import bluemira.geometry as geo
+import bluemira.geometry.face as face
+import bluemira.geometry.placement as placement
+import bluemira.geometry.tools as tools
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.display import plot_3d, plotter
 from bluemira.utilities.plot_tools import Plot3D
@@ -65,7 +67,7 @@ class TestPlotOptions:
         """
         Check the options can be obtained as a dictionary with a BluemiraPlacement
         """
-        the_placement = geo.placement.BluemiraPlacement()
+        the_placement = placement.BluemiraPlacement()
         the_options = plotter.PlotOptions(view=the_placement)
         options_dict = the_options.as_dict()
         for key, val in options_dict.items():
@@ -103,7 +105,7 @@ class TestPlotOptions:
         the_options.wire_options = {}
         the_options.face_options = {}
         the_options.view = "xyz"
-        the_options.view = geo.placement.BluemiraPlacement()
+        the_options.view = placement.BluemiraPlacement()
         the_options.ndiscr = 20
         the_options.byedges = not plotter.DEFAULT_PLOT_OPTIONS["byedges"]
 
@@ -118,16 +120,16 @@ class TestPlot3d:
 
     def test_plot_3d_same_axis(self):
         ax_orig = Plot3D()
-        ax_1 = plot_3d(geo.tools.make_circle(), show=False, ax=ax_orig)
-        ax_2 = plot_3d(geo.tools.make_circle(radius=2), show=False, ax=ax_1)
+        ax_1 = plot_3d(tools.make_circle(), show=False, ax=ax_orig)
+        ax_2 = plot_3d(tools.make_circle(radius=2), show=False, ax=ax_1)
 
         assert ax_1 is ax_orig
         assert ax_2 is ax_orig
 
     def test_plot_3d_new_axis(self):
         ax_orig = Plot3D()
-        ax_1 = plot_3d(geo.tools.make_circle(), show=False)
-        ax_2 = plot_3d(geo.tools.make_circle(radius=2), show=False)
+        ax_1 = plot_3d(tools.make_circle(), show=False)
+        ax_2 = plot_3d(tools.make_circle(radius=2), show=False)
 
         assert ax_1 is not ax_2
         assert ax_1 is not ax_orig
@@ -144,7 +146,7 @@ class TestPointsPlotter:
 
 class TestWirePlotter:
     def setup_method(self):
-        self.wire = geo.tools.make_polygon(SQUARE_POINTS)
+        self.wire = tools.make_polygon(SQUARE_POINTS)
 
     def test_plotting_2d(self):
         plotter.WirePlotter().plot_2d(self.wire)
@@ -161,9 +163,9 @@ class TestWirePlotter:
 
 class TestFacePlotter:
     def setup_method(self):
-        wire = geo.tools.make_polygon(SQUARE_POINTS)
+        wire = tools.make_polygon(SQUARE_POINTS)
         wire.close()
-        self.face = geo.face.BluemiraFace(wire)
+        self.face = face.BluemiraFace(wire)
 
     def test_plotting_2d(self):
         plotter.FacePlotter().plot_2d(self.face)
@@ -180,10 +182,10 @@ class TestFacePlotter:
 
 class TestComponentPlotter:
     def setup_method(self):
-        wire1 = geo.tools.make_polygon(SQUARE_POINTS, closed=True)
-        wire2 = geo.tools.make_polygon(SQUARE_POINTS + 2.0, closed=True)
-        face1 = geo.face.BluemiraFace(wire1)
-        face2 = geo.face.BluemiraFace(wire2)
+        wire1 = tools.make_polygon(SQUARE_POINTS, closed=True)
+        wire2 = tools.make_polygon(SQUARE_POINTS + 2.0, closed=True)
+        face1 = face.BluemiraFace(wire1)
+        face2 = face.BluemiraFace(wire2)
 
         self.group = Component("Parent")
         self.child1 = PhysicalComponent("Child1", shape=face1, parent=self.group)


### PR DESCRIPTION
## Linked Issues

Closes #1017 

## Description

We used to import some modules into sub package namespaces. For some reason this still worked unless the file was run individually.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
