### PR TITLE
🐛 remove weird discretisation condition for >1m coils

### DIFF
--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -31,7 +31,7 @@ import numpy as np
 from bluemira.base.look_and_feel import bluemira_debug
 from bluemira.equilibria.coils._field import CoilFieldsMixin
 from bluemira.equilibria.coils._tools import get_max_current
-from bluemira.equilibria.constants import NBTI_B_MAX, NBTI_J_MAX
+from bluemira.equilibria.constants import COIL_DISCR, NBTI_B_MAX, NBTI_J_MAX
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.plotting import CoilGroupPlotter
 from bluemira.utilities.tools import is_num
@@ -128,7 +128,7 @@ class Coil(CoilFieldsMixin):
     b_max
         Maximum magnetic field at the coil [T]
     discretisation
-        discretise the coil, value in [m]. The minimum size is 0.05m
+        discretise the coil, value in [m]. The minimum size is COIL_DISCR
     n_turns: int
         Number of turns
 
@@ -416,7 +416,7 @@ class Coil(CoilFieldsMixin):
     @discretisation.setter
     def discretisation(self, value: float):
         """Set coil discretisation"""
-        self._discretisation = np.clip(float(value), 0.05, None)
+        self._discretisation = np.clip(float(value), COIL_DISCR, None)
         self._discretise()
 
     def assign_material(

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -109,25 +109,25 @@ class Coil(CoilFieldsMixin):
 
     Parameters
     ----------
-    x: float
+    x
         Coil geometric centre x coordinate [m]
-    z: float
+    z
         Coil geometric centre z coordinate [m]
-    dx: float
+    dx
         Coil radial half-width [m] from coil centre to edge (either side)
-    dz: float
+    dz
         Coil vertical half-width [m] from coil centre to edge (either side)
-    name: str
+    name
         The name of the coil
-    ctype: Union[str, CoilType]
+    ctype
         Type of coil as defined in CoilType
-    current: float (default = 0)
-        Coil current [A]
-    j_max: float
+    current
+        Coil current [A] (default = 0)
+    j_max
         Maximum current density in the coil [A/m^2]
-    b_max: float
+    b_max
         Maximum magnetic field at the coil [T]
-    discretisation: float
+    discretisation
         discretise the coil, value in [m]. The minimum size is 0.05m
     n_turns: int
         Number of turns
@@ -168,12 +168,12 @@ class Coil(CoilFieldsMixin):
         current: float = 0,
         j_max: float = np.nan,
         b_max: float = np.nan,
-        discretisation: float = 1,
+        discretisation: float = np.nan,
         n_turns: int = 1,
     ):
         self._dx = None
         self._dz = None
-        self._discretisation = 1
+        self._discretisation = np.nan
         self._flag_sizefix = None not in (dx, dz)
 
         if dx is not None and x - dx < 0:
@@ -469,7 +469,7 @@ class Coil(CoilFieldsMixin):
         self._quad_weighting = np.ones_like(self._quad_x)
         self._einsum_str = "...j, ...j -> ..."
 
-        if self.discretisation < 1:
+        if not np.isnan(self.discretisation):
             # How fancy do we want the mesh or just smaller rectangles?
             self._rectangular_discretisation()
 

--- a/bluemira/equilibria/constants.py
+++ b/bluemira/equilibria/constants.py
@@ -93,3 +93,7 @@ PLT_PAUSE = 0.001  # Completely arbitrary number of seconds?
 # Minimum discretisation for finite difference grids.
 #       In practice should be much higher than this
 MIN_N_DISCR = 10
+
+# Minimum discretisation of a coil [m], limit imposed to avoid massive memory
+# usage
+COIL_DISCR = 0.05


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
If the discretisation of a coil was  >=1m it wouldn't be discretised this probably hasnt come up yet because a PF coil with a 1m width/height is very big. The default is now `np.nan` which is checked for when discretising.

Also moved minimum discretisation to constants

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
dicretisation defaults to `np.nan` instead of 1 but this has the same effect because of the changed discretise check

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
