### PR TITLE
Add support for optional component tree views

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -137,8 +137,8 @@ class Builder(abc.ABC):
 
         Returns
         -------
-        component
-
+        component:
+            The component comprising all views provided
         """
         component = Component(self.name)
         if xz:

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -26,7 +26,7 @@ Interfaces for builder classes.
 from __future__ import annotations
 
 import abc
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Optional, Type, Union
 
 from bluemira.base.components import Component
 from bluemira.base.parameter_frame import ParameterFrame, make_parameter_frame
@@ -118,18 +118,21 @@ class Builder(abc.ABC):
         pass
 
     def component_tree(
-        self, xz: List[Component], xy: List[Component], xyz: List[Component]
+        self,
+        xz: Optional[List[Component]],
+        xy: Optional[List[Component]],
+        xyz: Optional[List[Component]],
     ) -> Component:
         """
         Adds views of components to an overall component tree.
 
         Parameters
         ----------
-        xz: List[Component]
+        xz:
             xz view of component
-        xy: List[Component]
+        xy:
             xy view of component
-        xyz: List[Component]
+        xyz:
             xyz view of component
 
         Returns
@@ -138,9 +141,12 @@ class Builder(abc.ABC):
 
         """
         component = Component(self.name)
-        component.add_child(Component("xz", children=xz))
-        component.add_child(Component("xy", children=xy))
-        component.add_child(Component("xyz", children=xyz))
+        if xz:
+            component.add_child(Component("xz", children=xz))
+        if xy:
+            component.add_child(Component("xy", children=xy))
+        if xyz:
+            component.add_child(Component("xyz", children=xyz))
 
         set_component_view(component.get_component("xz"), "xz")
         set_component_view(component.get_component("xy"), "xy")


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

At present it is only possible to add a component tree on a builder with `self.component_tree([xz], [xy], [xyz])` if all views exist. There are cases where we will only want to add e.g. xz and xyz views to the resulting component. This is not possible at present.

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
