### PR TITLE
🐛 FreeCAD pivy pinning, fixes CAD viewer

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -21,7 +21,7 @@ variables:
 dependencies:
   - python=3.8
   - freecad=0.19.3
-  - pivy=0.6.5
+  - pivy=0.6.5 # later pivy versions (0.6.7 at the time of writing) crash our FreeCAD CAD viewer
   - numpy=1.21.5
   - fenics=2019.1.0
   - MeshPy=2020.1

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -21,6 +21,7 @@ variables:
 dependencies:
   - python=3.8
   - freecad=0.19.3
+  - pivy=0.6.5
   - numpy=1.21.5
   - fenics=2019.1.0
   - MeshPy=2020.1


### PR DESCRIPTION
## Linked Issues

Closes #997 
Closes #1020 

## Description

The FreeCAD conda package didnt pin pivy and the most recent pivy crashes our FreeCAD cad viewer.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
