### PR TITLE
⬆️ use the PROCESS hotfix tag

### DIFF
--- a/scripts/install-process.sh
+++ b/scripts/install-process.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Ensure we are working in the (bluemira) conda environment
-source ~/.miniforge-init.sh && conda activate bluemira
+source ~/.mambaforge-init.sh && conda activate bluemira
 
 if [[ $(basename $PWD) == *"bluemira"* ]]; then
   cd ..

--- a/scripts/install-process.sh
+++ b/scripts/install-process.sh
@@ -25,7 +25,7 @@ if [ "$1" ]
   then
     git checkout "$1"
 else
-    git checkout v2.3.0
+    git checkout v2.3.0-hotfix
 fi
 
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
PROCESS install has needed to be updated before a release because the FORD repository has moved which breaks the PROCESS install. This hotfix tag slightly ahead of 2.3.0. Once PROCESS has a new release and #1685 is done this is irrelevant.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
