### PR TITLE
Replace matplotlib private `QuadContourGenerator` with contourpy

### DIFF
--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -27,7 +27,7 @@ import operator
 
 import numba as nb
 import numpy as np
-from matplotlib._contour import QuadContourGenerator
+from contourpy import LineType, contour_generator
 from scipy.interpolate import RectBivariateSpline
 
 from bluemira.base.look_and_feel import bluemira_warn
@@ -443,11 +443,13 @@ def get_contours(x, z, array, value):
 
     Returns
     -------
-    value_loop: np.array(ni, mi)
-        The points of the value contour in the array
+    values: List[np.ndarray]
+        The list of arrays of value contour(s) in the array
     """
-    qcg = QuadContourGenerator(x, z, array, None, None, 0)
-    return qcg.create_contour(value)[0]
+    con_gen = contour_generator(
+        x, z, array, name="mpl2014", line_type=LineType.SeparateCode
+    )
+    return con_gen.lines(value)[0]
 
 
 def find_flux_surfs(x, z, psi, psinorm, o_points=None, x_points=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "asteval",
     "Babel",
     "click",
+    "contourpy",
     "CoolProp",
     "fortranformat",
     "gmsh",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ anytree==2.8.0
 asteval==0.9.27
 Babel==2.11.0
 click==8.1.3
-CoolProp==6.4.1
 contourpy==1.0.6
+CoolProp==6.4.1
 cycler==0.11.0
 fonttools==4.38.0
 fortranformat==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ asteval==0.9.27
 Babel==2.11.0
 click==8.1.3
 CoolProp==6.4.1
+contourpy==1.0.6
 cycler==0.11.0
 fonttools==4.38.0
 fortranformat==1.2.2


### PR DESCRIPTION
## Linked Issues

Closes #1452 

## Description

Replaces use of matplotlib private functionality for contour generation on quad grids (now removed in more recent matplotlib versions) with contourpy.

Note that `TriContourGenerator` in matplotlib is still presently used.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
