### PR TITLE
Fix check_release_due trigger schedule

### DIFF
--- a/.github/workflows/check_release_due.yml
+++ b/.github/workflows/check_release_due.yml
@@ -4,7 +4,7 @@ name: Check If Release Due
 on:
   schedule:
     # Runs every Monday at 06:12
-    - cron: "12 6 * * 0"
+    - cron: "12 6 * * 1"
 
 jobs:
   check-release-due:


### PR DESCRIPTION
## Description

The release checker was running on Sunday, not Monday. The 0th day is Sunday, not Monday! Whoops

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
