### PR TITLE
Comment issue/PR template instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,31 +9,33 @@ assignees: ''
 
 ## Describe the bug
 
-A clear and concise description of what the bug is.
+<!---A clear and concise description of what the bug is.--->
 
 ## Steps to reproduce
 
+<!---
 Steps to reproduce the behaviour:
 
 1. Using script '...'
 2. Run command '...'
 3. Note output '...'
 4. See error '...'
+--->
 
 ## Expected behaviour
 
-A clear and concise description of what you expected to happen.
+<!--- A clear and concise description of what you expected to happen. --->
 
 ## Screenshots / Tracebacks
 
-If applicable, add screenshots / tracebacks to help explain your problem.
+<!-- If applicable, add screenshots / tracebacks to help explain your problem. -->
 
 ## Environment (please complete the following information)
 
-- OS: [e.g. Ubuntu 18.04]
-- Version [e.g. 0.0.x]
-- Branch (if developing) [e.g. develop]
+- OS: <!-- [e.g. Ubuntu 18.04] -->
+- Version: <!-- [e.g. 0.0.x] -->
+- Branch: <!-- (if developing) [e.g. develop] -->
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/eu_demo_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/eu_demo_bug_report.md
@@ -9,31 +9,33 @@ assignees: ''
 
 ## Describe the bug
 
-A clear and concise description of what the bug is.
+<!---A clear and concise description of what the bug is.--->
 
 ## Steps to reproduce
 
+<!---
 Steps to reproduce the behaviour:
 
 1. Using script '...'
 2. Run command '...'
 3. Note output '...'
 4. See error '...'
+--->
 
 ## Expected behaviour
 
-A clear and concise description of what you expected to happen.
+<!--- A clear and concise description of what you expected to happen. --->
 
 ## Screenshots / Tracebacks
 
-If applicable, add screenshots / tracebacks to help explain your problem.
+<!-- If applicable, add screenshots / tracebacks to help explain your problem. -->
 
 ## Environment (please complete the following information)
 
-- OS: [e.g. Ubuntu 18.04]
-- Version [e.g. 0.0.x]
-- Branch (if developing) [e.g. develop]
+- OS: <!-- [e.g. Ubuntu 18.04] -->
+- Version: <!-- [e.g. 0.0.x] -->
+- Branch: <!-- (if developing) [e.g. develop] -->
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/eu_demo_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/eu_demo_feature_request.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
+<!-- Before requesting a new feature, please check the Issues to see if your idea is already being discussed. -->
 
 ## Description of issue / requirement to address
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## Proposed solution
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Alternative solutions
 
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,20 +6,20 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
+<!-- Before requesting a new feature, please check the Issues to see if your idea is already being discussed. -->
 
 ## Description of issue / requirement to address
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## Proposed solution
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Alternative solutions
 
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/step_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/step_bug_report.md
@@ -9,31 +9,33 @@ assignees: ''
 
 ## Describe the bug
 
-A clear and concise description of what the bug is.
+<!---A clear and concise description of what the bug is.--->
 
 ## Steps to reproduce
 
+<!---
 Steps to reproduce the behaviour:
 
 1. Using script '...'
 2. Run command '...'
 3. Note output '...'
 4. See error '...'
+--->
 
 ## Expected behaviour
 
-A clear and concise description of what you expected to happen.
+<!--- A clear and concise description of what you expected to happen. --->
 
 ## Screenshots / Tracebacks
 
-If applicable, add screenshots / tracebacks to help explain your problem.
+<!-- If applicable, add screenshots / tracebacks to help explain your problem. -->
 
 ## Environment (please complete the following information)
 
-- OS: [e.g. Ubuntu 18.04]
-- Version [e.g. 0.0.x]
-- Branch (if developing) [e.g. develop]
+- OS: <!-- [e.g. Ubuntu 18.04] -->
+- Version: <!-- [e.g. 0.0.x] -->
+- Branch: <!-- (if developing) [e.g. develop] -->
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/step_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/step_feature_request.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-Before requesting a new feature, please check the Issues to see if your idea is already being discussed.
+<!-- Before requesting a new feature, please check the Issues to see if your idea is already being discussed. -->
 
 ## Description of issue / requirement to address
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## Proposed solution
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Alternative solutions
 
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 ## Linked Issues
 
-Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team.
+<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->
 
-e.g. Closes #{ID}
+Closes #{ID}
 
 ## Description
 
-What is your PR trying to achieve? How did you go about achieving it?
+<!-- What is your PR trying to achieve? How did you go about achieving it? -->
 
 ## Interface Changes
 
-If you've had to update an interface or introduce a new interface as part of your change then let us know here.
+<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
 
 ## Checklist
 


### PR DESCRIPTION


## Linked Issues

Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team.

Closes #1626 

## Description

Comment out the instructions, so the writer can still see them, but the instructions are not rendered in the markup. This saves us having to delete a lot of the template in order to have a clean ticket.

## Interface Changes

Nope

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
