### PR TITLE
Added copy and filter_components to Component. 

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -92,11 +92,102 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         """
         return self.name + " (" + self.__class__.__name__ + ")"
 
+    def filter_components(self, names: List[str]):
+        """
+        Removes all components from the tree starting at this component,
+        that are siblings of each component specified in `names`
+        and that aren't in `names` themself.
+
+        Parameters
+        ----------
+        names: List[str]
+            The list of names of each component to search for.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+            This function mutates components in the subtree
+        """
+        for n in names:
+            descendent_comps = self.get_component(
+                n,
+                first=False,
+            )
+
+            if descendent_comps is None:
+                continue
+            if not isinstance(descendent_comps, Iterable):
+                descendent_comps = [descendent_comps]
+
+            for c in descendent_comps:
+                for c_sib in c.siblings:
+                    if c_sib.name not in names:
+                        c_sib.parent = None
+
     def tree(self) -> str:
         """
         Get the tree of descendants of this instance.
         """
         return str(RenderTree(self))
+
+    def copy(
+        self,
+        parent: Optional[Component] = None,
+    ) -> Component:
+        """
+        Copies this component and its children (recursively) and sets `parent` as this copy's parent.
+        This only creates copies of each Component, the shape and material instances
+        (for a PhysicalComponent for ex.) are shared (i.e. are the same instance).
+
+        Parameters
+        ----------
+        parent: Optional[Component]
+            The component to set as the copy's parent
+
+        Returns
+        -------
+        The copied component
+
+        Notes
+        -----
+            This function should be overridden by implementors
+        """
+
+        # Initially copy self with None children
+        self_copy = Component(
+            name=self.name,
+            parent=parent,
+            children=None,
+        )
+        # Attaches children to parent
+        self.copy_children(parent=self_copy)
+
+        return self_copy
+
+    def copy_children(
+        self,
+        parent: Component,
+    ) -> list[Component]:
+        """
+        Copies this component's children (recursively) and sets `parent` as the copied children's parent.
+
+        Parameters
+        ----------
+        parent: Optional[Component]
+            The component to set as the copied children's parent
+
+        Returns
+        -------
+        The copied children components
+
+        Notes
+        -----
+            This function should *not* be overridden by implementors
+        """
+        return [] if len(self.children) == 0 else [c.copy(parent) for c in self.children]
 
     def get_component(
         self, name: str, first: bool = True, full_tree: bool = False
@@ -224,6 +315,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
+        # rv
         if not isinstance(children, list) or len(children) == 0:
             child = children[0] if isinstance(children, list) else children
             return self.add_child(child)
@@ -274,6 +366,23 @@ class PhysicalComponent(Component):
         self.shape = shape
         self.material = material
 
+    def copy(
+        self,
+        parent: Optional[Component] = None,
+    ) -> Component:
+        # Initially copy self with None children
+        self_copy = PhysicalComponent(
+            name=self.name,
+            parent=parent,
+            children=None,
+            shape=self.shape,
+            material=self.material,
+        )
+        # Attaches children to parent
+        self.copy_children(parent=self_copy)
+
+        return self_copy
+
     @property
     def shape(self) -> BluemiraGeo:
         """
@@ -313,6 +422,24 @@ class MagneticComponent(PhysicalComponent):
     ):
         super().__init__(name, shape, material, parent, children)
         self.conductor = conductor
+
+    def copy(
+        self,
+        parent: Optional[Component] = None,
+    ) -> Component:
+        # Initially copy self with None children
+        self_copy = MagneticComponent(
+            name=self.name,
+            parent=parent,
+            children=None,
+            shape=self.shape,
+            material=self.material,
+            conductor=self.conductor,
+        )
+        # Attaches children to parent
+        self.copy_children(parent=self_copy)
+
+        return self_copy
 
     @property
     def conductor(self):

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -317,11 +317,12 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
-        # rv
         if isinstance(children, Component):
             return self.add_child(children)
-        if not isinstance(children, List[Component]):
-            raise Exception("children must a list of Components")
+        if not isinstance(children, list):
+            return
+        if len(children) == 0:
+            return
 
         duplicates = []
         child: Component

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -303,7 +303,11 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
         return self
 
-    def add_children(self, children: List[Component], merge_trees=False):
+    def add_children(
+        self,
+        children: Optional[Union[Component, List[Component]]],
+        merge_trees: bool = False,
+    ):
         """
         Add multiple children to this node
 
@@ -317,6 +321,8 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         self: Component
             This component.
         """
+        if children is None:
+            return
         if isinstance(children, Component):
             return self.add_child(children)
         if not isinstance(children, list):

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -318,9 +318,10 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
             This component.
         """
         # rv
-        if not isinstance(children, list) or len(children) == 0:
-            child = children[0] if isinstance(children, list) else children
-            return self.add_child(child)
+        if isinstance(children, Component):
+            return self.add_child(children)
+        if not isinstance(children, List[Component]):
+            raise Exception("children must a list of Components")
 
         duplicates = []
         child: Component

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -94,9 +94,9 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def filter_components(self, names: List[str]):
         """
-        Removes all components from the tree starting at this component,
+        Removes all components from the tree, starting at this component,
         that are siblings of each component specified in `names`
-        and that aren't in `names` themself.
+        and that aren't in `names` themselves.
 
         Parameters
         ----------

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -138,9 +138,11 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         parent: Optional[Component] = None,
     ) -> Component:
         """
-        Copies this component and its children (recursively) and sets `parent` as this copy's parent.
-        This only creates copies of each Component, the shape and material instances
-        (for a PhysicalComponent for ex.) are shared (i.e. are the same instance).
+        Copies this component and its children (recursively)
+        and sets `parent` as this copy's parent.
+        This only creates copies of each Component,
+        the shape and material instances (for a PhysicalComponent for ex.)
+        are shared (i.e. are the same instance).
 
         Parameters
         ----------
@@ -155,7 +157,6 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         -----
             This function should be overridden by implementors
         """
-
         # Initially copy self with None children
         self_copy = Component(
             name=self.name,
@@ -172,7 +173,8 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         parent: Component,
     ) -> list[Component]:
         """
-        Copies this component's children (recursively) and sets `parent` as the copied children's parent.
+        Copies this component's children (recursively)
+        and sets `parent` as the copied children's parent.
 
         Parameters
         ----------
@@ -370,6 +372,13 @@ class PhysicalComponent(Component):
         self,
         parent: Optional[Component] = None,
     ) -> Component:
+        """
+        Copies this component and its children (recursively)
+        and sets `parent` as this copy's parent.
+        This only creates copies of each Component,
+        the shape and material instances (for a PhysicalComponent for ex.)
+        are shared (i.e. are the same instance).
+        """
         # Initially copy self with None children
         self_copy = PhysicalComponent(
             name=self.name,
@@ -427,6 +436,13 @@ class MagneticComponent(PhysicalComponent):
         self,
         parent: Optional[Component] = None,
     ) -> Component:
+        """
+        Copies this component and its children (recursively)
+        and sets `parent` as this copy's parent.
+        This only creates copies of each Component,
+        the shape and material instances (for a PhysicalComponent for ex.)
+        are shared (i.e. are the same instance).
+        """
         # Initially copy self with None children
         self_copy = MagneticComponent(
             name=self.name,

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -117,7 +117,8 @@ class Reactor:
         # if a kw "dim" is given, it is only used
         if kw_dim := kwargs.pop("dim", None):
             warn(
-                "Using kwarg 'dim' is no longer supported. Simply pass in the dimensions you would like to show, e.g. show_cad('xz')",
+                "Using kwarg 'dim' is no longer supported. "
+                "Simply pass in the dimensions you would like to show, e.g. show_cad('xz')",
                 category=DeprecationWarning,
             )
             dims_to_show = (kw_dim,)

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -21,6 +21,7 @@
 """Base class for a Bluemira reactor."""
 
 from typing import Type
+from warnings import warn
 
 from bluemira.base.builder import ComponentManager
 from bluemira.base.components import Component
@@ -114,14 +115,16 @@ class Reactor:
         dims_to_show = ("xyz",) if len(dims) == 0 else dims
 
         # if a kw "dim" is given, it is only used
-        kw_dim = kwargs.get("dim")
-        if kw_dim is not None:
+        if kw_dim := kwargs.pop("dim", None):
+            warn(
+                "Using kwarg 'dim' is no longer supported. Simply pass in the dimensions you would like to show, e.g. show_cad('xz')",
+                category=DeprecationWarning,
+            )
             dims_to_show = (kw_dim,)
-
         for dim in dims_to_show:
             if dim not in _PLOT_DIMS:
                 raise ReactorError(
-                    f"Invalid plotting dimension '{dim}'. "
+                    f"Invalid plotting dimension '{dim}'."
                     f"Must be one of {str(_PLOT_DIMS)}"
                 )
 

--- a/examples/design/simple_reactor.ex.py
+++ b/examples/design/simple_reactor.ex.py
@@ -331,7 +331,7 @@ class PlasmaBuilder(Builder):
         Build the 3D (xyz) Component of the plasma by revolving the given face
         360 degrees.
         """
-        shape = revolve_shape(lcfs, degree=359)
+        shape = revolve_shape(lcfs, degree=360)
         component = PhysicalComponent("LCFS", shape)
         component.display_cad_options.color = BLUE_PALETTE["PL"]
         component.display_cad_options.transparency = 0.5

--- a/examples/design/simple_reactor.ex.py
+++ b/examples/design/simple_reactor.ex.py
@@ -584,3 +584,4 @@ reactor.plasma = plasma
 reactor.tf_coil = tf_coil
 
 reactor.show_cad()
+reactor.show_cad("xz")

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -227,8 +227,8 @@ class TestComponentClass:
         child1 = Component("Child1", parent=parent)
         child2 = Component("Child2", parent=parent)
 
-        child1A = Component("child1A", parent=child1)
-        child1B = Component("child1B", parent=child1)
+        child1a = Component("child1A", parent=child1)
+        child1b = Component("child1B", parent=child1)
 
         def attach_dims_and_physical_comps_to(comp: Component):
             xy = Component("xy", parent=comp)
@@ -254,8 +254,8 @@ class TestComponentClass:
                 material="pc_xyz material",
             )
 
-        attach_dims_and_physical_comps_to(child1A)
-        attach_dims_and_physical_comps_to(child1B)
+        attach_dims_and_physical_comps_to(child1a)
+        attach_dims_and_physical_comps_to(child1b)
         attach_dims_and_physical_comps_to(child2)
 
         parent.filter_components(["xz"])
@@ -273,8 +273,8 @@ class TestComponentClass:
         child1 = Component("Child1", parent=parent)
         child2 = Component("Child2", parent=parent)
 
-        child1A = Component("child1A", parent=child1)
-        child1B = Component("child1B", parent=child1)
+        child1a = Component("child1A", parent=child1)
+        child1b = Component("child1B", parent=child1)
 
         def attach_dims_and_physical_comps_to(comp: Component):
             xy = Component("xy", parent=comp)
@@ -300,8 +300,8 @@ class TestComponentClass:
                 material="pc_xyz material",
             )
 
-        attach_dims_and_physical_comps_to(child1A)
-        attach_dims_and_physical_comps_to(child1B)
+        attach_dims_and_physical_comps_to(child1a)
+        attach_dims_and_physical_comps_to(child1b)
         attach_dims_and_physical_comps_to(child2)
 
         parent.filter_components(["xy", "xz"])

--- a/tests/base/test_components.py
+++ b/tests/base/test_components.py
@@ -214,8 +214,8 @@ class TestComponentClass:
                     assert c.name in comp_children_names
 
             # test properties
-            if type(comp) is PhysicalComponent:
-                assert type(cpy) is PhysicalComponent
+            if isinstance(comp, PhysicalComponent):
+                assert isinstance(cpy, PhysicalComponent)
                 # assert they are the same instance
                 assert cpy.shape is comp.shape
                 assert cpy.material is comp.material


### PR DESCRIPTION
Changed Reactor show_cad to use filter_components and changed the interface to accept *dims and kwarg dim. Also added tests.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1076

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Implemented a method on Component that copies and filters the tree based on the given names.
The filtering gets each component given in `names` and removes the sibling nodes of that component whose name isn't in `names`

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

* `show_cad` in Reactor has changed to accepts string args (*dims). If kwarg "dim" is given, only it is used.
* added `copy `to Component
* added `filter_components` to Component

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
