### PR TITLE
Error running design_shapes example

### DIFF
--- a/bluemira/builders/shapes.py
+++ b/bluemira/builders/shapes.py
@@ -140,11 +140,11 @@ class OptimisedShapeBuilder(ParameterisedShapeBuilder):
         Optimise the shape using the provided parameterisation and optimiser.
         """
         bluemira_debug(
-            f"""Setting up design problem with:
-algorithm_name: {self._algorithm_name}
-n_variables: {self._shape.variables.n_free_variables}
-opt_conditions: {self._opt_conditions}
-opt_parameters: {self._opt_parameters}"""
+            f"Setting up design problem with:\n"
+            f"algorithm_name: {self._algorithm_name}\n"
+            f"n_variables: {self._shape.variables.n_free_variables}\n"
+            f"opt_conditions: {self._opt_conditions}\n"
+            f"opt_parameters: {self._opt_parameters}"
         )
         optimiser = Optimiser(
             self._algorithm_name,

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -62,11 +62,15 @@ def minimise_length(vector, grad, parameterisation, ad_args=None):
     grad: np.ndarray
         Local gradient of objective function used by LD NLOPT algorithms.
         Updated in-place.
+    ad_args: Dict
+        Additional arguments to pass to the `approx_derivative` function.
 
     Returns
     -------
     fom: Value of objective function (figure of merit).
     """
+    ad_args = ad_args if ad_args is not None else {}
+
     length = calculate_length(vector, parameterisation)
     if grad.size > 0:
         grad[:] = approx_derivative(
@@ -123,8 +127,8 @@ class GeometryOptimisationProblem(OptimisationProblem):
     def __init__(
         self,
         geometry_parameterisation: GeometryParameterisation,
-        optimiser: Optimiser = None,
-        objective: OptimisationObjective = None,
+        optimiser: Optimiser,
+        objective: OptimisationObjective,
         constraints: List[OptimisationConstraint] = None,
     ):
         super().__init__(geometry_parameterisation, optimiser, objective, constraints)

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -127,8 +127,8 @@ class GeometryOptimisationProblem(OptimisationProblem):
     def __init__(
         self,
         geometry_parameterisation: GeometryParameterisation,
-        optimiser: Optimiser,
-        objective: OptimisationObjective,
+        optimiser: Optimiser = None,
+        objective: OptimisationObjective = None,
         constraints: List[OptimisationConstraint] = None,
     ):
         super().__init__(geometry_parameterisation, optimiser, objective, constraints)

--- a/bluemira/geometry/optimisation.py
+++ b/bluemira/geometry/optimisation.py
@@ -193,17 +193,18 @@ class MinimiseLengthGOP(GeometryOptimisationProblem):
         objective = OptimisationObjective(
             minimise_length, {"parameterisation": parameterisation}
         )
-        koz_points = keep_out_zone.discretize(n_koz_points, byedges=True).xz
-        koz_constraint = OptimisationConstraint(
-            constrain_koz,
-            f_constraint_args={
-                "parameterisation": parameterisation,
-                "n_shape_discr": n_koz_points,
-                "koz_points": koz_points,
-            },
-            tolerance=koz_con_tol * np.ones(n_koz_points),
-        )
+        constraints = []
+        if keep_out_zone is not None:
+            koz_points = keep_out_zone.discretize(n_koz_points, byedges=True).xz
+            koz_constraint = OptimisationConstraint(
+                constrain_koz,
+                f_constraint_args={
+                    "parameterisation": parameterisation,
+                    "n_shape_discr": n_koz_points,
+                    "koz_points": koz_points,
+                },
+                tolerance=koz_con_tol * np.ones(n_koz_points),
+            )
+            constraints.append(koz_constraint)
 
-        super().__init__(
-            parameterisation, optimiser, objective, constraints=[koz_constraint]
-        )
+        super().__init__(parameterisation, optimiser, objective, constraints=constraints)

--- a/bluemira/utilities/opt_problems.py
+++ b/bluemira/utilities/opt_problems.py
@@ -103,7 +103,7 @@ class OptimisationObjective:
 
     def __init__(self, f_objective, f_objective_args=None):
         self._f_objective = f_objective
-        self._args = f_objective_args
+        self._args = f_objective_args if f_objective_args is not None else {}
 
     def __call__(self, vector, grad):
         """
@@ -164,7 +164,7 @@ class OptimisationProblem(ABC):
         self._objective = objective
         self._constraints = constraints
 
-    def set_up_optimiser(self, dimension: int, bounds: np.array):
+    def set_up_optimiser(self, dimension: int, bounds: np.ndarray):
         """
         Set up NLOpt-based optimiser with algorithm,  bounds, tolerances, and
         constraint & objective functions.
@@ -184,7 +184,8 @@ class OptimisationProblem(ABC):
         self._objective.apply_objective(self)
 
         # Apply constraints
-        self.apply_constraints(self.opt, self._constraints)
+        if self._constraints is not None:
+            self.apply_constraints(self.opt, self._constraints)
 
         # Set state vector bounds
         self.opt.set_lower_bounds(bounds[0])
@@ -205,9 +206,8 @@ class OptimisationProblem(ABC):
             Iterable of OptimisationConstraint objects containing optimisation
             constraints to be applied to the Optimiser.
         """
-        if opt_constraints is not None:
-            for _opt_constraint in opt_constraints:
-                _opt_constraint.apply_constraint(self)
+        for _opt_constraint in opt_constraints:
+            _opt_constraint.apply_constraint(self)
         return opt
 
     def initialise_state(self, parameterisation) -> np.array:

--- a/examples/design/design_shapes.ipynb
+++ b/examples/design/design_shapes.ipynb
@@ -5,7 +5,10 @@
       "metadata": {},
       "source": [
         "from bluemira.base.design import Design\n",
-        "from bluemira.geometry.optimisation import GeometryOptimisationProblem"
+        "from bluemira.geometry.optimisation import GeometryOptimisationProblem, calculate_length\n",
+        "from bluemira.geometry.parameterisations import GeometryParameterisation\n",
+        "from bluemira.utilities.opt_problems import OptimisationObjective\n",
+        "from bluemira.utilities.optimiser import Optimiser, approx_derivative"
       ],
       "outputs": [],
       "execution_count": null
@@ -34,34 +37,38 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "def maximise_length(vector, grad, parameterisation, ad_args=None):\n",
+        "    \"\"\"\n",
+        "    Objective function for maximising the length of the given parameterisation.\n",
+        "    \"\"\"\n",
+        "    ad_args = ad_args if ad_args is not None else {}\n",
+        "\n",
+        "    # Negative length since we are maximising\n",
+        "    length = -calculate_length(vector, parameterisation)\n",
+        "    if grad.size > 0:\n",
+        "        grad[:] = approx_derivative(\n",
+        "            calculate_length, vector, f0=length, args=(parameterisation,), **ad_args\n",
+        "        )\n",
+        "    return length\n",
+        "\n",
+        "\n",
         "class MaximiseLength(GeometryOptimisationProblem):\n",
         "    \"\"\"\n",
-        "    A simple geometry optimisation problem that minimises length without constraints.\n",
+        "    A simple geometry optimisation problem that maximises length without constraints.\n",
         "    \"\"\"\n",
         "\n",
-        "    def calculate_length(self, x):\n",
-        "        \"\"\"\n",
-        "        Calculate the length of the GeometryParameterisation.\n",
-        "\n",
-        "        Result is negative as we're maximising rather than minimising. Note that most\n",
-        "        real life problems will minimise.\n",
-        "        \"\"\"\n",
-        "        self.update_parameterisation(x)\n",
-        "        return -self.parameterisation.create_shape().length\n",
-        "\n",
-        "    def f_objective(self, x, grad):\n",
-        "        \"\"\"\n",
-        "        Objective function is the length of the parameterised shape.\n",
-        "        \"\"\"\n",
-        "        length = self.calculate_length(x)\n",
-        "\n",
-        "        if grad.size > 0:\n",
-        "            # Only called if a gradient-based optimiser is used\n",
-        "            grad[:] = self.optimiser.approx_derivative(\n",
-        "                self.calculate_length, x, f0=length\n",
-        "            )\n",
-        "\n",
-        "        return length"
+        "    def __init__(\n",
+        "        self,\n",
+        "        geometry_parameterisation: GeometryParameterisation,\n",
+        "        optimiser: Optimiser,\n",
+        "    ):\n",
+        "        objective = OptimisationObjective(\n",
+        "            f_objective=maximise_length,\n",
+        "            f_objective_args={\"parameterisation\": geometry_parameterisation},\n",
+        "        )\n",
+        "        super().__init__(\n",
+        "            geometry_parameterisation, optimiser, objective, constraints=None\n",
+        "        )"
       ],
       "outputs": [],
       "execution_count": null
@@ -236,7 +243,7 @@
       "source": [
         "tf_builder = design.get_builder(\"TF Coils\")\n",
         "tf_design_problem: GeometryOptimisationProblem = tf_builder.design_problem\n",
-        "print(tf_design_problem.parameterisation.variables)"
+        "print(tf_design_problem._parameterisation.variables)"
       ],
       "outputs": [],
       "execution_count": null
@@ -259,7 +266,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.13"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
## Linked Issues

Closes #1322 

## Description

Fixes the broken example (`examples/design/design_shapes.py`), which was using the old API for setting up an optimisation problem.

We need to look into writing some documentation for setting up optimisation problems. I think we could also consider writing a `run_geometry_optimisation` function that wraps all this object creation; I believe this would significantly lower the barrier to entry,

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
