### PR TITLE
Fix OptVariables tabulate bug

### DIFF
--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -585,7 +585,7 @@ class OptVariables:
         if keys is not None:
             columns = keys
 
-        records = sorted([tuple(val) for val in self.as_dict().values()])
+        records = sorted([tuple(val.values()) for val in self.as_dict().values()])
 
         return tabulate(
             records,

--- a/tests/utilities/test_opt_variables.py
+++ b/tests/utilities/test_opt_variables.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import os
+import re
 import shutil
 import tempfile
 
@@ -173,3 +174,27 @@ class TestOptVariables:
             new_vars.as_dict == self.vars.as_dict()
         finally:
             shutil.rmtree(tempdir)
+
+    def test_tabulate_displays_column_values(self):
+        v1 = BoundedVariable("a", 2, 0, 3, descr="var a")
+        v2 = BoundedVariable("b", 0, -1, 1, fixed=True)
+        v3 = BoundedVariable("c", -1, -10, 10)
+        opt_vars = OptVariables([v3, v1, v2])
+
+        table = opt_vars.tabulate()
+
+        table_pattern = "\n".join(
+            [
+                ".*",
+                ".*Name.*Value.*Lower Bound.*Upper Bound.*Fixed.*Description.*",
+                ".*",
+                ".*a.*2.*0.*3.*False.*var a.*",
+                ".*",
+                ".*b.*0.*-1.*1.*True.* .*",
+                ".*",
+                ".*c.*-1.*-10.*10.*False.* .*",
+                ".*",
+            ]
+        )
+        assert len(table.split("\n")) == 9
+        assert re.match(table_pattern, table, flags=re.MULTILINE)


### PR DESCRIPTION
## Description

Fixes a bug in `OptVariables.tabulate` not printing the variable's values.

Instead of each row displaying the values of the variables, the keys of the dictionary that contained the values were being displayed.

So we had this

```
╒════════╤═════════╤═══════════════╤═══════════════╤═════════╤═══════════════╕
│ Name   │ Value   │ Lower Bound   │ Upper Bound   │ Fixed   │ Description   │
╞════════╪═════════╪═══════════════╪═══════════════╪═════════╪═══════════════╡
│ name   │ _value  │ lower_bound   │ upper_bound   │ fixed   │ _description  │
├────────┼─────────┼───────────────┼───────────────┼─────────┼───────────────┤
│ name   │ _value  │ lower_bound   │ upper_bound   │ fixed   │ _description  │
├────────┼─────────┼───────────────┼───────────────┼─────────┼───────────────┤
│ name   │ _value  │ lower_bound   │ upper_bound   │ fixed   │ _description  │
╘════════╧═════════╧═══════════════╧═══════════════╧═════════╧═══════════════╛
```

rather than this

```
╒════════╤═════════╤═══════════════╤═══════════════╤═════════╤═══════════════╕
│ Name   │   Value │   Lower Bound │   Upper Bound │ Fixed   │ Description   │
╞════════╪═════════╪═══════════════╪═══════════════╪═════════╪═══════════════╡
│ a      │       2 │             0 │             3 │ False   │ var a         │
├────────┼─────────┼───────────────┼───────────────┼─────────┼───────────────┤
│ b      │       0 │            -1 │             1 │ True    │               │
├────────┼─────────┼───────────────┼───────────────┼─────────┼───────────────┤
│ c      │      -1 │           -10 │            10 │ False   │               │
╘════════╧═════════╧═══════════════╧═══════════════╧═════════╧═══════════════╛
```

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
