### PR TITLE
Bump ipython from 8.9.0 to 8.10.0

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -14,7 +14,7 @@ executing==1.2.0
 fastjsonschema==2.16.2
 importlib-resources==5.10.2
 ipykernel==6.20.2
-ipython==8.9.0
+ipython==8.10.0
 ipython-genutils==0.2.0
 jedi==0.18.2
 Jinja2==3.1.2


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Cherry picks  #1932 onto develop because of the security notice

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
