### PR TITLE
🐛 set html title without git hash

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -92,7 +92,7 @@ html_css_files = ["css/custom.css"]
 
 _html_version = release.split("+")[0]
 
-html_title = f"Welcome to bluemira’s documentation! &mdash; bluemira {_html_version} documentation"
+html_title = f"bluemira {_html_version} documentation"
 
 numfig = True
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -90,6 +90,10 @@ html_theme_options = {
 
 html_css_files = ["css/custom.css"]
 
+_html_version = release.split("+")[0]
+
+html_title = f"Welcome to bluemira’s documentation! &mdash; bluemira {_html_version} documentation"
+
 numfig = True
 
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1604 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Hard codes the html title stripping the version git hash. Other option is to just remove 'dirty' from the end of the string.
The git hash revision is still displayed at the bottom of each page.

https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_title

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
