### PR TITLE
Add SafetyProfileModel to PLASMOD api

### DIFF
--- a/bluemira/codes/plasmod/api/_inputs.py
+++ b/bluemira/codes/plasmod/api/_inputs.py
@@ -37,6 +37,7 @@ from bluemira.codes.plasmod.mapping import (
     ImpurityModel,
     PedestalModel,
     PLHModel,
+    SafetyProfileModel,
     SOLModel,
     TransportModel,
 )
@@ -46,6 +47,7 @@ MODEL_MAP: Mapping[str, Type[enum.Enum]] = {
     "i_modeltype": TransportModel,
     "i_equiltype": EquilibriumModel,
     "i_pedestal": PedestalModel,
+    "isawt": SafetyProfileModel,
     "isiccir": SOLModel,
     "plh": PLHModel,
 }
@@ -111,7 +113,7 @@ class PlasmodInputs:
     i_modeltype: TransportModel = TransportModel.GYROBOHM_1
     i_pedestal: PedestalModel = PedestalModel.SAARELMA
     Ip: float = 17.75
-    isawt: int = 1
+    isawt: SafetyProfileModel = SafetyProfileModel.FULLY_RELAXED
     isiccir: SOLModel = SOLModel.EICH_FIT
     k: float = 1.6969830041844367
     k95: float = 1.652

--- a/bluemira/codes/plasmod/mapping.py
+++ b/bluemira/codes/plasmod/mapping.py
@@ -72,6 +72,23 @@ class EquilibriumModel(Model):
     Ip_sawtooth = 2
 
 
+class SafetyProfileModel(Model):
+    """
+    Safety Factor Profile Model Selector
+
+    0 - PLASMOD allows q < 1 in the core (fully relaxed q profile)
+    1 - PLASMOD clamps q >= 1 in the core (sawteeth forced)
+
+    Plasmod variable name: isawt
+
+    NOTE: Running with 1 means that p' and FF' will not correspond well
+    with jpar.
+    """
+
+    FULLY_RELAXED = 0
+    SAWTEETH = 1
+
+
 class PedestalModel(Model):
     """
     Pedestal Model Selector
@@ -213,9 +230,6 @@ PLASMOD_INPUTS = {
     # ###### "BM_INP": ("capA", "dimensionless"),
     # [-] diagnostics for ASTRA (0 or 1)
     # ###### "BM_INP": ("i_diagz", "dimensionless"),
-    # [-] sawtooth correction of q
-    # (fix q = 1 if q below 1)
-    # ###### "BM_INP": ("isawt, "dimensionless")",
     # [-] number of interpolated grid points
     # ###### "BM_INP": ("nx", "dimensionless"),
     # [-] number of reduced grid points


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->
Adds a model selector for two distinct options in PLASMOD.
Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Changes the default model to fully_relaxed, meaning that p' and FF' correspond more correctly to the output plasma current profile.
## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
