### PR TITLE
Allow Union in `Parameter` typing

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -215,8 +215,14 @@ def _validate_parameter_field(field, member_type: Type) -> Tuple[Type, ...]:
         not hasattr(member_type, "__origin__") or member_type.__origin__ is not Parameter
     ):
         raise TypeError(f"Field '{field}' does not have type Parameter.")
-    value_types = get_args(member_type)
-    return value_types
+    value_types = list(get_args(member_type))
+    vt = []
+    for v in value_types:
+        if new_v := get_args(v):
+            vt.extend(new_v)
+        else:
+            vt.append(v)
+    return tuple(vt)
 
 
 def _validate_units(param_data: Dict, value_type: Iterable[Type]):

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -1,6 +1,7 @@
 import io
 from copy import deepcopy
 from dataclasses import dataclass
+from enum import Enum
 from typing import Union
 from unittest import mock
 
@@ -20,6 +21,15 @@ FRAME_DATA = {
 class BasicFrame(ParameterFrame):
     height: Parameter[float]
     age: Parameter[int]
+
+
+class MyEnum(Enum):
+    A = 1
+
+
+@dataclass
+class UnionFrame(ParameterFrame):
+    thing: Parameter[Union[str, MyEnum]]
 
 
 @dataclass
@@ -318,6 +328,12 @@ class TestParameterFrame:
         with pytest.raises(ValueError) as error:
             BasicFrame.from_json(["x"])
         assert "Cannot read JSON" in str(error)
+
+    def test_union_of_parameter_types(self):
+        strframe = UnionFrame.from_dict({"thing": {"value": "A", "unit": ""}})
+        enumframe = UnionFrame.from_dict({"thing": {"value": MyEnum.A, "unit": ""}})
+
+        assert enumframe.thing.value == MyEnum[strframe.thing.value]
 
 
 @dataclass


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Before this fix `Parameter[Union[str, MyEnum]` would fail because the type wouldnt be inspected. I have only done the first level of nesting `Union[Union[...,...], Union[...,...]]` etc wont work

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
