### PR TITLE
Increase robustness of EU-DEMO build and fix closure problem

### DIFF
--- a/bluemira/builders/EUDEMO/_varied_offset.py
+++ b/bluemira/builders/EUDEMO/_varied_offset.py
@@ -72,7 +72,7 @@ def varied_offset(
         New wire at a variable offset to the input.
     """
     _throw_if_inputs_invalid(wire, inboard_offset_degree, outboard_offset_degree)
-    coordinates = wire.discretize(num_points, byedges=False)
+    coordinates = wire.discretize(num_points, byedges=True)
     if not np.all(coordinates.normal_vector == [0, 1, 0]):
         raise GeometryError(
             "Cannot create a variable offset from a wire that is not xz planar."

--- a/bluemira/builders/EUDEMO/vacuum_vessel.py
+++ b/bluemira/builders/EUDEMO/vacuum_vessel.py
@@ -23,6 +23,7 @@
 Builder for making a parameterised EU-DEMO vacuum vessel.
 """
 
+from copy import deepcopy
 from typing import List
 
 import bluemira.utilities.plot_tools as bm_plot_tools
@@ -80,6 +81,9 @@ class VacuumVesselBuilder(Builder):
         """
         super().reinitialise(params)
 
+        if not ivc_koz.is_closed():
+            ivc_koz = deepcopy(ivc_koz)
+            ivc_koz.close()
         self._ivc_koz = ivc_koz
 
     def build(self) -> Component:
@@ -125,6 +129,9 @@ class VacuumVesselBuilder(Builder):
 
         component = Component("xz", children=[body])
         bm_plot_tools.set_component_view(component, "xz")
+        from bluemira.display import plot_2d
+
+        plot_2d([inner_vv, outer_vv])
         return component
 
     def build_xy(self):

--- a/bluemira/builders/EUDEMO/vacuum_vessel.py
+++ b/bluemira/builders/EUDEMO/vacuum_vessel.py
@@ -129,9 +129,6 @@ class VacuumVesselBuilder(Builder):
 
         component = Component("xz", children=[body])
         bm_plot_tools.set_component_view(component, "xz")
-        from bluemira.display import plot_2d
-
-        plot_2d([inner_vv, outer_vv])
         return component
 
     def build_xy(self):

--- a/bluemira/builders/thermal_shield.py
+++ b/bluemira/builders/thermal_shield.py
@@ -96,14 +96,14 @@ class VacuumVesselThermalShieldBuilder(Builder):
         vvts_inner_wire = offset_wire(
             self._vv_koz,
             self._params.g_vv_ts.value,
-            join="arc",
+            join="intersect",
             open_wire=False,
             ndiscr=600,
         )
         vvts_outer_wire = offset_wire(
             vvts_inner_wire,
             self._params.tk_ts.value,
-            join="arc",
+            join="intersect",
             open_wire=False,
             ndiscr=600,
         )

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -660,6 +660,9 @@ def discretize(w: Part.Wire, ndiscr: int = 10, dl: float = None):
     # discretization points array
     output = w.discretize(ndiscr)
     output = vector_to_numpy(output)
+
+    if w.isClosed():
+        output[-1] = output[0]
     return output
 
 

--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -99,9 +99,6 @@ class BluemiraFace(BluemiraGeo):
             if len(face.Faces) == 1:
                 face = face.Faces[0]
             else:
-                from bluemira.display import plot_2d
-
-                plot_2d(self.boundary)
                 raise DisjointedFace("Any or more than one face has been created.")
 
         if check_reverse:

--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -99,6 +99,9 @@ class BluemiraFace(BluemiraGeo):
             if len(face.Faces) == 1:
                 face = face.Faces[0]
             else:
+                from bluemira.display import plot_2d
+
+                plot_2d(self.boundary)
                 raise DisjointedFace("Any or more than one face has been created.")
 
         if check_reverse:

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -547,6 +547,9 @@ def offset_wire(
     wire: BluemiraWire
         Offset wire
     """
+    if not open_wire:
+        wire = wire.deepcopy()
+        wire.close()
     return BluemiraWire(
         cadapi.offset_wire(wire._shape, thickness, join, open_wire), label=label
     )

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -481,15 +481,22 @@ def _offset_wire_discretised(
     """
     Fallback function for discretised offsetting
 
-    Notes
-    -----
-    Can only handle closed wires
+    Raises
+    ------
+    GeometryError
+        If the wire is not closed. This function cannot handle the offet of an open
+        wire.
     """
     from bluemira.geometry._deprecated_offset import offset_clipper
 
-    if not open_wire:
+    if not wire.is_closed() and not open_wire:
         wire = wire.deepcopy()
         wire.close()
+
+    if not wire.is_closed() and open_wire:
+        raise GeometryError(
+            "Fallback function _offset_wire_discretised cannot handle open wires."
+        )
 
     coordinates = wire.discretize(byedges=byedges, ndiscr=ndiscr)
 

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -487,6 +487,10 @@ def _offset_wire_discretised(
     """
     from bluemira.geometry._deprecated_offset import offset_clipper
 
+    if not open_wire:
+        wire = wire.deepcopy()
+        wire.close()
+
     coordinates = wire.discretize(byedges=byedges, ndiscr=ndiscr)
 
     result = offset_clipper(
@@ -547,9 +551,6 @@ def offset_wire(
     wire: BluemiraWire
         Offset wire
     """
-    if not open_wire:
-        wire = wire.deepcopy()
-        wire.close()
     return BluemiraWire(
         cadapi.offset_wire(wire._shape, thickness, join, open_wire), label=label
     )


### PR DESCRIPTION
## Linked Issues

closes #1078 

## Description

Switches offset method in thermal shield to "intersect" which seems to be more robust in this case.

Adds some geometry closed checks.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
