### PR TITLE
✨ Mypy config and typing in documentation modification

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -98,6 +98,8 @@ numfig = True
 
 
 # --- Configuration for sphinx-autoapi ---
+autodoc_typehints = "both"
+
 extensions.append("sphinx.ext.inheritance_diagram")
 extensions.append("autoapi.extension")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dynamic=['version']
 classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v2.1 or later (LGPLv2.1+)",
         "Operating System :: POSIX :: Linux",
@@ -59,6 +59,7 @@ dev = [
     "flake8-absolute-import",
     "flake8-bandit",
     "flake8-docstrings",
+    "mypy",
     "pep8-naming",
     "pre-commit",
     "pytest",
@@ -119,6 +120,30 @@ profile = "black"
 skip_gitignore = true
 known_first_party = ["bluemira", "eudemo"]
 force_to_top = ["freecad"]
+
+[tool.mypy]
+python_version = "3.8"
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+ignore_missing_imports = true
+no_implicit_reexport = true
+strict_equality = true
+strict_concatenate = true
+warn_return_any = false
+warn_no_return = false
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "bluemira._version.*"
+follow_imports = "skip"
+ignore_errors = true
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This adds a basic mypy config with the eventual long term aim of enabling mypy in the CI system in some form.

It also modifies the API documentation so that types no longer need to be specified in the docstring. 

Types should now be specified in the function signature, they will be automatically added to both the signature and docstring when the documentation is built. Up for discussion however, we may just want the types in the description or signature.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
