### PR TITLE
📝 change badge to release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![docs](https://readthedocs.org/projects/bluemira/badge/?version=develop)](https://bluemira.readthedocs.io/en/develop) [![codecov](https://codecov.io/gh/Fusion-Power-Plant-Framework/bluemira/branch/develop/graph/badge.svg?token=BYTJ4CZ8BI)](https://codecov.io/gh/Fusion-Power-Plant-Framework/bluemira)
+[![docs](https://readthedocs.org/projects/bluemira/badge/?version=latest)](https://bluemira.readthedocs.io/en/latest) [![codecov](https://codecov.io/gh/Fusion-Power-Plant-Framework/bluemira/branch/develop/graph/badge.svg?token=BYTJ4CZ8BI)](https://codecov.io/gh/Fusion-Power-Plant-Framework/bluemira)
 
 
 # Bluemira


### PR DESCRIPTION
## Description

We should probably link to the release docs rather than dev docs from the badge. Unfortunately I've never found a way to do it dynamically 

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
