### PR TITLE
Improve ParameterFrame typing

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import copy
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Tuple, Type, TypeVar, Union, get_args
+from typing import Any, Dict, Tuple, Type, TypeVar, Union, get_args
 
-from bluemira.base.parameter_frame._parameter import NewParameter, ParameterValueType
+from bluemira.base.parameter_frame._parameter import NewParameter, ParamDictT
 
 _PfT = TypeVar("_PfT", bound="NewParameterFrame")
 
@@ -35,7 +35,7 @@ class NewParameterFrame:
     @classmethod
     def from_dict(
         cls: Type[_PfT],
-        data: Dict[str, Mapping[str, Union[str, ParameterValueType]]],
+        data: Dict[str, ParamDictT],
         allow_unknown=False,
     ) -> _PfT:
         """Initialize an instance from a dictionary."""
@@ -101,20 +101,18 @@ class NewParameterFrame:
 
 
 def make_parameter_frame(
-    params: Union[Dict, NewParameterFrame, None],
-    param_cls: Type[NewParameterFrame],
-) -> Union[NewParameterFrame, None]:
+    params: Union[Dict[str, ParamDictT], NewParameterFrame, None],
+    param_cls: Type[_PfT],
+) -> Union[_PfT, None]:
     """
-    Helper function to generate a `ParameterFrame` of a specific type
+    Factory function to generate a `ParameterFrame` of a specific type.
 
     Parameters
     ----------
-    params: Union[Dict, NewParameterFrame, None]
+    params: Union[Dict[str, ParamDictT], NewParameterFrame, None]
         The parameters to initialise the class with
     param_cls: Type[NewParameterFrame]
         The `ParameterFrame` class to generate
-
-
     """
     if param_cls is None:
         if params is None:

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import copy
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Tuple, Type, Union, get_args
+from typing import Any, Dict, Mapping, Tuple, Type, TypeVar, Union, get_args
 
 from bluemira.base.parameter_frame._parameter import NewParameter, ParameterValueType
+
+_PfT = TypeVar("_PfT", bound="NewParameterFrame")
 
 
 @dataclass
@@ -32,10 +34,10 @@ class NewParameterFrame:
 
     @classmethod
     def from_dict(
-        cls,
+        cls: Type[_PfT],
         data: Dict[str, Mapping[str, Union[str, ParameterValueType]]],
         allow_unknown=False,
-    ):
+    ) -> _PfT:
         """Initialize an instance from a dictionary."""
         data = copy.deepcopy(data)
         kwargs: Dict[str, NewParameter] = {}
@@ -52,26 +54,8 @@ class NewParameterFrame:
             raise ValueError(f"Unknown parameter(s) '{list(data)}' in dict.")
         return cls(**kwargs)
 
-    def to_dict(self) -> Dict[str, Dict[str, Any]]:
-        """Serialize this NewParameterFrame to a dictionary."""
-        out = {}
-        for member in self.__dataclass_fields__:
-            out[member] = getattr(self, member).to_dict()
-        return out
-
     @classmethod
-    def _validate_parameter_field(cls, field: str) -> Tuple[Type]:
-        member_type = cls.__dataclass_fields__[field].type
-        if (member_type is not NewParameter) and (
-            not hasattr(member_type, "__origin__")
-            or member_type.__origin__ is not NewParameter
-        ):
-            raise TypeError(f"Field '{field}' does not have type NewParameter.")
-        value_types = get_args(member_type)
-        return value_types
-
-    @classmethod
-    def from_frame(cls, frame: NewParameterFrame) -> NewParameterFrame:
+    def from_frame(cls: Type[_PfT], frame: NewParameterFrame) -> _PfT:
         """Initialise an instance from another NewParameterFrame."""
         kwargs = {}
         for field in cls.__dataclass_fields__:
@@ -85,7 +69,7 @@ class NewParameterFrame:
         return cls(**kwargs)
 
     @classmethod
-    def from_json(cls, json_in: Union[str, json.SupportsRead]) -> NewParameterFrame:
+    def from_json(cls: Type[_PfT], json_in: Union[str, json.SupportsRead]) -> _PfT:
         """Initialise an instance from a JSON file, string, or reader."""
         if hasattr(json_in, "read"):
             # load from file stream
@@ -96,6 +80,24 @@ class NewParameterFrame:
                 return cls.from_dict(json.load(f))
         # load from a JSON string
         return cls.from_dict(json.loads(json_in))
+
+    def to_dict(self) -> Dict[str, Dict[str, Any]]:
+        """Serialize this NewParameterFrame to a dictionary."""
+        out = {}
+        for member in self.__dataclass_fields__:
+            out[member] = getattr(self, member).to_dict()
+        return out
+
+    @classmethod
+    def _validate_parameter_field(cls, field: str) -> Tuple[Type, ...]:
+        member_type = cls.__dataclass_fields__[field].type
+        if (member_type is not NewParameter) and (
+            not hasattr(member_type, "__origin__")
+            or member_type.__origin__ is not NewParameter
+        ):
+            raise TypeError(f"Field '{field}' does not have type NewParameter.")
+        value_types = get_args(member_type)
+        return value_types
 
 
 def make_parameter_frame(

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -1,10 +1,21 @@
 import copy
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Tuple, Type, TypeVar
+from typing import Dict, Generic, List, Tuple, Type, TypedDict, TypeVar
 
 from typeguard import typechecked
 
 ParameterValueType = TypeVar("ParameterValueType")
+
+
+class ParamDictT(TypedDict, Generic[ParameterValueType]):
+    """Typed dictionary for a Parameter."""
+
+    name: str
+    value: ParameterValueType
+    unit: str
+    source: str
+    description: str
+    long_name: str
 
 
 @dataclass


### PR DESCRIPTION
## Description

Fixes a couple of typing issues that meant I was not getting autocomplete in cases where I was using the `classmethod` constructors of `ParameterFrame`.

Also rearranges the method declaration order in `ParameterFrame` so that all the constructors are together.