### PR TITLE
Generalise searching through a component

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Union
 
 import anytree
-import numpy as np
 from anytree import NodeMixin, RenderTree
 
 from bluemira.base.error import ComponentError
@@ -156,16 +155,11 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
                 return getattr(found_nodes, properties[0])
             return [getattr(found_nodes, prop) for prop in properties]
         else:
-            return tuple(
-                obj.tolist()
-                for obj in np.array(
-                    [
-                        [getattr(node, prop) for prop in properties]
-                        for node in found_nodes
-                    ],
-                    dtype=object,
-                ).T
-            )
+            # Collect values by property instead of by node
+            node_properties = [
+                [getattr(node, prop) for prop in properties] for node in found_nodes
+            ]
+            return tuple(map(list, zip(*node_properties)))
 
     def _get_thing(self, filter_: Callable, first: bool, full_tree: bool):
         found_nodes = anytree.search.findall(

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -312,7 +312,7 @@ def get_properties_from_components(
     comps: Union[Component, Iterable[Component]], properties: Union[str, Sized[str]]
 ):
     """
-    Get internal shapes and display options from Components
+    Get properties from Components
 
     Parameters
     ----------

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -25,7 +25,17 @@ Module containing the base Component class.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Sized, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Union,
+)
 
 import anytree
 from anytree import NodeMixin, RenderTree
@@ -116,7 +126,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def get_component_properties(
         self, properties: Union[Sized[str], str], first=True, full_tree=False
-    ):
+    ) -> Union[Tuple[List[Any]], List[Any], Any]:
         """
         Get properties from a component
 
@@ -132,7 +142,10 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
         Returns
         -------
-        Lists of properties of components
+        properties: Union[Tuple[List[Any]], List[Any], Any]
+            If multiple properties specified returns a tuple of the list of properties,
+            otherwise returns a list of the property.
+            If only one node has the property returns the value(s).
 
         Notes
         -----

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -25,7 +25,7 @@ Module containing the base Component class.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Sized, Union
 
 import anytree
 from anytree import NodeMixin, RenderTree
@@ -115,7 +115,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         )
 
     def get_component_properties(
-        self, properties: Union[Iterable[str], str], first=True, full_tree=False
+        self, properties: Union[Sized[str], str], first=True, full_tree=False
     ):
         """
         Get properties from a component
@@ -309,7 +309,7 @@ class MagneticComponent(PhysicalComponent):
 
 
 def get_properties_from_components(
-    comps: Union[Component, Iterable[Component]], properties: Union[str, Iterable[str]]
+    comps: Union[Component, Iterable[Component]], properties: Union[str, Sized[str]]
 ):
     """
     Get internal shapes and display options from Components
@@ -318,6 +318,8 @@ def get_properties_from_components(
     ----------
     comps: Union[Component, Iterable[Component]])
         A component or list of components
+    properties: Union[str, Sized[str]]
+        properties to collect
 
     Returns
     -------


### PR DESCRIPTION
## Linked Issues

Spurred by comments in #1145 

## Description

Generalise component search instead of homebrewed version. This really is a split out from #1145 because it was a bit out of scope to add a property search for a cad saver addition

## Interface Changes

New search for property function

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
