### PR TITLE
Bump jupyter-core from 4.11.1 to 4.11.2 

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -19,8 +19,8 @@ ipython-genutils==0.2.0
 jedi==0.18.1
 Jinja2==3.1.2
 jsonschema==4.16.0
-jupyter-client==7.3.5
-jupyter-core==4.11.1
+jupyter-client==7.4.2
+jupyter-core==4.11.2
 jupyterlab-pygments==0.2.2
 MarkupSafe==2.1.1
 matplotlib-inline==0.1.6


### PR DESCRIPTION
## Description

Bumps jupyter-core for security alert, cherry pick of #1547 

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
