### PR TITLE
🐛 fix indexing bug in inscribed_rect test

### DIFF
--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -1148,7 +1148,7 @@ def _parse_to_xyz_array(xyz_array):
 
 def _parse_array(xyz_array):
     try:
-        xyz_array = np.array(np.atleast_2d(xyz_array), dtype=np.float64)
+        xyz_array = np.array(np.atleast_2d(np.squeeze(xyz_array)), dtype=np.float64)
     except ValueError:
         raise CoordinatesError(
             "Cannot instantiate Coordinates with a ragged (3, N | M) array."

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -102,7 +102,9 @@ class TestInscribedRectangle:
 
                         if tf is not None:
                             # Some overlaps are points or lines of 0 area
-                            if not all([get_area(*t.xyz) == 0.0 for t in tf]):
+                            if not all(
+                                [get_area(*seg.xyz) == 0.0 for t in tf for seg in t]
+                            ):
                                 self.assertion_error_creator(
                                     "Overlap", [dx, dz, point, k, convex]
                                 )

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -24,6 +24,7 @@ import pytest
 
 from bluemira.display.plotter import PlotOptions, plot_2d
 from bluemira.geometry._private_tools import make_circle_arc
+from bluemira.geometry.constants import MINIMUM_LENGTH
 from bluemira.geometry.coordinates import Coordinates, get_area, in_polygon
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.inscribed_rect import _rect, inscribed_rect_in_poly
@@ -56,6 +57,8 @@ class TestInscribedRectangle:
     aspectratios = np.logspace(-1, 1, num=5)
 
     po = PlotOptions(face_options={})
+
+    MIN_AREA = MINIMUM_LENGTH**2
 
     @pytest.mark.parametrize("shape, convex", zip(shapes, convex))
     def test_inscribed_rectangle(self, shape, convex):
@@ -103,7 +106,11 @@ class TestInscribedRectangle:
                         if tf is not None:
                             # Some overlaps are points or lines of 0 area
                             if not all(
-                                [get_area(*seg.xyz) == 0.0 for t in tf for seg in t]
+                                [
+                                    get_area(*seg.xyz) <= self.MIN_AREA
+                                    for t in tf
+                                    for seg in t
+                                ]
                             ):
                                 self.assertion_error_creator(
                                     "Overlap", [dx, dz, point, k, convex]

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -96,7 +96,10 @@ class TestInscribedRectangle:
                                 BluemiraFace(make_polygon(sq.xyz, closed=True)),
                                 shape_face,
                             )
-                            tf = [seg.discretize(byedges=True, ndiscr=50) for seg in tf]
+                            tf = [
+                                Coordinates(seg.discretize(byedges=True, ndiscr=50))
+                                for seg in tf
+                            ]
                         except ValueError:
                             tf = None
 
@@ -105,13 +108,7 @@ class TestInscribedRectangle:
 
                         if tf is not None:
                             # Some overlaps are points or lines of 0 area
-                            if not all(
-                                [
-                                    get_area(*seg.xyz) <= self.MIN_AREA
-                                    for t in tf
-                                    for seg in t
-                                ]
-                            ):
+                            if not all([get_area(*t.xz) <= self.MIN_AREA for t in tf]):
                                 self.assertion_error_creator(
                                     "Overlap", [dx, dz, point, k, convex]
                                 )


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When trying to catch errors the indexing wasnt nested deep enough.
This is very hard to see if it fixes the occasional failure we see because I haven't had a local failing example

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
