### PR TITLE
👷 only fail CI if coverage upload fails on develop or main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         path: .report.json
 
     - name: "Upload coverage to Codecov"
+      env:
+        FAIL_CI: ${{ github.ref_name == "develop" || github.ref_name == "main" }}
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: ${FAIL_CI}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,4 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: ${{ github.ref_name == 'develop' && 'true' || github.ref_name == 'main' && 'true' || 'false' }}
+        fail_ci_if_error: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: "Upload coverage to Codecov"
       env:
-        FAIL_CI: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
+        FAIL_CI: ${{ github.ref_name == 'develop' && 'true' || github.ref_name == 'main' && 'true' || 'false' }}
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: ${FAIL_CI}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,6 @@ jobs:
         path: .report.json
 
     - name: "Upload coverage to Codecov"
-      env:
-        FAIL_CI: ${{ github.ref_name == 'develop' && 'true' || github.ref_name == 'main' && 'true' || 'false' }}
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: ${FAIL_CI}
+        fail_ci_if_error: ${{ github.ref_name == 'develop' && 'true' || github.ref_name == 'main' && 'true' || 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: "Upload coverage to Codecov"
       env:
-        FAIL_CI: ${{ github.ref_name == "develop" || github.ref_name == "main" }}
+        FAIL_CI: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: ${FAIL_CI}


### PR DESCRIPTION
## Description

Codecov upload is failing more. This makes it so the CI will only fail when the CI is run on main and develop for the codecov upload

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
