### PR TITLE
🐛 allow setting None when updating a parameterframe

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -28,6 +28,7 @@ from typing import Callable, List, Optional, Union
 import numpy as np
 from periodictable import elements
 from pint import Context, Quantity, Unit, UnitRegistry, set_application_registry
+from pint.errors import PintError
 from pint.util import UnitsContainer
 
 
@@ -51,7 +52,6 @@ class BMUnitRegistry(UnitRegistry):
     """
 
     def __init__(self):
-
         # Preprocessor replacements have spaces so
         # the units dont become prefixes or get prefixed
         # space before on % so that M% is not a thing
@@ -189,11 +189,9 @@ class BMUnitRegistry(UnitRegistry):
             [UnitRegistry, Union[float, complex, Quantity]], float
         ],
     ):
-
         formatters = ["{}", "{} / [time]"]
 
         for form in formatters:
-
             context.add_transformation(
                 form.format(units_from), form.format(units_to), forward_transform
             )
@@ -371,6 +369,17 @@ YR_TO_S = ureg.Quantity(1, ureg.year).to(ureg.second).magnitude
 
 # Seconds to years
 S_TO_YR = ureg.Quantity(1, ureg.second).to(ureg.year).magnitude
+
+
+def units_compatible(unit_1: str, unit_2: str) -> bool:
+    """
+    Test if units are compatible
+    """
+    try:
+        raw_uc(1, unit_1, unit_2)
+        return True
+    except PintError:
+        return False
 
 
 def raw_uc(

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -102,7 +102,9 @@ class ParameterFrame:
             value_type = _validate_parameter_field(key, self._types[key])
             new_param = Parameter(name=key, **value, _value_types=value_type)
             param.set_value(
-                new_param.value if param.unit == "" else new_param.value_as(param.unit),
+                new_param.value
+                if param.unit == "" or new_param.value is None
+                else new_param.value_as(param.unit),
                 new_param.source,
             )
             if new_param.long_name != "":
@@ -116,7 +118,10 @@ class ParameterFrame:
             if hasattr(self, o_param.name):
                 param = getattr(self, o_param.name)
                 param.set_value(
-                    raw_uc(o_param.value, o_param.unit, param.unit), o_param.source
+                    o_param.value
+                    if param.unit == "" or o_param.value is None
+                    else o_param.value_as(param.unit),
+                    o_param.source,
                 )
                 if o_param.long_name != "":
                     param._long_name = o_param.long_name

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -154,7 +154,7 @@ class Parameter(Generic[ParameterValueType]):
             if self.value is None:
                 try:
                     raw_uc(1, self.unit, unit)
-                    return
+                    return None
                 except pint.errors.PintError as pe2:
                     raise ValueError("Unit conversion failed") from pe2
             else:

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -7,7 +7,7 @@ from typing import Dict, Generic, List, Tuple, Type, TypedDict, TypeVar, Union
 import pint
 from typeguard import typechecked
 
-from bluemira.base.constants import raw_uc
+from bluemira.base.constants import raw_uc, units_compatible
 
 ParameterValueType = TypeVar("ParameterValueType")
 
@@ -152,11 +152,10 @@ class Parameter(Generic[ParameterValueType]):
             raise ValueError("Unit conversion failed") from pe
         except TypeError:
             if self.value is None:
-                try:
-                    raw_uc(1, self.unit, unit)
+                if units_compatible(self.unit, unit):
                     return None
-                except pint.errors.PintError as pe2:
-                    raise ValueError("Unit conversion failed") from pe2
+                else:
+                    raise ValueError("Unit conversion failed")
             else:
                 raise
 

--- a/tests/base/parameterframe/test_parameter.py
+++ b/tests/base/parameterframe/test_parameter.py
@@ -109,6 +109,26 @@ class TestParameter:
         param = Parameter(**s_param)
         assert param.value_as("km") == 1e-3 * s_param["value"]
 
+    def test_value_as_conversion_for_None(self):
+        s_param = copy.deepcopy(self.SERIALIZED_PARAM)
+        s_param["value"] = None
+        param = Parameter(**s_param)
+
+        with pytest.raises(ValueError):
+            param.value_as("W")
+
+        s_param["unit"] = "metre"
+        param = Parameter(**s_param)
+        assert param.value_as("km") is None
+
+    def test_value_as_conversion_for_bool(self):
+        s_param = copy.deepcopy(self.SERIALIZED_PARAM)
+        s_param["value"] = False
+
+        param = Parameter(**s_param)
+        with pytest.raises(TypeError):
+            param.value_as("km")
+
     @pytest.mark.parametrize(
         "param1, param2",
         [

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -252,6 +252,47 @@ class TestParameterFrame:
         assert frame.age.value == pint.Quantity(20, "years").to("s").magnitude
         assert frame.age.source != "a test"
 
+    @pytest.mark.parametrize("func", ("update_from_frame", "update"))
+    def test_update_from_frame_with_None(self, func):
+        frame = BasicFrame.from_dict(FRAME_DATA)
+        update_frame = BasicFrame.from_dict(
+            {
+                "height": {
+                    "value": 160.4,
+                    "unit": "m",
+                    "source": "a test",
+                },
+                "age": {"value": None, "unit": "years"},
+            }
+        )
+        getattr(frame, func)(update_frame)
+
+        assert frame.height.value == 160.4
+        assert frame.height.source == "a test"
+        assert frame.age.value is None
+        assert frame.age.source != "a test"
+
+    @pytest.mark.parametrize("func", ("update_from_dict", "update"))
+    def test_update_from_dict_with_None(self, func):
+        frame = BasicFrame.from_dict(FRAME_DATA)
+
+        getattr(frame, func)(
+            {
+                "height": {
+                    "name": "height",
+                    "value": 160.4,
+                    "unit": "m",
+                    "source": "a test",
+                },
+                "age": {"value": None, "unit": "years"},
+            }
+        )
+
+        assert frame.height.value == 160.4
+        assert frame.height.source == "a test"
+        assert frame.age.value is None
+        assert frame.age.source != "a test"
+
     def _call_tabulate(self, head_keys):
         frame_data = deepcopy(FRAME_DATA)
         frame_data["height"]["unit"] = "m"


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When we are updating from an external code sometimes the value doesnt exist in the output we warn and set it to None . This will then fail when we update subsequent frames.

The fix allows the `None` to be passed through harmlessly 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
