### PR TITLE
Cleanup seaborn config

### DIFF
--- a/bluemira/display/auto_config.py
+++ b/bluemira/display/auto_config.py
@@ -145,7 +145,7 @@ def plot_defaults(force=False):
 
     sf = 1 if force else get_figure_scale_factor(figsize)
 
-    sns.set(
+    sns.set_theme(
         context="paper",
         style="ticks",
         font="DejaVu Sans",
@@ -154,14 +154,10 @@ def plot_defaults(force=False):
         rc={
             "axes.labelweight": "normal",
             "axes.titlesize": 20 * sf,
+            "contour.negative_linestyle": "solid",
             "figure.figsize": list(figsize * sf),
             "lines.linewidth": 4 * sf,
             "lines.markersize": 13 * sf,
-            "contour.negative_linestyle": "solid",
-        },
-    )
-    sns.set_style(
-        {
             "xtick.direction": "in",
             "ytick.direction": "in",
             "xtick.major.size": 8 * sf,
@@ -169,6 +165,6 @@ def plot_defaults(force=False):
             "xtick.minor.size": 4 * sf,
             "ytick.minor.size": 4 * sf,
             "xtick.color": "k",
-        }
+        },
     )
     sns.set_palette(BLUEMIRA_PALETTE)


### PR DESCRIPTION
## Description

See below comments
<!-- What is your PR trying to achieve? How did you go about achieving it? -->
~~Our current seaborn config is a bit broken below are the differences (some highlights eg `colour: .15`) (- ours, + default).~~

```
-  'axes.axisbelow': True,
+  'axes.axisbelow': 'line',
-  'axes.edgecolor': '.15',
+  'axes.edgecolor': 'black',
-  'axes.labelcolor': '.15',
+  'axes.labelcolor': 'black',
-  'axes.labelsize': 10.792727272727275,
+  'axes.labelsize': 'medium',
-  'axes.titlesize': 8.993939393939394,
+  'axes.titlesize': 'large',
-  'grid.color': '.8',
+  'grid.color': '#b0b0b0',
-  'legend.fontsize': 9.893333333333334,
+  'legend.fontsize': 'medium',
-  'legend.title_fontsize': 10.792727272727275,
+  'legend.title_fontsize': None,
-  'lines.solid_capstyle': <CapStyle.round: 'round'>,
+  'lines.solid_capstyle': <CapStyle.projecting: 'projecting'>,
-  'patch.edgecolor': 'w',
+  'patch.edgecolor': 'black',
-  'patch.force_edgecolor': True,
+  'patch.force_edgecolor': False,
-  'text.color': '.15',
+  'text.color': 'black',
-  'xtick.labelsize': 9.893333333333334,
+  'xtick.labelsize': 'medium',
-  'ytick.color': '.15',
+  'ytick.color': 'black',
-  'ytick.labelsize': 9.893333333333334,
+  'ytick.labelsize': 'medium',
```

~~This broke annotation arrows that I was trying to add as part of #1287. Without the bluemira import or with this change it worked and with the bluemira import nothing is shown~~

```python
import matplotlib.pyplot as plt

# to get our config loaded
from bluemira.display.plotter import plot_2d

fig, ax = plt.subplots()

ax.set_xlim(-1.2, 1.2), ax.set_ylim(-1.2, 1.2)

ax.annotate(
       '', xy=(0, 0), xycoords='data',
       xytext=(1, 0), textcoords='data',
       arrowprops={'arrowstyle': '<->'})

plt.show()
```

EDIT 

seems I was slightly wrong, the edge colour was set to white...~~but the config was still slightly borked~~

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
