### PR TITLE
Remove absolute paths from eudemo config

### DIFF
--- a/eudemo/README.md
+++ b/eudemo/README.md
@@ -1,18 +1,22 @@
 # EU-DEMO Reactor Design
 
 This folder contains the EU-DEMO reactor design.
-To run the reactor design, or the EUDEMO tests,
-you must add the `eudemo` folder to your python path:
+To use the `eudemo` package, you must add its path to your Python path:
 
 ```bash
 export PYTHONPATH="<path/to/bluemira>/eudemo:${PYTHONPATH}"
 ```
 
-Run the design using the `reactor.py` file:
+To run the reactor build,
+`cd` into the `eudemo` directory and run the `reactor.py` file:
 
-```console
+```bash
+cd <path/to/bluemira>/eudemo
 python eudemo/eudemo/reactor.py
 ```
+
+The `cd` is required, as the paths in the build config are
+relative to the `eudemo` directory.
 
 In future this will be moved to a separate repository.
 It should be used as a template for how we expect

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -1,11 +1,11 @@
 {
     "Radial build": {
-        "file_path": "/home/matti/code/bluemira/eudemo/config/mockPROCESS.json"
+        "file_path": "config/mockPROCESS.json"
     },
     "Equilibrium": {
         "plot_optimisation": false,
         "run_mode": "read",
-        "file_path": "/home/matti/code/bluemira/eudemo/config/equilibrium_eqdsk.json"
+        "file_path": "config/equilibrium_eqdsk.json"
     },
     "IVC": {
         "Wall silhouette": {
@@ -28,7 +28,7 @@
         "param_class": "TripleArc",
         "variables_map": {},
         "run_mode": "read",
-        "file_path": "/home/matti/code/bluemira/eudemo/config/TFCoilDesign.json",
+        "file_path": "config/TFCoilDesign.json",
         "problem_class": "bluemira.builders.tf_coils::RippleConstrainedLengthGOP"
     }
 }


### PR DESCRIPTION
## Description

Get rid of the absolute paths in the EUDEMO reactor build's config.

You must now run the `reactor.py` file from within the `eudemo` directory.