### PR TITLE
Add Kuiroukidis flux surface parameterisation

### DIFF
--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -125,6 +125,8 @@ def flux_surface_kuiroukidis(
     Ap. Kuiroukidis and G. N. Throumoulopoulos, Plasma Phys. Contol. Fusion 57  (2015)
     078001
 
+    DOI: 10.1088/0741-3335/57/7/078001
+
     Parameters
     ----------
     r_0: float

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -107,6 +107,50 @@ def flux_surface_manickam(r_0, z_0, a, kappa=1, delta=0, indent=0, n=20):
     return Coordinates({"x": x, "z": z})
 
 
+def flux_surface_kuiroukidis(
+    r_0, z_0, a, kappa_u, kappa_l, delta_u, delta_l, grad_p, n_power=8, n_point=100
+):
+    n_upper = n_point // 2
+
+    e_0 = a / r_0
+    # upper part
+    theta_delta = np.pi - np.arctan(kappa_u / delta_u)
+    denom = np.pi * theta_delta**n_power - theta_delta**2 * np.pi ** (n_power - 1)
+    t_0 = theta_delta**n_power - 0.5 * np.pi**n_power / denom
+    t_1 = -(theta_delta**2) + 0.5 * np.pi**2 / denom
+    theta = np.linspace(0, np.pi, n_upper)
+    tau = t_0 * theta**2 + t_1 * theta**n_power
+
+    lizard_u = kappa_u * e_0
+    squiggle = (1 - delta_u) / e_0
+    alpha = np.arcsin(delta_u)
+    rho_delta = 1 - delta_u * e_0
+
+    x_upper = r_0 * (1 + e_0 * np.cos(tau + alpha * np.sin(tau)) - grad_p)
+    z_upper = r_0 * lizard_u * np.sin(tau)
+
+    import matplotlib.pyplot as plt
+
+    f, ax = plt.subplots()
+    ax.plot(x_upper, z_upper)
+    ax.set_aspect("equal")
+    plt.show()
+
+    # lower left
+
+    x_left = np.array([])
+    z_left = np.array([])
+
+    # lower right
+
+    x_right = np.array([])
+    z_right = np.array([])
+
+    x = np.concatenate([x_upper, x_left, x_right])
+    z = np.concatenate([z_upper, z_left, z_right])
+    return x, z
+
+
 def calc_t_neg(delta, kappa, phi_neg):
     return np.tan(phi_neg) * (1 - delta) / kappa
 

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -109,12 +109,54 @@ def flux_surface_manickam(r_0, z_0, a, kappa=1, delta=0, indent=0, n=20):
 
 
 def flux_surface_kuiroukidis(
-    r_0, z_0, a, kappa_u, kappa_l, delta_u, delta_l, grad_p, n_power=8, n_point=100
+    r_0,
+    z_0,
+    a,
+    kappa_u,
+    kappa_l,
+    delta_u,
+    delta_l,
+    grad_p,
+    n_power: int = 8,
+    n_points: int = 100,
 ):
-    """ """
-    n_half = n_point // 2
+    """
+    Make an up-down asymmetric flux surface with a lower X-point.
 
-    e_0 = a / r_0
+    Ap. Kuiroukidis and G. N. Throumoulopoulos, Plasma Phys. Contol. Fusion 57  (2015)
+    078001
+
+    Parameters
+    ----------
+    r_0: float
+        Plasma geometric major radius [m]
+    z_0: float
+        Plasma geometric vertical height [m]
+    a: float
+        Plasma geometric minor radius [m]
+    kappa_u: float
+        Upper plasma elongation
+    kappa_l: float
+        Lower plasma elongation
+    delta_u: float
+        Upper plasma triangularity
+    delta_l: float
+        Lower plasma triangularity
+    grad_p: float
+        Displacement parameter (mean value of dx/dtheta)
+    n_power: int
+        Exponent related to the steepness of the triangularity
+    n_points: int
+        Number of points
+
+    Returns
+    -------
+    flux_surface: Coordinates
+        Plasma flux surface shape
+    """
+    n_half = n_points // 2
+    e_0 = a / r_0  # inverse aspect ratio
+
     # upper part
     theta_delta = np.pi - np.arctan(kappa_u / delta_u)
     denom = np.pi * theta_delta**n_power - theta_delta**2 * np.pi ** (n_power - 1)
@@ -123,24 +165,19 @@ def flux_surface_kuiroukidis(
     theta = np.linspace(0, np.pi, n_half)
     tau = t_0 * theta**2 + t_1 * theta**n_power
 
-    lizard_u = kappa_u * e_0
-    alpha = np.arcsin(delta_u)
-
-    x_upper = r_0 * (1 + e_0 * np.cos(tau + alpha * np.sin(tau)) - grad_p)
-    z_upper = r_0 * lizard_u * np.sin(tau)
+    x_upper = r_0 * (1 + e_0 * np.cos(tau + np.arcsin(delta_u) * np.sin(tau)) - grad_p)
+    z_upper = r_0 * kappa_u * e_0 * np.sin(tau)
 
     # lower left
-    lizard_d = kappa_l * e_0
     theta_delta_lower = np.pi - np.arctan(kappa_l / delta_l)
-    p_1 = lizard_d**2 / (2 * e_0 * (1 + np.cos(theta_delta_lower)))
+    p_1 = (kappa_l * e_0) ** 2 / (2 * e_0 * (1 + np.cos(theta_delta_lower)))
     theta = np.linspace(np.pi, 2 * np.pi - theta_delta_lower, n_half // 2)
 
     x_left = r_0 * (1 + e_0 * np.cos(theta) - grad_p)
     z_left = -r_0 * np.sqrt(2 * p_1 * e_0 * (1 + np.cos(theta)))
 
     # lower right
-
-    p_2 = lizard_d**2 / (2 * e_0 * (1 - np.cos(theta_delta_lower)))
+    p_2 = (kappa_l * e_0) ** 2 / (2 * e_0 * (1 - np.cos(theta_delta_lower)))
     theta = np.linspace(2 * np.pi - theta_delta_lower, 2 * np.pi, n_half // 2)
 
     x_right = r_0 * (1 + e_0 * np.cos(theta) - grad_p)

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -232,10 +232,8 @@ def flux_surface_kuiroukidis(
     if lower_negative:
         x_left = -x_left + 2 * r_0
         x_right = -x_right + 2 * r_0
-        x_left = x_left[::-1]
-        z_left = z_left[::-1]
-        x_right = x_right[::-1]
-        z_right = z_right[::-1]
+        x_left, x_right = x_right[::-1], x_left[::-1]
+        z_left, z_right = z_right[::-1], z_left[::-1]
 
     import matplotlib.pyplot as plt
 

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -183,7 +183,18 @@ def flux_surface_kuiroukidis(
         (np.linspace(0, theta_delta, n_quart), np.linspace(theta_delta, np.pi, n_quart))
     )
     tau = t_0 * theta**2 + t_1 * theta**n_power
-    tau = np.clip(tau, None, np.pi)  # Bad theta parameterisation...
+
+    # The theta -> tau conversion approach seems flawed, and overshoots np.pi so we have
+    # to adjust
+    tau = np.clip(tau, None, np.pi)
+    clip_args = np.where(tau == np.pi)[0][0]
+    theta_max = theta[clip_args]
+    theta = np.concatenate(
+        (
+            np.linspace(0, theta_delta, n_quart),
+            np.linspace(theta_delta, theta_max, n_quart),
+        )
+    )
 
     x_upper = r_0 * (1 + e_0 * np.cos(tau + np.arcsin(delta_u) * np.sin(tau)))
     z_upper = r_0 * kappa_u * e_0 * np.sin(tau)

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -160,6 +160,12 @@ def flux_surface_kuiroukidis(
     is just an offset. The key may lie in understand what "relative to the X-point" means
     but it's not enough for me to go on at the moment.
     """
+    if delta_u < 0 and delta_l < 0:
+        delta_u *= -1
+        delta_l *= -1
+        negative = True
+    else:
+        negative = False
     n_quart = n_points // 4
     e_0 = a / r_0  # inverse aspect ratio
 
@@ -214,6 +220,9 @@ def flux_surface_kuiroukidis(
 
     x = np.concatenate([x_upper, x_left * correction, x_right * correction[::-1]])
     z = z_0 + np.concatenate([z_upper, z_left, z_right])
+
+    if negative:
+        x = -x + 2 * r_0
 
     return Coordinates({"x": x, "z": z})
 

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -35,6 +35,7 @@ __all__ = [
     "flux_surface_cunningham",
     "flux_surface_johner",
     "flux_surface_manickam",
+    "flux_surface_kuiroukidis",
     "JohnerLCFS",
 ]
 
@@ -110,45 +111,45 @@ def flux_surface_manickam(r_0, z_0, a, kappa=1, delta=0, indent=0, n=20):
 def flux_surface_kuiroukidis(
     r_0, z_0, a, kappa_u, kappa_l, delta_u, delta_l, grad_p, n_power=8, n_point=100
 ):
-    n_upper = n_point // 2
+    """ """
+    n_half = n_point // 2
 
     e_0 = a / r_0
     # upper part
     theta_delta = np.pi - np.arctan(kappa_u / delta_u)
     denom = np.pi * theta_delta**n_power - theta_delta**2 * np.pi ** (n_power - 1)
-    t_0 = theta_delta**n_power - 0.5 * np.pi**n_power / denom
-    t_1 = -(theta_delta**2) + 0.5 * np.pi**2 / denom
-    theta = np.linspace(0, np.pi, n_upper)
+    t_0 = (theta_delta**n_power - 0.5 * np.pi**n_power) / denom
+    t_1 = (-(theta_delta**2) + 0.5 * np.pi**2) / denom
+    theta = np.linspace(0, np.pi, n_half)
     tau = t_0 * theta**2 + t_1 * theta**n_power
 
     lizard_u = kappa_u * e_0
-    squiggle = (1 - delta_u) / e_0
     alpha = np.arcsin(delta_u)
-    rho_delta = 1 - delta_u * e_0
 
     x_upper = r_0 * (1 + e_0 * np.cos(tau + alpha * np.sin(tau)) - grad_p)
     z_upper = r_0 * lizard_u * np.sin(tau)
 
-    import matplotlib.pyplot as plt
-
-    f, ax = plt.subplots()
-    ax.plot(x_upper, z_upper)
-    ax.set_aspect("equal")
-    plt.show()
-
     # lower left
+    lizard_d = kappa_l * e_0
+    theta_delta_lower = np.pi - np.arctan(kappa_l / delta_l)
+    p_1 = lizard_d**2 / (2 * e_0 * (1 + np.cos(theta_delta_lower)))
+    theta = np.linspace(np.pi, 2 * np.pi - theta_delta_lower, n_half // 2)
 
-    x_left = np.array([])
-    z_left = np.array([])
+    x_left = r_0 * (1 + e_0 * np.cos(theta) - grad_p)
+    z_left = -r_0 * np.sqrt(2 * p_1 * e_0 * (1 + np.cos(theta)))
 
     # lower right
 
-    x_right = np.array([])
-    z_right = np.array([])
+    p_2 = lizard_d**2 / (2 * e_0 * (1 - np.cos(theta_delta_lower)))
+    theta = np.linspace(2 * np.pi - theta_delta_lower, 2 * np.pi, n_half // 2)
+
+    x_right = r_0 * (1 + e_0 * np.cos(theta) - grad_p)
+    z_right = -r_0 * np.sqrt(2 * p_2 * e_0 * (1 - np.cos(theta)))
 
     x = np.concatenate([x_upper, x_left, x_right])
-    z = np.concatenate([z_upper, z_left, z_right])
-    return x, z
+    z = z_0 + np.concatenate([z_upper, z_left, z_right])
+
+    return Coordinates({"x": x, "z": z})
 
 
 def calc_t_neg(delta, kappa, phi_neg):

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -160,7 +160,6 @@ def flux_surface_kuiroukidis(
     is just an offset. The key may lie in understand what "relative to the X-point" means
     but it's not enough for me to go on at the moment.
     """
-    n_half = n_points // 2
     n_quart = n_points // 4
     e_0 = a / r_0  # inverse aspect ratio
 
@@ -182,7 +181,7 @@ def flux_surface_kuiroukidis(
     theta_delta_lower = np.pi - np.arctan(kappa_l / delta_l)
     p_1 = (kappa_l * e_0) ** 2 / (2 * e_0 * (1 + np.cos(theta_delta_lower)))
     theta = np.linspace(np.pi, 2 * np.pi - theta_delta_lower, n_quart)
-    corr = delta_l - theta_delta_lower
+
     x_left = r_0 * (1 + e_0 * np.cos(theta))
     z_left = -r_0 * np.sqrt(2 * p_1 * e_0 * (1 + np.cos(theta)))
 

--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -235,21 +235,6 @@ def flux_surface_kuiroukidis(
         x_left, x_right = x_right[::-1], x_left[::-1]
         z_left, z_right = z_right[::-1], z_left[::-1]
 
-    import matplotlib.pyplot as plt
-
-    f, ax = plt.subplots()
-    ax.plot(x_upper, z_upper, color="b", marker="o", markersize=2)
-    ax.plot(x_upper[0], z_upper[0], color="b", marker="o")
-    ax.plot(x_upper[-1], z_upper[-1], color="b", marker="^")
-    ax.plot(x_left, z_left, color="r", marker="o", markersize=2)
-    ax.plot(x_left[0], z_left[0], color="r", marker="o")
-    ax.plot(x_left[-1], z_left[-1], color="r", marker="^")
-    ax.plot(x_right, z_right, color="g", marker="o", markersize=2)
-    ax.plot(x_right[0], z_right[0], color="g", marker="o")
-    ax.plot(x_right[-1], z_right[-1], color="g", marker="^")
-    ax.set_aspect("equal")
-    plt.show()
-
     x = np.concatenate([x_upper, x_left, x_right])
     z = z_0 + np.concatenate([z_upper, z_left, z_right])
 

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -112,25 +112,30 @@ class TestManickam:
 
     @classmethod
     def teardown_class(cls):
-        cls.f.suptitle("Kuirokidis parameterisations")
+        cls.f.suptitle("Manickam parameterisations")
         plt.show()
         plt.close(cls.f)
 
 
 class TestKuiroukidis:
     fixture = [
-        pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5),
-        pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5),
-        pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, 0.5),
-        pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, -0.5),
-        pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15),
+        pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5, [0, 0]),
+        pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5, [0, 1]),
+        pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, 0.5, [0, 2]),
+        pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, -0.5, [1, 0]),
+        pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15, [1, 1]),
+        pytest.param(9, 9 / 3, 1.55, 1.8, 0.333, 0.333, [1, 2]),
     ]
 
+    @classmethod
+    def setup_class(cls):
+        cls.f, cls.ax = plt.subplots(2, 3)
+
     @pytest.mark.parametrize(
-        "R_0, A, kappa_u, kappa_l, delta_u, delta_l",
+        "R_0, A, kappa_u, kappa_l, delta_u, delta_l, ax",
         fixture,
     )
-    def test_kuiroukidis_coords(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
+    def test_kuiroukidis_coords(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l, ax):
         flux_surface = flux_surface_kuiroukidis(
             R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 100
         )
@@ -148,10 +153,11 @@ class TestKuiroukidis:
         x_outer = R_0 + R_0 / A
         z_outer = 0.0
 
-        f, ax = plt.subplots()
-        ax.plot(flux_surface.x, flux_surface.z)
-        ax.set_aspect("equal")
-        plt.show()
+        n1, n2 = ax
+        self.ax[n1, n2].plot(flux_surface.x, flux_surface.z)
+        self.ax[n1, n2].set_xlabel("x")
+        self.ax[n1, n2].set_ylabel("z")
+        self.ax[n1, n2].set_aspect("equal")
 
         np.testing.assert_allclose(
             np.array([x_lower, z_lower]), flux_surface.xz.T[arg_lower]
@@ -167,15 +173,22 @@ class TestKuiroukidis:
         )
 
     @pytest.mark.parametrize(
-        "R_0, A, kappa_u, kappa_l, delta_u, delta_l",
+        "R_0, A, kappa_u, kappa_l, delta_u, delta_l, ax",
         fixture,
     )
-    def test_kuiroukidis_ccw(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
+    def test_kuiroukidis_ccw(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l, ax):
         flux_surface = flux_surface_kuiroukidis(
             R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 100
         )
         hull = ConvexHull(flux_surface.xz.T)
         np.testing.assert_approx_equal(hull.area, flux_surface.length)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.f.suptitle("Kuiroukidis parameterisations")
+        plt.subplots_adjust(hspace=0.4)
+        plt.show()
+        plt.close(cls.f)
 
 
 johner_names = [

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -121,6 +121,7 @@ class TestKuiroukidis:
         "R_0, A, kappa_u, kappa_l, delta_u, delta_l",
         [
             pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5),
+            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5),
             pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15),
         ],
     )

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -27,6 +27,7 @@ from bluemira.equilibria.shapes import (
     JohnerLCFS,
     flux_surface_cunningham,
     flux_surface_johner,
+    flux_surface_kuiroukidis,
     flux_surface_manickam,
 )
 
@@ -110,7 +111,56 @@ class TestManickam:
 
     @classmethod
     def teardown_class(cls):
-        cls.f.suptitle("Manickam parameterisations")
+        cls.f.suptitle("Kuirokidis parameterisations")
+        plt.show()
+        plt.close(cls.f)
+
+
+class TestKuiroukidis:
+    @classmethod
+    def setup_class(cls):
+        cls.f, cls.ax = plt.subplots(4, 2)
+
+    @pytest.mark.parametrize(
+        "R_0, A, kappa_u, kappa_l, delta_u, delta_l, grad_p",
+        [
+            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5, 0.0),
+            pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15, 0.05),
+        ],
+    )
+    def test_kuiroukidis(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l, grad_p):
+        flux_surface = flux_surface_kuiroukidis(
+            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, grad_p, 8, 200
+        )
+        arg_inner = np.argmin(flux_surface.x)
+        arg_outer = np.argmax(flux_surface.x)
+        arg_lower = np.argmin(flux_surface.z)
+        arg_upper = np.argmax(flux_surface.z)
+
+        x_lower = R_0 + delta_l * R_0 / A
+        z_lower = -kappa_l * R_0 / A
+        x_upper = R_0 + delta_u * R_0 / A
+        z_upper = kappa_u * R_0 / A
+        x_inner = R_0 - R_0 / A
+        z_inner = 0.0
+        x_outer = R_0 + R_0 / A
+        z_outer = 0.0
+        np.testing.assert_allclose(
+            np.array([x_lower, z_lower]), flux_surface.xz.T[arg_lower]
+        )
+        np.testing.assert_allclose(
+            np.array([x_upper, z_upper]), flux_surface.xz.T[arg_upper]
+        )
+        np.testing.assert_allclose(
+            np.array([x_inner, z_inner]), flux_surface.xz.T[arg_inner]
+        )
+        np.testing.assert_allclose(
+            np.array([x_outer, z_outer]), flux_surface.xz.T[arg_outer]
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        cls.f.suptitle("Kuiroukidis parameterisations")
         plt.show()
         plt.close(cls.f)
 

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -120,7 +120,7 @@ class TestKuiroukidis:
     @pytest.mark.parametrize(
         "R_0, A, kappa_u, kappa_l, delta_u, delta_l",
         [
-            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5),
+            pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5),
             pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15),
         ],
     )

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -157,6 +157,7 @@ class TestKuiroukidis:
         f, ax = plt.subplots()
         ax.plot(flux_surface.x, flux_surface.z)
         ax.set_aspect("equal")
+        plt.show()
 
 
 johner_names = [

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -172,7 +172,7 @@ class TestKuiroukidis:
     )
     def test_kuiroukidis_ccw(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
         flux_surface = flux_surface_kuiroukidis(
-            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 500
+            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 200
         )
         hull = ConvexHull(flux_surface.xz.T)
         np.testing.assert_approx_equal(hull.area, flux_surface.length)

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -122,6 +122,8 @@ class TestKuiroukidis:
         [
             pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5),
             pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5),
+            pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, 0.5),
+            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, -0.5),
             pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15),
         ],
     )
@@ -142,6 +144,12 @@ class TestKuiroukidis:
         z_inner = 0.0
         x_outer = R_0 + R_0 / A
         z_outer = 0.0
+
+        f, ax = plt.subplots()
+        ax.plot(flux_surface.x, flux_surface.z)
+        ax.set_aspect("equal")
+        plt.show()
+
         np.testing.assert_allclose(
             np.array([x_lower, z_lower]), flux_surface.xz.T[arg_lower]
         )
@@ -154,10 +162,6 @@ class TestKuiroukidis:
         np.testing.assert_allclose(
             np.array([x_outer, z_outer]), flux_surface.xz.T[arg_outer], atol=1e-12
         )
-        f, ax = plt.subplots()
-        ax.plot(flux_surface.x, flux_surface.z)
-        ax.set_aspect("equal")
-        plt.show()
 
 
 johner_names = [

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -154,6 +154,9 @@ class TestKuiroukidis:
         np.testing.assert_allclose(
             np.array([x_outer, z_outer]), flux_surface.xz.T[arg_outer], atol=1e-12
         )
+        f, ax = plt.subplots()
+        ax.plot(flux_surface.x, flux_surface.z)
+        ax.set_aspect("equal")
 
 
 johner_names = [

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -117,29 +117,25 @@ class TestManickam:
 
 
 class TestKuiroukidis:
-    @classmethod
-    def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(4, 2)
-
     @pytest.mark.parametrize(
-        "R_0, A, kappa_u, kappa_l, delta_u, delta_l, grad_p",
+        "R_0, A, kappa_u, kappa_l, delta_u, delta_l",
         [
-            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5, 0.0),
-            pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15, 0.05),
+            pytest.param(6.2, 3.1, 1.55, 2.0, 0.5, 0.5),
+            pytest.param(1.717, 1.717 / 0.5151, 1.55, 2.0, 0.15, 0.15),
         ],
     )
-    def test_kuiroukidis(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l, grad_p):
+    def test_kuiroukidis(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
         flux_surface = flux_surface_kuiroukidis(
-            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, grad_p, 8, 200
+            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 500
         )
         arg_inner = np.argmin(flux_surface.x)
         arg_outer = np.argmax(flux_surface.x)
         arg_lower = np.argmin(flux_surface.z)
         arg_upper = np.argmax(flux_surface.z)
 
-        x_lower = R_0 + delta_l * R_0 / A
+        x_lower = R_0 - delta_l * R_0 / A
         z_lower = -kappa_l * R_0 / A
-        x_upper = R_0 + delta_u * R_0 / A
+        x_upper = R_0 - delta_u * R_0 / A
         z_upper = kappa_u * R_0 / A
         x_inner = R_0 - R_0 / A
         z_inner = 0.0
@@ -152,17 +148,11 @@ class TestKuiroukidis:
             np.array([x_upper, z_upper]), flux_surface.xz.T[arg_upper]
         )
         np.testing.assert_allclose(
-            np.array([x_inner, z_inner]), flux_surface.xz.T[arg_inner]
+            np.array([x_inner, z_inner]), flux_surface.xz.T[arg_inner], atol=1e-12
         )
         np.testing.assert_allclose(
-            np.array([x_outer, z_outer]), flux_surface.xz.T[arg_outer]
+            np.array([x_outer, z_outer]), flux_surface.xz.T[arg_outer], atol=1e-12
         )
-
-    @classmethod
-    def teardown_class(cls):
-        cls.f.suptitle("Kuiroukidis parameterisations")
-        plt.show()
-        plt.close(cls.f)
 
 
 johner_names = [

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -132,7 +132,7 @@ class TestKuiroukidis:
     )
     def test_kuiroukidis_coords(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
         flux_surface = flux_surface_kuiroukidis(
-            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 500
+            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 100
         )
         arg_inner = np.argmin(flux_surface.x)
         arg_outer = np.argmax(flux_surface.x)
@@ -172,7 +172,7 @@ class TestKuiroukidis:
     )
     def test_kuiroukidis_ccw(self, R_0, A, kappa_u, kappa_l, delta_u, delta_l):
         flux_surface = flux_surface_kuiroukidis(
-            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 200
+            R_0, 0, R_0 / A, kappa_u, kappa_l, delta_u, delta_l, 8, 100
         )
         hull = ConvexHull(flux_surface.xz.T)
         np.testing.assert_approx_equal(hull.area, flux_surface.length)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Adds an alternative flux surface parameterisation which could be pretty useful for EU-DEMO, as it feels like it does a better job at capturing the upper surface. There are a couple of problems with the parameterisation as described, but the fudges I found produce what feels like a good shape.

![image](https://user-images.githubusercontent.com/26097289/211863921-57513a64-10be-4aa2-8714-126afabe0896.png)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Adds `flux_surface_kuiroukidis` to `equilibria.shapes.py`
## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
