### PR TITLE
📌 freeze mpl version more strictly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "fortranformat",
     "gmsh",
     "imageio",
-    "matplotlib>=3.5",
+    "matplotlib>=3.5,<3.6",
     "neutronics-material-maker==0.1.11",  # Crash on upgrade
     "nlopt",
     "numba",


### PR DESCRIPTION
## Description

Until #1452 and until #1457 can be merged we should limit matplotlib, because it breaks things otherwise

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
