### PR TITLE
Fix connection length calculation when using `Coordinates`

### DIFF
--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -27,7 +27,7 @@ Flux surface utility classes and calculations
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Iterable
+from typing import Iterable, Optional, Union
 
 import matplotlib.pyplot as plt
 import numba as nb
@@ -36,8 +36,9 @@ from scipy.integrate import solve_ivp
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import PSI_NORM_TOL
-from bluemira.equilibria.error import FluxSurfaceError
+from bluemira.equilibria.error import EquilibriaError, FluxSurfaceError
 from bluemira.equilibria.find import find_flux_surface_through_point
+from bluemira.equilibria.grid import Grid
 from bluemira.geometry.coordinates import (
     Coordinates,
     check_linesegment,
@@ -45,6 +46,7 @@ from bluemira.geometry.coordinates import (
     get_angle_between_points,
     get_area_2d,
     get_intersect,
+    in_polygon,
     join_intersect,
 )
 from bluemira.geometry.plane import BluemiraPlane
@@ -652,20 +654,35 @@ class FieldLineTracer:
         def __init__(self, boundary):
             self.boundary = boundary
             self.terminal = True
+            if isinstance(boundary, Grid):
+                self._check_inside = self._check_inside_grid
+            else:
+                self._check_inside = self._check_inside_coordinates
 
         def __call__(self, phi, xz, *args):
             """
             Function handle for the CollisionTerminator.
             """
-            if self.boundary.point_inside(xz[:2]):
+            if self._check_inside(xz[:2]):
                 return np.min(self.boundary.distance_to(xz[:2]))
             else:
                 return -np.min(self.boundary.distance_to(xz[:2]))
 
-    def __init__(self, eq, first_wall=None):
+        def _check_inside_grid(self, xz):
+            return self.boundary.point_inside(xz)
+
+        def _check_inside_coordinates(self, xz):
+            return in_polygon(*xz, self.boundary.xz, include_edges=True)
+
+    def __init__(self, eq, first_wall: Optional[Union[Grid, Coordinates]] = None):
         self.eq = eq
         if first_wall is None:
             first_wall = self.eq.grid
+        else:
+            if isinstance(first_wall, Coordinates) and not first_wall.is_planar:
+                raise EquilibriaError(
+                    "When tracing a field line, the coordinates object of the boundary must be planar."
+                )
         self.first_wall = first_wall
 
     def trace_field_line(self, x, z, n_points=200, forward=True, n_turns_max=20):

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -684,11 +684,10 @@ class FieldLineTracer:
         self.eq = eq
         if first_wall is None:
             first_wall = self.eq.grid
-        else:
-            if isinstance(first_wall, Coordinates) and not first_wall.is_planar:
-                raise EquilibriaError(
-                    "When tracing a field line, the coordinates object of the boundary must be planar."
-                )
+        elif isinstance(first_wall, Coordinates) and not first_wall.is_planar:
+            raise EquilibriaError(
+                "When tracing a field line, the coordinates object of the boundary must be planar."
+            )
         self.first_wall = first_wall
 
     def trace_field_line(self, x, z, n_points=200, forward=True, n_turns_max=20):

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -656,6 +656,9 @@ class FieldLineTracer:
             self.terminal = True
 
         def __call__(self, phi, xz, *args):
+            """
+            Function handle for the CollisionTerminator
+            """
             if isinstance(self.boundary, Grid):
                 return self._call_grid(xz)
             else:

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -157,6 +157,7 @@ class TestFieldLine:
         eq_name = "eqref_OOB.json"
         filename = os.sep.join([TEST_PATH, eq_name])
         cls.eq = Equilibrium.from_eqdsk(filename)
+        cls.cache = {}
 
     def test_connection_length(self):
         flt = FieldLineTracer(self.eq)
@@ -164,6 +165,24 @@ class TestFieldLine:
         assert np.isclose(
             field_line.connection_length, field_line.coords.length, rtol=5e-2
         )
+        self.cache["fl_con_length_grid"] = field_line.connection_length
+
+    def test_connection_length_coordinates(self):
+        xmin, xmax = self.eq.grid.x_min, self.eq.grid.x_max
+        zmin, zmax = self.eq.grid.z_min, self.eq.grid.z_max
+        coords = Coordinates(
+            {
+                "x": [xmin, xmax, xmax, xmin, xmin],
+                "y": 0,
+                "z": [zmin, zmin, zmax, zmax, zmin],
+            }
+        )
+        flt = FieldLineTracer(self.eq, coords)
+        field_line = flt.trace_field_line(13, 0, n_points=1000)
+        assert np.isclose(
+            field_line.connection_length, field_line.coords.length, rtol=5e-2
+        )
+        assert np.isclose(self.cache["fl_con_length_grid"], field_line.connection_length)
 
 
 def test_poloidal_angle():

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -167,7 +167,10 @@ class TestFieldLine:
         )
         self.cache["fl_con_length_grid"] = field_line.connection_length
 
-    def test_connection_length_coordinates(self):
+    def test_connection_length_coordinates_grid(self):
+        """
+        Check to see behaviour is the same with Coordinates and Grid
+        """
         xmin, xmax = self.eq.grid.x_min, self.eq.grid.x_max
         zmin, zmax = self.eq.grid.z_min, self.eq.grid.z_max
         coords = Coordinates(
@@ -183,6 +186,24 @@ class TestFieldLine:
             field_line.connection_length, field_line.coords.length, rtol=5e-2
         )
         assert np.isclose(self.cache["fl_con_length_grid"], field_line.connection_length)
+
+    def test_connection_length_coordinates(self):
+        coords = Coordinates(
+            {
+                "x": [self.eq.grid.x_min, 9, 12, 13, 13, 12, 4, self.eq.grid.x_min],
+                "y": 0,
+                "z": [self.eq.grid.z_min, -9, -7, -6, 6, 4, 9, self.eq.grid.z_min],
+            }
+        )
+        import matplotlib.pyplot as plt
+
+        f, ax = plt.subplots()
+        self.eq.plot(ax=ax)
+        ax.plot(*coords.xz)
+        flt = FieldLineTracer(self.eq, coords)
+        field_line = flt.trace_field_line(13, 0, n_points=1000)
+
+        field_line.pointcare_plot(ax=ax)
 
 
 def test_poloidal_angle():

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -27,7 +27,7 @@ import pytest
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.equilibria import Equilibrium
-from bluemira.equilibria.error import FluxSurfaceError
+from bluemira.equilibria.error import EquilibriaError, FluxSurfaceError
 from bluemira.equilibria.find import find_flux_surface_through_point
 from bluemira.equilibria.flux_surfaces import (
     ClosedFluxSurface,
@@ -165,6 +165,15 @@ class TestFieldLine:
         cls.eq = Equilibrium.from_eqdsk(filename)
         cls.flt = FieldLineTracer(cls.eq)
         cls.field_line = cls.flt.trace_field_line(13, 0, n_points=1000)
+
+    def test_non_planar_coodinates_raises_error(self):
+        with pytest.raises(EquilibriaError):
+            FieldLineTracer(
+                self.eq,
+                Coordinates(
+                    {"x": [6, 3, 3, 4, 5], "y": [0, 2, 0, 4, 0], "z": [1, 2, 3, 4, 5]}
+                ),
+            )
 
     def test_connection_length(self):
         assert np.isclose(

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -163,15 +163,13 @@ class TestFieldLine:
         eq_name = "eqref_OOB.json"
         filename = os.sep.join([TEST_PATH, eq_name])
         cls.eq = Equilibrium.from_eqdsk(filename)
-        cls.cache = {}
+        cls.flt = FieldLineTracer(cls.eq)
+        cls.field_line = cls.flt.trace_field_line(13, 0, n_points=1000)
 
     def test_connection_length(self):
-        flt = FieldLineTracer(self.eq)
-        field_line = flt.trace_field_line(13, 0, n_points=1000)
         assert np.isclose(
-            field_line.connection_length, field_line.coords.length, rtol=5e-2
+            self.field_line.connection_length, self.field_line.coords.length, rtol=5e-2
         )
-        self.cache["fl_con_length_grid"] = field_line.connection_length
 
     def test_connection_length_coordinates_grid(self):
         """
@@ -191,7 +189,9 @@ class TestFieldLine:
         assert np.isclose(
             field_line.connection_length, field_line.coords.length, rtol=5e-2
         )
-        assert np.isclose(self.cache["fl_con_length_grid"], field_line.connection_length)
+        assert np.isclose(
+            self.field_line.connection_length, field_line.connection_length
+        )
         self._check_endpoint(field_line, coords)
 
     def test_connection_length_coordinates(self):

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -206,7 +206,7 @@ class TestFieldLine:
         field_line = flt.trace_field_line(12.5, 0, n_points=1000, forward=False)
         self._check_endpoint(field_line, coords)
 
-    def _check_endpoint(self, field_line, coords, tol=1e-4):
+    def _check_endpoint(self, field_line, coords, tol=1e-8):
         """
         Check that the end point of a field line lies near enough to the boundary
         """


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1981 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

As we stripped out functionality from `Coordinates` this stuff got lost. I've put in a fix that does not change the API of `Coordinates`, checks for planar `Coordinates` when used in a `FieldLineTracer` and adds some proper tests that check for collision of the field line end point with the provided boundary.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
