### PR TITLE
🐛 exclude external code script from examples ci run

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,4 +36,5 @@ jobs:
           python ./scripts/run_examples.py \
             -e 'plasmod_example' \
             -e 'solver_example' \
-            -e 'equilibria/fem_fixed_boundary'
+            -e 'equilibria/fem_fixed_boundary' \
+            -e 'codes/ext_code_script

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,4 +37,4 @@ jobs:
             -e 'plasmod_example' \
             -e 'solver_example' \
             -e 'equilibria/fem_fixed_boundary' \
-            -e 'codes/ext_code_script
+            -e 'codes/ext_code_script'

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -118,6 +118,9 @@ def run_examples(
 
 
 if __name__ == "__main__":
+    # Hack to make external_code example run
+    sys.path.insert(0, str(Path(Path(__file__).parent.parent, "examples", "codes")))
+
     args = parse_args(sys.argv[1:])
     example_py_files = find_python_files(args.examples_dir, args.exclude_pattern)
     if not example_py_files:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
The `ext_code_script` is not an example so shouldnt run but should be executed by the example

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
