### PR TITLE
📝 Codes and MappedParameterFrame docs

### DIFF
--- a/documentation/source/codes/codes.rst
+++ b/documentation/source/codes/codes.rst
@@ -21,22 +21,33 @@ MappedParameterFrames
 ^^^^^^^^^^^^^^^^^^^^^
 
 `MappedParameterFrames` extend the base `ParameterFrame` to allow mapping to external codes variables through `ParameterMapping`_.
-Default values for external codes are also enabled for instances where there are many unmapped variables that are only exposed to experienced users through the :py:attr:`problem_settings` of a `Solver` which is a direct link to the external code's variables.
+:py:class:`.MappedParameterFrame` extends :py:class:`.ParameterFrame`
+to allow mapping to external codes' variables through `ParameterMapping`_.
+Default values for external codes' parameters are provided for instances
+where there are many unmapped variables,
+which are usually only known by users experienced with the external code.
+These unmapped parameters can be set using the :py:attr:`problem_settings` of a
+:py:class:`.SolverABC` instance.
 
 ParameterMapping
 """"""""""""""""
 
-ParameterMapping is used to create a connection between ``bluemira`` parameters and parameters on any external program. At its most basic level it is a key-value mapping between two variable names. On top of the mapping, how the parameter value flows between ``bluemira`` and the external program is modified by the :py:attr:`send` and :py:attr:`recv` attributes.
+:py:class:`.ParameterMapping` is used to create a connection
+between ``bluemira`` parameters and parameters of any external program.
+At its most basic level, it is a key-value mapping between two variable names.
+On top of the mapping, how the parameter value flows
+between ``bluemira`` and the external program
+is modified by the :py:attr:`send` and :py:attr:`recv` attributes.
 
 :py:attr:`send`
-    true - set bluemira parameter value as input to external code
+    ``True`` - set bluemira parameter value as input to external code
 
-    false - use default value as input to external code
+    ``False`` - use default value as input to external code
 
 :py:attr:`recv`
-    true - set external code result to the new value of the bluemira parameter
+    ``True`` - set external code result to the new value of the bluemira parameter
 
-    false - keep the original bluemira parameter value ignoring the external value
+    ``False`` - keep the original bluemira parameter value ignoring the external value
 
 FPIs
 ^^^^

--- a/documentation/source/codes/codes.rst
+++ b/documentation/source/codes/codes.rst
@@ -17,6 +17,27 @@ Any additional pluggable dependencies should have APIs created in a similar way.
 External Code Interfaces
 ------------------------
 
+MappedParameterFrames
+^^^^^^^^^^^^^^^^^^^^^
+
+`MappedParameterFrames` extend the base `ParameterFrame` to allow mapping to external codes variables through `ParameterMapping`_.
+Default values for external codes are also enabled for instances where there are many unmapped variables that are only exposed to experienced users through the :py:attr:`problem_settings` of a `Solver` which is a direct link to the external code's variables.
+
+ParameterMapping
+""""""""""""""""
+
+ParameterMapping is used to create a connection between ``bluemira`` parameters and parameters on any external program. At its most basic level it is a key-value mapping between two variable names. On top of the mapping, how the parameter value flows between ``bluemira`` and the external program is modified by the :py:attr:`send` and :py:attr:`recv` attributes.
+
+:py:attr:`send`
+    true - set bluemira parameter value as input to external code
+
+    false - use default value as input to external code
+
+:py:attr:`recv`
+    true - set external code result to the new value of the bluemira parameter
+
+    false - keep the original bluemira parameter value ignoring the external value
+
 FPIs
 ^^^^
 
@@ -29,58 +50,58 @@ The simplest interface would look like:
 
     from enum import auto
 
-    import bluemira.codes.interface as interface
+    from bluemira.base.solver import RunMode as BaseRunMode
+    from bluemira.codes.interface import CodesSolver, CodesTeardown, CodesSetup, CodesTask
 
 
-    class RunMode(interface.RunMode):
+    class RunMode(BaseRunMode):
         RUN = auto()
 
 
-    class Setup(interface.Setup):
+    class Setup(CodesSetup):
 
-        def _run(self):
+        def run(self):
             # Write input file
             pass
 
 
-    class Run(interface.Run):
+    class Run(CodesTask):
 
-        def _run(self):
-            self._run_subprocess(self._binary)
+        def run(self):
+            self._run_subprocess(self.binary)
 
 
-    class Teardown(interface.Teardown):
+    class Teardown(CodesTeardown):
 
-        def _run(self):
+        def run(self):
             # read from the output file
             pass
 
 
-    class Solver(interface.FileProgramInterface):
-        _runmode = RunMode
+    class Solver(CodesSolver):
+        name = "MYPROG"
+        setup_cls = Setup
+        run_cls = Run
+        teardown_cls = Teardown
+        run_mode_cls = RunMode
 
         def __init__(
             self,
             params,
-            build_config=None,
-            run_dir: Optional[str] = None,
+            build_config,
         ):
-            super().__init__(
-                "MYPROG",
-                params,
-                build_config.get("mode", "run"),
-                binary=build_config.get("binary", None),
-                run_dir=run_dir,
-                mappings=[],
-                problem_settings=build_config.get("problem_settings", None),
-            )
+            super().__init__(params)
+
+            self.build_config = build_config
+            self.binary=build_config.get("binary", None),
+            self.problem_settings=build_config.get("problem_settings", None)
 
 
-FileProgramInterface
-""""""""""""""""""""
+CodesSolver
+"""""""""""
 
-The ``FileProgramInterface`` class collects all the tasks together providing a single point to interface between bluemira and the external program.
-A child of FileProgramInterface is the only class that needs to be imported to run a specific solver as seen below.
+The ``CodesSolver`` class collects all the tasks together providing a single point to interface between bluemira and the external program.
+A child of CodesSolver is the only class that needs to be imported to run a specific solver as seen below.
 
 .. code-block:: python
 
@@ -90,25 +111,27 @@ A child of FileProgramInterface is the only class that needs to be imported to r
     build_config: Dict
 
     solver = mycode.Solver(params, build_config)
-    solver.run()
+    solver.execute("run")
 
-All mappings for a code are passed to the ``ParameterFrame`` from the child class. The ``RunMode``, ``Setup``, ``Run`` and ``Teardown`` classes are forced to inherit from their respective baseclasses, and a few properties for ease of access are defined. The runmode and the directory in which the code is run are set in the class initialisation.
+All mappings for a code are stored in the ``MappedParameterFrame``.
+The ``RunMode``, ``Setup``, ``Run`` and ``Teardown`` classes are forced to inherit from their respective baseclasses, and a few properties for ease of access are defined. The runmode and the directory in which the code is run are set in the class initialisation.
 
-Variables can be passed through the run method to each task. Using keyword arguments is recommended so that the variables are used correctly.
-
-The only class that technically needs to be defined is ``RunMode``. The rest can be set to None (although they will produce a warning) or just not defined in the inherited class attributes.
+The only class that technically needs to be defined is ``RunMode`` although nothing will happen in that case.
 
 RunMode
 """""""
 
-Each run mode of the code should be defined as a class attribute inherited from this class. The name of the run mode corresponds to the task method that is called when the solver is run. The method that is called is prefixed with '_' and the lower case version of the run mode eg. ``RunMode.RUN`` would call ``_run``. Tasks do not need to have any run methods. The methods will only be called if they exists.
+Each run mode of the code should be defined as a class attribute inherited from this class.
+The name of the run mode corresponds to the task method that is called when the solver is run,
+for instance the method that is called with ``RunMode.RUN`` is ``run``.
+Tasks do not need to have any run methods. The methods will only be called if they exists.
 
 Tasks
 """""
 
 The basic task that the three task types inherit from (``Setup``, ``Run``, ``Teardown``)
 The ``_run_subprocess`` method is defined here as some tasks other than ``Run`` may want to run an external program. All stdout/err outputs of any external code are captured here so we can control what is output to the screen. ``stdout`` is sent to the INFO logger and ``stderr`` is sent to the ERROR logger.
-The parent attribute of tasks is an instance of a ``FileProgramInterface`` child class which allows communication between tasks.
+The parent attribute of tasks is an instance of a ``CodesSolver`` child class which allows communication between tasks.
 
 All base tasks have a ``__init__`` method therefore any child task need to call ``super().__init__(**kwargs)`` to ensure the task is initialised completely.
 The tasks are defined as follows:

--- a/documentation/source/codes/codes.rst
+++ b/documentation/source/codes/codes.rst
@@ -20,7 +20,6 @@ External Code Interfaces
 MappedParameterFrames
 ^^^^^^^^^^^^^^^^^^^^^
 
-`MappedParameterFrames` extend the base `ParameterFrame` to allow mapping to external codes variables through `ParameterMapping`_.
 :py:class:`.MappedParameterFrame` extends :py:class:`.ParameterFrame`
 to allow mapping to external codes' variables through `ParameterMapping`_.
 Default values for external codes' parameters are provided for instances


### PR DESCRIPTION
## Description

Updates the Codes docs slightly, adds MappedParameterFrame and move ParameterMapping docs here too

based of #1567 

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
