### PR TITLE
⚡️ Timeout display check

### DIFF
--- a/bluemira/display/auto_config.py
+++ b/bluemira/display/auto_config.py
@@ -56,7 +56,10 @@ def get_primary_screen_size():
         val = result.get(timeout=3)
     except TimeoutError:
         pool.terminate()
-        bluemira_warn("Unable to get screensize, please check your X server")
+        bluemira_warn(
+            "Unable to get screensize, please check your X server."
+            " You may not be able to view live figures in this mode."
+        )
         return None, None
     else:
         pool.close()

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -45,9 +45,10 @@ class TestGetScreenSize:
 
     @patch(
         "bluemira.display.auto_config._get_primary_screen_size",
-        new=partial(timeout, 0.05),
+        new=partial(timeout, 0.1),
     )
     def test_timeout(self, caplog):
+        assert len(caplog.messages) == 0
         out = get_primary_screen_size(timeout=0.01)
         assert out == (None, None)
         assert len(caplog.messages) == 1
@@ -57,6 +58,7 @@ class TestGetScreenSize:
         new=partial(timeout, 0.01),
     )
     def test_no_timeout(self, caplog):
-        out = get_primary_screen_size(0.05)
+        assert len(caplog.messages) == 0
+        out = get_primary_screen_size(0.1)
         assert out
         assert len(caplog.messages) == 0

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -48,7 +48,6 @@ class TestGetScreenSize:
         new=partial(timeout, 0.1),
     )
     def test_timeout(self, caplog):
-        assert len(caplog.messages) == 0
         out = get_primary_screen_size(timeout=0.01)
         assert out == (None, None)
         assert len(caplog.messages) == 1
@@ -58,7 +57,6 @@ class TestGetScreenSize:
         new=partial(timeout, 0.01),
     )
     def test_no_timeout(self, caplog):
-        assert len(caplog.messages) == 0
-        out = get_primary_screen_size(0.1)
+        out = get_primary_screen_size(1)
         assert out
         assert len(caplog.messages) == 0

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -45,7 +45,7 @@ class TestGetScreenSize:
 
     @patch(
         "bluemira.display.auto_config._get_primary_screen_size",
-        new=partial(timeout, 0.02),
+        new=partial(timeout, 0.05),
     )
     def test_timeout(self, caplog):
         out = get_primary_screen_size(timeout=0.01)
@@ -57,6 +57,6 @@ class TestGetScreenSize:
         new=partial(timeout, 0.01),
     )
     def test_no_timeout(self, caplog):
-        out = get_primary_screen_size(0.02)
+        out = get_primary_screen_size(0.05)
         assert out
         assert len(caplog.messages) == 0

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -30,7 +30,7 @@ from unittest.mock import patch
 from bluemira.display.auto_config import get_primary_screen_size
 
 
-def timeout(t=4):
+def timeout(t=0.05):
     """
     The timeout in get_primary_screen_size is 3s
     """
@@ -40,18 +40,23 @@ def timeout(t=4):
 
 class TestGetScreenSize:
     def setup(self):
+        # clear lru_cache
         get_primary_screen_size.cache_clear()
 
-    @patch("bluemira.display.auto_config._get_primary_screen_size", new=timeout)
+    @patch(
+        "bluemira.display.auto_config._get_primary_screen_size",
+        new=partial(timeout, 0.02),
+    )
     def test_timeout(self, caplog):
-        out = get_primary_screen_size()
+        out = get_primary_screen_size(timeout=0.01)
         assert out == (None, None)
         assert len(caplog.messages) == 1
 
     @patch(
-        "bluemira.display.auto_config._get_primary_screen_size", new=partial(timeout, 1)
+        "bluemira.display.auto_config._get_primary_screen_size",
+        new=partial(timeout, 0.01),
     )
     def test_no_timeout(self, caplog):
-        out = get_primary_screen_size()
+        out = get_primary_screen_size(0.02)
         assert out
         assert len(caplog.messages) == 0

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -24,16 +24,18 @@ Tests for the display auto_config module.
 
 """
 import time
+from functools import partial
 from unittest.mock import patch
 
 from bluemira.display.auto_config import get_primary_screen_size
 
 
-def timeout():
+def timeout(t=4):
     """
     The timeout in get_primary_screen_size is 3s
     """
-    time.sleep(4)
+    time.sleep(t)
+    return True
 
 
 class TestGetScreenSize:
@@ -45,3 +47,11 @@ class TestGetScreenSize:
         out = get_primary_screen_size()
         assert out == (None, None)
         assert len(caplog.messages) == 1
+
+    @patch(
+        "bluemira.display.auto_config._get_primary_screen_size", new=partial(timeout, 1)
+    )
+    def test_no_timeout(self, caplog):
+        out = get_primary_screen_size()
+        assert out
+        assert len(caplog.messages) == 0

--- a/tests/display/test_auto_config.py
+++ b/tests/display/test_auto_config.py
@@ -1,0 +1,47 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for the display auto_config module.
+
+"""
+import time
+from unittest.mock import patch
+
+from bluemira.display.auto_config import get_primary_screen_size
+
+
+def timeout():
+    """
+    The timeout in get_primary_screen_size is 3s
+    """
+    time.sleep(4)
+
+
+class TestGetScreenSize:
+    def setup(self):
+        get_primary_screen_size.cache_clear()
+
+    @patch("bluemira.display.auto_config._get_primary_screen_size", new=timeout)
+    def test_timeout(self, caplog):
+        out = get_primary_screen_size()
+        assert out == (None, None)
+        assert len(caplog.messages) == 1


### PR DESCRIPTION
## Linked Issues

Closes #264

## Description

By using multiprocess with 1 core we can timeout the display checking function and produce a warning on timeout

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
