### PR TITLE
Avoid some CAD bugs in EUDEMO

### DIFF
--- a/bluemira/builders/plasma.py
+++ b/bluemira/builders/plasma.py
@@ -98,8 +98,8 @@ class PlasmaBuilder(Builder):
         lcfs: BluemiraWire
             LCFS wire
         """
-        inner = make_circle(lcfs.bounding_box.x_min, axis=[0, 1, 0])
-        outer = make_circle(lcfs.bounding_box.x_max, axis=[0, 1, 0])
+        inner = make_circle(lcfs.bounding_box.x_min)
+        outer = make_circle(lcfs.bounding_box.x_max)
         face = BluemiraFace([outer, inner], self.name)
         component = PhysicalComponent(self.LCFS, face)
         component.plot_options.face_options["color"] = BLUE_PALETTE["PL"]

--- a/eudemo/eudemo/ivc/divertor_silhouette.py
+++ b/eudemo/eudemo/ivc/divertor_silhouette.py
@@ -192,14 +192,19 @@ class DivertorSilhouetteDesigner(Designer[Tuple[BluemiraWire, ...]]):
         self, start: Sequence[float], end: Sequence[float], label: str
     ) -> BluemiraWire:
         """
-        Make a dome between the two given points
-        The dome shape follows a constant line of flux that is closest
-        to the input start coordinate. Finally, the nearset point on the
-        flux surface to the end point and the end point are joined.
-        """
-        # Get the flux surface that crosses the through the start point
-        # We can use this surface to guide the shape of the dome
+        Make a dome between the two given points.
 
+        Notes
+        -----
+        The dome shape follows a constant line of flux that is closest to the input
+        coordinates.
+        The nearset point on the flux surface to the start point and the end point are
+        joined.
+        The flux surface is picked based on the lowest z coordinate of the start and end
+        point to ensure a continuous divertor shape is produced.
+        """
+        # Get the flux surface that crosses the through the start or end point.
+        # We can use this surface to guide the shape of the dome.
         psi_start = self.equilibrium.psi(*(start if start[1] < end[1] else end))
         flux_surface = find_flux_surface_through_point(
             self.equilibrium.x,

--- a/eudemo/eudemo/ivc/divertor_silhouette.py
+++ b/eudemo/eudemo/ivc/divertor_silhouette.py
@@ -199,7 +199,8 @@ class DivertorSilhouetteDesigner(Designer[Tuple[BluemiraWire, ...]]):
         """
         # Get the flux surface that crosses the through the start point
         # We can use this surface to guide the shape of the dome
-        psi_start = self.equilibrium.psi(*start)
+
+        psi_start = self.equilibrium.psi(*(start if start[1] < end[1] else end))
         flux_surface = find_flux_surface_through_point(
             self.equilibrium.x,
             self.equilibrium.z,

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -35,7 +35,7 @@ from bluemira.builders.tools import (
 )
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
-from bluemira.geometry.tools import offset_wire
+from bluemira.geometry.tools import _offset_wire_discretised
 from bluemira.geometry.wire import BluemiraWire
 
 
@@ -107,9 +107,14 @@ class VacuumVesselBuilder(Builder):
         """
         Build the x-z components of the vacuum vessel.
         """
-        inner_vv = offset_wire(
-            self.ivc_koz, self.params.g_vv_bb.value, join="arc", open_wire=False
+        inner_vv = _offset_wire_discretised(
+            self.ivc_koz,
+            self.params.g_vv_bb.value,
+            join="arc",
+            open_wire=False,
+            ndiscr=600,
         )
+
         outer_vv = varied_offset(
             inner_vv,
             self.params.tk_vv_in.value,


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This is a work around for the bug @hsaunders1904  pointed out in #1965 and a workaround for the divertor dome.
If the outer divertor target was lower than the inner target the dome would be put on the wrong flux line.

There is still a bug in the blanket segmentation, for some reason the boolean cut produces a valid face and an invalid face (L204 eudemo/blanket.py).

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
