### PR TITLE
💚 miniforge -> mambaforge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         environment-file: conda/environment.yml
         miniforge-version: "latest"
         use-only-tar-bz2: true
+        miniforge-variant: Mambaforge
+        use-mamba: true
 
     - name: Freeze conda env
       shell: bash -l {0}


### PR DESCRIPTION
## Description

The CI has been broken for a few days seemingly the fix is to use mambaforge instead of miniforge for the package resolving

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
