### PR TITLE
Remove ParameterFrame from radiation_transport module

### DIFF
--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -23,11 +23,12 @@
 A simplified 2-D solver for calculating charged particle heat loads.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.axes import Axes
 
 from bluemira.base.constants import EPS
 from bluemira.base.look_and_feel import bluemira_warn
@@ -493,7 +494,13 @@ class ChargedParticleSolver:
     def _make_params(self, config):
         """Convert the given params to ``ChargedParticleSolverParams``"""
         if isinstance(config, dict):
-            return ChargedParticleSolverParams(**config)
+            try:
+                return ChargedParticleSolverParams(**config)
+            except TypeError:
+                unknown = [
+                    k for k in config if k not in fields(ChargedParticleSolverParams)
+                ]
+                raise TypeError(f"Unknown config parameter(s) {str(unknown)[1:-1]}")
         elif isinstance(config, ChargedParticleSolverParams):
             return config
         else:

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -461,7 +461,7 @@ class ChargedParticleSolver:
             / (Bp * 2 * np.pi * x)
         )
 
-    def plot(self, ax=None):
+    def plot(self, ax: Axes = None, show=False):
         """
         Plot the ChargedParticleSolver results.
         """
@@ -488,8 +488,11 @@ class ChargedParticleSolver:
             zorder=40,
             cmap="plasma",
         )
-        f = plt.gcf()
-        f.colorbar(cm, label="MW/m^2")
+        f = ax.figure
+        f.colorbar(cm, label="MW/m²")
+        if show:
+            plt.show()
+        return ax
 
     def _make_params(self, config):
         """Convert the given params to ``ChargedParticleSolverParams``"""

--- a/examples/radiation_transport/heat_flux_calculation.ipynb
+++ b/examples/radiation_transport/heat_flux_calculation.ipynb
@@ -9,7 +9,6 @@
         "import matplotlib.pyplot as plt\n",
         "\n",
         "from bluemira.base.file import get_bluemira_path\n",
-        "from bluemira.base.parameter import ParameterFrame\n",
         "from bluemira.equilibria import Equilibrium\n",
         "from bluemira.geometry._deprecated_loop import Loop\n",
         "from bluemira.radiation_transport.advective_transport import ChargedParticleSolver"
@@ -31,7 +30,7 @@
       "source": [
         "read_path = get_bluemira_path(\"equilibria\", subfolder=\"data\")\n",
         "eq_name = \"EU-DEMO_EOF.json\"\n",
-        "eq_name = os.sep.join([read_path, eq_name])\n",
+        "eq_name = os.path.join(read_path, eq_name)\n",
         "eq = Equilibrium.from_eqdsk(eq_name)"
       ],
       "outputs": [],
@@ -52,7 +51,7 @@
       "source": [
         "read_path = get_bluemira_path(\"radiation_transport/test_data\", subfolder=\"tests\")\n",
         "fw_name = \"first_wall.json\"\n",
-        "fw_name = os.sep.join([read_path, fw_name])\n",
+        "fw_name = os.path.join(read_path, fw_name)\n",
         "fw_shape = Loop.from_file(fw_name)"
       ],
       "outputs": [],
@@ -63,27 +62,23 @@
       "metadata": {},
       "source": [
         "\n",
-        "Then we define some input `Parameter`s for the solve."
+        "Then we define some input `Parameter`s for the solver."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "params = ParameterFrame(\n",
-        "    # fmt: off\n",
-        "    [\n",
-        "        [\"P_sep_particle\", \"Separatrix power\", 150, \"MW\", None, \"Input\"],\n",
-        "        [\"f_p_sol_near\", \"near scrape-off layer power rate\", 0.50, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_near_omp\", \"Lambda q near SOL at the outboard\", 0.01, \"m\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_far_omp\", \"Lambda q far SOL at the outboard\", 0.05, \"m\", None, \"Input\"],\n",
-        "        [\"f_lfs_lower_target\", \"Fraction of SOL power deposited on the LFS lower target\", 0.75, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_hfs_lower_target\", \"Fraction of SOL power deposited on the HFS lower target\", 0.25, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_lfs_upper_target\", \"Fraction of SOL power deposited on the LFS upper target (DN only)\", 0, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_hfs_upper_target\", \"Fraction of SOL power deposited on the HFS upper target (DN only)\", 0, \"dimensionless\", None, \"Input\"],\n",
-        "    ]\n",
-        "    # fmt:on\n",
-        ")"
+        "params = {\n",
+        "    \"P_sep_particle\": 150,\n",
+        "    \"f_p_sol_near\": 0.50,\n",
+        "    \"fw_lambda_q_near_omp\": 0.01,\n",
+        "    \"fw_lambda_q_far_omp\": 0.05,\n",
+        "    \"f_lfs_lower_target\": 0.75,\n",
+        "    \"f_hfs_lower_target\": 0.25,\n",
+        "    \"f_lfs_upper_target\": 0,\n",
+        "    \"f_hfs_upper_target\": 0,\n",
+        "}"
       ],
       "outputs": [],
       "execution_count": null

--- a/examples/radiation_transport/heat_flux_calculation.py
+++ b/examples/radiation_transport/heat_flux_calculation.py
@@ -29,7 +29,6 @@ import os
 import matplotlib.pyplot as plt
 
 from bluemira.base.file import get_bluemira_path
-from bluemira.base.parameter import ParameterFrame
 from bluemira.equilibria import Equilibrium
 from bluemira.geometry._deprecated_loop import Loop
 from bluemira.radiation_transport.advective_transport import ChargedParticleSolver
@@ -41,7 +40,7 @@ from bluemira.radiation_transport.advective_transport import ChargedParticleSolv
 # %%
 read_path = get_bluemira_path("equilibria", subfolder="data")
 eq_name = "EU-DEMO_EOF.json"
-eq_name = os.sep.join([read_path, eq_name])
+eq_name = os.path.join(read_path, eq_name)
 eq = Equilibrium.from_eqdsk(eq_name)
 
 # %%[markdown]
@@ -52,29 +51,25 @@ eq = Equilibrium.from_eqdsk(eq_name)
 # %%
 read_path = get_bluemira_path("radiation_transport/test_data", subfolder="tests")
 fw_name = "first_wall.json"
-fw_name = os.sep.join([read_path, fw_name])
+fw_name = os.path.join(read_path, fw_name)
 fw_shape = Loop.from_file(fw_name)
 
 # %%[markdown]
 
-# Then we define some input `Parameter`s for the solve.
+# Then we define some input `Parameter`s for the solver.
 
 # %%
 
-params = ParameterFrame(
-    # fmt: off
-    [
-        ["P_sep_particle", "Separatrix power", 150, "MW", None, "Input"],
-        ["f_p_sol_near", "near scrape-off layer power rate", 0.50, "dimensionless", None, "Input"],
-        ["fw_lambda_q_near_omp", "Lambda q near SOL at the outboard", 0.01, "m", None, "Input"],
-        ["fw_lambda_q_far_omp", "Lambda q far SOL at the outboard", 0.05, "m", None, "Input"],
-        ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.75, "dimensionless", None, "Input"],
-        ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.25, "dimensionless", None, "Input"],
-        ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0, "dimensionless", None, "Input"],
-        ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0, "dimensionless", None, "Input"],
-    ]
-    # fmt:on
-)
+params = {
+    "P_sep_particle": 150,
+    "f_p_sol_near": 0.50,
+    "fw_lambda_q_near_omp": 0.01,
+    "fw_lambda_q_far_omp": 0.05,
+    "f_lfs_lower_target": 0.75,
+    "f_hfs_lower_target": 0.25,
+    "f_lfs_upper_target": 0,
+    "f_hfs_upper_target": 0,
+}
 
 # %%[markdown]
 

--- a/examples/radiation_transport/heat_flux_calculation_DN.ipynb
+++ b/examples/radiation_transport/heat_flux_calculation_DN.ipynb
@@ -9,7 +9,6 @@
         "import matplotlib.pyplot as plt\n",
         "\n",
         "from bluemira.base.file import get_bluemira_path\n",
-        "from bluemira.base.parameter import ParameterFrame\n",
         "from bluemira.equilibria import Equilibrium\n",
         "from bluemira.geometry._deprecated_loop import Loop\n",
         "from bluemira.radiation_transport.advective_transport import ChargedParticleSolver"
@@ -31,7 +30,7 @@
       "source": [
         "read_path = get_bluemira_path(\"equilibria\", subfolder=\"data\")\n",
         "eq_name = \"DN-DEMO_eqref.json\"\n",
-        "eq_name = os.sep.join([read_path, eq_name])\n",
+        "eq_name = os.path.join(read_path, eq_name)\n",
         "eq = Equilibrium.from_eqdsk(eq_name)"
       ],
       "outputs": [],
@@ -52,7 +51,7 @@
       "source": [
         "read_path = get_bluemira_path(\"radiation_transport/test_data\", subfolder=\"tests\")\n",
         "fw_name = \"DN_fw_shape.json\"\n",
-        "fw_name = os.sep.join([read_path, fw_name])\n",
+        "fw_name = os.path.join(read_path, fw_name)\n",
         "fw_shape = Loop.from_file(fw_name)"
       ],
       "outputs": [],
@@ -63,29 +62,25 @@
       "metadata": {},
       "source": [
         "\n",
-        "Then we define some input `Parameter`s for the solve."
+        "Then we define some input `Parameter`s for the solver."
       ]
     },
     {
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "params = ParameterFrame(\n",
-        "    # fmt: off\n",
-        "    [\n",
-        "        [\"P_sep_particle\", \"Separatrix power\", 150, \"MW\", None, \"Input\"],\n",
-        "        [\"f_p_sol_near\", \"near scrape-off layer power rate\", 0.65, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_near_omp\", \"Lambda q near SOL at the outboard\", 0.003, \"m\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_far_omp\", \"Lambda q far SOL at the outboard\", 0.1, \"m\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_near_imp\", \"Lambda q near SOL at the inboard\", 0.003, \"m\", None, \"Input\"],\n",
-        "        [\"fw_lambda_q_far_imp\", \"Lambda q far SOL at the inboard\", 0.1, \"m\", None, \"Input\"],\n",
-        "        [\"f_lfs_lower_target\", \"Fraction of SOL power deposited on the LFS lower target\", 0.9 * 0.5, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_hfs_lower_target\", \"Fraction of SOL power deposited on the HFS lower target\", 0.1 * 0.5, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_lfs_upper_target\", \"Fraction of SOL power deposited on the LFS upper target (DN only)\", 0.9 * 0.5, \"dimensionless\", None, \"Input\"],\n",
-        "        [\"f_hfs_upper_target\", \"Fraction of SOL power deposited on the HFS upper target (DN only)\", 0.1 * 0.5, \"dimensionless\", None, \"Input\"],\n",
-        "    ]\n",
-        "    # fmt: on\n",
-        ")"
+        "params = {\n",
+        "    \"P_sep_particle\": 150,\n",
+        "    \"f_p_sol_near\": 0.65,\n",
+        "    \"fw_lambda_q_near_omp\": 0.003,\n",
+        "    \"fw_lambda_q_far_omp\": 0.1,\n",
+        "    \"fw_lambda_q_near_imp\": 0.003,\n",
+        "    \"fw_lambda_q_far_imp\": 0.1,\n",
+        "    \"f_lfs_lower_target\": 0.9 * 0.5,\n",
+        "    \"f_hfs_lower_target\": 0.1 * 0.5,\n",
+        "    \"f_lfs_upper_target\": 0.9 * 0.5,\n",
+        "    \"f_hfs_upper_target\": 0.1 * 0.5,\n",
+        "}"
       ],
       "outputs": [],
       "execution_count": null

--- a/examples/radiation_transport/heat_flux_calculation_DN.py
+++ b/examples/radiation_transport/heat_flux_calculation_DN.py
@@ -29,7 +29,6 @@ import os
 import matplotlib.pyplot as plt
 
 from bluemira.base.file import get_bluemira_path
-from bluemira.base.parameter import ParameterFrame
 from bluemira.equilibria import Equilibrium
 from bluemira.geometry._deprecated_loop import Loop
 from bluemira.radiation_transport.advective_transport import ChargedParticleSolver
@@ -41,7 +40,7 @@ from bluemira.radiation_transport.advective_transport import ChargedParticleSolv
 # %%
 read_path = get_bluemira_path("equilibria", subfolder="data")
 eq_name = "DN-DEMO_eqref.json"
-eq_name = os.sep.join([read_path, eq_name])
+eq_name = os.path.join(read_path, eq_name)
 eq = Equilibrium.from_eqdsk(eq_name)
 
 
@@ -53,30 +52,26 @@ eq = Equilibrium.from_eqdsk(eq_name)
 # %%
 read_path = get_bluemira_path("radiation_transport/test_data", subfolder="tests")
 fw_name = "DN_fw_shape.json"
-fw_name = os.sep.join([read_path, fw_name])
+fw_name = os.path.join(read_path, fw_name)
 fw_shape = Loop.from_file(fw_name)
 
 # %%[markdown]
 
-# Then we define some input `Parameter`s for the solve.
+# Then we define some input `Parameter`s for the solver.
 
 # %%
-params = ParameterFrame(
-    # fmt: off
-    [
-        ["P_sep_particle", "Separatrix power", 150, "MW", None, "Input"],
-        ["f_p_sol_near", "near scrape-off layer power rate", 0.65, "dimensionless", None, "Input"],
-        ["fw_lambda_q_near_omp", "Lambda q near SOL at the outboard", 0.003, "m", None, "Input"],
-        ["fw_lambda_q_far_omp", "Lambda q far SOL at the outboard", 0.1, "m", None, "Input"],
-        ["fw_lambda_q_near_imp", "Lambda q near SOL at the inboard", 0.003, "m", None, "Input"],
-        ["fw_lambda_q_far_imp", "Lambda q far SOL at the inboard", 0.1, "m", None, "Input"],
-        ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.9 * 0.5, "dimensionless", None, "Input"],
-        ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.1 * 0.5, "dimensionless", None, "Input"],
-        ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0.9 * 0.5, "dimensionless", None, "Input"],
-        ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0.1 * 0.5, "dimensionless", None, "Input"],
-    ]
-    # fmt: on
-)
+params = {
+    "P_sep_particle": 150,
+    "f_p_sol_near": 0.65,
+    "fw_lambda_q_near_omp": 0.003,
+    "fw_lambda_q_far_omp": 0.1,
+    "fw_lambda_q_near_imp": 0.003,
+    "fw_lambda_q_far_imp": 0.1,
+    "f_lfs_lower_target": 0.9 * 0.5,
+    "f_hfs_lower_target": 0.1 * 0.5,
+    "f_lfs_upper_target": 0.9 * 0.5,
+    "f_hfs_upper_target": 0.1 * 0.5,
+}
 
 # %%[markdown]
 

--- a/tests/codes/plasmod/test_solver.py
+++ b/tests/codes/plasmod/test_solver.py
@@ -438,6 +438,6 @@ class TestPlasmodSolver:
         with open(file_path, "r") as f:
             input_file = f.read()
         param_regex = param + r" +([0-9]+(\.[0-9]+E[\+-][0-9]+)?)"
-        match = re.search(param_regex, input_file, re.MULTILINE)
-        if match:
-            return float(match.group(1))
+        re_match = re.search(param_regex, input_file, re.MULTILINE)
+        if re_match:
+            return float(re_match.group(1))

--- a/tests/radiation_transport/test_advective_transport.py
+++ b/tests/radiation_transport/test_advective_transport.py
@@ -144,15 +144,19 @@ class TestChargedParticleRecursionSN:
         assert np.allclose(self.x, x)
         assert np.allclose(self.z, z)
 
+    def test_plotting(self):
+        ax = self.solver.plot(show=True)
+        assert len(ax.lines) > 2
+
 
 class TestChargedParticleRecursionDN:
     @classmethod
     def setup_class(cls):
         eq_name = "DN-DEMO_eqref.json"
-        filename = os.sep.join([EQ_PATH, eq_name])
+        filename = os.path.join(EQ_PATH, eq_name)
         eq = Equilibrium.from_eqdsk(filename)
         fw_name = "DN_fw_shape.json"
-        filename = os.sep.join([TEST_PATH, fw_name])
+        filename = os.path.join(TEST_PATH, fw_name)
         fw = Loop.from_file(filename)
 
         cls.params = {

--- a/tests/radiation_transport/test_advective_transport.py
+++ b/tests/radiation_transport/test_advective_transport.py
@@ -55,15 +55,22 @@ class TestChargedParticleInputs:
         with pytest.raises(AdvectionTransportError):
             ChargedParticleSolver(params, None)
 
+    def test_TypeError_given_unknown_parameter(self):
+        params = {"not_a_param": 0.1}
+
+        with pytest.raises(TypeError) as type_error:
+            ChargedParticleSolver(params, None)
+        assert "not_a_param" in str(type_error)
+
 
 class TestChargedParticleRecursionSN:
     @classmethod
     def setup_class(cls):
         eq_name = "EU-DEMO_EOF.json"
-        filename = os.sep.join([EQ_PATH, eq_name])
+        filename = os.path.join(EQ_PATH, eq_name)
         eq = Equilibrium.from_eqdsk(filename)
         fw_name = "first_wall.json"
-        filename = os.sep.join([TEST_PATH, fw_name])
+        filename = os.path.join(TEST_PATH, fw_name)
         fw = Loop.from_file(filename)
 
         cls.params = {

--- a/tests/radiation_transport/test_advective_transport.py
+++ b/tests/radiation_transport/test_advective_transport.py
@@ -25,7 +25,6 @@ import numpy as np
 import pytest
 
 from bluemira.base.file import get_bluemira_path
-from bluemira.base.parameter import ParameterFrame
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.geometry._deprecated_loop import Loop
 from bluemira.radiation_transport.advective_transport import ChargedParticleSolver
@@ -37,27 +36,22 @@ EQ_PATH = get_bluemira_path("equilibria", subfolder="data")
 
 class TestChargedParticleInputs:
     def test_bad_fractions(self):
-
-        # fmt: off
-        params = ParameterFrame([
-            ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.1, "dimensionless", None, "Input"],
-            ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.1, "dimensionless", None, "Input"],
-            ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0.1, "dimensionless", None, "Input"],
-            ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0.1, "dimensionless", None, "Input"],
-        ])
-        # fmt: on
+        params = {
+            "f_lfs_lower_target": 0.1,
+            "f_hfs_lower_target": 0.1,
+            "f_lfs_upper_target": 0.1,
+            "f_hfs_upper_target": 0.1,
+        }
 
         with pytest.raises(AdvectionTransportError):
             ChargedParticleSolver(params, None)
 
-        # fmt: off
-        params = ParameterFrame([
-            ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.9, "dimensionless", None, "Input"],
-            ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.9, "dimensionless", None, "Input"],
-            ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0, "dimensionless", None, "Input"],
-            ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0.9, "dimensionless", None, "Input"],
-        ])
-        # fmt: on
+        params = {
+            "f_lfs_lower_target": 0.9,
+            "f_hfs_lower_target": 0.9,
+            "f_lfs_upper_target": 0,
+            "f_hfs_upper_target": 0.9,
+        }
         with pytest.raises(AdvectionTransportError):
             ChargedParticleSolver(params, None)
 
@@ -72,18 +66,16 @@ class TestChargedParticleRecursionSN:
         filename = os.sep.join([TEST_PATH, fw_name])
         fw = Loop.from_file(filename)
 
-        # fmt: off
-        cls.params = ParameterFrame([
-            ["P_sep_particle", "power crossing the separatrix", 100, "MW", None, "Input"],
-            ["f_p_sol_near", "near scrape-off layer power rate", 0.50, "dimensionless", None, "Input"],
-            ["fw_lambda_q_near_omp", "Lambda q near SOL at the outboard", 0.05, "m", None, "Input"],
-            ["fw_lambda_q_far_omp", "Lambda q far SOL at the outboard", 0.05, "m", None, "Input"],
-            ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.75, "dimensionless", None, "Input"],
-            ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.25, "dimensionless", None, "Input"],
-            ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0, "dimensionless", None, "Input"],
-            ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0, "dimensionless", None, "Input"],
-        ])
-        # fmt:on
+        cls.params = {
+            "P_sep_particle": 100,
+            "f_p_sol_near": 0.50,
+            "fw_lambda_q_near_omp": 0.05,
+            "fw_lambda_q_far_omp": 0.05,
+            "f_lfs_lower_target": 0.75,
+            "f_hfs_lower_target": 0.25,
+            "f_lfs_upper_target": 0,
+            "f_hfs_upper_target": 0,
+        }
 
         solver = ChargedParticleSolver(cls.params, eq, dx_mp=0.001)
         x, z, hf = solver.analyse(fw)
@@ -156,20 +148,18 @@ class TestChargedParticleRecursionDN:
         filename = os.sep.join([TEST_PATH, fw_name])
         fw = Loop.from_file(filename)
 
-        # fmt: off
-        cls.params = ParameterFrame([
-            ["P_sep_particle", "power crossing the separatrix", 140, "MW", None, "Input"],
-            ["f_p_sol_near", "near scrape-off layer power rate", 0.65, "dimensionless", None, "Input"],
-            ["fw_lambda_q_near_omp", "Lambda q near SOL at the outboard", 0.003, "m", None, "Input"],
-            ["fw_lambda_q_far_omp", "Lambda q far SOL at the outboard", 0.1, "m", None, "Input"],
-            ["fw_lambda_q_near_imp", "Lambda q near SOL at the inboard", 0.003, "m", None, "Input"],
-            ["fw_lambda_q_far_imp", "Lambda q far SOL at the inboard", 0.1, "m", None, "Input"],
-            ["f_lfs_lower_target", "Fraction of SOL power deposited on the LFS lower target", 0.9 * 0.5, "dimensionless", None, "Input"],
-            ["f_hfs_lower_target", "Fraction of SOL power deposited on the HFS lower target", 0.1 * 0.5, "dimensionless", None, "Input"],
-            ["f_lfs_upper_target", "Fraction of SOL power deposited on the LFS upper target (DN only)", 0.9 * 0.5, "dimensionless", None, "Input"],
-            ["f_hfs_upper_target", "Fraction of SOL power deposited on the HFS upper target (DN only)", 0.1 * 0.5, "dimensionless", None, "Input"],
-        ])
-        # fmt: on
+        cls.params = {
+            "P_sep_particle": 140,
+            "f_p_sol_near": 0.65,
+            "fw_lambda_q_near_omp": 0.003,
+            "fw_lambda_q_far_omp": 0.1,
+            "fw_lambda_q_near_imp": 0.003,
+            "fw_lambda_q_far_imp": 0.1,
+            "f_lfs_lower_target": 0.9 * 0.5,
+            "f_hfs_lower_target": 0.1 * 0.5,
+            "f_lfs_upper_target": 0.9 * 0.5,
+            "f_hfs_upper_target": 0.1 * 0.5,
+        }
 
         solver = ChargedParticleSolver(cls.params, eq, dx_mp=0.001)
         x, z, hf = solver.analyse(fw)


### PR DESCRIPTION
## Linked Issues

Part of #1422 

## Description

Remove use of `ParameterFrame` in the `radiation_transport` module. It's replaced with a dataclass.

## Interface Changes

Initialise a `ChargedParticleSolver` with a dictionary, instead of a `ParameterFrame`.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
