### PR TITLE
🎨 Remove Loop from opt_constraints

### DIFF
--- a/bluemira/equilibria/opt_constraints.py
+++ b/bluemira/equilibria/opt_constraints.py
@@ -36,7 +36,7 @@ from bluemira.equilibria.opt_constraint_funcs import (
     field_constraints,
 )
 from bluemira.equilibria.plotting import ConstraintPlotter
-from bluemira.geometry._deprecated_loop import Loop
+from bluemira.geometry._deprecated_tools import interpolate_points
 from bluemira.utilities.opt_problems import OptimisationConstraint
 from bluemira.utilities.tools import abs_rel_difference, is_num
 
@@ -870,9 +870,7 @@ class AutoConstraints(MagneticConstraintSet):
             ]
 
         # Interpolate some points on the LCFS
-        loop = Loop(x=x, z=z)
-        loop.interpolate(n_points)
-        x_boundary, z_boundary = loop.x, loop.z
+        x_boundary, _, z_boundary = interpolate_points(x, np.zeros_like[x], z, n_points)
 
         # Apply an appropriate constraint on the LCFS
         if psi_boundary is None:

--- a/bluemira/geometry/_deprecated_tools.py
+++ b/bluemira/geometry/_deprecated_tools.py
@@ -25,6 +25,7 @@ A collection of geometry tools.
 
 from functools import partial
 from itertools import zip_longest
+from typing import Tuple
 
 import numba as nb
 import numpy as np
@@ -269,7 +270,9 @@ def get_angle_between_points(p0, p1, p2):
     return get_angle_between_vectors(ba, bc)
 
 
-def get_angle_between_vectors(v1, v2, signed=False):
+def get_angle_between_vectors(
+    v1: np.ndarray, v2: np.ndarray, signed: bool = False
+) -> float:
     """
     Angle between vectors. Will return the signed angle if specified.
 
@@ -304,7 +307,7 @@ def get_angle_between_vectors(v1, v2, signed=False):
     return sign * angle
 
 
-def segment_lengths(x: np.ndarray, y: np.ndarray, z: np.ndarray):
+def segment_lengths(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> np.ndarray:
     """
     Returns the length of each individual segment in a set of coordinates
 
@@ -325,42 +328,44 @@ def segment_lengths(x: np.ndarray, y: np.ndarray, z: np.ndarray):
     return np.sqrt(np.diff(x) ** 2 + np.diff(y) ** 2 + np.diff(z) ** 2)
 
 
-def bounding_box(x, y, z):
+def bounding_box(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> Tuple[np.ndarray]:
     """
     Calculates a bounding box for a set of 3-D coordinates
 
     Parameters
     ----------
-    x: np.array(N)
+    x: np.ndarray
         The x coordinates
-    y: np.array(N)
+    y: np.ndarray
         The y coordinates
-    z: np.array(N)
+    z: np.ndarray
         The z coordinates
 
     Returns
     -------
-    x_b: np.array(8)
+    x_b: np.ndarray
         The x coordinates of the bounding box rectangular cuboid
-    y_b: np.array(8)
+    y_b: np.ndarray
         The y coordinates of the bounding box rectangular cuboid
-    z_b: np.array(8)
+    z_b: np.ndarray
         The z coordinates of the bounding box rectangular cuboid
     """
     return BoundingBox.from_xyz(x, y, z).get_box_arrays()
 
 
-def interpolate_points(x, y, z, n_points):
+def interpolate_points(
+    x: np.ndarray, y: np.ndarray, z: np.ndarray, n_points: int
+) -> Tuple[np.ndarray]:
     """
     Interpolate Points
 
     Parameters
     ----------
-    x: np.array
+    x: np.darray
         The x coordinates
-    y: np.array
+    y: np.darray
         The y coordinates
-    z: np.array
+    z: np.darray
         The z coordinates
     n_points: int
         number of points
@@ -377,22 +382,22 @@ def interpolate_points(x, y, z, n_points):
     return x, y, z
 
 
-def vector_lengthnorm(x, y, z):
+def vector_lengthnorm(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> np.ndarray:
     """
     Get a normalised 1-D parameterisation of a set of x-y-z coordinates.
 
     Parameters
     ----------
-    x: np.array
+    x: np.ndarray
         The x coordinates
-    y: np.array
+    y: np.ndarray
         The y coordinates
-    z: np.array
+    z: np.ndarray
         The z coordinates
 
     Returns
     -------
-    length_: np.array(n)
+    length_: np.ndarray
         The normalised length vector
     """
     length_ = np.append(

--- a/bluemira/geometry/_deprecated_tools.py
+++ b/bluemira/geometry/_deprecated_tools.py
@@ -350,6 +350,33 @@ def bounding_box(x, y, z):
     return BoundingBox.from_xyz(x, y, z).get_box_arrays()
 
 
+def interpolate_points(x, y, z, n_points):
+    """
+    Interpolate Points
+
+    Parameters
+    ----------
+    x: np.array
+        The x coordinates
+    y: np.array
+        The y coordinates
+    z: np.array
+        The z coordinates
+    n_points: int
+        number of points
+
+    Returns
+    -------
+    x, y, z
+    """
+    ll = vector_lengthnorm(x, y, z)
+    linterp = np.linspace(0, 1, int(n_points))
+    x = interp1d(ll, x)(linterp)
+    y = interp1d(ll, y)(linterp)
+    z = interp1d(ll, z)(linterp)
+    return x, y, z
+
+
 def vector_lengthnorm(x, y, z):
     """
     Get a normalised 1-D parameterisation of a set of x-y-z coordinates.


### PR DESCRIPTION
## Linked Issues

Part of #1323 

## Description

Removes `Loop` from opt_constraints. It feels like `_deprecated_tools` will be the last to go so I've moved the interpolation functionality there for now

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
