### PR TITLE
🧱 Enable forced example notebooks along with some converter script fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,7 @@ jobs:
     - name: Check Code Quality
       shell: bash -l {0}
       run: |
-        SKIP=flake8,black,black-jupyter,regenerate-ipynb-examples pre-commit run --all-files
-        # python examples/convert_py_to_ipynb.py --check --ci
+        SKIP=flake8,black,black-jupyter pre-commit run --all-files
         flake8 --count
         black --check .
 


### PR DESCRIPTION
## Description

Enables notebook checking in CI and slightly clean the converter script

## Interface Changes

You now need to notebook your examples

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
