### PR TITLE
🐛 topology workaround

### DIFF
--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -131,6 +131,8 @@ class BluemiraFace(BluemiraGeo):
                 w_orientation = w.Orientation
                 bm_wire = BluemiraWire(w)
                 bm_wire._orientation = w_orientation
+                if cadapi.is_closed(w):
+                    bm_wire.close()
                 bmwires += [bm_wire]
             bmface = cls(bmwires, label=label)
             bmface._orientation = orientation

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -98,11 +98,7 @@ class BluemiraWire(BluemiraGeo):
                 for w in o.Wires:
                     wire = cadapi.apiWire(w.OrderedEdges)
                     if self._orientation != _Orientation(wire.Orientation):
-                        edges = []
-                        for edge in wire.OrderedEdges:
-                            edge.reverse()
-                            edges.append(edge)
-                        wire = cadapi.apiWire(edges)
+                        wire.reverse()
                     wires += [wire]
             else:
                 wires += o._wires

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+from unittest.mock import patch
+
 import freecad  # noqa: F401
 import numpy as np
 import Part
@@ -45,6 +47,28 @@ class TestFreecadapi:
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ]
+
+    def test_offset_wire_arranged_edges(self):
+        def offsetter(wire):
+            return cadapi.offset_wire(
+                wire,
+                0.05,
+                join="intersect",
+                open_wire=False,
+            )
+
+        circ = cadapi.make_circle(10)
+        with patch("bluemira.codes._freecadapi.arrange_edges", new=lambda a, b: b):
+            wire1 = offsetter(circ)
+            wire2 = offsetter(wire1)
+
+        wire1_a = offsetter(circ)
+        wire2_a = offsetter(wire1_a)
+        assert circ.Length < wire1.Length
+        # these two should break in future, this mean the topo naming may be fixed
+        assert circ.Length == wire2.Length
+        assert wire1.Length > wire2.Length
+        assert circ.Length < wire1_a.Length < wire2_a.Length
 
     def test_fail_vector_to_numpy(self):
         with pytest.raises(TypeError):

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -48,27 +48,45 @@ class TestFreecadapi:
             (0.0, 0.0, 0.0),
         ]
 
-    def test_offset_wire_arranged_edges(self):
-        def offsetter(wire):
-            return cadapi.offset_wire(
-                wire,
-                0.05,
-                join="intersect",
-                open_wire=False,
-            )
+    @staticmethod
+    def offsetter(wire):
+        return cadapi.offset_wire(
+            wire,
+            0.05,
+            join="intersect",
+            open_wire=False,
+        )
+
+    def test_multi_offset_wire(self):
+        circ = cadapi.make_circle(10)
+        wire1 = self.offsetter(circ)
+        wire2 = self.offsetter(wire1)
+
+        assert circ.Length < wire1.Length < wire2.Length
+
+    def test_multi_offset_wire_without_arranged_edges(self):
+        """
+        FreeCAD Topological naming bug
+
+        As of 08/2022 FreeCAD has a ordering/naming bug as detailed in #1347.
+        The result is that some operations do not work as expected (such as offset_wire)
+        Some operations when repeated also raise errors such as DisjointedFace errors.
+        arrange_edges tries to reorder the internal edges of a wire to attempt to side
+        step the issue.
+
+        FreeCAD aims to fix this for v1 which is due for release in 2023.
+        When that happens our work arounds can be removed (including this test)
+        """
 
         circ = cadapi.make_circle(10)
         with patch("bluemira.codes._freecadapi.arrange_edges", new=lambda a, b: b):
-            wire1 = offsetter(circ)
-            wire2 = offsetter(wire1)
+            wire1 = self.offsetter(circ)
+            wire2 = self.offsetter(wire1)
 
-        wire1_a = offsetter(circ)
-        wire2_a = offsetter(wire1_a)
         assert circ.Length < wire1.Length
         # these two should break in future, this mean the topo naming may be fixed
         assert circ.Length == wire2.Length
         assert wire1.Length > wire2.Length
-        assert circ.Length < wire1_a.Length < wire2_a.Length
 
     def test_fail_vector_to_numpy(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
## Linked Issues

Part of #1347 and #1319 

## Description

This makes offset wire a bit more robust and therefore hopefully most of the build

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
