### PR TITLE
📝 Documentation infrastructure improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Build Documentation bluemira
       shell: bash -l {0}
       run: |
-        sphinx-build -W documentation/source documentation/build
+        sphinx-build -j auto -W documentation/source documentation/build
 
     - name: Run pytest bluemira
       shell: bash -l {0}

--- a/bluemira/codes/plasmod/api/_teardown.py
+++ b/bluemira/codes/plasmod/api/_teardown.py
@@ -99,12 +99,19 @@ class Teardown(CodesTeardown):
         """
         Check the returned exit code of plasmod.
 
-        1: PLASMOD converged successfully
-        -1: Max number of iterations achieved
-            (equilibrium oscillating, pressure too high, reduce H)
-            0: transport solver crashed (abnormal parameters
-            or too large dtmin and/or dtmin
-        -2: Equilibrium solver crashed: too high pressure
+        1: PLASMOD converged successfully:
+
+        -1: Max number of iterations achieved:
+
+            Equilibrium oscillating, pressure too high, reduce H
+
+        0: transport solver crashed:
+
+            Abnormal parameters or too large dtmin and/or dtmin
+
+        -2: Equilibrium solver crashed:
+
+            Pressure too high
 
         Raises
         ------

--- a/bluemira/equilibria/coils.py
+++ b/bluemira/equilibria/coils.py
@@ -1029,7 +1029,7 @@ class CoilGroup:
     @staticmethod
     def _sum_all(seq, method, *args):
         """
-        Sums all the responses in a sequence of objects for obj.method(*args)
+        Sums all the responses in a sequence of objects for a given method result
         """
         a = np.array([getattr(obj, method)(*args) for obj in seq])
         return a.sum(axis=0)
@@ -1037,7 +1037,7 @@ class CoilGroup:
     @staticmethod
     def _all_if(seq, method, *args):
         """
-        Sums all the responses in a sequence of objects for obj.method(*args)
+        Sums all the responses in a sequence of objects for a given method result
         if obj.control is True
         """
         return [getattr(obj, method)(*args) for obj in seq if obj.control]

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -130,8 +130,8 @@ class MHDState:
         Stores Green's functions arrays in a dictionary of coils. Used upon
         initialisation and must be called after meshing of coils.
 
-        Modifies:
-        ------
+        Modifies
+        --------
         ._pgreen: dict
             Greens function coil mapping for psi
         ._bxgreen: dict

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -130,14 +130,16 @@ class MHDState:
         Stores Green's functions arrays in a dictionary of coils. Used upon
         initialisation and must be called after meshing of coils.
 
-        Modifies
-        --------
-        ._pgreen: dict
-            Greens function coil mapping for psi
-        ._bxgreen: dict
-            Greens function coil mapping for Bx
-        .bzgreen: dict
-            Greens function coil mapping for Bz
+        Notes
+        -----
+        Modifies:
+
+            ._pgreen: dict
+                Greens function coil mapping for psi
+            ._bxgreen: dict
+                Greens function coil mapping for Bx
+            .bzgreen: dict
+                Greens function coil mapping for Bz
         """
         self._psi_green = self.coilset.map_psi_greens(self.x, self.z)
         self._bx_green = self.coilset.map_Bx_greens(self.x, self.z)
@@ -826,9 +828,10 @@ class Equilibrium(MHDState):
         Note
         ----
         Modifies the following in-place:
-            .plasma_psi                                                          \n
-            .psi_func                                                            \n
-            ._I_p                                                                 \n
+
+            .plasma_psi
+            .psi_func
+            ._I_p
             ._Jtor
         """
         if self._li is None:

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -49,6 +49,9 @@ from bluemira.utilities.opt_variables import BoundedVariable, OptVariables
 __all__ = [
     "GeometryParameterisation",
     "PictureFrame",
+    "PictureFrameMeta",
+    "PictureFrameTools",
+    "PFrameSection",
     "PolySpline",
     "PrincetonD",
     "SextupleArc",
@@ -1323,21 +1326,32 @@ class PFrameSection(Enum):
     TAPERED_INNER = partial(PictureFrameTools._make_tapered_inner_leg)
 
     def __call__(self, *args, **kwargs):
+        """
+        Call linked function on access
+        """
         return self.value(*args, **kwargs)
 
 
 class PictureFrameMeta(type(GeometryParameterisation), type(PictureFrameTools)):
+    """
+    A Metaclass to define the customisations on a given PictureFrame parameterisation
 
-    __SECT_STR = Union[str, PFrameSection]
+    The methods required to create a modified of the upper, lower or inner legs
+    are set here
+
+    """
 
     def __call__(
         cls,  # noqa: N805
         var_dict: Optional[Dict] = None,
         *,
-        upper: __SECT_STR = PFrameSection.FLAT,
-        lower: __SECT_STR = PFrameSection.FLAT,
-        inner: Optional[__SECT_STR] = None,
-    ):
+        upper: Union[str, PFrameSection] = PFrameSection.FLAT,
+        lower: Union[str, PFrameSection] = PFrameSection.FLAT,
+        inner: Optional[Union[str, PFrameSection]] = None,
+    ) -> PictureFrame:
+        """
+        Setup the modified PictureFrame class
+        """
         cls.upper = upper if isinstance(upper, PFrameSection) else PFrameSection[upper]
         cls.lower = lower if isinstance(lower, PFrameSection) else PFrameSection[lower]
 

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1336,7 +1336,7 @@ class PictureFrameMeta(type(GeometryParameterisation), type(PictureFrameTools)):
     """
     A Metaclass to define the customisations on a given PictureFrame parameterisation
 
-    The methods required to create a modified of the upper, lower or inner legs
+    The methods required to create modified upper, lower or inner legs
     are set here
 
     """
@@ -1350,7 +1350,7 @@ class PictureFrameMeta(type(GeometryParameterisation), type(PictureFrameTools)):
         inner: Optional[Union[str, PFrameSection]] = None,
     ) -> PictureFrame:
         """
-        Setup the modified PictureFrame class
+        Set up the modified PictureFrame class
         """
         cls.upper = upper if isinstance(upper, PFrameSection) else PFrameSection[upper]
         cls.lower = lower if isinstance(lower, PFrameSection) else PFrameSection[lower]

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -92,21 +92,27 @@ html_css_files = ["css/custom.css"]
 
 numfig = True
 
+
 # --- Configuration for sphinx-autoapi ---
 extensions.append("sphinx.ext.inheritance_diagram")
 extensions.append("autoapi.extension")
 
 autoapi_type = "python"
 autoapi_dirs = ["../../bluemira"]
-autoapi_keep_files = False
+autoapi_keep_files = True
 autoapi_options = [
     "members",
     "undoc-members",
+    "private-members",
     "show-inheritance",
     "show-inheritance-diagram",
     "show-module-summary",
     "special-members",
 ]
+
+# --- Configuration for graphviz ---
+extensions.append("sphinx.ext.graphviz")
+graphviz_output_format = "svg"
 
 
 class ParamsDirective(Directive):
@@ -160,20 +166,19 @@ class SkipAlreadyDocumented:
     """
 
     def __init__(self):
-        lis = [
+        skip_list = [
             "bluemira.codes.process.api.ENABLED",
             "bluemira.codes.process.api.PROCESS_DICT",
+            "bluemira.codes._nlopt_api.NLOPTOptimiser._opt_inputs_ready",
         ]
 
-        self.dict = {i: 0 for i in lis}
+        self.skip_dict = {i: 0 for i in skip_list}
 
     def __call__(self, app, what, name, obj, skip, options):
         """autoapi-skip-member definition"""
-        if name in self.dict:
+        if name in self.skip_dict:
             # Skip first occurrence
-            if self.dict[name] < 1:
+            if self.skip_dict[name] < 1:
                 skip = True
-            else:
-                skip = False
-            self.dict[name] += 1
+            self.skip_dict[name] += 1
         return skip

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -194,7 +194,19 @@ def html_visit_inheritance_diagram(self, node):
     """
     Hacks the uri of the inheritance diagram if its an autoapi diagram
 
-    Otherwise we get 404 links from the diagram
+    By default the refuri link is to ../../<expected file>.html whereas
+    the actual file lives at autapi/bluemira/<expected file>.html.
+
+    refuri is used for parent classes outside of the current file.
+
+    The original function appends a further ../ to the refuri which has the
+    effect of returning to the root directory of the built documentation.
+
+    I havent found a method to set the default expected path and it seems to
+    be a slight incompatibility between autoapi and inheritance-diagram
+
+    This replaces the wrong path with a corrected path to the autoapi folder,
+    otherwise we get 404 links from the diagram links.
     """
     current_filename = self.builder.current_docname + self.builder.out_suffix
     if "autoapi" in current_filename:

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -182,3 +182,28 @@ class SkipAlreadyDocumented:
                 skip = True
             self.skip_dict[name] += 1
         return skip
+
+
+# autoapi inheritance diagram hack
+import sphinx.ext.inheritance_diagram as inheritance_diagram  # noqa: E402
+
+_old_html_visit_inheritance_diagram = inheritance_diagram.html_visit_inheritance_diagram
+
+
+def html_visit_inheritance_diagram(self, node):
+    """
+    Hacks the uri of the inheritance diagram if its an autoapi diagram
+
+    Otherwise we get 404 links from the diagram
+    """
+    current_filename = self.builder.current_docname + self.builder.out_suffix
+    if "autoapi" in current_filename:
+        for n in node:
+            refuri = n.get("refuri")
+            if refuri is not None:
+                n["refuri"] = f"autoapi/bluemira/{refuri[6:]}"
+
+    return _old_html_visit_inheritance_diagram(self, node)
+
+
+inheritance_diagram.html_visit_inheritance_diagram = html_visit_inheritance_diagram

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -195,7 +195,7 @@ def html_visit_inheritance_diagram(self, node):
     Hacks the uri of the inheritance diagram if its an autoapi diagram
 
     By default the refuri link is to ../../<expected file>.html whereas
-    the actual file lives at autapi/bluemira/<expected file>.html.
+    the actual file lives at autoapi/bluemira/<expected file>.html.
 
     refuri is used for parent classes outside of the current file.
 


### PR DESCRIPTION
## Description

This makes most methods documented. Something I've found, if `__all__` is defined and the object is not in all it doesn't get documented. Should have a look through as part of #1418 to make sure we're not missing anything.

Made the documentation build multicore if they exist (`-j auto`)

Hacks the autoapi inheritance diagrams to have the correct uri

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
