### PR TITLE
🐛 skip tests if not a git repo

### DIFF
--- a/tests/base/test_look_and_feel.py
+++ b/tests/base/test_look_and_feel.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import os
+import subprocess  # noqa :S404
 from unittest import mock
 
 import pytest
@@ -45,14 +46,28 @@ from bluemira.base.look_and_feel import (
 ROOT = get_bluemira_root()
 
 
+GIT_WORKTREE = subprocess.run(  # noqa: S607
+    ["git", "rev-parse", "--is-inside-work-tree"], shell=False  # noqa: S603
+)
+
+
+@pytest.mark.skipif(
+    GIT_WORKTREE.returncode != 0, reason="Not inside functioning git repository"
+)
 def test_get_git_version():
     assert isinstance(get_git_version(ROOT), bytes)
 
 
+@pytest.mark.skipif(
+    GIT_WORKTREE.returncode != 0, reason="Not inside functioning git repository"
+)
 def test_get_git_branch():
     assert isinstance(get_git_branch(ROOT), str)
 
 
+@pytest.mark.skipif(
+    GIT_WORKTREE.returncode != 0, reason="Not inside functioning git repository"
+)
 def test_count_slocs():
     branch = get_git_branch(ROOT)
     slocs = count_slocs(ROOT, branch)


### PR DESCRIPTION
## Description

If you have the repo but it isnt a valid git repo for any reason these tests curently fail, skip them if the repo isnt valid

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
