### PR TITLE
✨ Add show_faces to geometry plotting tutorial

### DIFF
--- a/examples/geometry/plotting_tutorial.ipynb
+++ b/examples/geometry/plotting_tutorial.ipynb
@@ -380,6 +380,30 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "## Face Plot with only Points\n",
+        "\n",
+        "Only show the wire of a face"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "f, ax = plt.subplots()\n",
+        "fplotter = FacePlotter(plane=\"xz\")\n",
+        "fplotter.options.show_wires = True\n",
+        "fplotter.options.show_faces = False\n",
+        "fplotter.plot_2d(face, ax=ax, show=False)\n",
+        "ax.set_title(\"Face plot its wire\")\n",
+        "plt.show()"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## Make a Second Face\n",
         "\n",
         "A second geometry is created, surrounding our original face."
@@ -592,6 +616,32 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "## PhysicalComponent Plot\n",
+        "\n",
+        "Creates a `PhysicalComponent` and plots only the wire and not the face.\n",
+        "\n",
+        "Note that unlike the `FacePlotter` when `show_faces = False` the wire is\n",
+        "shown by default."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "c = PhysicalComponent(\"Comp\", face)\n",
+        "c.plot_options.plane = \"xz\"\n",
+        "c.plot_options.show_faces = False\n",
+        "ax = c.plot_2d(show=False)\n",
+        "ax.set_title(\"test component plot wire of face\")\n",
+        "plt.show(block=True)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## Component Plot\n",
         "\n",
         "Creates a `Component` and plots it in the xz plane using matplotlib defaults.\n",
@@ -729,7 +779,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.12"
+      "version": "3.8.13"
     }
   },
   "nbformat": 4,

--- a/examples/geometry/plotting_tutorial.py
+++ b/examples/geometry/plotting_tutorial.py
@@ -235,6 +235,20 @@ ax.set_title("Face plot with points")
 plt.show()
 
 # %%[markdown]
+# ## Face Plot with only Points
+#
+# Only show the wire of a face
+
+# %%
+f, ax = plt.subplots()
+fplotter = FacePlotter(plane="xz")
+fplotter.options.show_wires = True
+fplotter.options.show_faces = False
+fplotter.plot_2d(face, ax=ax, show=False)
+ax.set_title("Face plot its wire")
+plt.show()
+
+# %%[markdown]
 # ## Make a Second Face
 #
 # A second geometry is created, surrounding our original face.
@@ -366,6 +380,22 @@ c.plot_options.plane = "xz"
 c.plot_options.ndiscr = 30
 ax = c.plot_2d(show=False)
 ax.set_title("test component plot")
+plt.show(block=True)
+
+# %%[markdown]
+# ## PhysicalComponent Plot
+#
+# Creates a `PhysicalComponent` and plots only the wire and not the face.
+
+# Note that unlike the `FacePlotter` when `show_faces = False` the wire is
+# shown by default.
+
+# %%
+c = PhysicalComponent("Comp", face)
+c.plot_options.plane = "xz"
+c.plot_options.show_faces = False
+ax = c.plot_2d(show=False)
+ax.set_title("test component plot wire of face")
 plt.show(block=True)
 
 # %%[markdown]


### PR DESCRIPTION
## Description

I was asked to add a little for geometry plotting example only showing the wires not the faces
<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

None
<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
