### PR TITLE
🚸 min mpl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "gmsh",
     "imageio",
     "ipykernel",
-    "matplotlib",
+    "matplotlib>=3.5",
     "natsort",
     "neutronics-material-maker==0.1.11",  # Crash on upgrade
     "nlopt",


### PR DESCRIPTION
## Description

To avoid #1046 happening again set a lower limit on the mpl version in setup.py. I've tested mpl v3.5.0 onwards and everything seems to work

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
