### PR TITLE
👷 split out warnings comment from main CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
                --json-report-indent=3 \
                tests examples/design/EU-DEMO --reactor --private ${PYTEST_LONGRUN}
 
-    - name: Upload test report (push only)
+    - name: Upload test report
       uses: actions/upload-artifact@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,56 +120,14 @@ jobs:
         name: report-json
         path: .report.json
 
-    - name: Download reference test report (PR only)
+    - name: Upload test report (PR only)
       if: ${{ github.event_name == 'pull_request' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        artifact_url="$( \
-          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "report-json") | select(.workflow_run.head_sha == "${{ github.event.pull_request.base.sha }}") | .archive_download_url')"
-        if [ ! -z "${artifact_url}" ]; then
-          gh api ${artifact_url} > report-json.zip
-          mkdir ref_report
-          unzip report-json.zip -d ref_report
-        fi
-
-    - name: Generate warning report
-      if: ${{ github.event_name == 'pull_request' }}
-      id: warning-report
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        if [ -f "ref_report/.report.json" ]; then
-          compare_args="--compare ref_report/.report.json"
-        fi
-        report_str=$(python scripts/format_warning_report.py .report.json ${compare_args}) || true
-        # Ugly stuff to escape new lines
-        report_str="${report_str//'%'/'%25'}"
-        report_str="${report_str//$'\n'/'%0A'}"
-        echo "::set-output name=report::"${report_str}""
-
-    - name: Find warning report comment
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: peter-evans/find-comment@v2
-      id: find-warning-report-comment
+      uses: actions/upload-artifact@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: "github-actions[bot]"
-        body-includes: ⚠️ Warning Report
-        direction: last
-
-    - name: Create or update warning report comment
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: peter-evans/create-or-update-comment@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: ${{ steps.warning-report.outputs.report }}
-        edit-mode: replace
+        name: PR-report-json
+        path: .report.json
 
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,21 +112,11 @@ jobs:
                tests examples/design/EU-DEMO --reactor --private ${PYTEST_LONGRUN}
 
     - name: Upload test report (push only)
-      if: ${{ github.event_name == 'push' }}
       uses: actions/upload-artifact@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: report-json
-        path: .report.json
-
-    - name: Upload test report (PR only)
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/upload-artifact@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        name: PR-report-json
         path: .report.json
 
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -31,11 +31,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         artifact_url="$( \
-          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "PR-report-json") | select(.workflow_run.head_sha == "${{ github.event.workflow_run.head_sha }}") | .archive_download_url')"
+          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "report-json") | select(.workflow_run.head_sha == "${{ github.event.workflow_run.head_sha }}") | .archive_download_url')"
         if [ ! -z "${artifact_url}" ]; then
-          gh api ${artifact_url} > PR-report-json.zip
+          gh api ${artifact_url} > report-json.zip
           mkdir PR_report
-          unzip PR-report-json.zip -d PR_report
+          unzip report-json.zip -d PR_report
         fi
     - name: Generate warning report
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,7 +1,7 @@
 name: PR Comments
 
 # This workflow should only be used for low permission actions
-# for instance those that on't need the repository checked out.
+# for instance those that don't need the repository checked out.
 on:
   workflow_run:
     workflows: ["bluemira_ci"]

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        issue-number: ${{ github.event.pull_request.number }}
+        issue-number: ${{ github.event.workflow_run.pull_request.number }}
         comment-author: "github-actions[bot]"
         body-includes: ⚠️ Warning Report
         direction: last

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,0 +1,74 @@
+name: PR Comments
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["bluemira_ci"]
+    types:
+      - completed
+
+jobs:
+  warnings-comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - name: Download reference test report
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        artifact_url="$( \
+          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "report-json") | select(.workflow_run.head_sha == "${{ github.event.workflow_run.pull_request.base.sha }}") | .archive_download_url')"
+        if [ ! -z "${artifact_url}" ]; then
+          gh api ${artifact_url} > report-json.zip
+          mkdir ref_report
+          unzip report-json.zip -d ref_report
+        fi
+    - name: Download PR test report
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        artifact_url="$( \
+          gh api repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "PR-report-json") | select(.workflow_run.head_sha == "${{ github.event.workflow_run.head_sha }}") | .archive_download_url')"
+        if [ ! -z "${artifact_url}" ]; then
+          gh api ${artifact_url} > PR-report-json.zip
+          mkdir PR_report
+          unzip PR-report-json.zip -d PR_report
+        fi
+    - name: Generate warning report
+      if: ${{ github.event_name == 'pull_request' }}
+      id: warning-report
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ -f "ref_report/.report.json" ]; then
+          compare_args="--compare ref_report/.report.json"
+        fi
+        report_str=$(python scripts/format_warning_report.py PR_report/.report.json ${compare_args}) || true
+        # Ugly stuff to escape new lines
+        report_str="${report_str//'%'/'%25'}"
+        report_str="${report_str//$'\n'/'%0A'}"
+        echo "::set-output name=report::"${report_str}""
+
+    - name: Find warning report comment
+      uses: peter-evans/find-comment@v2
+      id: find-warning-report-comment
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: ⚠️ Warning Report
+        direction: last
+
+    - name: Create or update warning report comment
+      uses: peter-evans/create-or-update-comment@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        comment-id: ${{ steps.find-warning-report-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.workflow_run.pull_request.number }}
+        body: ${{ steps.warning-report.outputs.report }}
+        edit-mode: replace

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,7 +1,7 @@
 name: PR Comments
 
-# read-write repo token
-# access to secrets
+# This workflow should only be used for low permission actions
+# for instance those that on't need the repository checked out.
 on:
   workflow_run:
     workflows: ["bluemira_ci"]


### PR DESCRIPTION
## Linked Issues

Closes #1268 

## Description

This splits out the warnings comment to be fixed in a later PR so it doesn't fail our CI

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
