### PR TITLE
Add warnings to CI and run more tests for the develop dependencies PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,14 @@ jobs:
 
     - name: Run pytest bluemira
       shell: bash -l {0}
+      env:
+        # https://github.com/actions/runner/issues/409#issuecomment-752775072
+        PYTEST_LONGRUN: ${{ github.ref_name == "develop_dependencies" && "--longrun" || "" }}
       run: |
         pytest --cov=bluemira \
                --cov-report html:htmlcov_bluemira \
                --cov-report xml \
-               tests examples/design/EU-DEMO --reactor --private
+               tests examples/design/EU-DEMO --reactor --private ${PYTEST_LONGRUN}
 
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,16 @@ jobs:
 
     - name: Download reference test report (PR only)
       if: ${{ github.event_name == 'pull_request' }}
-      # Do not fail if the report is not found. It may not exist if the
-      # artifact has expired, or there is a build of develop in progress.
-      # In case we don't find an old report, we just report all the warnings.
-      continue-on-error: true
-      uses: dawidd6/action-download-artifact@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        workflow: ci.ymls
-        name: report-json
-        commit: ${{ github.event.pull_request.ref.sha }}
-        path: ref_report
-        search_artifacts: true
+      run: |
+        artifact_url="$( \
+          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "report-json") | select(.workflow_run.head_sha == "${{ github.event.pull_request.base.sha }}") | .archive_download_url')"
+        if [ ! -z "${artifact_url}" ]; then
+          gh api ${artifact_url} > report-json.zip
+          mkdir ref_report
+          unzip report-json.zip -d ref_report
+        fi
 
     - name: Generate warning report
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       if: ${{ github.event_name == 'push' }}
       uses: actions/upload-artifact@v3
       env:
-        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: report-json
         path: .report.json
@@ -129,9 +129,9 @@ jobs:
       continue-on-error: true
       uses: dawidd6/action-download-artifact@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        workflow: ci.yml
+        workflow: ci.ymls
         name: report-json
         commit: ${{ github.event.pull_request.ref.sha }}
         path: ref_report
@@ -141,7 +141,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       id: warning-report
       env:
-        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if [ -f "ref_report/.report.json" ]; then
           compare_args="--compare ref_report/.report.json"
@@ -157,7 +157,7 @@ jobs:
       uses: peter-evans/find-comment@v2
       id: find-warning-report-comment
       env:
-        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
@@ -168,7 +168,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/create-or-update-comment@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       if: ${{ github.event_name == 'push' }}
       uses: actions/upload-artifact@v3
       env:
-        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
+        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
       with:
         name: report-json
         path: .report.json
@@ -129,7 +129,7 @@ jobs:
       continue-on-error: true
       uses: dawidd6/action-download-artifact@v2
       env:
-        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
+        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
       with:
         workflow: ci.yml
         name: report-json
@@ -141,7 +141,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       id: warning-report
       env:
-        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
+        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
       run: |
         if [ -f "ref_report/.report.json" ]; then
           compare_args="--compare ref_report/.report.json"
@@ -157,7 +157,7 @@ jobs:
       uses: peter-evans/find-comment@v2
       id: find-warning-report-comment
       env:
-        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
+        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
@@ -168,7 +168,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/create-or-update-comment@v2
       env:
-        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
+        GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
       with:
         comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       env:
         # Flag to run longrun tests when merging dependency updates
         # https://github.com/actions/runner/issues/409#issuecomment-752775072
-        PYTEST_LONGRUN: ${{ github.event.pull_request.head == "develop_dependencies" && "--longrun" || "" }}
+        PYTEST_LONGRUN: ${{ github.event.pull_request.head.ref == 'develop_dependencies' && '--longrun' || '' }}
       run: |
         pytest --cov=bluemira \
                --cov-report html:htmlcov_bluemira \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,69 @@ jobs:
     - name: Run pytest bluemira
       shell: bash -l {0}
       env:
+        # Flag to run longrun tests when merging dependency updates
         # https://github.com/actions/runner/issues/409#issuecomment-752775072
-        PYTEST_LONGRUN: ${{ github.ref_name == "develop_dependencies" && "--longrun" || "" }}
+        PYTEST_LONGRUN: ${{ github.event.pull_request.head == "develop_dependencies" && "--longrun" || "" }}
       run: |
         pytest --cov=bluemira \
                --cov-report html:htmlcov_bluemira \
                --cov-report xml \
+               --json-report \
+               --json-report-indent=3 \
                tests examples/design/EU-DEMO --reactor --private ${PYTEST_LONGRUN}
+
+    - name: Upload test report (push only)
+      if: ${{ github.event_name == 'push' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: report-json
+        path: .report.json
+
+    - name: Download reference test report (PR only)
+      if: ${{ github.event_name == 'pull_request' }}
+      # Do not fail if the report is not found. It may not exist if the
+      # artifact has expired, or there is a build of develop in progress.
+      # In case we don't find an old report, we just report all the warnings.
+      continue-on-error: true
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ci.yml
+        name: report-json
+        commit: ${{ github.event.pull_request.ref.sha }}
+        path: ref_report
+        search_artifacts: true
+
+    - name: Generate warning report
+      if: ${{ github.event_name == 'pull_request' }}
+      id: warning-report
+      run: |
+        if [ -f "ref_report/.report.json" ]; then
+          compare_args="--compare ref_report/.report.json"
+        fi
+        report_str=$(python scripts/format_warning_report.py .report.json ${compare_args}) || true
+        # Ugly stuff to escape new lines
+        report_str="${report_str//'%'/'%25'}"
+        report_str="${report_str//$'\n'/'%0A'}"
+        echo "::set-output name=report::"${report_str}""
+
+    - name: Find warning report comment
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: peter-evans/find-comment@v2
+      id: find-warning-report-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: ⚠️ Warning Report
+        direction: last
+
+    - name: Create or update warning report comment
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: ${{ steps.warning-report.outputs.report }}
+        edit-mode: replace
 
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
     - name: Upload test report (push only)
       if: ${{ github.event_name == 'push' }}
       uses: actions/upload-artifact@v3
+      env:
+        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
       with:
         name: report-json
         path: .report.json
@@ -126,6 +128,8 @@ jobs:
       # In case we don't find an old report, we just report all the warnings.
       continue-on-error: true
       uses: dawidd6/action-download-artifact@v2
+      env:
+        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
       with:
         workflow: ci.yml
         name: report-json
@@ -136,6 +140,8 @@ jobs:
     - name: Generate warning report
       if: ${{ github.event_name == 'pull_request' }}
       id: warning-report
+      env:
+        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
       run: |
         if [ -f "ref_report/.report.json" ]; then
           compare_args="--compare ref_report/.report.json"
@@ -150,6 +156,8 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/find-comment@v2
       id: find-warning-report-comment
+      env:
+        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
@@ -159,6 +167,8 @@ jobs:
     - name: Create or update warning report comment
       if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/create-or-update-comment@v2
+      env:
+        GITHUB_TOKEN: FPPF_BOT_AUTH_KEY
       with:
         comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -11,6 +11,7 @@ pytest==7.1.2
 pytest-cov==3.0.0
 pytest-html==3.1.1
 pytest-metadata==2.0.1
+pytest-json-report==1.5.0
 sphinx==4.5.0
 sphinx-autoapi==1.8.4
 sphinx-rtd-theme==1.0.0

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -112,7 +112,7 @@ def format_warning_report(sys_args: List[str]) -> int:
     if inputs.compare is not None:
         ref_warnings = load_warnings(inputs.compare)
         new, fixed = compare_warnings(warnings, ref_warnings)
-        tada = " 🎉" if len(new) == 0 and len(fixed) >= 0 else ""
+        tada = " 🎉" if len(new) == 0 else ""
         report.append(
             f"Found {len(new)} new warning{'' if len(new) == 1 else 's'}, "
             f"{len(fixed)} fixed warning{'' if len(fixed) == 1 else 's'}.{tada}\n"

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python3
+"""
+Take a '.report.json' output from pytest-json-report, and generate a
+markdown formatted report of any warnings generated.
+
+The script can also compare one JSON report to another, 'baseline',
+report and generate a markdown report that lists new warnings.
+
+In compare mode, the exit code is the number of new warnings. In normal
+mode, the exit code is the number of warnings. A negative exit code
+indicates an error.
+"""
 
 import argparse
 import json
@@ -12,6 +23,8 @@ WARNINGS_KEY = "warnings"
 
 @dataclass(frozen=True, eq=True)
 class Warning:
+    """Stores information from a Python warning."""
+
     message: str
     category: str
     when: str
@@ -19,10 +32,12 @@ class Warning:
     lineno: int
 
     def __str__(self) -> str:
+        """Convert to formatted string."""
         return f"{self.filename}:{self.lineno}: {self.category}: {self.message}"
 
 
 def parse_args(sys_args: List[str]) -> argparse.Namespace:
+    """Parse command line options."""
     parser = argparse.ArgumentParser(PROG)
     parser.add_argument("report_file", help="path to .report.json to parse")
     parser.add_argument(
@@ -32,42 +47,45 @@ def parse_args(sys_args: List[str]) -> argparse.Namespace:
 
 
 def load_warnings(file_path: str) -> Set[Warning]:
+    """Load a set of warnings from file."""
     with open(file_path, "r") as f:
         data = json.load(f)
-    return set([Warning(**warning) for warning in data[WARNINGS_KEY]])
+    try:
+        return set([Warning(**warning) for warning in data[WARNINGS_KEY]])
+    except KeyError:  # no warnings found
+        return set()
 
 
-def format_warnings_markdown(warnings: Iterable[Warning]):
+def format_warnings_list(warnings: Iterable[Warning]) -> List[str]:
+    """Format the list of warnings into lines of markdown."""
     whens: Dict[str, List[Warning]] = {}
     for warning in warnings:
         try:
             whens[warning.when].append(warning)
         except KeyError:
             whens[warning.when] = [warning]
-    markdown = ""
+    lines = []
     for when, warns in whens.items():
-        markdown += f"## On {when}\n\n"
+        lines.append(f"#### On {when}\n")
         for warn in warns:
-            markdown += f"- `{warn}`\n"
-        markdown += "\n"
-    return markdown[:-1]
+            lines.append(f"- `{warn}`")
+        lines.append("")
+    return lines[:-1]  # we do not need a trailing new line
 
 
-def make_collapsable_md(markdown: str, summary: str):
-    lines = markdown.split("\n")
-    indented_lines = [f"{line}" for line in lines]
-    new_lines = (
-        [
-            "<details>\n",
-            f"{' '*INDENT_SIZE}<summary>{summary}</summary>\n",
-        ]
-        + indented_lines
-        + ["</details>"]
-    )
-    return "\n".join(new_lines)
+def make_collapsable(md_lines: List[str], summary: str) -> List[str]:
+    """Surround the given lines in html to make them collapsable."""
+    lines = [
+        "<details>\n",
+        f"{' '*INDENT_SIZE}<summary>{summary}</summary>\n",
+    ]
+    lines.extend(md_lines)
+    lines.append("\n</details>")
+    return lines
 
 
 def elements_not_in(head: Iterable[Any], ref: Iterable[Any]) -> List:
+    """Find the elements that are in head, but not ref."""
     not_in = []
     for head_el in head:
         if head_el not in ref:
@@ -78,33 +96,51 @@ def elements_not_in(head: Iterable[Any], ref: Iterable[Any]) -> List:
 def compare_warnings(
     head_warnings: Set[Warning], ref_warnings: Set[Warning]
 ) -> Tuple[List[Warning], List[Warning]]:
+    """Find new and fixed warnings in 'head' using 'ref' as baseline."""
     new_warnings = elements_not_in(head_warnings, ref_warnings)
     fixed_warnings = elements_not_in(ref_warnings, head_warnings)
     return new_warnings, fixed_warnings
 
 
-def format_warning_report(sys_args: List[str]) -> str:
+def format_warning_report(sys_args: List[str]) -> int:
+    """Run the script."""
     inputs = parse_args(sys_args)
     warnings = load_warnings(inputs.report_file)
-    report = ["# ⚠️ Warning Report\n"]
-    warning_list_md = format_warnings_markdown(warnings)
+    exit_code = len(warnings)
+    report = ["### ⚠️ Warning Report\n"]
+    warning_list_md = format_warnings_list(warnings)
     if inputs.compare is not None:
         ref_warnings = load_warnings(inputs.compare)
         new, fixed = compare_warnings(warnings, ref_warnings)
-        report.append(f"Found {len(new)} new warnings, {len(fixed)} fixed warnings.\n")
-        if new:
-            warning_list = format_warnings_markdown(new)
-            report.append(make_collapsable_md(warning_list, "New warnings"))
-    else:
-        report.append(f"Found {len(warnings)} warnings.\n")
-    if warnings:
+        tada = " 🎉" if len(new) == 0 and len(fixed) >= 0 else ""
         report.append(
-            make_collapsable_md(warning_list_md, f"All warnings ({len(warnings)})")
+            f"Found {len(new)} new warning{'' if len(new) == 1 else 's'}, "
+            f"{len(fixed)} fixed warning{'' if len(fixed) == 1 else 's'}.{tada}\n"
         )
-    return "\n".join(report)
+        if new:
+            warning_list = format_warnings_list(new)
+            report.extend(
+                make_collapsable(warning_list, f"New warnings ({len(warnings)})")
+            )
+        exit_code = len(new)
+    else:
+        plural = "" if len(warnings) == 1 else "s"
+        tada = " 🎉" if len(warnings) == 0 else ""
+        report.append(f"Found {len(warnings)} warning{plural}.{tada}\n")
+    if warnings:
+        report.extend(
+            make_collapsable(warning_list_md, f"All warnings ({len(warnings)})")
+        )
+    print("\n".join(report))
+    return exit_code
 
 
 if __name__ == "__main__":
     import sys
 
-    print(format_warning_report(sys.argv[1:]))
+    try:
+        exit_code = format_warning_report(sys.argv[1:])
+    except Exception as exc:
+        print(exc)
+        exit_code = -1
+    sys.exit(exit_code)

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -38,10 +38,13 @@ class Warning:
 
 def parse_args(sys_args: List[str]) -> argparse.Namespace:
     """Parse command line options."""
-    parser = argparse.ArgumentParser(PROG)
+    parser = argparse.ArgumentParser(PROG, description=__doc__)
     parser.add_argument("report_file", help="path to .report.json to parse")
     parser.add_argument(
-        "--compare", default=None, help="path to .report.json to compare warnings to"
+        "--compare",
+        default=None,
+        help="path to .report.json to compare warnings to",
+        metavar="baseline_report_file",
     )
     return parser.parse_args(sys_args)
 

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Set
+
+PROG = "format_warning_report"
+WARNINGS_KEY = "warnings"
+
+
+@dataclass(frozen=True, eq=True)
+class Warning:
+    message: str
+    category: str
+    when: str
+    filename: str
+    lineno: int
+
+    def __str__(self) -> str:
+        return (
+            f"On {self.when}:\n"
+            f"  {self.filename}:{self.lineno}: {self.category}: {self.message}"
+        )
+
+
+def parse_args(sys_args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(PROG)
+    parser.add_argument("report_file", help="path to .report.json to parse")
+    return parser.parse_args(sys_args)
+
+
+def load_json(file_path: str) -> Dict:
+    with open(file_path, "r") as f:
+        return json.load(f)
+
+
+def parse_warning_list(warning_data: Iterable[Dict]) -> Set[Warning]:
+    # Convert to set to remove duplicates
+    return set([Warning(**warning) for warning in warning_data])
+
+
+def display_warnings(warnings: Set[Warning]):
+    print(f"{PROG}: found {len(warnings)} warnings.")
+    for warning in warnings:
+        print(warning)
+
+
+def format_warning_report(sys_args: List[str]) -> int:
+    inputs = parse_args(sys_args)
+    report = load_json(inputs.report_file)
+    warnings = parse_warning_list(report[WARNINGS_KEY])
+    display_warnings(warnings)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    format_warning_report(sys.argv[1:])

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -3,8 +3,9 @@
 import argparse
 import json
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Set
+from typing import Any, Dict, Iterable, List, Set, Tuple
 
+INDENT_SIZE = 2
 PROG = "format_warning_report"
 WARNINGS_KEY = "warnings"
 
@@ -18,43 +19,92 @@ class Warning:
     lineno: int
 
     def __str__(self) -> str:
-        return (
-            f"On {self.when}:\n"
-            f"  {self.filename}:{self.lineno}: {self.category}: {self.message}"
-        )
+        return f"{self.filename}:{self.lineno}: {self.category}: {self.message}"
 
 
 def parse_args(sys_args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(PROG)
     parser.add_argument("report_file", help="path to .report.json to parse")
+    parser.add_argument(
+        "--compare", default=None, help="path to .report.json to compare warnings to"
+    )
     return parser.parse_args(sys_args)
 
 
-def load_json(file_path: str) -> Dict:
+def load_warnings(file_path: str) -> Set[Warning]:
     with open(file_path, "r") as f:
-        return json.load(f)
+        data = json.load(f)
+    return set([Warning(**warning) for warning in data[WARNINGS_KEY]])
 
 
-def parse_warning_list(warning_data: Iterable[Dict]) -> Set[Warning]:
-    # Convert to set to remove duplicates
-    return set([Warning(**warning) for warning in warning_data])
-
-
-def display_warnings(warnings: Set[Warning]):
-    print(f"{PROG}: found {len(warnings)} warnings.")
+def format_warnings_markdown(warnings: Iterable[Warning]):
+    whens: Dict[str, List[Warning]] = {}
     for warning in warnings:
-        print(warning)
+        try:
+            whens[warning.when].append(warning)
+        except KeyError:
+            whens[warning.when] = [warning]
+    markdown = ""
+    for when, warns in whens.items():
+        markdown += f"## On {when}\n\n"
+        for warn in warns:
+            markdown += f"- `{warn}`\n"
+        markdown += "\n"
+    return markdown[:-1]
 
 
-def format_warning_report(sys_args: List[str]) -> int:
+def make_collapsable_md(markdown: str, summary: str):
+    lines = markdown.split("\n")
+    indented_lines = [f"{line}" for line in lines]
+    new_lines = (
+        [
+            "<details>\n",
+            f"{' '*INDENT_SIZE}<summary>{summary}</summary>\n",
+        ]
+        + indented_lines
+        + ["</details>"]
+    )
+    return "\n".join(new_lines)
+
+
+def elements_not_in(head: Iterable[Any], ref: Iterable[Any]) -> List:
+    not_in = []
+    for head_el in head:
+        if head_el not in ref:
+            not_in.append(head_el)
+    return not_in
+
+
+def compare_warnings(
+    head_warnings: Set[Warning], ref_warnings: Set[Warning]
+) -> Tuple[List[Warning], List[Warning]]:
+    new_warnings = elements_not_in(head_warnings, ref_warnings)
+    fixed_warnings = elements_not_in(ref_warnings, head_warnings)
+    return new_warnings, fixed_warnings
+
+
+def format_warning_report(sys_args: List[str]) -> str:
     inputs = parse_args(sys_args)
-    report = load_json(inputs.report_file)
-    warnings = parse_warning_list(report[WARNINGS_KEY])
-    display_warnings(warnings)
-    return 0
+    warnings = load_warnings(inputs.report_file)
+    report = ["# ⚠️ Warning Report\n"]
+    warning_list_md = format_warnings_markdown(warnings)
+    if inputs.compare is not None:
+        ref_warnings = load_warnings(inputs.compare)
+        new, fixed = compare_warnings(warnings, ref_warnings)
+        report.append(f"Found {len(new)} new warnings, {len(fixed)} fixed warnings.\n")
+        if new:
+            warning_list = format_warnings_markdown(new)
+            report.append(make_collapsable_md(warning_list, "New warnings"))
+    else:
+        report.append(f"Found {len(warnings)} warnings.\n")
+    if warnings:
+        report.append(
+            make_collapsable_md(warning_list_md, f"All warnings ({len(warnings)})")
+        )
+    return "\n".join(report)
 
 
 if __name__ == "__main__":
     import sys
 
-    format_warning_report(sys.argv[1:])
+    print(format_warning_report(sys.argv[1:]))

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ dev_requires = [
     "pytest-cov",
     "pytest-html",
     "pytest-metadata",
+    "pytest-json-report",
     "sphinx",
     "sphinx-autoapi",
     "sphinx-rtd-theme",


### PR DESCRIPTION
## Linked Issues

Closes #1174 

## Description

Add steps to the CI to notify us if there are warnings in our PRs. These notifications take the form of PR comments that list the warnings that pytest has collected.

It also adds a step when the CI is run on "push", i.e. it's run on the develop/main branch, to generate a 'baseline' report. On PRs, we can then use the baseline report and only notify about _new_ warnings. Hopefully this makes managing new warnings more straight-forward.

This PR also adds the `--longrun` flag to the pytest call if `develop_dependencies` is the _head_ branch of PR. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
