### PR TITLE
Add missing 2pi factor in FEM fixed boundary equilibrium solver

### DIFF
--- a/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
+++ b/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
@@ -308,7 +308,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
                 a = r * (pprime(x_psi) if callable(pprime) else pprime)
                 b = 1 / MU_0 / r * (ffprime(x_psi) if callable(ffprime) else ffprime)
 
-                return self.k * (a + b)
+                return self.k * 2 * np.pi * (a + b)
 
         return g
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Noticed that plasma current correction factor k was high. Realised we were missing a term when combining the flux functions.

For flux functions that correspond correctly to the total plasma current, k is now generally very close to 1 (as expected)

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
