### PR TITLE
Add PLASMOD post-processing flux function hack

### DIFF
--- a/bluemira/codes/plasmod/api/_plotting.py
+++ b/bluemira/codes/plasmod/api/_plotting.py
@@ -55,10 +55,22 @@ def plot_default_profiles(plasmod_solver, show=True, f=None, ax=None):
 
     rho = plasmod_solver.get_profile("x")
     R_0 = plasmod_solver.params.R_0.value
+
+    # Corrected flux function profiles (used as output profiles)
     pprime = plasmod_solver.get_profile("pprime")
     ffprime = plasmod_solver.get_profile("ffprime")
+
+    # Actual flux function profiles
+
+    pprime_true_but_wrong = plasmod_solver.plasmod_outputs().pprime
+    pprime_true_but_wrong = plasmod_solver._from_phi_to_psi(pprime_true_but_wrong)
+    ffprime_true_but_wrong = plasmod_solver.plasmod_outputs().ffprime
+    ffprime_true_but_wrong = plasmod_solver._from_phi_to_psi(ffprime_true_but_wrong)
     # Current density profile reconstruction from flux functions
     jpar_recon = 2 * np.pi * (R_0 * pprime + ffprime / (MU_0 * R_0))
+    jpar_recon_true_but_wrong = (
+        2 * np.pi * (R_0 * pprime_true_but_wrong + ffprime_true_but_wrong / (MU_0 * R_0))
+    )
 
     # Temperature profiles
     ti = plasmod_solver.get_profile("Ti")
@@ -74,7 +86,8 @@ def plot_default_profiles(plasmod_solver, show=True, f=None, ax=None):
     ax[0, 1].plot(rho, jpar, label="$j_{||}$")
     ax[0, 1].plot(rho, jbs, label="$j_{BS}$")
     ax[0, 1].plot(rho, jcd, label="$j_{CD}$")
-    ax[0, 1].plot(rho, jpar_recon, label="$j_{p', FF'}$")
+    ax[0, 1].plot(rho, jpar_recon_true_but_wrong, linestyle="--", label="$j_{p', FF'}$")
+    ax[0, 1].plot(rho, jpar_recon, linestyle="--", label="$j_{p', FF'_{*corr}}$")
     ax[0, 1].set_ylabel("Current density [A/m²]")
 
     # Density profiles
@@ -90,12 +103,14 @@ def plot_default_profiles(plasmod_solver, show=True, f=None, ax=None):
     ax[1, 1].set_ylabel("Safety factor")
 
     # Flux functions
-    ax[0, 2].plot(rho, pprime, label="p'")
+    ax[0, 2].plot(rho, pprime, label="$p'_{*corr}$")
+    ax[0, 2].plot(rho, pprime_true_but_wrong, linestyle="--", label="$p'$")
     ax[0, 2].set_ylabel("[Pa/Wb]")
     axi: plt.Axes = ax[0, 2]
     axi.ticklabel_format(axis="y", style="scientific", scilimits=(0, 0))
 
-    ax[1, 2].plot(rho, ffprime, label="FF'")
+    ax[1, 2].plot(rho, ffprime, label="$FF'_{*corr}$")
+    ax[1, 2].plot(rho, ffprime_true_but_wrong, linestyle="--", label="$FF'$")
     ax[1, 2].set_ylabel("[T]")
 
     for axe in ax.flat:

--- a/bluemira/codes/plasmod/api/_solver.py
+++ b/bluemira/codes/plasmod/api/_solver.py
@@ -200,10 +200,10 @@ class Solver(CodesSolver):
 
         Notes
         -----
-        pprime and ffprime profiles from PLASMOD are currently inconsistent with the output
-        jpar profile, even if isawt=FULLY_RELAXED. This is a known issue, and is under
-        investigation. In the meantime, a crude rescaling of the flux functions is
-        provided here.
+        pprime and ffprime profiles from PLASMOD are currently inconsistent with the
+        output jpar profile, even if isawt=FULLY_RELAXED. This is a known issue,
+        and is under investigation. In the meantime, a crude rescaling of the flux
+        functions is provided here.
         """
         if isinstance(profile, str):
             profile = Profiles(profile)
@@ -225,8 +225,8 @@ class Solver(CodesSolver):
                 )
             )
 
-            # Scale the flux functions with the correction ratio of the reconstructed jpar profile
-            # indiscriminately applied to pprime and ffprime
+            # Scale the flux functions with the correction ratio of the reconstructed
+            # jpar profile. Indiscriminately applied to pprime and ffprime
             ratio = jpar_true / jpar_recon
             prof_data = getattr(self.plasmod_outputs(), profile.name)
             prof_data = ratio * self._from_phi_to_psi(prof_data)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Applies a hack to PLASMOD output flux functions

In the case of a sawtoothed q profile:
![image](https://user-images.githubusercontent.com/26097289/215778310-40f46f02-fcf1-4d68-815b-3d700ca64f0e.png)

In the case of a fully relaxed q profile:
![image](https://user-images.githubusercontent.com/26097289/215778617-1c8da645-fd38-4283-929e-d0585421d70a.png)

@ivanmaione I note that the equilibrium does not quite converge after 15 iterations...


## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
