### PR TITLE
🥅 catch freecad error

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -79,7 +79,7 @@ MAX_PRECISION = 1e-5
 # ======================================================================================
 
 
-def catch_caderr(raise_error):
+def catch_caderr(new_error_type):
     """
     Catch CAD errors with given error
     """
@@ -89,7 +89,7 @@ def catch_caderr(raise_error):
             try:
                 return func(*args, **kwargs)
             except FreeCADError as fe:
-                raise raise_error(fe.args[0]) from None
+                raise new_error_type(fe.args[0]) from fe
 
         return wrapper
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -73,6 +73,29 @@ apiCompound = Part.Compound  # noqa :N816
 WORKING_PRECISION = 1e-5
 MIN_PRECISION = 1e-5
 MAX_PRECISION = 1e-5
+
+# ======================================================================================
+# Error catching
+# ======================================================================================
+
+
+def catch_caderr(raise_error):
+    """
+    Catch CAD errors with given error
+    """
+
+    def argswrap(func):
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except FreeCADError as fe:
+                raise raise_error(fe.args[0]) from None
+
+        return wrapper
+
+    return argswrap
+
+
 # ======================================================================================
 # Array, List, Vector, Point manipulation
 # ======================================================================================

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -51,6 +51,7 @@ from bluemira.geometry.solid import BluemiraSolid
 from bluemira.geometry.wire import BluemiraWire
 
 
+@cadapi.catch_caderr(GeometryError)
 def convert(apiobj, label=""):
     """Convert a FreeCAD shape into the corresponding BluemiraGeo object."""
     if isinstance(apiobj, cadapi.apiWire):

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -28,6 +28,7 @@ import pytest
 from FreeCAD import Base
 
 import bluemira.codes._freecadapi as cadapi
+from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import D_TOLERANCE
 
 
@@ -245,3 +246,11 @@ class TestFreecadapi:
 
         assert isinstance(end_point, np.ndarray)
         np.testing.assert_equal(end_point, np.array([1, 1, 0]))
+
+    def test_catcherror(self):
+        @cadapi.catch_caderr(ValueError)
+        def func():
+            raise FreeCADError("Error")
+
+        with pytest.raises(ValueError):
+            func()


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1309

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
I created it as a decorator so that the api would be constant but I'm open to other options. 

Possibly could generalise it further and have the error to catch and the error to raise as input and put the function in utilities

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
`tools.convert` will now raise a geometry error instead of a FreeCADError on failure

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
