### PR TITLE
Improve psi axis finding in fixed boundary equilibrium

### DIFF
--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -346,6 +346,41 @@ def calculate_plasma_shape_params(
     return r_geo, kappa, delta
 
 
+def find_psi_axis(psi_func, mesh):
+    """
+    Find the magnetic axis in the poloidal flux map
+    Parameters
+    ----------
+    psi_func: callable
+        Function to return psi at a given point
+    mesh: dolfin.Mesh
+        Mesh object to use to estimate extrema prior to optimisation
+    Returns
+    -------
+    psi_axis: float
+        Maximum psi in the continuous psi function
+    """
+    points = mesh.coordinates()
+    psi_array = [psi_func(x) for x in points]
+    psi_max_arg = np.argmax(psi_array)
+
+    x0 = points[psi_max_arg]
+    search_range = mesh.hmax()
+    bounds = [(xi - search_range, xi + search_range) for xi in x0]
+
+    result = scipy.optimize.minimize(
+        lambda x: -psi_func(x),
+        x0,
+        method="SLSQP",
+        bounds=bounds,
+        options={"disp": False, "ftol": 1e-10, "maxiter": 1000},
+    )
+    if not result.success:
+        bluemira_warn("Poloidal flux maximum finding failing:\n" f"{result.message}")
+
+    return psi_func(result.x)
+
+
 class Solovev:
     """
     Solov'ev analytical solution to a fixed boundary equilibrium problem with a symmetric

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -352,7 +352,7 @@ def find_psi_axis(psi_func, mesh):
 
     Parameters
     ----------
-    psi_func: callable
+    psi_func: Callable
         Function to return psi at a given point
     mesh: dolfin.Mesh
         Mesh object to use to estimate extrema prior to optimisation

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -356,6 +356,7 @@ def find_psi_axis(psi_func, mesh):
         Function to return psi at a given point
     mesh: dolfin.Mesh
         Mesh object to use to estimate extrema prior to optimisation
+
     Returns
     -------
     psi_axis: float

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -348,7 +348,7 @@ def calculate_plasma_shape_params(
 
 def find_psi_axis(psi_func, mesh):
     """
-    Find the magnetic axis in the poloidal flux map
+    Find the magnetic axis in the poloidal flux map.
     Parameters
     ----------
     psi_func: callable
@@ -358,7 +358,7 @@ def find_psi_axis(psi_func, mesh):
     Returns
     -------
     psi_axis: float
-        Maximum psi in the continuous psi function
+        Maximum psi in the continuous psi function [V.s]
     """
     points = mesh.coordinates()
     psi_array = [psi_func(x) for x in points]

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -349,6 +349,7 @@ def calculate_plasma_shape_params(
 def find_psi_axis(psi_func, mesh):
     """
     Find the magnetic axis in the poloidal flux map.
+
     Parameters
     ----------
     psi_func: callable


### PR DESCRIPTION
Requires #1067 
Supercedes #1404 

## Linked Issues
Closes #1255 

## Description
Calculates the psi axis via optimisation rather than taking the maximum of the grid points in the fixed boundary equilibrium solver.

For the example `examples/equilibria/fem_fixed_boundary/equilibrium_example.py` on `ivanmaione/clean_fixed_boundary` exhibits slightly improved convergence behaviour:

![image](https://user-images.githubusercontent.com/26097289/189079772-84fb3560-0d5e-44d7-84bc-a94accbde32c.png)

There are two additional internal G-S iterations (outer iterations 1 and 4), but 7 fewer in total, as the last outer iteration is not required (in this example).

As for the 95th flux surface extremum finding, just using scipy `minimize` for now. Best to pick up #1253 on both counts in a separate future PR (not so urgent).

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
