### PR TITLE
Bump scipy from 1.6.2 to 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ tables==3.7.0
 tabulate==0.8.10
 threadpoolctl==3.1.0
 wrapt==1.14.1
-scipy==1.6.2
+scipy==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ pinned = [
     "numba-scipy==0.3.0",
     "numpy==1.22.4",
     "matplotlib==3.5.2",
-    "scipy==1.6.2",
+    "scipy==1.7.3",
 ]
 
 dev_requires = [


### PR DESCRIPTION
Upgrade scipy now numba-scipy allows a newer version
