### PR TITLE
👷 ::set-output is deprecated 

### DIFF
--- a/.github/workflows/check_release_due.yml
+++ b/.github/workflows/check_release_due.yml
@@ -21,7 +21,7 @@ jobs:
           CURRENT_DATE="$(date --date="$(date +'%y%m%d')" +%s)"
           DAYS_DIFF=$(( ("${INITIAL_RELEASE_DATE}" - "${CURRENT_DATE}")/(60*60*24) ))
           if [ $(("${DAYS_DIFF}" % 42)) -eq 0 ]; then
-            echo ::set-output name=release_due::true
+            echo release_due::true >> $GITHUB_OUTPUT
           else
             echo "Release is not due"
           fi

--- a/.github/workflows/check_release_due.yml
+++ b/.github/workflows/check_release_due.yml
@@ -21,7 +21,7 @@ jobs:
           CURRENT_DATE="$(date --date="$(date +'%y%m%d')" +%s)"
           DAYS_DIFF=$(( ("${INITIAL_RELEASE_DATE}" - "${CURRENT_DATE}")/(60*60*24) ))
           if [ $(("${DAYS_DIFF}" % 42)) -eq 0 ]; then
-            echo release_due::true >> $GITHUB_OUTPUT
+            echo release_due=true >> $GITHUB_OUTPUT
           else
             echo "Release is not due"
           fi

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -56,7 +56,7 @@ jobs:
         # Ugly stuff to escape new lines
         report_str="${report_str//'%'/'%25'}"
         report_str="${report_str//$'\n'/'%0A'}"
-        echo report::"${report_str}"" >> $GITHUB_OUTPUT
+        echo report="${report_str}"" >> $GITHUB_OUTPUT
 
     - name: Find warning report comment
       if: env.RESULT == 'success' && steps.workflow-run-info.outputs.pullRequestNumber != ''

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -56,7 +56,7 @@ jobs:
         # Ugly stuff to escape new lines
         report_str="${report_str//'%'/'%25'}"
         report_str="${report_str//$'\n'/'%0A'}"
-        echo "::set-output name=report::"${report_str}""
+        echo report::"${report_str}"" >> $GITHUB_OUTPUT
 
     - name: Find warning report comment
       if: env.RESULT == 'success' && steps.workflow-run-info.outputs.pullRequestNumber != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             exit 1;
           fi
 
-          echo tag::${TAG} >> $GITHUB_OUTPUT
+          echo tag=${TAG} >> $GITHUB_OUTPUT
 
       - name: Update main
         id: update-main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             exit 1;
           fi
 
-          echo ::set-output name=tag::${TAG}
+          echo tag::${TAG} >> $GITHUB_OUTPUT
 
       - name: Update main
         id: update-main


### PR DESCRIPTION
## Description

`::set-output name=` in github actions has been deprecated replaced with `>> $GITHUB_OUTPUT` as described:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Interface Changes

If you've had to update an interface or introduce a new interface as part of your change then let us know here.

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
