### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,10 +49,9 @@ jobs:
 
       - name: Update main
         id: update-main
-        env:
-          GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
-
         run: |
+          git config user.email "107038218+fppf-bot@users.noreply.github.com"
+          git config user.name "fppf-bot"
           git fetch origin main
           git checkout main
           # The 'Checkout' action performs a shallow checkout of develop.
@@ -72,8 +71,7 @@ jobs:
         run: |
           # Rebase develop_dependencies on develop, so that it's up-to-date and
           # we don't run into conflicts next time we merge.
-          git config user.email "107038218+fppf-bot@users.noreply.github.com"
-          git config user.name "fppf-bot"
+
           git fetch origin develop_dependencies
           git switch develop_dependencies --force
           git rebase origin/develop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Update main
         id: update-main
+        env:
+          GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+
         run: |
           git fetch origin main
           git checkout main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
           git fetch origin main
           git checkout main
           # The 'Checkout' action performs a shallow checkout of develop.
-          # We need the history up to the HEAD of main in order to do the merge.
-          git fetch origin develop --shallow-since=$(git log -1 --format=%ct)
+          # We need the history in order to do the merge with main.
+          git fetch origin develop --unshallow
           git merge origin/develop --ff-only
           git push origin main:main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,13 @@ jobs:
       - name: Update main
         id: update-main
         run: |
-          git fetch origin main develop
+          git fetch origin main
           git checkout main
+          # The 'Checkout' action performs a shallow checkout of develop.
+          # We need the history up to the HEAD of main in order to do the merge.
+          git fetch origin develop --shallow-since=$(git log -1 --format=%ct)
           git merge origin/develop --ff-only
-          git push origin main
+          git push origin main:main
 
       - name: Create release
         id: create-release
@@ -66,6 +69,9 @@ jobs:
         run: |
           # Rebase develop_dependencies on develop, so that it's up-to-date and
           # we don't run into conflicts next time we merge.
+          git config user.email "107038218+fppf-bot@users.noreply.github.com"
+          git config user.name "fppf-bot"
+          git fetch origin develop_dependencies
           git switch develop_dependencies --force
           git rebase origin/develop
           git push --force-with-lease origin develop_dependencies:develop_dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,12 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.FPPF_BOT_AUTH_KEY }}
 
       - name: Validate
         id: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Create release
         id: create-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.FPPF_BOT_AUTH_KEY }}
         run: |
           gh release create "${{ steps.validate.outputs.tag }}" \
             --generate-notes \
@@ -73,7 +75,6 @@ jobs:
         run: |
           # Rebase develop_dependencies on develop, so that it's up-to-date and
           # we don't run into conflicts next time we merge.
-
           git fetch origin develop_dependencies
           git switch develop_dependencies --force
           git rebase origin/develop


### PR DESCRIPTION
## Linked Issues

Related to #1087 

## Description

Fixes issue caused by GitHub's 'Checkout' action performing a shallow checkout of develop,  which meant the merge with `main` failed. 


