### PR TITLE
⬆️ upgrade isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       exclude: test_data
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.1
+    rev: 5.12.0
     hooks:
     - id: isort
 

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -22,6 +22,7 @@ idna==3.4
 imagesize==1.4.1
 importlib-metadata==5.2.0
 iniconfig==1.1.1
+isort==5.12.0
 Jinja2==3.1.2
 lazy-object-proxy==1.8.0
 MarkupSafe==2.1.1


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
The `isort` installation procedure has somehow broken without changing the version see https://github.com/PyCQA/isort/issues/ 2083
Upgrading isort fixes the problem (or more accurately bypasses it)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
