### PR TITLE
Run plotting tests with non-interactive backend

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,9 +23,10 @@
 Used by pytest for configuration like adding command line options.
 """
 
+from unittest import mock
+
 import matplotlib as mpl
 
-import tests
 from bluemira.base.file import try_get_bluemira_private_data_root
 
 
@@ -37,7 +38,7 @@ def pytest_addoption(parser):
         "--plotting-on",
         action="store_true",
         default=False,
-        help="switch on plotting in tests",
+        help="switch on interactive plotting in tests",
     )
     parser.addoption(
         "--longrun",
@@ -67,11 +68,14 @@ def pytest_configure(config):
     """
     Configures pytest with the plotting and longrun command line options.
     """
-    if config.getoption("--plotting-on"):
-        tests.PLOTTING = True
-    else:
+    if not config.getoption("--plotting-on"):
         # We're not displaying plots so use a display-less backend
         mpl.use("Agg")
+        # Disable CAD viewer by mocking out QApplication.exec
+        from PySide2.QtWidgets import QApplication
+
+        app = QApplication([])
+        mock.patch.object(app, "exec_").start()
 
     options = {
         "longrun": config.option.longrun,

--- a/conftest.py
+++ b/conftest.py
@@ -71,11 +71,9 @@ def pytest_configure(config):
     if not config.getoption("--plotting-on"):
         # We're not displaying plots so use a display-less backend
         mpl.use("Agg")
-        # Disable CAD viewer by mocking out QApplication.exec
-        from PySide2.QtWidgets import QApplication
-
-        app = QApplication([])
-        mock.patch.object(app, "exec_").start()
+        # Disable CAD viewer by mocking out FreeCAD API's displayer.
+        # Note that if we use a new CAD backend, this must be changed.
+        mock.patch("bluemira.codes._freecadapi.show_cad").start()
 
     options = {
         "longrun": config.option.longrun,

--- a/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
@@ -185,7 +185,6 @@ class TestEUDEMO:
             ],
         ).plot_2d()
 
-    @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_show_cad(self):
         """
         Display the results.
@@ -210,5 +209,5 @@ class TestEUDEMO:
         component.add_child(plasma_builder.build_xyz(degree=270))
         component.add_child(tf_coils_builder.build_xyz(degree=270))
         component.add_child(pf_coils_builder.build_xyz(degree=270))
-        if tests.PLOTTING:
-            component.show_cad()
+
+        component.show_cad()

--- a/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
@@ -35,7 +35,6 @@ from EUDEMO_builders.plasma import PlasmaBuilder, PlasmaComponent
 from EUDEMO_builders.reactor import EUDEMOReactorDesign
 from EUDEMO_builders.tf_coils import TFCoilsBuilder, TFCoilsComponent
 
-import tests
 from bluemira.base.components import Component
 from bluemira.base.file import get_bluemira_root
 from bluemira.base.logs import get_log_level, set_log_level

--- a/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/test_reactor.py
@@ -153,7 +153,6 @@ class TestEUDEMO:
         tf_component = self.component.get_component(EUDEMOReactorDesign.PF_COILS)
         assert tf_component is not None
 
-    @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_plot_xz(self):
         """
         Display the results.
@@ -170,7 +169,6 @@ class TestEUDEMO:
             ],
         ).plot_2d()
 
-    @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_plot_xy(self):
         """
         Display the results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ markers = [
     "private"
 ]
 addopts = "--html=report.html --self-contained-html --strict-markers"
+filterwarnings = ['ignore:Matplotlib is currently using agg:UserWarning']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,5 +18,3 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
-
-PLOTTING = False

--- a/tests/balance_of_plant/test_plotting.py
+++ b/tests/balance_of_plant/test_plotting.py
@@ -31,6 +31,9 @@ from bluemira.display.auto_config import plot_defaults
 
 
 class TestSuperSankey:
+    def teardown_method(self):
+        plt.close()
+
     def test_sankey_ring(self):
         plot_defaults(True)
 

--- a/tests/balance_of_plant/test_plotting.py
+++ b/tests/balance_of_plant/test_plotting.py
@@ -78,6 +78,7 @@ class TestSuperSankey:
         figure = plt.gcf()
         new_file = tempfile.NamedTemporaryFile()
         figure.savefig(new_file)
+        plt.show()
 
         path = get_bluemira_path("balance_of_plant/test_data", subfolder="tests")
         reference_file = os.path.join(path, "sankey_test.png")

--- a/tests/base/test_design.py
+++ b/tests/base/test_design.py
@@ -28,7 +28,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import tests
 from bluemira.base.design import Design
 from bluemira.base.error import DesignError
 
@@ -80,8 +79,7 @@ class TestDesign:
         tf_coils_component = component.get_component("TF Coils")
         assert [child.name for child in tf_coils_component.children] == ["Shape"]
 
-        if tests.PLOTTING:
-            component.plot_2d()
+        component.plot_2d()
 
     def test_stage_usage(self):
         design = Design(self.params, self.build_config)

--- a/tests/base/test_design.py
+++ b/tests/base/test_design.py
@@ -27,6 +27,7 @@ import copy
 from unittest.mock import MagicMock
 
 import pytest
+from matplotlib import pyplot as plt
 
 from bluemira.base.design import Design
 from bluemira.base.error import DesignError
@@ -80,6 +81,7 @@ class TestDesign:
         assert [child.name for child in tf_coils_component.children] == ["Shape"]
 
         component.plot_2d()
+        plt.close()
 
     def test_stage_usage(self):
         design = Design(self.params, self.build_config)

--- a/tests/builders/test_plasma.py
+++ b/tests/builders/test_plasma.py
@@ -26,6 +26,8 @@ Tests for plasma builders
 import sys
 from unittest import mock
 
+from matplotlib import pyplot as plt
+
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.builders.plasma import MakeParameterisedPlasma
 
@@ -69,6 +71,7 @@ class TestMakeParameterisedPlasma:
             else:
                 lcfs.plot_options.face_options["color"] = color
                 lcfs.plot_2d()
+                plt.close("all")
 
     def test_builder_with_import_isolation(self):
         """Check that the build works with a clean set of imports."""

--- a/tests/builders/test_plasma.py
+++ b/tests/builders/test_plasma.py
@@ -26,7 +26,6 @@ Tests for plasma builders
 import sys
 from unittest import mock
 
-import tests
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.builders.plasma import MakeParameterisedPlasma
 
@@ -62,15 +61,14 @@ class TestMakeParameterisedPlasma:
             lcfs: PhysicalComponent = child.get_component("LCFS")
             assert lcfs is not None
 
-            if tests.PLOTTING:
-                color = (0.80078431, 0.54, 0.80078431)
-                if dim == "xyz":
-                    lcfs.display_cad_options.color = color
-                    lcfs.display_cad_options.transparency = 0.2
-                    lcfs.show_cad()
-                else:
-                    lcfs.plot_options.face_options["color"] = color
-                    lcfs.plot_2d()
+            color = (0.80078431, 0.54, 0.80078431)
+            if dim == "xyz":
+                lcfs.display_cad_options.color = color
+                lcfs.display_cad_options.transparency = 0.2
+                lcfs.show_cad()
+            else:
+                lcfs.plot_options.face_options["color"] = color
+                lcfs.plot_2d()
 
     def test_builder_with_import_isolation(self):
         """Check that the build works with a clean set of imports."""

--- a/tests/builders/test_shapes.py
+++ b/tests/builders/test_shapes.py
@@ -30,7 +30,6 @@ import tempfile
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.components import PhysicalComponent
 from bluemira.builders.shapes import MakeOptimisedShape, MakeParameterisedShape
 from bluemira.geometry.optimisation import GeometryOptimisationProblem, minimise_length
@@ -82,8 +81,7 @@ class TestMakeParameterisedShape:
             self.build_config["variables_map"]["dz"]["value"], abs=1e-2
         )
 
-        if tests.PLOTTING:
-            self.component.plot_2d()
+        self.component.plot_2d()
 
     def test_save_shape(self):
         """
@@ -171,5 +169,4 @@ class TestMakeOptimisedShape:
             build_config["variables_map"]["dz"]["value"], abs=1e-2
         )
 
-        if tests.PLOTTING:
-            component.plot_2d()
+        component.plot_2d()

--- a/tests/builders/test_shapes.py
+++ b/tests/builders/test_shapes.py
@@ -29,6 +29,7 @@ import tempfile
 
 import numpy as np
 import pytest
+from matplotlib import pyplot as plt
 
 from bluemira.base.components import PhysicalComponent
 from bluemira.builders.shapes import MakeOptimisedShape, MakeParameterisedShape
@@ -82,6 +83,7 @@ class TestMakeParameterisedShape:
         )
 
         self.component.plot_2d()
+        plt.close("all")
 
     def test_save_shape(self):
         """
@@ -170,3 +172,4 @@ class TestMakeOptimisedShape:
         )
 
         component.plot_2d()
+        plt.close("all")

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -38,9 +38,6 @@ from tests.display.helpers import PatchQApp, PatchQuarterWidget
 _FREECAD_REF = "bluemira.codes._freecadapi"
 
 
-# TODO(hsaunders1904): the plots in this module are never shown
-
-
 class TestDisplayCADOptions:
     def test_default_options(self):
         """

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -23,18 +23,22 @@
 Tests for the displayer module.
 """
 
-import contextlib
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.display import displayer
 from bluemira.display.error import DisplayError
-from bluemira.geometry.tools import extrude_shape, make_polygon
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.tools import extrude_shape, make_circle, make_polygon
 from tests.display.helpers import PatchQApp, PatchQuarterWidget
+
+_FREECAD_REF = "bluemira.codes._freecadapi"
+
+
+# TODO(hsaunders1904): the plots in this module are never shown
 
 
 class TestDisplayCADOptions:
@@ -107,20 +111,12 @@ class TestComponentDisplayer:
         wire2 = make_polygon(square_points + 1.0, closed=True)
 
         group = Component("Parent")
-        child1 = PhysicalComponent(
-            "Child1",
-            shape=wire1,
-            parent=group,
-        )
+        child1 = PhysicalComponent("Child1", shape=wire1, parent=group)
         child1.display_cad_options.color = (0.0, 1.0, 0.0)
         child2 = PhysicalComponent("Child2", shape=wire2, parent=group)
 
-        with contextlib.nullcontext() if tests.PLOTTING else patch(
-            "bluemira.codes._freecadapi.QApplication", PatchQApp
-        ):
-            with contextlib.nullcontext() if tests.PLOTTING else patch(
-                "bluemira.codes._freecadapi.quarter.QuarterWidget", PatchQuarterWidget
-            ):
+        with patch(f"{_FREECAD_REF}.QApplication", PatchQApp):
+            with patch(f"{_FREECAD_REF}.quarter.QuarterWidget", PatchQuarterWidget):
                 child1.show_cad()
                 group.show_cad()
                 child2.display_cad_options = displayer.DisplayCADOptions(
@@ -146,12 +142,8 @@ class TestGeometryDisplayer:
         wire1 = make_polygon(self.square_points, label="wire1", closed=False)
         box1 = extrude_shape(wire1, vec=(0.0, 0.0, 1.0), label="box1")
 
-        with contextlib.nullcontext() if tests.PLOTTING else patch(
-            "bluemira.codes._freecadapi.QApplication", PatchQApp
-        ):
-            with contextlib.nullcontext() if tests.PLOTTING else patch(
-                "bluemira.codes._freecadapi.quarter.QuarterWidget", PatchQuarterWidget
-            ):
+        with patch(f"{_FREECAD_REF}.QApplication", PatchQApp):
+            with patch(f"{_FREECAD_REF}.quarter.QuarterWidget", PatchQuarterWidget):
                 displayer.show_cad(wire1)
                 displayer.show_cad(
                     box1, displayer.DisplayCADOptions(color=(1.0, 0.0, 1.0))
@@ -181,3 +173,10 @@ class TestGeometryDisplayer:
                             displayer.DisplayCADOptions(color=(0.0, 1.0, 0.0)),
                         ],
                     )
+
+    def test_3d_cad_displays_shape(self):
+        circle_wire = make_circle(radius=5, axis=(0, 0, 1), label="my_wire")
+        circle_face = BluemiraFace(circle_wire, label="my_face")
+        cylinder = extrude_shape(circle_face, vec=(0, 0, 10), label="my_solid")
+
+        displayer.show_cad(cylinder)

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -28,7 +28,6 @@ import numpy as np
 import bluemira.geometry.face as face
 import bluemira.geometry.placement as placement
 import bluemira.geometry.tools as tools
-import tests
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.display import plot_3d, plotter
 from bluemira.utilities.plot_tools import Plot3D
@@ -139,10 +138,10 @@ class TestPlot3d:
 
 class TestPointsPlotter:
     def test_plotting_2d(self):
-        plotter.PointsPlotter().plot_2d(SQUARE_POINTS, show=tests.PLOTTING)
+        plotter.PointsPlotter().plot_2d(SQUARE_POINTS)
 
     def test_plotting_3d(self):
-        plotter.PointsPlotter().plot_3d(SQUARE_POINTS, show=tests.PLOTTING)
+        plotter.PointsPlotter().plot_3d(SQUARE_POINTS)
 
 
 class TestWirePlotter:
@@ -150,16 +149,16 @@ class TestWirePlotter:
         self.wire = tools.make_polygon(SQUARE_POINTS)
 
     def test_plotting_2d(self):
-        plotter.WirePlotter().plot_2d(self.wire, show=tests.PLOTTING)
+        plotter.WirePlotter().plot_2d(self.wire)
 
     def test_plotting_2d_with_points(self):
-        plotter.WirePlotter(show_points=True).plot_2d(self.wire, show=tests.PLOTTING)
+        plotter.WirePlotter(show_points=True).plot_2d(self.wire)
 
     def test_plotting_3d(self):
-        plotter.WirePlotter().plot_3d(self.wire, show=tests.PLOTTING)
+        plotter.WirePlotter().plot_3d(self.wire)
 
     def test_plotting_3d_with_points(self):
-        plotter.WirePlotter(show_points=True).plot_3d(self.wire, show=tests.PLOTTING)
+        plotter.WirePlotter(show_points=True).plot_3d(self.wire)
 
 
 class TestFacePlotter:
@@ -169,18 +168,16 @@ class TestFacePlotter:
         self.face = face.BluemiraFace(wire)
 
     def test_plotting_2d(self):
-        plotter.FacePlotter().plot_2d(self.face, show=tests.PLOTTING)
+        plotter.FacePlotter().plot_2d(self.face)
 
     def test_plotting_2d_with_wire(self):
-        plotter.FacePlotter(show_wires=True).plot_2d(self.face, show=tests.PLOTTING)
+        plotter.FacePlotter(show_wires=True).plot_2d(self.face)
 
     def test_plotting_3d(self):
-        plotter.FacePlotter().plot_3d(self.face, show=tests.PLOTTING)
+        plotter.FacePlotter().plot_3d(self.face)
 
     def test_plotting_3d_with_wire_and_points(self):
-        plotter.FacePlotter(show_wires=True, show_points=True).plot_3d(
-            self.face, show=tests.PLOTTING
-        )
+        plotter.FacePlotter(show_wires=True, show_points=True).plot_3d(self.face)
 
 
 class TestComponentPlotter:
@@ -195,17 +192,13 @@ class TestComponentPlotter:
         self.child2 = PhysicalComponent("Child2", shape=face2, parent=self.group)
 
     def test_plotting_2d(self):
-        plotter.ComponentPlotter().plot_2d(self.group, show=tests.PLOTTING)
+        plotter.ComponentPlotter().plot_2d(self.group)
 
     def test_plotting_2d_no_wires(self):
-        plotter.ComponentPlotter(show_wires=True).plot_2d(
-            self.group, show=tests.PLOTTING
-        )
+        plotter.ComponentPlotter(show_wires=True).plot_2d(self.group)
 
     def test_plotting_3d(self):
-        plotter.ComponentPlotter().plot_3d(self.group, show=tests.PLOTTING)
+        plotter.ComponentPlotter().plot_3d(self.group)
 
     def test_plotting_3d_with_wires_and_points(self):
-        plotter.ComponentPlotter(show_wires=True, show_points=True).plot_3d(
-            self.group, show=tests.PLOTTING
-        )
+        plotter.ComponentPlotter(show_wires=True, show_points=True).plot_3d(self.group)

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -23,6 +23,7 @@
 Tests for the plotter module.
 """
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 import bluemira.geometry.face as face
@@ -118,6 +119,9 @@ class TestPlot3d:
     Generic 3D plotting tests.
     """
 
+    def teardown_method(self):
+        plt.close("all")
+
     def test_plot_3d_same_axis(self):
         ax_orig = Plot3D()
         ax_1 = plot_3d(tools.make_circle(), show=False, ax=ax_orig)
@@ -137,6 +141,9 @@ class TestPlot3d:
 
 
 class TestPointsPlotter:
+    def teardown_method(self):
+        plt.close("all")
+
     def test_plotting_2d(self):
         plotter.PointsPlotter().plot_2d(SQUARE_POINTS)
 
@@ -145,6 +152,9 @@ class TestPointsPlotter:
 
 
 class TestWirePlotter:
+    def teardown_method(self):
+        plt.close("all")
+
     def setup_method(self):
         self.wire = tools.make_polygon(SQUARE_POINTS)
 
@@ -166,6 +176,9 @@ class TestFacePlotter:
         wire = tools.make_polygon(SQUARE_POINTS)
         wire.close()
         self.face = face.BluemiraFace(wire)
+
+    def teardown_method(self):
+        plt.close("all")
 
     def test_plotting_2d(self):
         plotter.FacePlotter().plot_2d(self.face)
@@ -190,6 +203,9 @@ class TestComponentPlotter:
         self.group = Component("Parent")
         self.child1 = PhysicalComponent("Child1", shape=face1, parent=self.group)
         self.child2 = PhysicalComponent("Child2", shape=face2, parent=self.group)
+
+    def teardown_method(self):
+        plt.close("all")
 
     def test_plotting_2d(self):
         plotter.ComponentPlotter().plot_2d(self.group)

--- a/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
+++ b/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import bluemira.geometry.tools as tools
-import tests
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.equilibria.fem_fixed_boundary.fem_magnetostatic_2D import (
     FemMagnetostatic2d,
@@ -100,9 +99,8 @@ class TestGetNormal:
             subdomains=True,
         )
 
-        if tests.PLOTTING:
-            dolfin.plot(mesh)
-            plt.show()
+        dolfin.plot(mesh)
+        plt.show()
 
         em_solver = FemMagnetostatic2d(mesh, boundaries, 3)
 

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -49,6 +49,10 @@ class TestCoil:
         cls.cs_coil = Coil(4, 4, 10e6, ctype="CS", j_max=NBTI_J_MAX)
         cls.no_coil = Coil(4, 4, 10e6, ctype="asrgd", j_max=NBTI_J_MAX)
 
+    @classmethod
+    def teardown_cls(cls):
+        plt.close("all")
+
     def test_name(self):
         def extract_int(coil):
             return int(coil.name.split("_")[-1])
@@ -196,6 +200,9 @@ class TestSemiAnalytic:
         cls.grid = Grid(0.1, 8, 0, 8, 100, 100)
         cls.x_corner = np.append(cls.coil.x_corner, cls.coil.x_corner[0])
         cls.z_corner = np.append(cls.coil.z_corner, cls.coil.z_corner[0])
+
+    def teardown_method(self):
+        plt.close("all")
 
     def test_bx(self):
         gp = self.coil.control_Bx(self.grid.x, self.grid.z)

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -23,7 +23,6 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.base.constants import MU_0
 from bluemira.equilibria.coils import (
     CS_COIL_NAME,
@@ -105,33 +104,31 @@ class TestCoil:
 
         gbx = c.control_Bx(x, z)
         gbz = c.control_Bz(x, z)
-        gbp = np.sqrt(gbx**2 + gbz**2)
-        gp = c.control_psi(x, z)
+        _ = np.sqrt(gbx**2 + gbz**2)
+        _ = c.control_psi(x, z)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            cc = ax.contourf(x, z, gbx)
+        _, ax = plt.subplots()
+        cc = ax.contourf(x, z, gbx)
 
-            plt.colorbar(cc)
-            ax.set_aspect("equal")
-            ax.set_xlim([2, 6])
-            ax.set_ylim([-3, 3])
+        plt.colorbar(cc)
+        ax.set_aspect("equal")
+        ax.set_xlim([2, 6])
+        ax.set_ylim([-3, 3])
 
         c.mesh_coil(0.1)
 
         gbxn = c.control_Bx(x, z)
-        gbzn = c.control_Bz(x, z)
-        gbpn = np.sqrt(gbx**2 + gbz**2)
-        gpn = c.control_psi(x, z)
+        _ = c.control_Bz(x, z)
+        _ = np.sqrt(gbx**2 + gbz**2)
+        _ = c.control_psi(x, z)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            c = ax.contourf(x, z, gbxn)
-            plt.colorbar(c)
-            ax.set_aspect("equal")
-            ax.set_xlim([2, 6])
-            ax.set_ylim([-3, 3])
-            plt.show()
+        _, ax = plt.subplots()
+        c = ax.contourf(x, z, gbxn)
+        plt.colorbar(c)
+        ax.set_aspect("equal")
+        ax.set_xlim([2, 6])
+        ax.set_ylim([-3, 3])
+        plt.show()
 
     @staticmethod
     def callable_tester(f_callable):
@@ -205,36 +202,34 @@ class TestSemiAnalytic:
         gp_greens = self.coil._control_Bx_greens(self.grid.x, self.grid.z)
         gp_analytic = self.coil._control_Bx_analytical(self.grid.x, self.grid.z)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots(1, 3)
-            levels = np.linspace(np.amin(gp), np.amax(gp), 20)
-            ax[0].contourf(self.grid.x, self.grid.z, gp_greens)
-            ax[1].contourf(self.grid.x, self.grid.z, gp, levels=levels)
-            ax[2].contourf(self.grid.x, self.grid.z, gp_analytic, levels=levels)
-            for axis in ax:
-                axis.plot(self.x_corner, self.z_corner, color="r")
-                axis.set_aspect("equal")
-            ax[0].set_title("Green's functions")
-            ax[1].set_title("Combined Green's and semi-analytic")
-            ax[2].set_title("Semi-analytic method")
+        _, ax = plt.subplots(1, 3)
+        levels = np.linspace(np.amin(gp), np.amax(gp), 20)
+        ax[0].contourf(self.grid.x, self.grid.z, gp_greens)
+        ax[1].contourf(self.grid.x, self.grid.z, gp, levels=levels)
+        ax[2].contourf(self.grid.x, self.grid.z, gp_analytic, levels=levels)
+        for axis in ax:
+            axis.plot(self.x_corner, self.z_corner, color="r")
+            axis.set_aspect("equal")
+        ax[0].set_title("Green's functions")
+        ax[1].set_title("Combined Green's and semi-analytic")
+        ax[2].set_title("Semi-analytic method")
 
     def test_bz(self):
         gp = self.coil.control_Bz(self.grid.x, self.grid.z)
         gp_greens = self.coil._control_Bz_greens(self.grid.x, self.grid.z)
         gp_analytic = self.coil._control_Bz_analytical(self.grid.x, self.grid.z)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots(1, 3)
-            levels = np.linspace(np.amin(gp), np.amax(gp), 20)
-            ax[0].contourf(self.grid.x, self.grid.z, gp_greens)
-            ax[1].contourf(self.grid.x, self.grid.z, gp, levels=levels)
-            ax[2].contourf(self.grid.x, self.grid.z, gp_analytic, levels=levels)
-            for axis in ax:
-                axis.plot(self.x_corner, self.z_corner, color="r")
-                axis.set_aspect("equal")
-            ax[0].set_title("Green's functions")
-            ax[1].set_title("Combined Green's and semi-analytic")
-            ax[2].set_title("Semi-analytic method")
+        _, ax = plt.subplots(1, 3)
+        levels = np.linspace(np.amin(gp), np.amax(gp), 20)
+        ax[0].contourf(self.grid.x, self.grid.z, gp_greens)
+        ax[1].contourf(self.grid.x, self.grid.z, gp, levels=levels)
+        ax[2].contourf(self.grid.x, self.grid.z, gp_analytic, levels=levels)
+        for axis in ax:
+            axis.plot(self.x_corner, self.z_corner, color="r")
+            axis.set_aspect("equal")
+        ax[0].set_title("Green's functions")
+        ax[1].set_title("Combined Green's and semi-analytic")
+        ax[2].set_title("Semi-analytic method")
 
 
 class TestCoilGroup:

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -211,6 +211,7 @@ class TestFields:
         )
         ax4.set_aspect("equal")
         ax4.set_title("plasma_Bp")
+        plt.close("all")
 
 
 class TestEquilibrium:

--- a/tests/equilibria/test_positioner.py
+++ b/tests/equilibria/test_positioner.py
@@ -24,7 +24,6 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.equilibria.coils import Coil, CoilSet, SymmetricCircuit
 from bluemira.equilibria.positioner import CoilPositioner, RegionMapper, XZLMapper
@@ -192,11 +191,10 @@ class TestZLMapper:
         cls.xz_map = XZLMapper(
             tf, solenoid.radius, solenoid.z_min, solenoid.z_max, solenoid.gap, CS=True
         )
-        if tests.PLOTTING:
-            f, cls.ax = plt.subplots()
-            up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
-            lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
-            eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+        f, cls.ax = plt.subplots()
+        up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+        lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+        eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
 
     def test_cs_zl(self):
         l_pos, lb, ub = self.xz_map.get_Lmap(
@@ -214,9 +212,8 @@ class TestZLMapper:
         z = np.sort(z)  # [::-1]  # Fixed somewhere else jcrois
         assert np.allclose(z, zcs), z - zcs
 
-        if tests.PLOTTING:
-            self.xz_map.plot(ax=self.ax)
-            plt.show()
+        self.xz_map.plot(ax=self.ax)
+        plt.show()
 
 
 class TestZLMapperEdges:
@@ -243,11 +240,11 @@ class TestZLMapperEdges:
         cls.xz_map = XZLMapper(
             tf, solenoid.radius, solenoid.z_min, solenoid.z_max, solenoid.gap, CS=True
         )
-        if tests.PLOTTING:
-            f, cls.ax = plt.subplots()
-            up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
-            lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
-            eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+
+        _, cls.ax = plt.subplots()
+        up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+        lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+        eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
 
     def test_cs_zl(self):
 
@@ -266,9 +263,8 @@ class TestZLMapperEdges:
         z = np.sort(z)  # [::-1]  # Fixed somewhere else jcrois
         assert np.allclose(z, zcs), z - zcs
 
-        if tests.PLOTTING:
-            self.xz_map.plot(ax=self.ax)
-            plt.show()
+        self.xz_map.plot(ax=self.ax)
+        plt.show()
 
 
 class TestRegionMapper:

--- a/tests/equilibria/test_positioner.py
+++ b/tests/equilibria/test_positioner.py
@@ -35,7 +35,7 @@ DATA_PATH = get_bluemira_path("geometry", subfolder="data")
 class TestXZLMapper:
     @classmethod
     def setup_class(cls):
-        f, cls.ax = plt.subplots()
+        cls.fig, cls.ax = plt.subplots()
         tf = Loop.from_file(os.sep.join([DATA_PATH, "TFreference.json"]))
         tf = tf.offset(2.5)
         clip = np.where(tf.x >= 3.5)
@@ -53,6 +53,10 @@ class TestXZLMapper:
         solenoid = cls.coilset.get_solenoid()
         cls.coilset.set_control_currents(1e6 * np.ones(cls.coilset.n_coils))
         cls.xzl_map = XZLMapper(tf, solenoid.radius, -10, 10, 0.1, CS=False)
+
+    @classmethod
+    def teardown_cls(cls):
+        plt.close(cls.fig)
 
     def test_xzl(self):
         l_pos, lb, ub = self.xzl_map.get_Lmap(
@@ -191,10 +195,14 @@ class TestZLMapper:
         cls.xz_map = XZLMapper(
             tf, solenoid.radius, solenoid.z_min, solenoid.z_max, solenoid.gap, CS=True
         )
-        f, cls.ax = plt.subplots()
+        cls.fig, cls.ax = plt.subplots()
         up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
         lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
         eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+
+    @classmethod
+    def teardown_cls(cls):
+        plt.close(cls.fig)
 
     def test_cs_zl(self):
         l_pos, lb, ub = self.xz_map.get_Lmap(
@@ -245,6 +253,10 @@ class TestZLMapperEdges:
         up.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
         lp.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
         eq.plot(cls.ax, fill=False, linestyle="-", edgecolor="r")
+
+    @classmethod
+    def teardown_cls(cls):
+        plt.close("all")
 
     def test_cs_zl(self):
 

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -70,6 +70,7 @@ class TestCunningham:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Cunningham parameterisations")
+        plt.close(cls.f)
 
 
 class TestManickam:
@@ -110,6 +111,8 @@ class TestManickam:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Manickam parameterisations")
+        plt.show()
+        plt.close(cls.f)
 
 
 johner_names = [
@@ -169,6 +172,7 @@ class TestJohner:
     def teardown_class(cls):
         cls.f.suptitle("Johner parameterisations")
         plt.show()
+        plt.close(cls.f)
 
 
 class TestJohnerCAD:

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -23,7 +23,6 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.equilibria.shapes import (
     JohnerLCFS,
     flux_surface_cunningham,
@@ -32,7 +31,6 @@ from bluemira.equilibria.shapes import (
 )
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 class TestCunningham:
     @classmethod
     def setup_class(cls):
@@ -74,7 +72,6 @@ class TestCunningham:
         cls.f.suptitle("Cunningham parameterisations")
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 class TestManickam:
     @classmethod
     def setup_class(cls):
@@ -154,7 +151,6 @@ johner_params = [
 ]
 
 
-# @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 class TestJohner:
     @classmethod
     def setup_class(cls):
@@ -172,8 +168,7 @@ class TestJohner:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Johner parameterisations")
-        if tests.PLOTTING:
-            plt.show()
+        plt.show()
 
 
 class TestJohnerCAD:

--- a/tests/fuel_cycle/test_blocks.py
+++ b/tests/fuel_cycle/test_blocks.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy.interpolate import interp1d
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.fuel_cycle.blocks import FuelCycleComponent
 from bluemira.fuel_cycle.tools import (
@@ -39,8 +38,7 @@ from bluemira.fuel_cycle.tools import (
 class TestFuelCycleComponent:
     @classmethod
     def setup_class(cls):
-        if tests.PLOTTING:
-            _, cls.ax = plt.subplots()
+        _, cls.ax = plt.subplots()
 
     def test_bathtub(self):
         t = np.linspace(0, 30, 1900)
@@ -50,8 +48,7 @@ class TestFuelCycleComponent:
         component.add_in_flow(m)
         component.run()
 
-        if tests.PLOTTING:
-            self.ax.plot(t, component.inventory, label="linear")
+        self.ax.plot(t, component.inventory, label="linear")
 
     def test_sqrtbathtub(self):
         t = np.linspace(0, 60, 1900)
@@ -65,10 +62,9 @@ class TestFuelCycleComponent:
         component.add_in_flow(m)
         component.run()
 
-        if tests.PLOTTING:
-            self.ax.plot(t, component.inventory, label="sqrt")
-            self.ax.legend()
-            plt.show()
+        self.ax.plot(t, component.inventory, label="sqrt")
+        self.ax.legend()
+        plt.show()
 
 
 class TestSqrtFittedSinks:
@@ -107,8 +103,7 @@ class TestSqrtFittedSinks:
         # Now build an example TCycleComponent for the HCPB upper
         # with a constant mass flux equivalent to that modelled
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
+        f, ax = plt.subplots()
 
         r_2_values = []
 
@@ -153,18 +148,16 @@ class TestSqrtFittedSinks:
             ss_res = np.sum((y_interp - y_model) ** 2)
             r_2 = 1 - ss_res / ss_tot
 
-            if tests.PLOTTING:
-                ax.plot(t[:-1], y_interp, label=label)
-                ax.plot(t[:-1], y_model, label=label + " fit", linestyle="--")
+            ax.plot(t[:-1], y_interp, label=label)
+            ax.plot(t[:-1], y_model, label=label + " fit", linestyle="--")
 
             r_2_values.append(r_2)
 
-        if tests.PLOTTING:
-            ax.set_xlabel("time [fpy]")
-            ax.set_ylabel("inventory [kg]")
-            box = ax.get_position()
-            ax.set_position([box.x0, box.y0, box.width * 0.6, box.height])
-            ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-            plt.show()
+        ax.set_xlabel("time [fpy]")
+        ax.set_ylabel("inventory [kg]")
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0, box.width * 0.6, box.height])
+        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+        plt.show()
 
         assert np.all(np.array(r_2_values) > 0.9995)

--- a/tests/fuel_cycle/test_blocks.py
+++ b/tests/fuel_cycle/test_blocks.py
@@ -38,7 +38,11 @@ from bluemira.fuel_cycle.tools import (
 class TestFuelCycleComponent:
     @classmethod
     def setup_class(cls):
-        _, cls.ax = plt.subplots()
+        cls.f, cls.ax = plt.subplots()
+
+    @classmethod
+    def teardown_cls(cls):
+        plt.close(cls.f)
 
     def test_bathtub(self):
         t = np.linspace(0, 30, 1900)
@@ -159,5 +163,6 @@ class TestSqrtFittedSinks:
         ax.set_position([box.x0, box.y0, box.width * 0.6, box.height])
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
         plt.show()
+        plt.close(f)
 
         assert np.all(np.array(r_2_values) > 0.9995)

--- a/tests/fuel_cycle/test_tools.py
+++ b/tests/fuel_cycle/test_tools.py
@@ -53,6 +53,10 @@ class TestSinkTools:
         self.I_min, self.I_max = 3.0, 5.0
         self.t_in, self.t_out = 5.0, 6.0
 
+    @classmethod
+    def teardown_class(cls):
+        plt.close("all")
+
     def test_timestep(self):
         """
         th \\n

--- a/tests/fuel_cycle/test_tools.py
+++ b/tests/fuel_cycle/test_tools.py
@@ -23,7 +23,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.constants import T_LAMBDA
 from bluemira.fuel_cycle.timeline_tools import (
     generate_exponential_distribution,
@@ -83,19 +82,19 @@ class TestSinkTools:
         cross = 80
         dt15 = _find_t15(inventory, eta, m_in, 0, time_y, cross)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots(figsize=[10, 8])
-            ax.plot(t, i, label="Idecay+m_in")
-            ax.plot(t, ii, label="Idecay")
-            ax.plot(time_y, iend, marker="o", ms=15)
-            ax.plot(time_y, iend2, marker="s", ms=15)
+        _, ax = plt.subplots(figsize=[10, 8])
+        ax.plot(t, i, label="Idecay+m_in")
+        ax.plot(t, ii, label="Idecay")
+        ax.plot(time_y, iend, marker="o", ms=15)
+        ax.plot(time_y, iend2, marker="s", ms=15)
 
-            ax.plot([dt15, dt15], [0, inventory])
+        ax.plot([dt15, dt15], [0, inventory])
 
-            ax.plot([0, time_y], [cross, cross])
+        ax.plot([0, time_y], [cross, cross])
 
-            ax.plot(dt15, cross, color="r", marker="*", ms=15)
-            plt.show()
+        ax.plot(dt15, cross, color="r", marker="*", ms=15)
+        plt.show()
+
         # high n required to converge..
         assert np.isclose(iend2, i[-1], rtol=0.01), f"{iend2} != {i[-1]}"
         assert np.isclose(iend, ii[-1], rtol=0.0001), f"{iend} != {ii[-1]}"
@@ -117,9 +116,7 @@ class TestSinkTools:
 
     def test_tlossft(self):
         def _build():
-            if not tests.PLOTTING:
-                return
-            f, ax = plt.subplots(figsize=[10, 8])
+            _, ax = plt.subplots(figsize=[10, 8])
             ax.plot(
                 [self.t_in - 0.5, self.t_out + 0.5],
                 [self.I_min, self.I_min],
@@ -140,14 +137,9 @@ class TestSinkTools:
             return ax
 
         def plot(ax, i_new, label=None):
-            if not tests.PLOTTING:
-                return
-
             ax.plot([self.t_in, self.t_out], [inventory, i_new], marker="o", label=label)
 
         def plotter():
-            if not tests.PLOTTING:
-                return
             ax = _build()
             plot(ax, i2, label="little")
             plot(ax, i22, label="decay only")

--- a/tests/geometry/test_deprecated_loop.py
+++ b/tests/geometry/test_deprecated_loop.py
@@ -27,7 +27,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.geometry._deprecated_loop import Loop
 from bluemira.geometry.error import GeometryError
@@ -209,7 +208,6 @@ class TestLoop:
         assert not a._check_already_in([4, 4])
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 class Test3Dplotting:
     def test_looks_good(self):
         loop = Loop(x=[0.4, 4, 6, 7, 8, 4, 0.4], y=[1, 1, 2, 2, 3, 3, 1], z=0)

--- a/tests/geometry/test_deprecated_loop.py
+++ b/tests/geometry/test_deprecated_loop.py
@@ -209,6 +209,9 @@ class TestLoop:
 
 
 class Test3Dplotting:
+    def teardown_method(self):
+        plt.close("all")
+
     def test_looks_good(self):
         loop = Loop(x=[0.4, 4, 6, 7, 8, 4, 0.4], y=[1, 1, 2, 2, 3, 3, 1], z=0)
         ax = Plot3D()

--- a/tests/geometry/test_deprecated_offset.py
+++ b/tests/geometry/test_deprecated_offset.py
@@ -56,12 +56,12 @@ class TestClipperOffset:
         coordinates = Coordinates({"x": x, "y": y, "z": np.random.rand()})
         c = offset_clipper(coordinates, delta, method=method)
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
         ax.plot(x, y, "k")
         ax.plot(c.x, c.y, "r", marker="o")
         ax.set_aspect("equal")
         plt.show()
-        plt.close()  # make sure we don't have lots of plots open
+        plt.close(fig)  # make sure we don't have lots of plots open
 
         distance = self._calculate_offset(coordinates, c)
         np.testing.assert_almost_equal(distance, abs(delta))
@@ -86,13 +86,14 @@ class TestClipperOffset:
             # distance = self._calculate_offset(coordinates, offset_coordinates)
             # np.testing.assert_almost_equal(distance, 1.5)
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
         ax.plot(coordinates.x, coordinates.z, color="k")
         colors = ["r", "g", "y"]
         for offset_coordinates, c in zip(offsets, colors):
             ax.plot(offset_coordinates.x, offset_coordinates.z, color=c)
         ax.set_aspect("equal")
         plt.show()
+        plt.close(fig)
 
     def test_wrong_method(self):
         coordinates = Coordinates({"x": [0, 1, 2, 0], "y": [0, 1, -1, 0]})

--- a/tests/geometry/test_deprecated_offset.py
+++ b/tests/geometry/test_deprecated_offset.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.geometry._deprecated_offset import offset_clipper
 from bluemira.geometry.coordinates import Coordinates
@@ -35,8 +34,6 @@ from bluemira.geometry.tools import distance_to, make_polygon
 
 
 class TestClipperOffset:
-    plot = tests.PLOTTING
-
     options = [("square"), ("miter")]
     # NOTE: "round" can be montrously slow..
 
@@ -58,12 +55,13 @@ class TestClipperOffset:
     def test_complex_polygon(self, x, y, delta, method):
         coordinates = Coordinates({"x": x, "y": y, "z": np.random.rand()})
         c = offset_clipper(coordinates, delta, method=method)
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(x, y, "k")
-            ax.plot(c.x, c.y, "r", marker="o")
-            ax.set_aspect("equal")
-            plt.show()
+
+        _, ax = plt.subplots()
+        ax.plot(x, y, "k")
+        ax.plot(c.x, c.y, "r", marker="o")
+        ax.set_aspect("equal")
+        plt.show()
+        plt.close()  # make sure we don't have lots of plots open
 
         distance = self._calculate_offset(coordinates, c)
         np.testing.assert_almost_equal(distance, abs(delta))
@@ -88,14 +86,13 @@ class TestClipperOffset:
             # distance = self._calculate_offset(coordinates, offset_coordinates)
             # np.testing.assert_almost_equal(distance, 1.5)
 
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(coordinates.x, coordinates.z, color="k")
-            colors = ["r", "g", "y"]
-            for offset_coordinates, c in zip(offsets, colors):
-                ax.plot(offset_coordinates.x, offset_coordinates.z, color=c)
-            ax.set_aspect("equal")
-            plt.show()
+        _, ax = plt.subplots()
+        ax.plot(coordinates.x, coordinates.z, color="k")
+        colors = ["r", "g", "y"]
+        for offset_coordinates, c in zip(offsets, colors):
+            ax.plot(offset_coordinates.x, offset_coordinates.z, color=c)
+        ax.set_aspect("equal")
+        plt.show()
 
     def test_wrong_method(self):
         coordinates = Coordinates({"x": [0, 1, 2, 0], "y": [0, 1, -1, 0]})

--- a/tests/geometry/test_deprecated_tools.py
+++ b/tests/geometry/test_deprecated_tools.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry._deprecated_base import GeometryError, Plane
@@ -159,13 +158,11 @@ class TestLoopPlane:
         intersect = loop_plane_intersect(loop, plane)
         assert len(intersect) == 2
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop.plot(ax)
+        _, ax = plt.subplots()
+        loop.plot(ax)
 
         for i in intersect:
-            if tests.PLOTTING:
-                ax.plot(i[0], i[2], marker="o", color="r")
+            ax.plot(i[0], i[2], marker="o", color="r")
             assert on_polygon(i[0], i[2], loop.d2.T)
 
         plane = Plane([0, 0, 2.7], [1, 0, 2.7], [0, 1, 2.7])  # x-y offset
@@ -173,16 +170,14 @@ class TestLoopPlane:
         assert len(intersect) == 4
 
         for i in intersect:
-            if tests.PLOTTING:
-                ax.plot(i[0], i[2], marker="o", color="r")
+            ax.plot(i[0], i[2], marker="o", color="r")
             assert on_polygon(i[0], i[2], loop.d2.T)
 
         plane = Plane([0, 0, 4], [1, 0, 4], [0, 1, 4])  # x-y offset
         intersect = loop_plane_intersect(loop, plane)
         assert len(intersect) == 1
         for i in intersect:
-            if tests.PLOTTING:
-                ax.plot(i[0], i[2], marker="o", color="r")
+            ax.plot(i[0], i[2], marker="o", color="r")
 
             assert on_polygon(i[0], i[2], loop.d2.T)
 
@@ -199,12 +194,11 @@ class TestLoopPlane:
         intersect = loop_plane_intersect(loop, plane)
         assert len(intersect) == 2
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop.plot(ax)
-            for i in intersect:
-                ax.plot(i[0], i[2], marker="o", color="r")
-            plt.show()
+        _, ax = plt.subplots()
+        loop.plot(ax)
+        for i in intersect:
+            ax.plot(i[0], i[2], marker="o", color="r")
+        plt.show()
 
         plane = Plane([0, 10, 0], [1, 10, 0], [0, 10, 1])  # x-y
         intersect = loop_plane_intersect(loop, plane)
@@ -219,12 +213,10 @@ class TestLoopPlane:
         plane = Plane([0, 0, 0], [1, 1, 1], [2, 0, 0])  # x-y-z
         intersect = loop_plane_intersect(loop, plane)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop.plot(ax)
+        _, ax = plt.subplots()
+        loop.plot(ax)
         for i in intersect:
-            if tests.PLOTTING:
-                ax.plot(i[0], i[2], marker="o", color="r")
+            ax.plot(i[0], i[2], marker="o", color="r")
             assert on_polygon(i[0], i[2], loop.d2.T)
 
     def test_flat_intersect(self):
@@ -272,24 +264,22 @@ class TestInPolygon:
             [-2, 2],
         ]
 
-        if tests.PLOTTING:
-            plt.close("all")
-            f, ax = plt.subplots()
-            loop.plot(ax, edgecolor="k")
-            for point in in_points:
-                check = in_polygon(*point, loop.d2.T)
-                c = "b" if check else "r"
-                ax.plot(*point, marker="s", color=c)
-            for point in on_points:
-                check = in_polygon(*point, loop.d2.T)
-                c = "b" if check else "r"
-                ax.plot(*point, marker="o", color=c)
-            for point in out_points:
-                check = in_polygon(*point, loop.d2.T)
-                c = "b" if check else "r"
-                ax.plot(*point, marker="*", color=c)
-
-            plt.show()
+        plt.close("all")
+        _, ax = plt.subplots()
+        loop.plot(ax, edgecolor="k")
+        for point in in_points:
+            check = in_polygon(*point, loop.d2.T)
+            c = "b" if check else "r"
+            ax.plot(*point, marker="s", color=c)
+        for point in on_points:
+            check = in_polygon(*point, loop.d2.T)
+            c = "b" if check else "r"
+            ax.plot(*point, marker="o", color=c)
+        for point in out_points:
+            check = in_polygon(*point, loop.d2.T)
+            c = "b" if check else "r"
+            ax.plot(*point, marker="*", color=c)
+        plt.show()
 
         # Test single and arrays
         for p in in_points:
@@ -329,11 +319,11 @@ class TestInPolygon:
             for j in range(m):
                 if in_polygon(x[i, j], z[i, j], lcfs.d2.T):
                     mask[i, j] = 1
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            lcfs.plot(ax, fill=False, edgecolor="k")
-            ax.contourf(x, z, mask, levels=[0, 0.5, 1])
-            plt.show()
+
+        _, ax = plt.subplots()
+        lcfs.plot(ax, fill=False, edgecolor="k")
+        ax.contourf(x, z, mask, levels=[0, 0.5, 1])
+        plt.show()
 
         hits = np.count_nonzero(mask)
         assert hits == 1171, hits
@@ -364,12 +354,6 @@ class TestRotationMatrix:
 
 
 class TestOffset:
-    plot = tests.PLOTTING
-
-    @classmethod
-    def setup_class(cls):
-        pass
-
     def test_rectangle(self):
         # Rectangle - positive offset
         x = [1, 3, 3, 1, 1, 3]
@@ -377,11 +361,11 @@ class TestOffset:
         o = offset(x, y, 0.25)
         assert sum(o[0] - np.array([0.75, 3.25, 3.25, 0.75, 0.75])) == 0
         assert sum(o[1] - np.array([0.75, 0.75, 3.25, 3.25, 0.75])) == 0
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(x, y, "k")
-            ax.plot(*o, "r", marker="o")
-            ax.set_aspect("equal")
+
+        _, ax = plt.subplots()
+        ax.plot(x, y, "k")
+        ax.plot(*o, "r", marker="o")
+        ax.set_aspect("equal")
 
     def test_triangle(self):
         x = [1, 2, 1.5, 1, 2]
@@ -392,11 +376,11 @@ class TestOffset:
             < 1e-3
         )
         assert abs(sum(t[1] - np.array([1.25, 1.25, 2.47930937, 1.25])) - 0) < 1e-3
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(x, y, "k")
-            ax.plot(*t, "r", marker="o")
-            ax.set_aspect("equal")
+
+        _, ax = plt.subplots()
+        ax.plot(x, y, "k")
+        ax.plot(*t, "r", marker="o")
+        ax.set_aspect("equal")
 
     def test_complex_open(self):
         # fmt:off
@@ -405,11 +389,11 @@ class TestOffset:
         # fmt:on
 
         c = offset(x, y, 1)
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(x, y, "k")
-            ax.plot(*c, "r", marker="o")
-            ax.set_aspect("equal")
+
+        _, ax = plt.subplots()
+        ax.plot(x, y, "k")
+        ax.plot(*c, "r", marker="o")
+        ax.set_aspect("equal")
 
     def test_complex_closed(self):
         # fmt:off
@@ -418,11 +402,11 @@ class TestOffset:
         # fmt:on
 
         c = offset(x, y, 1)
-        if self.plot:
-            f, ax = plt.subplots()
-            ax.plot(x, y, "k")
-            ax.plot(*c, "r", marker="o")
-            ax.set_aspect("equal")
+
+        _, ax = plt.subplots()
+        ax.plot(x, y, "k")
+        ax.plot(*c, "r", marker="o")
+        ax.set_aspect("equal")
 
 
 class TestIntersections:
@@ -452,11 +436,12 @@ class TestIntersections:
         loop1 = Loop(x=[0, 0.5, 1, 2, 3, 5, 4.5, 4, 0], z=[1, 1, 1, 1, 2, 4, 4.5, 5, 5])
         loop2 = Loop(x=[1.5, 1.5, 2.5, 2.5, 2.5], z=[4, -4, -4, -4, 5])
         join_intersect(loop1, loop2)
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop1.plot(ax, fill=False, edgecolor="k", points=True)
-            loop2.plot(ax, fill=False, edgecolor="r", points=True)
-            plt.show()
+
+        _, ax = plt.subplots()
+        loop1.plot(ax, fill=False, edgecolor="k", points=True)
+        loop2.plot(ax, fill=False, edgecolor="r", points=True)
+        plt.show()
+
         assert np.allclose(loop1[3], [1.5, 0, 1])
         assert np.allclose(loop1[5], [2.5, 0, 1.5])
         assert np.allclose(loop1[10], [2.5, 0, 5])
@@ -465,11 +450,11 @@ class TestIntersections:
         loop2 = Loop(x=[1.5, 1.5, 2.5, 2.5, 2.5], y=[4, -4, -4, -4, 5])
         join_intersect(loop1, loop2)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop1.plot(ax, fill=False, edgecolor="k", points=True)
-            loop2.plot(ax, fill=False, edgecolor="r", points=True)
-            plt.show()
+        _, ax = plt.subplots()
+        loop1.plot(ax, fill=False, edgecolor="k", points=True)
+        loop2.plot(ax, fill=False, edgecolor="r", points=True)
+        plt.show()
+
         assert np.allclose(loop1[3], [1.5, 1, 0])
         assert np.allclose(loop1[5], [2.5, 1.5, 0])
         assert np.allclose(loop1[8], [2.5, 5, 0])
@@ -478,11 +463,11 @@ class TestIntersections:
         loop2 = Loop(z=[1.5, 1.5, 2.5, 2.5, 2.5], y=[4, -4, -4, -4, 5])
         join_intersect(loop1, loop2)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            loop1.plot(ax, fill=False, edgecolor="k", points=True)
-            loop2.plot(ax, fill=False, edgecolor="r", points=True)
-            plt.show()
+        _, ax = plt.subplots()
+        loop1.plot(ax, fill=False, edgecolor="k", points=True)
+        loop2.plot(ax, fill=False, edgecolor="r", points=True)
+        plt.show()
+
         assert np.allclose(loop1[1], [0, 5, 2.5])
         assert np.allclose(loop1[4], [0, 1.5, 2.5])
         assert np.allclose(loop1[6], [0, 1, 1.5])
@@ -492,10 +477,10 @@ class TestIntersections:
         lp = Loop.from_file(os.sep.join([TEST_PATH, "test_LP_intersect.json"]))
         eq = Loop.from_file(os.sep.join([TEST_PATH, "test_EQ_intersect.json"]))
         up = Loop.from_file(os.sep.join([TEST_PATH, "test_UP_intersect.json"]))
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            for loop in [tf, up, eq, lp]:
-                loop.plot(ax, fill=False)
+
+        _, ax = plt.subplots()
+        for loop in [tf, up, eq, lp]:
+            loop.plot(ax, fill=False)
 
         args = []
         intx, intz = [], []
@@ -505,24 +490,25 @@ class TestIntersections:
             args.extend(a)
             intx.extend(i[0])
             intz.extend(i[1])
-        if tests.PLOTTING:
-            for loop in [tf, up, eq, lp]:
-                loop.plot(ax, fill=False, points=True)
-            ax.plot(*tf.d2.T[args].T, marker="o", color="r")
-            ax.plot(intx, intz, marker="^", color="k")
+
+        for loop in [tf, up, eq, lp]:
+            loop.plot(ax, fill=False, points=True)
+        ax.plot(*tf.d2.T[args].T, marker="o", color="r")
+        ax.plot(intx, intz, marker="^", color="k")
+
         assert len(intx) == len(args), f"{len(intx)} != {len(args)}"
         assert np.allclose(np.sort(intx), np.sort(tf.x[args]))
         assert np.allclose(np.sort(intz), np.sort(tf.z[args]))
 
     def test_join_intersect_arg2(self):
-        tf = Loop.from_file(os.sep.join([TEST_PATH, "test_TF_intersect2.json"]))
-        lp = Loop.from_file(os.sep.join([TEST_PATH, "test_LP_intersect2.json"]))
-        eq = Loop.from_file(os.sep.join([TEST_PATH, "test_EQ_intersect2.json"]))
-        up = Loop.from_file(os.sep.join([TEST_PATH, "test_UP_intersect2.json"]))
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            for loop in [tf, up, eq, lp]:
-                loop.plot(ax, fill=False)
+        tf = Loop.from_file(os.path.join(TEST_PATH, "test_TF_intersect2.json"))
+        lp = Loop.from_file(os.path.join(TEST_PATH, "test_LP_intersect2.json"))
+        eq = Loop.from_file(os.path.join(TEST_PATH, "test_EQ_intersect2.json"))
+        up = Loop.from_file(os.path.join(TEST_PATH, "test_UP_intersect2.json"))
+
+        _, ax = plt.subplots()
+        for loop in [tf, up, eq, lp]:
+            loop.plot(ax, fill=False)
 
         args = []
         intx, intz = [], []
@@ -532,9 +518,10 @@ class TestIntersections:
             args.extend(a)
             intx.extend(i[0])
             intz.extend(i[1])
-        if tests.PLOTTING:
-            ax.plot(*tf.d2.T[args].T, marker="o", color="r")
-            ax.plot(intx, intz, marker="^", color="k")
+
+        ax.plot(*tf.d2.T[args].T, marker="o", color="r")
+        ax.plot(intx, intz, marker="^", color="k")
+
         assert len(intx) == len(args), f"{len(intx)} != {len(args)}"
         assert np.allclose(np.sort(intx), np.sort(tf.x[args])), f"{intx} != {tf.x[args]}"
         assert np.allclose(np.sort(intz), np.sort(tf.z[args])), f"{intz} != {tf.z[args]}"

--- a/tests/geometry/test_deprecated_tools.py
+++ b/tests/geometry/test_deprecated_tools.py
@@ -142,6 +142,10 @@ class TestOnPolygon:
 
 
 class TestLoopPlane:
+    @classmethod
+    def teardown_class(cls):
+        plt.close("all")
+
     def test_simple(self):
         loop = Loop(x=[0, 1, 2, 2, 0, 0], z=[-1, -1, -1, 1, 1, -1])
         plane = Plane([0, 0, 0], [1, 0, 0], [0, 1, 0])  # x-y
@@ -228,6 +232,10 @@ class TestLoopPlane:
 
 
 class TestInPolygon:
+    @classmethod
+    def teardown_class(cls):
+        plt.close("all")
+
     def test_simple(self):
         loop = Loop(x=[-2, 2, 2, -2, -2, -2], z=[-2, -2, 2, 2, 1.5, -2])
         in_points = [
@@ -264,7 +272,6 @@ class TestInPolygon:
             [-2, 2],
         ]
 
-        plt.close("all")
         _, ax = plt.subplots()
         loop.plot(ax, edgecolor="k")
         for point in in_points:
@@ -354,6 +361,10 @@ class TestRotationMatrix:
 
 
 class TestOffset:
+    @classmethod
+    def teardown_class(cls):
+        plt.close("all")
+
     def test_rectangle(self):
         # Rectangle - positive offset
         x = [1, 3, 3, 1, 1, 3]
@@ -410,6 +421,10 @@ class TestOffset:
 
 
 class TestIntersections:
+    @classmethod
+    def teardown_class(cls):
+        plt.close("all")
+
     def test_get_intersect(self):
         loop1 = Loop(x=[0, 0.5, 1, 2, 3, 4, 0], z=[1, 1, 1, 1, 2, 5, 5])
         loop2 = Loop(x=[1.5, 1.5, 2.5, 2.5, 2.5], z=[4, -4, -4, -4, 5])
@@ -652,7 +667,7 @@ class TestMixedFaces:
         """
         Tests a particularly tricky face that can result in a seg fault...
         """
-        fn = os.sep.join([TEST_PATH, "divertor_seg_fault_LDS.json"])
+        fn = os.path.join(TEST_PATH, "divertor_seg_fault_LDS.json")
         loop: Loop = Loop.from_file(fn)
         face = make_mixed_face(*loop.xyz)
         true_props = {
@@ -687,15 +702,15 @@ class TestMixedFaces:
         """
         Tests some shell mixed faces
         """
-        inner: Loop = Loop.from_file(os.sep.join([TEST_PATH, f"{name}_inner.json"]))
-        outer: Loop = Loop.from_file(os.sep.join([TEST_PATH, f"{name}_outer.json"]))
+        inner: Loop = Loop.from_file(os.path.join(TEST_PATH, f"{name}_inner.json"))
+        outer: Loop = Loop.from_file(os.path.join(TEST_PATH, f"{name}_outer.json"))
         inner_wire = make_mixed_wire(*inner.xyz)
         outer_wire = make_mixed_wire(*outer.xyz)
         face = BluemiraFace([outer_wire, inner_wire])
         self.assert_properties(true_props, face)
 
     def test_coordinate_cleaning(self):
-        fn = os.sep.join([TEST_PATH, "bb_ob_bss_test.json"])
+        fn = os.path.join(TEST_PATH, "bb_ob_bss_test.json")
         loop: Loop = Loop.from_file(fn)
         make_mixed_wire(*loop.xyz, allow_fallback=False)
 

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -63,7 +63,7 @@ class TestInscribedRectangle:
         points[0] += np.min(shape.x)
         points[1] += np.min(shape.z)
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
         shape.plot(ax, linewidth=0.1)
 
         shape_face = BluemiraFace(make_polygon(shape.xyz))
@@ -115,6 +115,7 @@ class TestInscribedRectangle:
                         if not np.allclose(dx / dz, k):
                             self.assertion_error_creator("Aspect", [dx, dz, dx / dz, k])
         plt.show()
+        plt.close(fig)
 
         if self.r is not False:
             raise AssertionError(self.r)

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -22,7 +22,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.geometry._deprecated_loop import Loop
 from bluemira.geometry._deprecated_tools import make_circle_arc
 from bluemira.geometry.face import BluemiraFace
@@ -64,9 +63,8 @@ class TestInscribedRectangle:
         points[0] += np.min(shape.x)
         points[1] += np.min(shape.z)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            shape.plot(ax, linewidth=0.1)
+        _, ax = plt.subplots()
+        shape.plot(ax, linewidth=0.1)
 
         shape_face = BluemiraFace(make_polygon(shape.xyz))
         for i in range(x):
@@ -95,9 +93,8 @@ class TestInscribedRectangle:
                         except ValueError:
                             tf = None
 
-                        if tests.PLOTTING:
-                            ax.plot(*point, marker="o")
-                            sq.plot(ax, linewidth=0.1)
+                        ax.plot(*point, marker="o")
+                        sq.plot(ax, linewidth=0.1)
 
                         if tf is not None:
                             # Some overlaps are points or lines of 0 area
@@ -105,20 +102,20 @@ class TestInscribedRectangle:
                                 self.assertion_error_creator(
                                     "Overlap", [dx, dz, point, k, convex]
                                 )
-                                if tests.PLOTTING:
-                                    for t in tf:
-                                        t.plot(
-                                            ax,
-                                            facecolor="r",
-                                            edgecolor="r",
-                                            linewidth=1,
-                                            zorder=40,
-                                        )
+
+                                for t in tf:
+                                    t.plot(
+                                        ax,
+                                        facecolor="r",
+                                        edgecolor="r",
+                                        linewidth=1,
+                                        zorder=40,
+                                    )
+
                         if not np.allclose(dx / dz, k):
                             self.assertion_error_creator("Aspect", [dx, dz, dx / dz, k])
+        plt.show()
 
-        if tests.PLOTTING:
-            plt.show()
         if self.r is not False:
             raise AssertionError(self.r)
 

--- a/tests/magnetostatics/setup_methods.py
+++ b/tests/magnetostatics/setup_methods.py
@@ -74,3 +74,4 @@ def _plot_verification_test(
         axis.set_aspect("equal")
 
     plt.show()
+    plt.close(f)

--- a/tests/magnetostatics/test_biot_savart.py
+++ b/tests/magnetostatics/test_biot_savart.py
@@ -151,6 +151,7 @@ def plot_errors(x, z, Bx, Bz, Bp, Bx2, Bz2, Bp2):
     ax[2, 2].set_aspect("equal")
     ax[2, 3].set_aspect(20)
     plt.show()
+    plt.close(f)
 
 
 @pytest.mark.longrun
@@ -179,3 +180,4 @@ def test_inductance():
     cm = ax[3].contourf(xx, yy, diff, levels=np.linspace(-10, 10, 100))
     f.colorbar(cm)
     plt.show()
+    plt.close(f)

--- a/tests/magnetostatics/test_biot_savart.py
+++ b/tests/magnetostatics/test_biot_savart.py
@@ -23,7 +23,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-import tests
 from bluemira.base.constants import MU_0
 from bluemira.display.auto_config import plot_defaults
 from bluemira.geometry._deprecated_loop import Loop
@@ -78,8 +77,7 @@ def test_biot_savart_loop():
     rms_Bz = np.average((Bz - Bz2) ** 2)
     rms_Bp = np.average((Bp - Bp2) ** 2)
 
-    if tests.PLOTTING:
-        plot_errors(x_2d, z_2d, Bx, Bz, Bp, Bx2, Bz2, Bp2)
+    plot_errors(x_2d, z_2d, Bx, Bz, Bp, Bx2, Bz2, Bp2)
 
     # Note that we're using a lot of points on our circle...
     # But the errors are predominantly around the centre of the coil
@@ -171,14 +169,13 @@ def test_inductance():
             ind2[i, j] = circular_coil_inductance_kirchhoff(r, rc)
             ind3[i, j] = bsf.inductance()
 
-    if tests.PLOTTING:
-        levels = np.linspace(np.amin(ind), np.amax(ind), 20)
-        f, ax = plt.subplots(1, 4)
-        xx, yy = np.meshgrid(radii, rci)
-        ax[0].contourf(xx, yy, ind, levels=levels)
-        ax[1].contourf(xx, yy, ind2, levels=levels)
-        ax[2].contourf(xx, yy, ind3, levels=levels)
-        diff = 100 * (ind - ind3) / ind
-        cm = ax[3].contourf(xx, yy, diff, levels=np.linspace(-10, 10, 100))
-        f.colorbar(cm)
-        plt.show()
+    levels = np.linspace(np.amin(ind), np.amax(ind), 20)
+    f, ax = plt.subplots(1, 4)
+    xx, yy = np.meshgrid(radii, rci)
+    ax[0].contourf(xx, yy, ind, levels=levels)
+    ax[1].contourf(xx, yy, ind2, levels=levels)
+    ax[2].contourf(xx, yy, ind3, levels=levels)
+    diff = 100 * (ind - ind3) / ind
+    cm = ax[3].contourf(xx, yy, diff, levels=np.linspace(-10, 10, 100))
+    f.colorbar(cm)
+    plt.show()

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -137,9 +137,11 @@ def test_mixedsourcesolver():
     assert np.allclose(bt_bl, bt_tl)
 
     solver.plot()
-    _, ax = plt.subplots()
+    fig, ax = plt.subplots()
     ax.contourf(xx, zz, Bt)
     ax.set_aspect("equal")
+    plt.show()
+    plt.close(fig)
 
 
 class TestArbitraryPlanarXSCircuit:
@@ -292,7 +294,7 @@ class TestCariddiBenchmark:
 
         ripple = self.cage.ripple(self.x_rip[1:19], np.zeros(18), self.z_rip[1:19])
 
-        _, (ax2, ax) = plt.subplots(1, 2)
+        fig, (ax2, ax) = plt.subplots(1, 2)
         ax.scatter(list(range(1, 19)), self.cariddi_ripple, marker="o", label="CARIDDI")
         ax.scatter(list(range(1, 19)), ripple, marker="x", label="bluemira", zorder=20)
         ax.legend(loc="upper left")
@@ -306,5 +308,6 @@ class TestCariddiBenchmark:
         ax2.plot(self.coil_loop.x, self.coil_loop.z, color="b")
         ax2.plot(self.x_rip[1:19], self.z_rip[1:19], marker=".", color="r")
         plt.show()
+        plt.close(fig)
 
         assert np.max(np.abs(ripple - self.cariddi_ripple)) < 0.04

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -26,7 +26,6 @@ import numpy as np
 import pytest
 from scipy.interpolate import interp1d
 
-import tests
 from bluemira.base.file import get_bluemira_path
 from bluemira.geometry._deprecated_tools import (
     innocent_smoothie,
@@ -137,11 +136,10 @@ def test_mixedsourcesolver():
     assert np.allclose(bt_bl, bt_tr)
     assert np.allclose(bt_bl, bt_tl)
 
-    if tests.PLOTTING:
-        solver.plot()
-        f, ax = plt.subplots()
-        ax.contourf(xx, zz, Bt)
-        ax.set_aspect("equal")
+    solver.plot()
+    _, ax = plt.subplots()
+    ax.contourf(xx, zz, Bt)
+    ax.set_aspect("equal")
 
 
 class TestArbitraryPlanarXSCircuit:
@@ -294,24 +292,19 @@ class TestCariddiBenchmark:
 
         ripple = self.cage.ripple(self.x_rip[1:19], np.zeros(18), self.z_rip[1:19])
 
-        if tests.PLOTTING:
-            f, (ax2, ax) = plt.subplots(1, 2)
-            ax.scatter(
-                list(range(1, 19)), self.cariddi_ripple, marker="o", label="CARIDDI"
-            )
-            ax.scatter(
-                list(range(1, 19)), ripple, marker="x", label="bluemira", zorder=20
-            )
-            ax.legend(loc="upper left")
+        _, (ax2, ax) = plt.subplots(1, 2)
+        ax.scatter(list(range(1, 19)), self.cariddi_ripple, marker="o", label="CARIDDI")
+        ax.scatter(list(range(1, 19)), ripple, marker="x", label="bluemira", zorder=20)
+        ax.legend(loc="upper left")
 
-            ax.set_ylabel("$\\delta_{\\phi}$ [%]")
-            ax.yaxis.set_label_position("right")
-            ax.yaxis.tick_right()
-            ax.set_xlabel("Point index")
-            ax.set_xticks(np.arange(1, 19, 2))
+        ax.set_ylabel("$\\delta_{\\phi}$ [%]")
+        ax.yaxis.set_label_position("right")
+        ax.yaxis.tick_right()
+        ax.set_xlabel("Point index")
+        ax.set_xticks(np.arange(1, 19, 2))
 
-            ax2.plot(self.coil_loop.x, self.coil_loop.z, color="b")
-            ax2.plot(self.x_rip[1:19], self.z_rip[1:19], marker=".", color="r")
-            plt.show()
+        ax2.plot(self.coil_loop.x, self.coil_loop.z, color="b")
+        ax2.plot(self.x_rip[1:19], self.z_rip[1:19], marker=".", color="r")
+        plt.show()
 
         assert np.max(np.abs(ripple - self.cariddi_ripple)) < 0.04

--- a/tests/magnetostatics/test_circular_arc.py
+++ b/tests/magnetostatics/test_circular_arc.py
@@ -21,7 +21,6 @@
 
 import numpy as np
 
-import tests
 from bluemira.magnetostatics.circular_arc import CircularArcCurrentSource
 from bluemira.magnetostatics.semianalytic_2d import semianalytic_Bx, semianalytic_Bz
 from tests.magnetostatics.setup_methods import _plot_verification_test
@@ -67,22 +66,21 @@ class TestCircularArcCurrentSource:
         assert np.allclose(Bx_coil, Bx)
         assert np.allclose(Bz_coil, Bz)
 
-        if tests.PLOTTING:
-            self.arc.plot()
-            _plot_verification_test(
-                self.xc,
-                self.zc,
-                self.dx,
-                self.dz,
-                xx,
-                zz,
-                Bx_coil,
-                Bz_coil,
-                Bp_coil,
-                Bx,
-                Bz,
-                Bp,
-            )
+        self.arc.plot()
+        _plot_verification_test(
+            self.xc,
+            self.zc,
+            self.dx,
+            self.dz,
+            xx,
+            zz,
+            Bx_coil,
+            Bz_coil,
+            Bp_coil,
+            Bx,
+            Bz,
+            Bp,
+        )
 
     def test_singularities(self):
         """

--- a/tests/magnetostatics/test_semianalytic_2d.py
+++ b/tests/magnetostatics/test_semianalytic_2d.py
@@ -117,7 +117,7 @@ class TestSemiAnalyticBxBz:
         assert np.all(bx_array == bx_results)
         assert np.all(bz_array == bz_results)
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
         ax.plot(bp_fe, marker="s", label="FE", ms=20)
         ax.plot(bp_paper, marker="^", label="Paper", ms=20)
         ax.plot(bp, marker="X", label="New", ms=20)
@@ -125,6 +125,7 @@ class TestSemiAnalyticBxBz:
         ax.set_xlabel("Point number")
         ax.set_ylabel("$B_{p}$ [T]")
         plt.show()
+        plt.close(fig)
 
     def test_tough_Bz_integration_does_not_raise_error(self):
         """
@@ -180,7 +181,7 @@ class TestPoloidalFieldBenchmark:
         filename = os.sep.join([self.path, "new_B_along_z-z.json"])
         x, z, B = self.load_data(filename)
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
 
         x_values = np.unique(x)
         for x_value in x_values:
@@ -206,12 +207,13 @@ class TestPoloidalFieldBenchmark:
         ax.set_xlim([40, 80])
         ax.set_xlabel("z")
         ax.set_ylabel("$B_{p}$")
+        plt.close(fig)
 
     def test_field_inside_coil_x_x(self):
         filename = os.sep.join([self.path, "new_B_along_x-x.json"])
         x, z, B = self.load_data(filename)
 
-        f, ax = plt.subplots()
+        fig, ax = plt.subplots()
 
         z_values = np.unique(z)[:5]  # Mirrored about coil zc-axis
         for z_value in z_values:
@@ -236,3 +238,4 @@ class TestPoloidalFieldBenchmark:
         ax.set_xlim([0, 8])
         ax.set_xlabel("x")
         ax.set_ylabel("$B_{p}$")
+        plt.close(fig)

--- a/tests/magnetostatics/test_semianalytic_2d.py
+++ b/tests/magnetostatics/test_semianalytic_2d.py
@@ -25,9 +25,7 @@ import os
 import numpy as np
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.base.file import get_bluemira_path
-from bluemira.display.auto_config import plot_defaults
 from bluemira.magnetostatics.semianalytic_2d import semianalytic_Bx, semianalytic_Bz
 
 
@@ -119,16 +117,14 @@ class TestSemiAnalyticBxBz:
         assert np.all(bx_array == bx_results)
         assert np.all(bz_array == bz_results)
 
-        if tests.PLOTTING:
-            plot_defaults()
-            f, ax = plt.subplots()
-            ax.plot(bp_fe, marker="s", label="FE", ms=20)
-            ax.plot(bp_paper, marker="^", label="Paper", ms=20)
-            ax.plot(bp, marker="X", label="New", ms=20)
-            ax.legend()
-            ax.set_xlabel("Point number")
-            ax.set_ylabel("$B_{p}$ [T]")
-            plt.show()
+        _, ax = plt.subplots()
+        ax.plot(bp_fe, marker="s", label="FE", ms=20)
+        ax.plot(bp_paper, marker="^", label="Paper", ms=20)
+        ax.plot(bp, marker="X", label="New", ms=20)
+        ax.legend()
+        ax.set_xlabel("Point number")
+        ax.set_ylabel("$B_{p}$ [T]")
+        plt.show()
 
     def test_tough_Bz_integration_does_not_raise_error(self):
         """
@@ -184,8 +180,7 @@ class TestPoloidalFieldBenchmark:
         filename = os.sep.join([self.path, "new_B_along_z-z.json"])
         x, z, B = self.load_data(filename)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
+        _, ax = plt.subplots()
 
         x_values = np.unique(x)
         for x_value in x_values:
@@ -199,27 +194,24 @@ class TestPoloidalFieldBenchmark:
 
             assert max(abs(b_fe - b_calc)) < self.peak_discrepancy
 
-            if tests.PLOTTING:
-                p = ax.plot(z_x, b_fe, label="ERMES x=" + str(x_value))
-                ax.plot(
-                    z_x,
-                    b_calc,
-                    linestyle="--",
-                    color=p[0].get_color(),
-                    label="bluemira x=" + str(x_value),
-                )
-        if tests.PLOTTING:
-            ax.legend()
-            ax.set_xlim([40, 80])
-            ax.set_xlabel("z")
-            ax.set_ylabel("$B_{p}$")
+            p = ax.plot(z_x, b_fe, label="ERMES x=" + str(x_value))
+            ax.plot(
+                z_x,
+                b_calc,
+                linestyle="--",
+                color=p[0].get_color(),
+                label="bluemira x=" + str(x_value),
+            )
+        ax.legend()
+        ax.set_xlim([40, 80])
+        ax.set_xlabel("z")
+        ax.set_ylabel("$B_{p}$")
 
     def test_field_inside_coil_x_x(self):
         filename = os.sep.join([self.path, "new_B_along_x-x.json"])
         x, z, B = self.load_data(filename)
 
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
+        f, ax = plt.subplots()
 
         z_values = np.unique(z)[:5]  # Mirrored about coil zc-axis
         for z_value in z_values:
@@ -232,17 +224,15 @@ class TestPoloidalFieldBenchmark:
             b_calc = np.hypot(bx, bz)
             assert max(abs(b_fe - b_calc)) < self.peak_discrepancy
 
-            if tests.PLOTTING:
-                p = ax.plot(x_z, b_fe, label="ERMES z=" + str(z_value))
-                ax.plot(
-                    x_z,
-                    b_calc,
-                    linestyle="--",
-                    color=p[0].get_color(),
-                    label="bluemira z=" + str(z_value),
-                )
-        if tests.PLOTTING:
-            ax.legend()
-            ax.set_xlim([0, 8])
-            ax.set_xlabel("x")
-            ax.set_ylabel("$B_{p}$")
+            p = ax.plot(x_z, b_fe, label="ERMES z=" + str(z_value))
+            ax.plot(
+                x_z,
+                b_calc,
+                linestyle="--",
+                color=p[0].get_color(),
+                label="bluemira z=" + str(z_value),
+            )
+        ax.legend()
+        ax.set_xlim([0, 8])
+        ax.set_xlabel("x")
+        ax.set_ylabel("$B_{p}$")

--- a/tests/materials/test_material.py
+++ b/tests/materials/test_material.py
@@ -113,6 +113,7 @@ class TestMaterials:
         self.nb_3_sn_2.plot(b_min, b_max, t_min, t_max, eps)
         self.nbti.plot(b_min, b_max, t_min, t_max)
         plt.show()
+        plt.close()
 
 
 class TestLiquids:

--- a/tests/materials/test_material.py
+++ b/tests/materials/test_material.py
@@ -33,7 +33,8 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=UserWarning)
     from neutronics_material_maker.utils import make_serpent_material
 
-import tests
+import matplotlib.pyplot as plt
+
 from bluemira.base.constants import kgm3_to_gcm3, to_kelvin
 from bluemira.utilities.tools import is_num
 from tests.materials.materials_helpers import MATERIAL_CACHE
@@ -77,7 +78,6 @@ class TestMaterials:
     nb_3_sn = MATERIAL_CACHE.get_material("Nb3Sn - WST")
     nb_3_sn_2 = MATERIAL_CACHE.get_material("Nb3Sn - EUTF4")
     nbti = MATERIAL_CACHE.get_material("NbTi")
-    plot = tests.PLOTTING
 
     def test_density_load(self):
         self.beryllium.temperature = 300
@@ -106,13 +106,13 @@ class TestMaterials:
         assert " tmp 400 " in s.splitlines()[0]
 
     def test_superconductor_plot(self):
-        if self.plot:
-            b_min, b_max = 3, 16
-            t_min, t_max = 2, 6
-            eps = -0.66
-            self.nb_3_sn.plot(b_min, b_max, t_min, t_max, eps)
-            self.nb_3_sn_2.plot(b_min, b_max, t_min, t_max, eps)
-            self.nbti.plot(b_min, b_max, t_min, t_max)
+        b_min, b_max = 3, 16
+        t_min, t_max = 2, 6
+        eps = -0.66
+        self.nb_3_sn.plot(b_min, b_max, t_min, t_max, eps)
+        self.nb_3_sn_2.plot(b_min, b_max, t_min, t_max, eps)
+        self.nbti.plot(b_min, b_max, t_min, t_max)
+        plt.show()
 
 
 class TestLiquids:

--- a/tests/structural/test_crosssection.py
+++ b/tests/structural/test_crosssection.py
@@ -22,6 +22,7 @@
 
 import numpy as np
 import pytest
+from matplotlib import pyplot as plt
 
 from bluemira.display import plot_2d
 from bluemira.structural.crosssection import (
@@ -46,6 +47,7 @@ class TestIbeam:
     def test_plot(self):
         i_beam = IBeam(1, 1, 0.25, 0.5)
         plot_2d(i_beam.geometry, show_points=True)
+        plt.close()
 
     def test_errors(self):
         props = [

--- a/tests/structural/test_crosssection.py
+++ b/tests/structural/test_crosssection.py
@@ -23,7 +23,6 @@
 import numpy as np
 import pytest
 
-import tests
 from bluemira.display import plot_2d
 from bluemira.structural.crosssection import (
     AnalyticalCrossSection,
@@ -44,7 +43,6 @@ class TestIbeam:
         assert i_beam.i_zz == 46875000000e-12
         assert np.isclose(i_beam.j, 114583333333.3333e-12)
 
-    @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_plot(self):
         i_beam = IBeam(1, 1, 0.25, 0.5)
         plot_2d(i_beam.geometry, show_points=True)

--- a/tests/structural/test_geometry.py
+++ b/tests/structural/test_geometry.py
@@ -43,9 +43,10 @@ class TestKMatrix:
 
         k_matrix = geometry.k_matrix()
 
-        _, ax = plt.subplots()
+        fig, ax = plt.subplots()
         ax.matshow(k_matrix)
         plt.show()
+        plt.close(fig)
 
         assert np.allclose(k_matrix, k_matrix.T)
 

--- a/tests/structural/test_geometry.py
+++ b/tests/structural/test_geometry.py
@@ -23,14 +23,13 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.structural.crosssection import IBeam
 from bluemira.structural.geometry import Geometry
 from bluemira.structural.material import SS316
 
 
-@pytest.mark.longrun
+@pytest.mark.longrun  # TODO(hsaunders1904): remove this
 class TestKMatrix:
     def test_k(self):
         geometry = Geometry()
@@ -43,10 +42,12 @@ class TestKMatrix:
         geometry.add_element(1, 2, i_300_200, SS316)
 
         k_matrix = geometry.k_matrix()
+
+        _, ax = plt.subplots()
+        ax.matshow(k_matrix)
+        plt.show()
+
         assert np.allclose(k_matrix, k_matrix.T)
-        if tests.PLOTTING:
-            f, ax = plt.subplots()
-            ax.matshow(k_matrix)
 
 
 class TestMembership:

--- a/tests/structural/test_geometry.py
+++ b/tests/structural/test_geometry.py
@@ -20,7 +20,6 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-import pytest
 from matplotlib import pyplot as plt
 
 from bluemira.geometry.coordinates import Coordinates
@@ -29,7 +28,6 @@ from bluemira.structural.geometry import Geometry
 from bluemira.structural.material import SS316
 
 
-@pytest.mark.longrun  # TODO(hsaunders1904): remove this
 class TestKMatrix:
     def test_k(self):
         geometry = Geometry()

--- a/tests/structural/test_model.py
+++ b/tests/structural/test_model.py
@@ -23,8 +23,8 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
+from matplotlib import pyplot as plt
 
-import tests
 from bluemira.base.constants import ANSI_COLOR
 from bluemira.structural.crosssection import IBeam, RectangularBeam
 from bluemira.structural.error import StructuralError
@@ -520,7 +520,6 @@ class TestLFrame:
         assert np.isclose(delta_cz, deflections[6 * 2 + 2], rtol=1e-2)
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 @pytest.mark.longrun
 class TestCompoundDeflection:
     def test_fixedfixed(self):
@@ -588,9 +587,9 @@ class TestCompoundDeflection:
 
         result = model.solve(load_case)
         result.plot()
+        plt.show()
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 @pytest.mark.longrun
 class TestGravityLoads:
     def test_angled_cantilever(self):
@@ -611,11 +610,12 @@ class TestGravityLoads:
 
         result = model.solve()
         result.plot()
+        plt.show()
+
         # Check that tip displacements in the x and y directions are equal
         assert np.isclose(result.deflections[6 * n], result.deflections[6 * n + 1])
 
 
-@pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
 class TestFixedFixedStress:
     def test_stress(self):
         model = FiniteElementModel()
@@ -636,7 +636,10 @@ class TestFixedFixedStress:
         model.add_support(3, True, True, True, True, True, True)
         model.add_distributed_load(0, -w, "Fz")
         model.add_distributed_load(1, -w, "Fz")
-        model.solve()
+        result = model.solve()
+
+        result.plot()
+        plt.show()
 
 
 @pytest.mark.longrun
@@ -728,16 +731,17 @@ class TestMiniEiffelTower:
         model.add_node(0, 0, 324)
         model.add_element(20, 21, cs5, SS316)
 
-        if tests.PLOTTING:
-            model.plot()
+        model.plot()
+        plt.show()
+
         cls.model = model
 
-    @pytest.mark.skipif(not tests.PLOTTING, reason="plotting disabled")
     def test_something(self):
         self.model.add_gravity_loads()
         result = self.model.solve()
         result.plot(stress=True)
         self.model.clear_loads()
+        plt.show()
 
 
 @pytest.mark.longrun
@@ -770,5 +774,6 @@ class TestInterpolation:
         model.add_gravity_loads()
 
         result = model.solve()
-        if tests.PLOTTING:
-            result.plot(stress=True)
+
+        result.plot(stress=True)
+        plt.show()

--- a/tests/structural/test_plotting.py
+++ b/tests/structural/test_plotting.py
@@ -21,7 +21,6 @@
 
 import matplotlib.pyplot as plt
 
-import tests
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.structural.crosssection import RectangularBeam
 from bluemira.structural.geometry import Geometry
@@ -85,6 +84,5 @@ class TestPlotting:
 
         fem.apply_load_case(load_case)
 
-        if tests.PLOTTING:
-            GeometryPlotter(geometry)
-            plt.show()
+        GeometryPlotter(geometry)
+        plt.show()

--- a/tests/structural/test_symmetry.py
+++ b/tests/structural/test_symmetry.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 import numpy as np
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.geometry.tools import make_circle
 from bluemira.structural.crosssection import IBeam
 from bluemira.structural.material import SS316
@@ -76,10 +75,9 @@ class TestCyclicSymmetry:
         result = model.solve(sparse=False)
         fullresult = fullmodel.solve(sparse=True)
 
-        if tests.PLOTTING:
-            result.plot(100, stress=True, pattern=True)
-            fullresult.plot(100, stress=True)
-            plt.show()
+        result.plot(100, stress=True, pattern=True)
+        fullresult.plot(100, stress=True)
+        plt.show()
 
         left = model.cycle_sym.left_nodes
         right = model.cycle_sym.right_nodes

--- a/tests/structural/test_transformation.py
+++ b/tests/structural/test_transformation.py
@@ -108,7 +108,6 @@ class TestLambdaTransformationMatrices:
             self.plot_nodes(
                 Node(1, 1, 1, 0), Node(1 + v[0], 1 + v[1], 1 + v[2], 1), local
             )
-            plt.show()
 
     def test_big_random(self):
         for _ in range(100):

--- a/tests/structural/test_transformation.py
+++ b/tests/structural/test_transformation.py
@@ -24,7 +24,6 @@ import itertools
 import numpy as np
 from matplotlib import pyplot as plt
 
-import tests
 from bluemira.structural.node import Node
 from bluemira.structural.transformation import (
     _direction_cosine_matrix,
@@ -48,11 +47,7 @@ class TestLambdaTransformationMatrices:
         assert np.isclose(abs(np.linalg.det(dcm)), 1)
 
     @staticmethod
-    def assert_looks_good(node1, node2, local, fig=None, ax=None):
-        if not tests.PLOTTING:
-            return
-
-        # TODO: not an assert
+    def plot_nodes(node1, node2, local, fig=None, ax=None):
         # Visualise transform
         if fig is None:
             fig = plt.figure()
@@ -107,10 +102,11 @@ class TestLambdaTransformationMatrices:
             dcm, local = _direction_cosine_matrix_debugging(*v, debug=True)
             self.assert_maths_good(dcm, msg=f"coords: {v}")
 
-            # TODO: these are not asserts
             self.assert_works_good(dcm, local, msg=f"coords: {v}")
-            # self.assert_looks_good(Node(1, 1, 1, 0), Node(1+v[0], 1+v[1], 1+v[2], 1),
-            #                       local)
+            self.plot_nodes(
+                Node(1, 1, 1, 0), Node(1 + v[0], 1 + v[1], 1 + v[2], 1), local
+            )
+            plt.show()
 
     def test_big_random(self):
         for _ in range(100):
@@ -144,7 +140,6 @@ class TestLambdaTransformationMatrices:
         self.assert_maths_good(dcm)
 
         self.assert_works_good(dcm, self.global_cs)
-        # self.assert_looks_good(N1, N2, self.global_cs)
 
     def test_random2(self):
         for _ in range(100):

--- a/tests/structural/test_transformation.py
+++ b/tests/structural/test_transformation.py
@@ -71,6 +71,8 @@ class TestLambdaTransformationMatrices:
         ax.set_xlim([-2, 2])
         ax.set_ylim([-2, 2])
         ax.set_zlim([-2, 2])
+        plt.show()
+        plt.close(fig)
 
     def assert_works_good(self, dcm, local, msg=""):
         global_check = dcm @ local


### PR DESCRIPTION
## Linked Issues

Closes #1173 

## Description

Plotting tests are now enabled by default and run with a non-interactive backend. This means we run all the plotting tests on the CI etc., but no interactive windows prevent the execution of subsequent tests. The `--plotting-on` flag still remains, and is used to switch to an interactive backend. The `exec_` method on `QApplication` is mocked before the test suite is run, so no blocking window is opened to display CAD; again this behaviour can be overridden using the `--plotting-on` flag.

Sorry for so many review requests, but this touches almost everything!

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
