### PR TITLE
✨ Component tree method and get_n_sectors function

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -26,11 +26,12 @@ Interfaces for builder classes.
 from __future__ import annotations
 
 import abc
-from typing import Dict, Generic, Optional, Type, TypeVar, Union
+from typing import Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from bluemira.base.components import Component
 from bluemira.base.designer import Designer
 from bluemira.base.parameter import ParameterFrame
+from bluemira.utilities.plot_tools import set_component_view
 
 _ComponentManagerT = TypeVar("_ComponentManagerT")
 _ParameterFrameT = TypeVar("_ParameterFrameT", bound=ParameterFrame)
@@ -80,6 +81,36 @@ class Builder(abc.ABC, Generic[_ComponentManagerT]):
     def build(self) -> _ComponentManagerT:
         """Build the component."""
         return Component(self.name)
+
+    def component_tree(
+        self, xz: List[Component], xy: List[Component], xyz: List[Component]
+    ) -> Component:
+        """
+        Adds views of components to an overall component tree
+
+        Parameters
+        ----------
+        xz: List[Component]
+            xz view of component
+        xy: List[Component]
+            xy view of component
+        xyz: List[Component]
+            xyz view of component
+
+        Returns
+        -------
+        component
+
+        """
+        component = super().build()
+        component.add_child(Component("xz", children=xz))
+        component.add_child(Component("xy", children=xy))
+        component.add_child(Component("xyz", children=xyz))
+
+        set_component_view(component.get_component("xz"), "xz")
+        set_component_view(component.get_component("xy"), "xy")
+
+        return component
 
     def _init_params(
         self, params: Union[Dict, _ParameterFrameT, None]

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -102,7 +102,7 @@ class Builder(abc.ABC, Generic[_ComponentManagerT]):
         component
 
         """
-        component = super().build()
+        component = Builder.build(self)
         component.add_child(Component("xz", children=xz))
         component.add_child(Component("xy", children=xy))
         component.add_child(Component("xyz", children=xyz))

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -88,12 +88,13 @@ class PFCoilBuilder(Builder):
         Build the PFCoil component.
         """
         xz_cross_section = self.designer.run()
-
-        component = super().build()
-        component.add_child(Component("xz", children=self.build_xz(xz_cross_section)))
-        component.add_child(Component("xy", children=self.build_xy(xz_cross_section)))
-        component.add_child(Component("xyz", children=self.build_xyz(xz_cross_section)))
-        return PFCoil(component)
+        return PFCoil(
+            self.component_tree(
+                xz=self.build_xz(xz_cross_section),
+                xy=self.build_xy(xz_cross_section),
+                xyz=self.build_xyz(xz_cross_section),
+            )
+        )
 
     def build_xy(self, shape: BluemiraWire) -> List[PhysicalComponent]:
         """

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -34,6 +34,10 @@ from bluemira.geometry.wire import BluemiraWire
 
 
 class Plasma:
+    """
+    Plasma Component Manager TODO
+    """
+
     def __init__(self, component_tree: Component):
         self._component_tree = component_tree
 
@@ -68,17 +72,41 @@ class PlasmaBuilder(Builder):
         super().__init__(None, build_config, designer)
 
     def build(self) -> Plasma:
+        """
+        Build the plasma component.
+        """
         xz_lcfs = self.designer.run()
-        component = self._build_component_tree(xz_lcfs)
-        return Plasma(component)
+        return Plasma(
+            self.component_tree(
+                xz=[self.build_xz(xz_lcfs)],
+                xy=[self.build_xy(xz_lcfs)],
+                xyz=[self.build_xyz(xz_lcfs)],
+            )
+        )
 
     def build_xz(self, lcfs: BluemiraWire) -> PhysicalComponent:
+        """
+        Build the x-z components of the plasma.
+
+        Parameters
+        ----------
+        lcfs: BluemiraWire
+            LCFS wire
+        """
         face = BluemiraFace(lcfs, self.name)
         component = PhysicalComponent(self.LCFS, face)
         component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]
         return component
 
     def build_xy(self, lcfs: BluemiraWire) -> PhysicalComponent:
+        """
+        Build the x-y components of the plasma.
+
+        Parameters
+        ----------
+        lcfs: BluemiraWire
+            LCFS wire
+        """
         inner = make_circle(lcfs.bounding_box.x_min, axis=[0, 1, 0])
         outer = make_circle(lcfs.bounding_box.x_max, axis=[0, 1, 0])
         face = BluemiraFace([outer, inner], self.name)
@@ -87,14 +115,17 @@ class PlasmaBuilder(Builder):
         return component
 
     def build_xyz(self, lcfs: BluemiraWire, degree: float = 360.0) -> PhysicalComponent:
+        """
+        Build the x-y-z components of the plasma.
+
+        Parameters
+        ----------
+        lcfs: BluemiraWire
+            LCFS wire
+        degree: float
+            degrees to sweep the shape
+        """
         shell = revolve_shape(lcfs, direction=(0, 0, 1), degree=degree)
         component = PhysicalComponent(self.LCFS, shell)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
-        return component
-
-    def _build_component_tree(self, lcfs: BluemiraWire) -> Component:
-        component = Component(self.name)
-        component.add_child(Component("xz", children=[self.build_xz(lcfs)]))
-        component.add_child(Component("xy", children=[self.build_xy(lcfs)]))
-        component.add_child(Component("xyz", children=[self.build_xyz(lcfs)]))
         return component

--- a/bluemira/builders/tools.py
+++ b/bluemira/builders/tools.py
@@ -46,11 +46,37 @@ from bluemira.geometry.tools import (
 )
 
 __all__ = [
+    "get_n_sectors",
     "circular_pattern_component",
     "pattern_revolved_silhouette",
     "pattern_lofted_silhouette",
     "varied_offset",
+    "find_xy_plane_radii",
+    "make_circular_xy_ring",
 ]
+
+
+def get_n_sectors(no_obj, degree=360):
+    """
+    Get sector count and angle size for a given number of degrees of the reactor.
+
+    Parameters
+    ----------
+    no_obj: int
+        total number of components (eg TF coils)
+    degree: float
+        angle to view of reactor
+
+    Returns
+    -------
+    sector_degree: float
+        number of degrees per sector
+    n_sectors: int
+        number of sectors
+    """
+    sector_degree = 360 / no_obj
+    n_sectors = max(1, int(degree // int(sector_degree)))
+    return sector_degree, n_sectors
 
 
 def circular_pattern_component(

--- a/tests/base/test_builder.py
+++ b/tests/base/test_builder.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 from bluemira.base.builder import Builder
+from bluemira.base.components import Component
 
 
 class ParamClass:
@@ -49,3 +50,21 @@ class TestBuilder:
         builder = StubBuilder(self._params, {})
 
         assert builder.name == "Stub"
+
+    def test_component_tree(self):
+        builder = StubBuilder(self._params, {})
+        component = builder.component_tree(
+            xz=[Component("p1")], xy=[Component("p2")], xyz=[Component("p3")]
+        )
+        assert len(component.descendants) == 6
+        assert len(component.children) == 3
+        assert [ch.name for ch in component.children] == ["xz", "xy", "xyz"]
+        # xyz child's view is not changed from the default
+        assert [desc.plot_options.view for desc in component.descendants] == [
+            "xz",
+            "xz",
+            "xy",
+            "xy",
+            "xz",
+            "xz",
+        ]

--- a/tests/builders/test_tools.py
+++ b/tests/builders/test_tools.py
@@ -27,6 +27,7 @@ from scipy.interpolate import interp1d
 
 from bluemira.base.error import BuilderError
 from bluemira.builders.tools import (
+    get_n_sectors,
     make_circular_xy_ring,
     pattern_lofted_silhouette,
     pattern_revolved_silhouette,
@@ -42,6 +43,37 @@ from bluemira.geometry.tools import (
     make_polygon,
 )
 from bluemira.geometry.wire import BluemiraWire
+
+
+class TestGetNSectors:
+    sector_degree = [
+        360.0,
+        180.0,
+        120.0,
+        90.0,
+        72.0,
+        60.0,
+        51.42857142857143,
+        45.0,
+        40.0,
+        36.0,
+        32.72727272727273,
+        30.0,
+        27.692307692307693,
+        25.714285714285715,
+        24.0,
+    ]
+
+    @pytest.mark.parametrize("ttl, sector_degree", zip(np.arange(1, 16), sector_degree))
+    @pytest.mark.parametrize("degree", np.arange(0, 361, step=60))
+    def test_get_n_sectors(self, degree, ttl, sector_degree):
+        s_deg, n_sec = get_n_sectors(ttl, degree)
+        assert np.isclose(s_deg, sector_degree)
+        try:
+            assert np.isclose(degree // sector_degree, n_sec)
+        except AssertionError:
+            # a sector at both ends
+            assert np.isclose((degree // sector_degree) + 1, n_sec)
 
 
 class TestVariedOffsetFunction:

--- a/tests/builders/test_tools.py
+++ b/tests/builders/test_tools.py
@@ -64,16 +64,24 @@ class TestGetNSectors:
         24.0,
     ]
 
+    n_sectors = {
+        1: [1, 1, 1, 1, 1, 1, 1],
+        5: [1, 1, 1, 2, 3, 4, 5],
+        7: [1, 1, 2, 3, 4, 5, 7],
+        9: [1, 1, 3, 4, 6, 7, 9],
+    }
+
     @pytest.mark.parametrize("ttl, sector_degree", zip(np.arange(1, 16), sector_degree))
     @pytest.mark.parametrize("degree", np.arange(0, 361, step=60))
-    def test_get_n_sectors(self, degree, ttl, sector_degree):
-        s_deg, n_sec = get_n_sectors(ttl, degree)
+    def test_get_n_sectors_degree(self, degree, ttl, sector_degree):
+        s_deg, _ = get_n_sectors(ttl, degree)
         assert np.isclose(s_deg, sector_degree)
-        try:
-            assert np.isclose(degree // sector_degree, n_sec)
-        except AssertionError:
-            # a sector at both ends
-            assert np.isclose((degree // sector_degree) + 1, n_sec)
+
+    @pytest.mark.parametrize("ttl", n_sectors.keys())
+    @pytest.mark.parametrize("degree", np.arange(0, 361, step=60))
+    def test_get_n_sectors_amount(self, degree, ttl):
+        _, n_sec = get_n_sectors(ttl, degree)
+        assert np.isclose(n_sec, self.n_sectors[ttl].pop(0))
 
 
 class TestVariedOffsetFunction:


### PR DESCRIPTION
## Description

Adds some helper functions for builders. Unsure about whether I should get the `component` in the `component_tree` function, it feels nicer from usability as written though.

Possibly overkill on the `get_n_sectors` tests but couldn't think of a nicer test/ less of them (~100 now). Could halve it again?

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
