### PR TITLE
Remove repeated name in param definitions

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -154,6 +154,12 @@ def make_parameter_frame(
 
     param_cls: Type[NewParameterFrame]
         The `ParameterFrame` class to create a new instance of.
+
+    Returns
+    -------
+    Union[ParameterFrame, None]
+        A frame of the type `param_cls`, or `None` if `params` and
+        `param_cls` are both `None`.
     """
     if param_cls is None:
         if params is None:

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -150,7 +150,7 @@ def make_parameter_frame(
             * None:
                 For the case where no parameters are actually required.
                 This is intended for internal use, to aid in validation
-                of parameters in `Builder`s and `Designer`s.
+                of parameters in `Builder`\\s and `Designer`\\s.
 
     param_cls: Type[NewParameterFrame]
         The `ParameterFrame` class to create a new instance of.

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -131,10 +131,29 @@ def make_parameter_frame(
 
     Parameters
     ----------
-    params: Union[Dict[str, ParamDictT], NewParameterFrame, None]
-        The parameters to initialise the class with
+    params: Union[Dict[str, ParamDictT], NewParameterFrame, str, None]
+        The parameters to initialise the class with.
+        This parameter can be several types:
+
+            * Dict[str, ParamDictT]:
+                A dict where the keys are parameter names, and the
+                values are the data associated with the corresponding
+                name.
+            * ParameterFrame:
+                A reference to the parameters on this frame will be
+                assigned to the new ParameterFrame's parameters. Note
+                that this makes no copies, so updates to parameters in
+                the new frame will propagate to the old, and vice versa.
+            * str:
+                The path to a JSON file, or, if the string starts with
+                '{', a JSON string.
+            * None:
+                For the case where no parameters are actually required.
+                This is intended for internal use, to aid in validation
+                of parameters in `Builder`s and `Designer`s.
+
     param_cls: Type[NewParameterFrame]
-        The `ParameterFrame` class to generate
+        The `ParameterFrame` class to create a new instance of.
     """
     if param_cls is None:
         if params is None:

--- a/examples/design/EU-DEMO/EUDEMO_tests/equilibria/test_data/params.json
+++ b/examples/design/EU-DEMO/EUDEMO_tests/equilibria/test_data/params.json
@@ -1,163 +1,136 @@
 {
     "A": {
         "long_name": "Plasma aspect ratio",
-        "name": "A",
         "unit": "dimensionless",
         "value": 3.1
     },
     "B_0": {
         "long_name": "Toroidal field at R_0",
-        "name": "B_0",
         "unit": "T",
         "value": 6
     },
     "CS_bmax": {
         "long_name": "Maximum peak field to use in CS modules",
-        "name": "CS_bmax",
         "unit": "T",
         "value": 13
     },
     "CS_jmax": {
         "long_name": "Maximum current density to use in CS modules",
-        "name": "CS_jmax",
         "unit": "MA/m^2",
         "value": 16
     },
     "I_p": {
         "long_name": "Plasma current",
-        "name": "I_p",
         "unit": "MA",
         "value": 19
     },
     "PF_bmax": {
         "long_name": "Maximum peak field to use in PF modules",
-        "name": "PF_bmax",
         "unit": "T",
         "value": 11
     },
     "PF_jmax": {
         "long_name": "Maximum current density to use in PF modules",
-        "name": "PF_jmax",
         "unit": "MA/m^2",
         "value": 12.5
     },
     "R_0": {
         "long_name": "Major radius",
-        "name": "R_0",
         "unit": "m",
         "value": 9
     },
     "beta_p": {
         "long_name": "Ratio of plasma pressure to poloidal magnetic pressure",
-        "name": "beta_p",
         "unit": "dimensionless",
         "value": 0.04
     },
     "delta_95": {
         "long_name": "Last closed surface plasma triangularity",
-        "name": "delta",
         "unit": "dimensionless",
         "value": 0.5
     },
     "delta": {
         "long_name": "95th percentile plasma triangularity",
-        "name": "delta_95",
         "unit": "dimensionless",
         "value": 0.333
     },
     "div_L2D_ib": {
         "long_name": "Inboard divertor leg length",
-        "name": "div_L2D_ib",
         "unit": "m",
         "value": 1.1
     },
     "div_L2D_ob": {
         "long_name": "Outboard divertor leg length",
-        "name": "div_L2D_ob",
         "unit": "m",
         "value": 1.45
     },
     "g_cs_mod": {
         "long_name": "Gap between CS modules",
-        "name": "g_cs_mod",
         "unit": "m",
         "value": 0.05
     },
     "kappa": {
         "long_name": "Last closed surface plasma elongation",
-        "name": "kappa",
         "unit": "dimensionless",
         "value": 1.792
     },
     "kappa_95": {
         "long_name": "95th percentile plasma elongation",
-        "name": "kappa_95",
         "unit": "dimensionless",
         "value": 1.6
     },
     "l_i": {
         "long_name": "Normalised internal plasma inductance",
-        "name": "l_i",
         "unit": "dimensionless",
         "value": 0.8
     },
     "n_CS": {
         "long_name": "Number of CS coil divisions",
-        "name": "n_CS",
         "unit": "dimensionless",
         "value": 5
     },
     "n_PF": {
         "long_name": "Number of PF coils",
-        "name": "n_PF",
         "unit": "dimensionless",
         "value": 6
     },
     "q_95": {
         "long_name": "Plasma safety factor",
-        "name": "q_95",
         "unit": "dimensionless",
         "value": 3.5
     },
     "r_cs_in": {
         "long_name": "Central Solenoid inner radius",
-        "name": "r_cs_in",
         "unit": "m",
         "value": 2.2
     },
     "r_tf_in_centre": {
         "long_name": "Inboard TF leg centre radius",
-        "name": "r_tf_in_centre",
         "unit": "m",
         "value": 3.7
     },
     "r_tf_out_centre": {
         "long_name": "Outboard TF leg centre radius",
-        "name": "r_tf_out_centre",
         "unit": "m",
         "value": 16.2
     },
     "tk_cs": {
         "long_name": "Thickness of the CS coil insulation",
-        "name": "tk_cs_insulation",
         "unit": "m",
         "value": 0.005
     },
     "tk_cs_casing": {
         "long_name": "Thickness of the CS coil casing",
-        "name": "tk_cs_casing",
         "unit": "m",
         "value": 0.07
     },
     "tk_cs_insulation": {
         "long_name": "Thickness of the CS coil insulation",
-        "name": "tk_cs_insulation",
         "unit": "m",
         "value": 0.005
     },
     "shaf_shift": {
         "long_name": "Shafranov shift of plasma (geometric=>magnetic)",
-        "name": "shaf_shift",
         "unit": "m",
         "value": 0.5
     }

--- a/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_divertor_silhouette.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_divertor_silhouette.py
@@ -45,11 +45,11 @@ def get_turning_point_idxs(z: np.ndarray):
 class TestDivertorSilhouetteDesigner:
 
     _default_params = {
-        "div_type": {"name": "div_type", "value": "SN"},
-        "div_L2D_ib": {"name": "div_L2D_ib", "value": 1.1},
-        "div_L2D_ob": {"name": "div_L2D_ob", "value": 1.45},
-        "div_Ltarg": {"name": "div_Ltarg", "value": 0.5},
-        "div_open": {"name": "div_open", "value": False},
+        "div_type": {"value": "SN"},
+        "div_L2D_ib": {"value": 1.1},
+        "div_L2D_ob": {"value": 1.45},
+        "div_Ltarg": {"value": 0.5},
+        "div_open": {"value": False},
     }
 
     @classmethod

--- a/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_ivc_boundary.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_ivc_boundary.py
@@ -33,10 +33,10 @@ class TestIVCBoundaryDesigner:
 
     picture_frame = PictureFrame({"ro": {"value": 6}, "ri": {"value": 3}}).create_shape()
     params = {
-        "tk_bb_ib": {"name": "tk_bb_ib", "value": 0.8},
-        "tk_bb_ob": {"name": "tk_bb_ob", "value": 1.1},
-        "ib_offset_angle": {"name": "ib_offset_angle", "value": 45},
-        "ob_offset_angle": {"name": "ob_offset_angle", "value": 175},
+        "tk_bb_ib": {"value": 0.8},
+        "tk_bb_ob": {"value": 1.1},
+        "ib_offset_angle": {"value": 45},
+        "ob_offset_angle": {"value": 175},
     }
 
     def test_DesignError_given_wall_shape_not_closed(self):

--- a/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_plasma_face.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_plasma_face.py
@@ -31,8 +31,8 @@ from EUDEMO_builders.ivc import PlasmaFaceDesigner
 class TestPlasmaFaceDesigner:
 
     _params = {
-        "div_type": {"name": "div_type", "value": "SN"},
-        "c_rm": {"name": "c_rm", "value": 0.02},
+        "div_type": {"value": "SN"},
+        "c_rm": {"value": 0.02},
     }
 
     @classmethod

--- a/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_wall_silhouette.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/ivc/test_wall_silhouette.py
@@ -55,15 +55,15 @@ CONFIG = {
     "problem_class": f"{OPTIMISER_MODULE_REF}::MinimiseLengthGOP",
 }
 PARAMS = {
-    "R_0": {"name": "R_0", "value": 10.5},
-    "kappa_95": {"name": "kappa_95", "value": 1.6},
-    "r_fw_ib_in": {"name": "r_fw_ib_in", "value": 5.8},
-    "r_fw_ob_in": {"name": "r_fw_ob_in", "value": 12.1},
-    "A": {"name": "A", "value": 3.1},
-    "tk_sol_ib": {"name": "tk_sol_ib", "value": 0.225},
-    "fw_psi_n": {"name": "fw_psi_n", "value": 1.07},
-    "div_L2D_ib": {"name": "div_L2D_ib", "value": 1.1},
-    "div_L2D_ob": {"name": "div_L2D_ob", "value": 1.45},
+    "R_0": {"value": 10.5},
+    "kappa_95": {"value": 1.6},
+    "r_fw_ib_in": {"value": 5.8},
+    "r_fw_ob_in": {"value": 12.1},
+    "A": {"value": 3.1},
+    "tk_sol_ib": {"value": 0.225},
+    "fw_psi_n": {"value": 1.07},
+    "div_L2D_ib": {"value": 1.1},
+    "div_L2D_ob": {"value": 1.45},
 }
 
 
@@ -153,9 +153,9 @@ class TestWallSilhouetteDesigner:
         params = copy.deepcopy(PARAMS)
         params.update(
             {
-                "R_0": {"name": "R_0", "value": 10},
-                "kappa_95": {"name": "kappa_95", "value": 2},
-                "A": {"name": "A", "value": 2},
+                "R_0": {"value": 10},
+                "kappa_95": {"value": 2},
+                "A": {"value": 2},
             }
         )
         config = copy.deepcopy(CONFIG)

--- a/examples/design/EU-DEMO/EUDEMO_tests/test_blanket.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/test_blanket.py
@@ -27,10 +27,10 @@ class TestDivertorBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "n_bb_inboard": {"name": "n_bb_inboard", "value": 2},
-            "n_bb_outboard": {"name": "n_bb_outboard", "value": 3},
-            "c_rm": {"name": "c_rm", "value": 0.02},
-            "n_TF": {"name": "n_TF", "value": 12},
+            "n_bb_inboard": {"value": 2},
+            "n_bb_outboard": {"value": 3},
+            "c_rm": {"value": 0.02},
+            "n_TF": {"value": 12},
         }
         cls.silhouette = BluemiraFace(
             make_polygon(

--- a/examples/design/EU-DEMO/EUDEMO_tests/test_vacuum_vessel.py
+++ b/examples/design/EU-DEMO/EUDEMO_tests/test_vacuum_vessel.py
@@ -26,14 +26,14 @@ class TestVacuumVesselBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "r_vv_ib_in": {"name": "r_vv_ib_in", "value": 5.1},
-            "r_vv_ob_in": {"name": "r_vv_ob_in", "value": 14.5},
-            "tk_vv_in": {"name": "tk_vv_in", "value": 0.6},
-            "tk_vv_out": {"name": "tk_vv_out", "value": 1.1},
-            "g_vv_bb": {"name": "g_vv_bb", "value": 0.02},
-            "n_TF": {"name": "n_TF", "value": 16},
-            "vv_in_off_deg": {"name": "vv_in_off_deg", "value": 80},
-            "vv_out_off_deg": {"name": "vv_out_off_deg", "value": 160},
+            "r_vv_ib_in": {"value": 5.1},
+            "r_vv_ob_in": {"value": 14.5},
+            "tk_vv_in": {"value": 0.6},
+            "tk_vv_out": {"value": 1.1},
+            "g_vv_bb": {"value": 0.02},
+            "n_TF": {"value": 16},
+            "vv_in_off_deg": {"value": 80},
+            "vv_out_off_deg": {"value": 160},
         }
 
         cls.picture_frame = PictureFrame(

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -10,8 +10,8 @@ from bluemira.base.parameter_frame import NewParameterFrame as ParameterFrame
 from bluemira.base.parameter_frame import make_parameter_frame, parameter_frame
 
 FRAME_DATA = {
-    "height": {"name": "height", "value": 180.5, "unit": "cm"},
-    "age": {"name": "age", "value": 30, "unit": "years"},
+    "height": {"value": 180.5, "unit": "cm"},
+    "age": {"value": 30, "unit": "years"},
 }
 
 
@@ -42,8 +42,8 @@ class TestParameterFrame:
     )
     def test_from_dict_TypeError_given_invalid_type(self, name, value):
         data = {
-            "height": {"name": "height", "value": 180.5, "unit": "cm"},
-            "age": {"name": "age", "value": 30, "unit": "years"},
+            "height": {"value": 180.5, "unit": "cm"},
+            "age": {"value": 30, "unit": "years"},
         }
         data["age"][name] = value
 
@@ -52,16 +52,16 @@ class TestParameterFrame:
 
     def test_from_dict_ValueError_given_unknown_parameter(self):
         data = {
-            "height": {"name": "height", "value": 180.5, "unit": "m"},
-            "age": {"name": "age", "value": 30, "unit": "years"},
-            "weight": {"name": "weight", "value": 60, "unit": "kg"},
+            "height": {"value": 180.5, "unit": "m"},
+            "age": {"value": 30, "unit": "years"},
+            "weight": {"value": 60, "unit": "kg"},
         }
 
         with pytest.raises(ValueError):
             BasicFrame.from_dict(data)
 
     def test_from_dict_ValueError_given_missing_parameter(self):
-        data = {"height": {"name": "height", "value": 180.5, "unit": "m"}}
+        data = {"height": {"value": 180.5, "unit": "m"}}
 
         with pytest.raises(ValueError):
             BasicFrame.from_dict(data)
@@ -78,7 +78,7 @@ class TestParameterFrame:
         class GenericFrame(ParameterFrame):
             x: Parameter
 
-        frame = GenericFrame.from_dict({"x": {"name": "x", "value": 10}})
+        frame = GenericFrame.from_dict({"x": {"value": 10}})
 
         assert frame.x.value == 10
 
@@ -89,7 +89,7 @@ class TestParameterFrame:
             x: Parameter[Union[str, list]]
 
         with pytest.raises(TypeError):
-            GenericFrame.from_dict({"x": {"name": "x", "value": value}})
+            GenericFrame.from_dict({"x": {"value": value}})
 
     def test_TypeError_given_field_does_not_have_Parameter_type(self):
         @dataclass
@@ -97,7 +97,7 @@ class TestParameterFrame:
             x: int
 
         with pytest.raises(TypeError):
-            BadFrame.from_dict({"x": {"name": "x", "value": 10}})
+            BadFrame.from_dict({"x": {"value": 10}})
 
     def test_a_default_frame_is_empty(self):
         assert len(ParameterFrame().to_dict()) == 0
@@ -112,8 +112,8 @@ class TestParameterFrame:
 
     def test_from_json_reads_json_string(self):
         json_str = """{
-            "height": {"name": "height", "value": 180.5, "unit": "cm"},
-            "age": {"name": "age", "value": 30, "unit": "years"}
+            "height": {"value": 180.5, "unit": "cm"},
+            "age": {"value": 30, "unit": "years"}
         }"""
 
         frame = BasicFrame.from_json(json_str)
@@ -125,8 +125,8 @@ class TestParameterFrame:
 
     def test_from_json_reads_json_io(self):
         json_str = """{
-            "height": {"name": "height", "value": 180.5, "unit": "cm"},
-            "age": {"name": "age", "value": 30, "unit": "years"}
+            "height": {"value": 180.5, "unit": "cm"},
+            "age": {"value": 30, "unit": "years"}
         }"""
         json_io = io.StringIO(json_str)
 
@@ -139,8 +139,8 @@ class TestParameterFrame:
 
     def test_from_json_reads_from_file(self):
         json_str = """{
-            "height": {"name": "height", "value": 180.5, "unit": "cm"},
-            "age": {"name": "age", "value": 30, "unit": "years"}
+            "height": {"value": 180.5, "unit": "cm"},
+            "age": {"value": 30, "unit": "years"}
         }"""
         with mock.patch(
             "builtins.open", new_callable=mock.mock_open, read_data=json_str
@@ -167,7 +167,7 @@ class TestParameterFrame:
 
         frame1 = BasicFrame.from_dict(FRAME_DATA)
         frame2 = OtherFrame.from_dict(
-            {**FRAME_DATA, "weight": {"name": "weight", "value": 58.2, "unit": "kg"}}
+            {**FRAME_DATA, "weight": {"value": 58.2, "unit": "kg"}}
         )
 
         assert frame1 != frame2

--- a/tests/base/test_builder.py
+++ b/tests/base/test_builder.py
@@ -42,8 +42,8 @@ class StubBuilder(Builder):
 
 class TestBuilder:
     _params = {
-        "param_1": {"name": "param_1", "unit": "m", "value": 1},
-        "param_2": {"name": "param_2", "unit": "T", "value": 2},
+        "param_1": {"unit": "m", "value": 1},
+        "param_2": {"unit": "T", "value": 2},
     }
 
     def test_default_name_is_class_name_sans_builder(self):

--- a/tests/builders/test_cryostat.py
+++ b/tests/builders/test_cryostat.py
@@ -31,13 +31,13 @@ class TestCryostatBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "g_cr_ts": {"name": "g_cr_ts", "value": 0.3},
-            "n_TF": {"name": "n_TF", "value": 16},
-            "tk_cr_vv": {"name": "tk_cr_vv", "value": 0.3},
-            "well_depth": {"name": "well_depth", "value": 5},
-            "x_g_support": {"name": "x_g_support", "value": 13},
-            "x_gs_kink_diff": {"name": "x_gs_kink_diff", "value": 2},
-            "z_gs": {"name": "z_gs", "value": -15},
+            "g_cr_ts": {"value": 0.3},
+            "n_TF": {"value": 16},
+            "tk_cr_vv": {"value": 0.3},
+            "well_depth": {"value": 5},
+            "x_g_support": {"value": 13},
+            "x_gs_kink_diff": {"value": 2},
+            "z_gs": {"value": -15},
         }
 
     def test_components_and_segments(self):
@@ -55,7 +55,7 @@ class TestCryostatBuilder:
 class TestCryostatDesigner:
     @classmethod
     def setup_class(cls):
-        cls.params = {"g_cr_ts": {"name": "g_cr_ts", "value": 0.3}}
+        cls.params = {"g_cr_ts": {"value": 0.3}}
         cls.z_max = 10
         cls.x_max = 5
         bb = mock.Mock(z_max=cls.z_max, x_max=cls.x_max)

--- a/tests/builders/test_divertor.py
+++ b/tests/builders/test_divertor.py
@@ -27,9 +27,9 @@ class TestDivertorBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "n_div_cassettes": {"name": "n_div_cassettes", "value": 3},
-            "c_rm": {"name": "c_rm", "value": 0.02},
-            "n_TF": {"name": "n_TF", "value": 12},
+            "n_div_cassettes": {"value": 3},
+            "c_rm": {"value": 0.02},
+            "n_TF": {"value": 12},
         }
         cls.div_koz = BluemiraFace(
             make_polygon([[1, 0, -5], [1, 0, -10], [5, 0, -10], [5, 0, -5]], closed=True)

--- a/tests/builders/test_pf_coil.py
+++ b/tests/builders/test_pf_coil.py
@@ -32,9 +32,9 @@ class TestPFCoilBuilder:
             [(1, 0, 1), (3, 0, 1), (3, 0, -1), (1, 0, -1)], closed=True
         )
         cls.params = {
-            "tk_insulation": {"value": 0.1, "unit": "m", "name": "tk_insulation"},
-            "tk_casing": {"value": 0.2, "unit": "m", "name": "tk_casing"},
-            "ctype": {"value": "PF", "unit": "dimensionless", "name": "ctype"},
+            "tk_insulation": {"value": 0.1, "unit": "m"},
+            "tk_casing": {"value": 0.2, "unit": "m"},
+            "ctype": {"value": "PF", "unit": "dimensionless"},
         }
 
     def test_component_dimensions_are_built(self):

--- a/tests/builders/test_thermal_shield.py
+++ b/tests/builders/test_thermal_shield.py
@@ -34,9 +34,9 @@ class TestVVTSBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "g_vv_ts": {"name": "g_vv_ts", "value": 0.05},
-            "n_TF": {"name": "n_TF", "value": 16},
-            "tk_ts": {"name": "tk_ts", "value": 0.05},
+            "g_vv_ts": {"value": 0.05},
+            "n_TF": {"value": 16},
+            "tk_ts": {"value": 0.05},
         }
         cls.vv_koz = make_circle(10, center=(15, 0, 0), axis=(0.0, 1.0, 0.0))
 
@@ -60,10 +60,10 @@ class TestCryostatTSBuilder:
     @classmethod
     def setup_class(cls):
         cls.params = {
-            "g_ts_pf": {"name": "g_ts_pf", "value": 0.3},
-            "g_ts_tf": {"name": "g_ts_tf", "value": 0.3},
-            "n_TF": {"name": "n_TF", "value": 16},
-            "tk_ts": {"name": "tk_ts", "value": 0.3},
+            "g_ts_pf": {"value": 0.3},
+            "g_ts_tf": {"value": 0.3},
+            "n_TF": {"value": 16},
+            "tk_ts": {"value": 0.3},
         }
         size_1_sq = np.array([[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]]).T
         pf_shifts = np.array([(5, 8), (13, 5), (15, 0)])


### PR DESCRIPTION
## Description

Removes the requirement to have the `name` key when defining parameters in a dict or JSON file using the new ParameterFrame class.
