### PR TITLE
🐛 fix enum specified inner and remove limitations

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1356,7 +1356,10 @@ class PictureFrameMeta(type(GeometryParameterisation), type(PictureFrameTools)):
         cls.lower = lower if isinstance(lower, PFrameSection) else PFrameSection[lower]
 
         if isinstance(inner, str):
-            cls.inner = PFrameSection[inner]
+            inner = PFrameSection[inner]
+
+        if isinstance(inner, PFrameSection):
+            cls.inner = inner
             cls.inner_vars = lambda self, v: (v.x1, v.x3, v.z3, v.z1 - v.ri, v.z2 + v.ri)
         elif inner is None:
             cls.inner = cls._connect_straight_to_inner_limb

--- a/tests/geometry/test_parameterisations.py
+++ b/tests/geometry/test_parameterisations.py
@@ -190,34 +190,66 @@ class TestPictureFrame:
 
 class TestComplexPictureFrame:
     @pytest.mark.parametrize(
-        "upper, lower, result",
+        "upper, lower, inner, result",
         [
-            ["CURVED", "CURVED", 57.6308],
-            ["CURVED", "FLAT", 56.829],
-            ["FLAT", "CURVED", 56.829],
-            [PFrameSection.CURVED, PFrameSection.CURVED, 57.6308],
-            [PFrameSection.CURVED, PFrameSection.FLAT, 56.829],
-            [PFrameSection.FLAT, PFrameSection.CURVED, 56.829],
+            ["CURVED", "CURVED", "TAPERED_INNER", 56.331],
+            ["CURVED", "FLAT", "TAPERED_INNER", 54.714],
+            ["FLAT", "CURVED", "TAPERED_INNER", 54.714],
+            [
+                PFrameSection.CURVED,
+                PFrameSection.CURVED,
+                PFrameSection.TAPERED_INNER,
+                56.331,
+            ],
+            [
+                PFrameSection.CURVED,
+                PFrameSection.FLAT,
+                PFrameSection.TAPERED_INNER,
+                54.714,
+            ],
+            [
+                PFrameSection.FLAT,
+                PFrameSection.CURVED,
+                PFrameSection.TAPERED_INNER,
+                54.714,
+            ],
+            ["CURVED", "CURVED", None, 57.6308],
+            ["CURVED", "FLAT", None, 56.014],
+            ["FLAT", "CURVED", None, 56.014],
+            [PFrameSection.CURVED, PFrameSection.CURVED, None, 57.6308],
+            [PFrameSection.CURVED, PFrameSection.FLAT, None, 56.014],
+            [PFrameSection.FLAT, PFrameSection.CURVED, None, 56.014],
         ],
     )
-    def test_length(self, upper, lower, result):
-        p = PictureFrame(upper=upper, lower=lower)
+    def test_length(self, upper, lower, inner, result):
+        p = PictureFrame(upper=upper, lower=lower, inner=inner)
         wire = p.create_shape()
         assert np.isclose(wire.length, result, rtol=1e-4, atol=1e-5)
 
     @pytest.mark.parametrize(
-        "upper, lower",
+        "upper, lower, inner",
         [
-            ["CURVED", "CURVED"],
-            ["CURVED", "FLAT"],
-            ["FLAT", "CURVED"],
-            [PFrameSection.CURVED, PFrameSection.CURVED],
-            [PFrameSection.CURVED, PFrameSection.FLAT],
-            [PFrameSection.FLAT, PFrameSection.CURVED],
+            # should these pass?
+            # ["FLAT", "FLAT", "TAPERED_INNER"],
+            # ["CURVED", "CURVED", "TAPERED_INNER"],
+            # ["CURVED", "FLAT", "TAPERED_INNER"],
+            # ["FLAT", "CURVED", "TAPERED_INNER"],
+            # [PFrameSection.FLAT, PFrameSection.FLAT, PFrameSection.TAPERED_INNER],
+            # [PFrameSection.CURVED, PFrameSection.CURVED, PFrameSection.TAPERED_INNER],
+            # [PFrameSection.CURVED, PFrameSection.FLAT, PFrameSection.TAPERED_INNER],
+            # [PFrameSection.FLAT, PFrameSection.CURVED, PFrameSection.TAPERED_INNER],
+            ["FLAT", "FLAT", None],
+            ["CURVED", "CURVED", None],
+            ["CURVED", "FLAT", None],
+            ["FLAT", "CURVED", None],
+            [PFrameSection.FLAT, PFrameSection.FLAT, None],
+            [PFrameSection.CURVED, PFrameSection.CURVED, None],
+            [PFrameSection.CURVED, PFrameSection.FLAT, None],
+            [PFrameSection.FLAT, PFrameSection.CURVED, None],
         ],
     )
-    def test_ordering(self, upper, lower):
-        p = PictureFrame(upper=upper, lower=lower)
+    def test_ordering(self, upper, lower, inner):
+        p = PictureFrame(upper=upper, lower=lower, inner=inner)
         wire = p.create_shape()
         assert _wire_edges_tangent(wire._shape)
 

--- a/tests/geometry/test_parameterisations.py
+++ b/tests/geometry/test_parameterisations.py
@@ -31,6 +31,7 @@ from bluemira.codes._freecadapi import _wire_edges_tangent
 from bluemira.geometry.error import GeometryParameterisationError
 from bluemira.geometry.parameterisations import (
     GeometryParameterisation,
+    PFrameSection,
     PictureFrame,
     PolySpline,
     PrincetonD,
@@ -194,6 +195,9 @@ class TestComplexPictureFrame:
             ["CURVED", "CURVED", 57.6308],
             ["CURVED", "FLAT", 56.829],
             ["FLAT", "CURVED", 56.829],
+            [PFrameSection.CURVED, PFrameSection.CURVED, 57.6308],
+            [PFrameSection.CURVED, PFrameSection.FLAT, 56.829],
+            [PFrameSection.FLAT, PFrameSection.CURVED, 56.829],
         ],
     )
     def test_length(self, upper, lower, result):
@@ -202,7 +206,15 @@ class TestComplexPictureFrame:
         assert np.isclose(wire.length, result, rtol=1e-4, atol=1e-5)
 
     @pytest.mark.parametrize(
-        "upper, lower", [["CURVED", "CURVED"], ["CURVED", "FLAT"], ["FLAT", "CURVED"]]
+        "upper, lower",
+        [
+            ["CURVED", "CURVED"],
+            ["CURVED", "FLAT"],
+            ["FLAT", "CURVED"],
+            [PFrameSection.CURVED, PFrameSection.CURVED],
+            [PFrameSection.CURVED, PFrameSection.FLAT],
+            [PFrameSection.FLAT, PFrameSection.CURVED],
+        ],
     )
     def test_ordering(self, upper, lower):
         p = PictureFrame(upper=upper, lower=lower)
@@ -220,7 +232,14 @@ class TestComplexPictureFrame:
 
     @pytest.mark.parametrize(
         "vals",
-        [{"inner": "CURVED"}, {"upper": "TAPERED_INNER"}, {"lower": "TAPERED_INNER"}],
+        [
+            {"inner": "CURVED"},
+            {"upper": "TAPERED_INNER"},
+            {"lower": "TAPERED_INNER"},
+            {"inner": PFrameSection.CURVED},
+            {"upper": PFrameSection.TAPERED_INNER},
+            {"lower": PFrameSection.TAPERED_INNER},
+        ],
     )
     def test_bad_combinations_raise_ValueError(self, vals):
         with pytest.raises(ValueError):

--- a/tests/geometry/test_parameterisations.py
+++ b/tests/geometry/test_parameterisations.py
@@ -229,15 +229,34 @@ class TestComplexPictureFrame:
     @pytest.mark.parametrize(
         "upper, lower, inner",
         [
-            # should these pass?
-            # ["FLAT", "FLAT", "TAPERED_INNER"],
-            # ["CURVED", "CURVED", "TAPERED_INNER"],
-            # ["CURVED", "FLAT", "TAPERED_INNER"],
-            # ["FLAT", "CURVED", "TAPERED_INNER"],
-            # [PFrameSection.FLAT, PFrameSection.FLAT, PFrameSection.TAPERED_INNER],
-            # [PFrameSection.CURVED, PFrameSection.CURVED, PFrameSection.TAPERED_INNER],
-            # [PFrameSection.CURVED, PFrameSection.FLAT, PFrameSection.TAPERED_INNER],
-            # [PFrameSection.FLAT, PFrameSection.CURVED, PFrameSection.TAPERED_INNER],
+            pytest.param("FLAT", "FLAT", "TAPERED_INNER", marks=pytest.mark.xfail),
+            pytest.param("CURVED", "CURVED", "TAPERED_INNER", marks=pytest.mark.xfail),
+            pytest.param("CURVED", "FLAT", "TAPERED_INNER", marks=pytest.mark.xfail),
+            pytest.param("FLAT", "CURVED", "TAPERED_INNER", marks=pytest.mark.xfail),
+            pytest.param(
+                PFrameSection.FLAT,
+                PFrameSection.FLAT,
+                PFrameSection.TAPERED_INNER,
+                marks=pytest.mark.xfail,
+            ),
+            pytest.param(
+                PFrameSection.CURVED,
+                PFrameSection.CURVED,
+                PFrameSection.TAPERED_INNER,
+                marks=pytest.mark.xfail,
+            ),
+            pytest.param(
+                PFrameSection.CURVED,
+                PFrameSection.FLAT,
+                PFrameSection.TAPERED_INNER,
+                marks=pytest.mark.xfail,
+            ),
+            pytest.param(
+                PFrameSection.FLAT,
+                PFrameSection.CURVED,
+                PFrameSection.TAPERED_INNER,
+                marks=pytest.mark.xfail,
+            ),
             ["FLAT", "FLAT", None],
             ["CURVED", "CURVED", None],
             ["CURVED", "FLAT", None],


### PR DESCRIPTION
## Description

`inner` PictureFrame parameterisation adjustment doesnt work if directly specified with enum. This fixes it and adds some tests to that effect.

Also removed limitation so you can now have tapered inner with either domed or flat sections

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
