### PR TITLE
Add proposal for ADR document templates

### DIFF
--- a/documentation/developer/adr/0001-record-architecture-decisions.md
+++ b/documentation/developer/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,26 @@
+# 1. Record architecture decisions
+
+Date: 2022-06-14
+
+## Status
+
+Proposed
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records,
+as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+The templates can be adapted to include other relevant headers
+(e.g. 'Alternative Solutions Considered'),
+but each document should contain the headers used in this ADR.
+
+## Consequences
+
+See Michael Nygard's article, linked above.
+For a lightweight ADR toolset,
+see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
## Description

Adds a document that describes how we will format and record architectural decisions. The document also serves as an example of an ADR.

I've opted for putting the documents in the repository, the main advantages being that everyone can read and review them, and the point at which the decision was made is clear in the project's history. I've also gone with vanilla markdown, as I don't think these documents call for the extra maintenance required to build `rst`, there's also no reason they need to be linked to the user accessible documentation.

We should document decisions made in the upcoming workshop using these templates.