### PR TITLE
Refactor Designer

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -26,10 +26,9 @@ Interfaces for builder classes.
 from __future__ import annotations
 
 import abc
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Type, Union
 
 from bluemira.base.components import Component
-from bluemira.base.designer import Designer
 from bluemira.base.parameter_frame import NewParameterFrame as ParameterFrame
 from bluemira.base.parameter_frame import make_parameter_frame
 from bluemira.utilities.plot_tools import set_component_view
@@ -101,19 +100,13 @@ class Builder(abc.ABC):
     `param_cls` to `None` and pass `None` into this class's constructor.
     """
 
-    def __init__(
-        self,
-        params: Union[ParameterFrame, Dict, None],
-        build_config: Dict,
-        designer: Optional[Designer] = None,
-    ):
+    def __init__(self, params: Union[ParameterFrame, Dict, None], build_config: Dict):
         super().__init__()
         self.name = build_config.get(
             "name", _remove_suffix(self.__class__.__name__, "Builder")
         )
         self.params = make_parameter_frame(params, self.param_cls)
         self.build_config = build_config
-        self.designer = designer
 
     @abc.abstractproperty
     def param_cls(self) -> Union[Type[ParameterFrame], None]:

--- a/bluemira/base/designer.py
+++ b/bluemira/base/designer.py
@@ -31,7 +31,7 @@ from bluemira.base.parameter_frame import make_parameter_frame
 _DesignerReturnT = TypeVar("_DesignerReturnT")
 
 
-class Designer(Generic[_DesignerReturnT]):
+class Designer(abc.ABC, Generic[_DesignerReturnT]):
     """
     Base class for 'Designers' that solver design problems as part of
     building a reactor component.

--- a/bluemira/base/designer.py
+++ b/bluemira/base/designer.py
@@ -38,7 +38,7 @@ class Designer(abc.ABC, Generic[_DesignerReturnT]):
 
     Parameters
     ----------
-    params: Optional[ParameterFrame, Dict]
+    params: Union[Dict, ParameterFrame, None]
         The parameters required by the designer.
     build_config: Optional[Dict]
         The build configuration options for the designer.

--- a/bluemira/builders/cryostat.py
+++ b/bluemira/builders/cryostat.py
@@ -22,6 +22,7 @@
 """
 Cryostat builder
 """
+from dataclasses import dataclass
 from typing import Dict, List, Tuple, Type, Union
 
 import numpy as np
@@ -31,7 +32,6 @@ from bluemira.base.components import PhysicalComponent
 from bluemira.base.designer import Designer
 from bluemira.base.parameter_frame import NewParameter as Parameter
 from bluemira.base.parameter_frame import NewParameterFrame as ParameterFrame
-from bluemira.base.parameter_frame import parameter_frame
 from bluemira.builders.tools import circular_pattern_component, get_n_sectors
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
@@ -44,8 +44,8 @@ class Cryostat(ComponentManager):
     """
 
 
-@parameter_frame
-class CryostatDesignerParams:
+@dataclass
+class CryostatDesignerParams(ParameterFrame):
     """
     Cryostat designer parameters
     """
@@ -53,8 +53,8 @@ class CryostatDesignerParams:
     g_cr_ts: Parameter[float]
 
 
-@parameter_frame
-class CryostatBuilderParams:
+@dataclass
+class CryostatBuilderParams(ParameterFrame):
     """
     Cryostat builder parameters
     """
@@ -71,7 +71,7 @@ class CryostatBuilderParams:
     z_gs: Parameter[float]
 
 
-class CryostatDesigner(Designer[BluemiraFace]):
+class CryostatDesigner(Designer[Tuple[float, float]]):
     """
     Designer for the cryostat
     """
@@ -86,7 +86,7 @@ class CryostatDesigner(Designer[BluemiraFace]):
         super().__init__(params)
         self.cryo_ts_xz = cryo_ts_xz
 
-    def run(self) -> Tuple[float]:
+    def run(self) -> Tuple[float, float]:
         """
         Cryostat designer run method
         """

--- a/bluemira/builders/cryostat.py
+++ b/bluemira/builders/cryostat.py
@@ -106,18 +106,28 @@ class CryostatBuilder(Builder):
     CRYO = "Cryostat VV"
     param_cls: Type[CryostatBuilderParams] = CryostatBuilderParams
 
+    def __init__(
+        self,
+        params: Union[ParameterFrame, Dict, None],
+        build_config: Dict,
+        x_out: float,
+        z_top: float,
+    ):
+        super().__init__(params, build_config)
+        self.x_out = x_out
+        self.z_top = z_top
+
     def build(self) -> Cryostat:
         """
         Build the cryostat component.
         """
-        x_out, z_top = self.designer.run()
-        xz_cryostat = self.build_xz(x_out, z_top)
-        xz_cross_section = xz_cryostat.get_component_properties("shape")
+        xz_cryostat = self.build_xz(self.x_out, self.z_top)
+        xz_cross_section: BluemiraFace = xz_cryostat.get_component_properties("shape")
 
         return Cryostat(
             self.component_tree(
                 xz=[xz_cryostat],
-                xy=[self.build_xy(x_out)],
+                xy=[self.build_xy(self.x_out)],
                 xyz=self.build_xyz(xz_cross_section),
             )
         )

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -72,20 +72,20 @@ class PFCoilBuilder(Builder):
         self,
         params: Union[PFCoilBuilderParams, Dict],
         build_config: Dict,
-        designer: Designer[BluemiraWire],
+        xz_cross_section: BluemiraWire,
     ):
-        super().__init__(params, build_config, designer)
+        super().__init__(params, build_config)
+        self.xz_cross_section = xz_cross_section
 
     def build(self) -> PFCoil:
         """
         Build the PFCoil component.
         """
-        xz_cross_section = self.designer.run()
         return PFCoil(
             self.component_tree(
-                xz=self.build_xz(xz_cross_section),
-                xy=self.build_xy(xz_cross_section),
-                xyz=self.build_xyz(xz_cross_section),
+                xz=self.build_xz(self.xz_cross_section),
+                xy=self.build_xy(self.xz_cross_section),
+                xyz=self.build_xyz(self.xz_cross_section),
             )
         )
 

--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -26,7 +26,6 @@ from typing import Dict
 
 from bluemira.base.builder import Builder, ComponentManager
 from bluemira.base.components import PhysicalComponent
-from bluemira.base.designer import Designer
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import make_circle, revolve_shape
@@ -61,20 +60,20 @@ class PlasmaBuilder(Builder):
     def __init__(
         self,
         build_config: Dict,
-        designer: Designer[BluemiraWire],
+        xz_lcfs: BluemiraWire,
     ):
-        super().__init__(None, build_config, designer)
+        super().__init__(None, build_config)
+        self.xz_lcfs = xz_lcfs
 
     def build(self) -> Plasma:
         """
         Build the plasma component.
         """
-        xz_lcfs = self.designer.run()
         return Plasma(
             self.component_tree(
-                xz=[self.build_xz(xz_lcfs)],
-                xy=[self.build_xy(xz_lcfs)],
-                xyz=[self.build_xyz(xz_lcfs)],
+                xz=[self.build_xz(self.xz_lcfs)],
+                xy=[self.build_xy(self.xz_lcfs)],
+                xyz=[self.build_xyz(self.xz_lcfs)],
             )
         )
 

--- a/tests/base/test_designer.py
+++ b/tests/base/test_designer.py
@@ -24,6 +24,8 @@ from bluemira.base.designer import Designer
 
 
 class SimpleDesigner(Designer):
+    param_cls = None
+
     def run(self) -> int:
         return 10
 
@@ -35,8 +37,6 @@ class SimpleDesigner(Designer):
 
 
 class TestDesigner:
-    param_cls = None
-
     def test_execute_calls_run_if_no_run_mode_in_build_config(self):
         designer = SimpleDesigner(None, {})
 

--- a/tests/base/test_designer.py
+++ b/tests/base/test_designer.py
@@ -1,0 +1,53 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris,
+#                    D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+import pytest
+
+from bluemira.base.designer import Designer
+
+
+class SimpleDesigner(Designer):
+    def run(self) -> int:
+        return 10
+
+    def mock(self) -> int:
+        return 11
+
+    def read(self) -> int:
+        return 12
+
+
+class TestDesigner:
+    param_cls = None
+
+    def test_execute_calls_run_if_no_run_mode_in_build_config(self):
+        designer = SimpleDesigner(None, {})
+
+        assert designer.execute() == 10
+
+    @pytest.mark.parametrize("mode, output", [("run", 10), ("mock", 11), ("read", 12)])
+    def test_execute_calls_function_given_by_run_mode(self, mode, output):
+        designer = SimpleDesigner(None, {"run_mode": mode})
+
+        assert designer.execute() == output
+
+    def test_ValueError_on_init_given_unknown_run_mode(self):
+        with pytest.raises(ValueError):
+            SimpleDesigner(None, {"run_mode": "not_a_mode"})

--- a/tests/base/test_designer.py
+++ b/tests/base/test_designer.py
@@ -35,6 +35,9 @@ class SimpleDesigner(Designer):
     def read(self) -> int:
         return 12
 
+    def custom_run_mode(self) -> int:
+        return 13
+
 
 class TestDesigner:
     def test_execute_calls_run_if_no_run_mode_in_build_config(self):
@@ -42,7 +45,10 @@ class TestDesigner:
 
         assert designer.execute() == 10
 
-    @pytest.mark.parametrize("mode, output", [("run", 10), ("mock", 11), ("read", 12)])
+    @pytest.mark.parametrize(
+        "mode, output",
+        [("run", 10), ("mock", 11), ("read", 12), ("custom_run_mode", 13)],
+    )
     def test_execute_calls_function_given_by_run_mode(self, mode, output):
         designer = SimpleDesigner(None, {"run_mode": mode})
 

--- a/tests/builders/test_cryostat.py
+++ b/tests/builders/test_cryostat.py
@@ -41,8 +41,7 @@ class TestCryostatBuilder:
         }
 
     def test_components_and_segments(self):
-        designer = mock.Mock(run=lambda: (10, 10))
-        builder = CryostatBuilder(self.params, {}, designer)
+        builder = CryostatBuilder(self.params, {}, 10, 10)
         cryostat = builder.build()
 
         assert cryostat.component().get_component("xz")

--- a/tests/builders/test_pf_coil.py
+++ b/tests/builders/test_pf_coil.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-from unittest import mock
-
 from bluemira.builders.pf_coil import PFCoilBuilder
 from bluemira.geometry.tools import make_polygon
 
@@ -40,8 +38,7 @@ class TestPFCoilBuilder:
         }
 
     def test_component_dimensions_are_built(self):
-        designer = mock.Mock(run=lambda: self.square)
-        builder = PFCoilBuilder(self.params, {}, designer)
+        builder = PFCoilBuilder(self.params, {}, self.square)
 
         coil = builder.build()
 

--- a/tests/builders/test_plasma.py
+++ b/tests/builders/test_plasma.py
@@ -23,8 +23,6 @@
 Tests for plasma builder.
 """
 
-from unittest import mock
-
 from bluemira.builders.plasma import PlasmaBuilder
 from bluemira.geometry.tools import make_polygon
 
@@ -39,8 +37,7 @@ class TestPlasmaBuilder:
         )
 
     def test_plasma_contains_components_in_3_dimensions(self):
-        designer = mock.Mock(run=lambda: self.square)
-        builder = PlasmaBuilder({}, designer)
+        builder = PlasmaBuilder({}, self.square)
         plasma = builder.build()
 
         assert plasma.component().get_component("xz")
@@ -48,8 +45,7 @@ class TestPlasmaBuilder:
         assert plasma.component().get_component("xyz")
 
     def test_lcfs_eq_to_designer_shape(self):
-        designer = mock.Mock(run=lambda: self.square)
-        builder = PlasmaBuilder({}, designer)
+        builder = PlasmaBuilder({}, self.square)
 
         plasma = builder.build()
 

--- a/tests/builders/test_thermal_shield.py
+++ b/tests/builders/test_thermal_shield.py
@@ -22,16 +22,9 @@
 """
 Tests for thermal shield builders.
 """
-from unittest import mock
-
 import numpy as np
 
-from bluemira.builders.thermal_shield import (
-    CryostatTSBuilder,
-    CryostatTSDesigner,
-    VVTSBuilder,
-    VVTSDesigner,
-)
+from bluemira.builders.thermal_shield import CryostatTSBuilder, VVTSBuilder
 from bluemira.display.displayer import show_cad
 from bluemira.geometry.parameterisations import PrincetonD
 from bluemira.geometry.tools import make_circle, make_polygon
@@ -48,9 +41,7 @@ class TestVVTSBuilder:
         cls.vv_koz = make_circle(10, center=(15, 0, 0), axis=(0.0, 1.0, 0.0))
 
     def test_components_and_segments(self):
-        designer = mock.Mock(run=lambda: self.vv_koz)
-
-        builder = VVTSBuilder(self.params, {}, designer)
+        builder = VVTSBuilder(self.params, {}, self.vv_koz)
         vvts = builder.build()
 
         assert vvts.component().get_component("xz")
@@ -90,8 +81,7 @@ class TestCryostatTSBuilder:
         cls.tf_xz_koz = PrincetonD().create_shape()
 
     def test_components_and_segments(self):
-        designer = mock.Mock(run=lambda: (self.pf_coil_koz, self.tf_xz_koz))
-        builder = CryostatTSBuilder(self.params, {}, designer)
+        builder = CryostatTSBuilder(self.params, {}, self.pf_coil_koz, self.tf_xz_koz)
         cryostat_ts = builder.build()
 
         assert cryostat_ts.component().get_component("xz")
@@ -100,19 +90,3 @@ class TestCryostatTSBuilder:
         xyz = cryostat_ts.component().get_component("xyz")
         assert xyz
         assert len(xyz.leaves) == self.params["n_TF"]["value"]
-
-
-class TestThermalShieldDesigners:
-    """
-    What goes in comes out
-    """
-
-    def test_vvtsdesigner(self):
-        _in = 1
-        designer = VVTSDesigner(_in)
-        assert designer.run() == _in
-
-    def test_cryotsdesigner(self):
-        _in = 1, 2
-        designer = CryostatTSDesigner(*_in)
-        assert designer.run() == _in


### PR DESCRIPTION
## Description

Updates the `Designer` interface to include a mandatory `run` method, and optional `read` and `mock` modes.

Makes `Builder` and the base `Builders` agnostic of `Designer`s - this means we can remove all the in-out designers we were having to define.

I haven't looked at updating the EUDEMO designers yet - maybe we should do those separately.