### PR TITLE
➖ Remove trimesh as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,6 @@ threadpoolctl==3.1.0
 toml==0.10.2
 tornado==6.1
 traitlets==5.1.1
-trimesh==3.11.2
 typing-extensions==4.2.0
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ install_requires = [
     "Shapely",
     "tables",
     "tabulate",
-    "trimesh",
     "scipy<=1.5.3",
     "wrapt",
 ]


### PR DESCRIPTION
## Description

As said in #710 this was only a dependency for BLUEPRINT therefore removing

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
