### PR TITLE
📝 Fix '.ex.py' links in docs

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -238,3 +238,30 @@ def html_visit_inheritance_diagram(self, node):
 
 
 inheritance_diagram.html_visit_inheritance_diagram = html_visit_inheritance_diagram
+
+
+# myst-nb link hack
+import myst_nb.sphinx_ as myst_sphinx  # noqa: E402
+
+
+def new_parse_wrapper(parse):
+    """Wrap `myst_nb.sphinx_.Parser.parse`"""
+
+    def wrapper(self, inputstring, document):
+        """
+        Hacks links to other example notebooks written in py:percent format
+
+        The linking to other py:percent formatted examples only gets converted to an
+        html link if the extension is 'ipynb'. We replace '.ex.py' with '.ipynb' for
+        all text in the original file.
+
+        This could be made more robust but it is unlikely that '.ex.py' is used anywhere
+        else.
+        """
+        inputstring = inputstring.replace(".ex.py", ".ipynb")
+        return parse(self, inputstring, document)
+
+    return wrapper
+
+
+myst_sphinx.Parser.parse = new_parse_wrapper(myst_sphinx.Parser.parse)

--- a/examples/design/simple_reactor.ex.py
+++ b/examples/design/simple_reactor.ex.py
@@ -160,9 +160,9 @@ class MyReactor(Reactor):
 # the any part of the coil is always a minimum distance away from the plasma.
 #
 # Further information on geometry can be found in the
-# [geometry tutorial](../geometry/geometry_tutorial.ipynb) and information about
+# [geometry tutorial](../geometry/geometry_tutorial.ex.py) and information about
 # geometry optimisation can be found in the
-# [geometry optimisation tutorial](../geometry/optimisation_tutorial.ipynb).
+# [geometry optimisation tutorial](../geometry/optimisation_tutorial.ex.py).
 
 # %%
 class MyTFCoilOptProblem(GeometryOptimisationProblem):


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Links to other notebooks didn't work before unless you used the '.ipynb' extension for the rendered docs.
Obviously that file doesnt exist so you had a choice of working in docs or working in the notebook.

This is a naiive hack on those links to piggyback on the change to html so the links will now work in both places 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
