### PR TITLE
👷 flake8 has moved repo location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - id: black
       language_version: python3.8
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8


### PR DESCRIPTION

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Flake8 has shutdown its gitlab repo and moved to github 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None 

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
