### PR TITLE
Fix failing plotting tests

### DIFF
--- a/bluemira/structural/plotting.py
+++ b/bluemira/structural/plotting.py
@@ -312,10 +312,10 @@ class BasePlotter:
             y = [element.node_1.y, element.node_2.y]
             z = [element.node_1.z, element.node_2.z]
 
-            if self.options["show_stress"]:
+            if self.options["show_stress"] and self.color_normer:
                 color = STRESS_COLOR(self.color_normer(element.max_stress))
-            elif self.options["show_deflection"]:
-                color = DEFLECT_COLOR(self.color_normer(element.max_deflection))
+            elif self.options["show_deflection"] and self.color_normer:
+                color = DEFLECT_COLOR(self.color_normer(element.max_displacement))
             else:
                 color = default_color
 

--- a/tests/structural/test_crosssection.py
+++ b/tests/structural/test_crosssection.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 
 import tests
+from bluemira.display import plot_2d
 from bluemira.structural.crosssection import (
     AnalyticalCrossSection,
     CircularBeam,
@@ -46,7 +47,7 @@ class TestIbeam:
     @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_plot(self):
         i_beam = IBeam(1, 1, 0.25, 0.5)
-        i_beam.geometry.plot(points=True)
+        plot_2d(i_beam.geometry, show_points=True)
 
     def test_errors(self):
         props = [


### PR DESCRIPTION
## Linked Issues

Closes #1002 

## Description

Fixes some plotting test failures.

I've done my best to resolve the failing `test_model` tests (relevant changes in plotting.py), but it may be worth someone who is more familiar with the code checking it looks correct. The docstring for the `max_displacement` property suggests it's the same thing as `max_deflection` (there's no attribute `max_deflection`).

Probably worth someone else running `pytest --plotting-on --longrun`. They all pass on my PC.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
