### PR TITLE
Move EUDEMO params and config to the new ReactorConfig object

### DIFF
--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -35,6 +35,25 @@ class ReactorConfig:
     config_path: str | dict
         The path to the config JSON file or a dict of the data.
 
+    global_params_type: Type
+        The ParameterFrame type for the global params.
+
+    global_params_path: Optional[str | dict]
+        A path to a JSON file
+        holding the global params or a dict of the params.
+
+    warn_on_duplicate_keys: bool
+        Print a warning when duplicate keys are found,
+        whose value will be overwritten.
+
+    warn_on_empty_local_params: bool
+        Print a warning when the local params for some args are empty,
+        when calling params_for(*args)
+
+    warn_on_empty_config: bool
+        Print a warning when the config for some args are empty,
+        when calling config_for(*args)
+
     Example
     -------
 

--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -38,7 +38,7 @@ class ReactorConfig:
     global_params_type: Type
         The ParameterFrame type for the global params.
 
-    global_params_path: Optional[str | dict]
+    global_params_path: Optional[Union[str, dict]]
         A path to a JSON file
         holding the global params or a dict of the params.
 
@@ -48,11 +48,11 @@ class ReactorConfig:
 
     warn_on_empty_local_params: bool
         Print a warning when the local params for some args are empty,
-        when calling params_for(*args)
+        when calling params_for(args)
 
     warn_on_empty_config: bool
         Print a warning when the config for some args are empty,
-        when calling config_for(*args)
+        when calling config_for(args)
 
     Example
     -------

--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -32,25 +32,25 @@ class ReactorConfig:
 
     Parameters
     ----------
-    config_path: str | dict
+    config_path
         The path to the config JSON file or a dict of the data.
 
-    global_params_type: Type
+    global_params_type
         The ParameterFrame type for the global params.
 
-    global_params_path: Optional[Union[str, dict]]
+    global_params_path
         A path to a JSON file
         holding the global params or a dict of the params.
 
-    warn_on_duplicate_keys: bool
+    warn_on_duplicate_keys
         Print a warning when duplicate keys are found,
         whose value will be overwritten.
 
-    warn_on_empty_local_params: bool
+    warn_on_empty_local_params
         Print a warning when the local params for some args are empty,
         when calling params_for(args)
 
-    warn_on_empty_config: bool
+    warn_on_empty_config
         Print a warning when the config for some args are empty,
         when calling config_for(args)
 

--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -95,9 +95,9 @@ class ReactorConfig:
         config_path: Union[str, dict],
         global_params_type: Type[_PfT],
         global_params_path: Optional[Union[str, dict]] = None,
-        warn_on_duplicate_keys=True,
-        warn_on_empty_local_params=True,
-        warn_on_empty_config=True,
+        warn_on_duplicate_keys: bool = True,
+        warn_on_empty_local_params: bool = True,
+        warn_on_empty_config: bool = True,
     ):
         self.warn_on_duplicate_keys = warn_on_duplicate_keys
         self.warn_on_empty_local_params = warn_on_empty_local_params

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -55,7 +55,7 @@
         }
     },
     "Free boundary equilibrium": {
-        "run_mode": "run",
+        "run_mode": "read",
         "plot": true,
         "fixed_eq_file_path": "config/fixed_boundary_eqdsk.json",
         "file_path": "config/equilibrium_eqdsk.json",
@@ -84,7 +84,7 @@
                     "value": "r_fw_ob_in"
                 }
             },
-            "run_mode": "run",
+            "run_mode": "read",
             "name": "First Wall",
             "file_path": "config/FirstWallDesign.json",
             "problem_class": "bluemira.geometry.optimisation::MinimiseLengthGOP",
@@ -102,7 +102,7 @@
         "Divertor silhouette": {}
     },
     "TF coils": {
-        "run_mode": "run",
+        "run_mode": "read",
         "file_path": "config/TFCoilDesign.json",
         "plot": true,
         "param_class": "TripleArc",
@@ -123,7 +123,7 @@
         }
     },
     "PF coils": {
-        "run_mode": "run",
+        "run_mode": "read",
         "file_path": "config/PFCoilDesign.json",
         "verbose": false,
         "plot": true,

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -55,7 +55,7 @@
         }
     },
     "Free boundary equilibrium": {
-        "run_mode": "read",
+        "run_mode": "run",
         "plot": true,
         "fixed_eq_file_path": "config/fixed_boundary_eqdsk.json",
         "file_path": "config/equilibrium_eqdsk.json",
@@ -84,7 +84,7 @@
                     "value": "r_fw_ob_in"
                 }
             },
-            "run_mode": "read",
+            "run_mode": "run",
             "name": "First Wall",
             "file_path": "config/FirstWallDesign.json",
             "problem_class": "bluemira.geometry.optimisation::MinimiseLengthGOP",
@@ -102,7 +102,7 @@
         "Divertor silhouette": {}
     },
     "TF coils": {
-        "run_mode": "read",
+        "run_mode": "run",
         "file_path": "config/TFCoilDesign.json",
         "plot": true,
         "param_class": "TripleArc",
@@ -123,7 +123,7 @@
         }
     },
     "PF coils": {
-        "run_mode": "read",
+        "run_mode": "run",
         "file_path": "config/PFCoilDesign.json",
         "verbose": false,
         "plot": true,

--- a/eudemo/eudemo/coil_structure.py
+++ b/eudemo/eudemo/coil_structure.py
@@ -25,7 +25,7 @@ Coil structure stuff
 from dataclasses import dataclass
 
 from bluemira.base.components import Component
-from bluemira.base.parameter_frame import Parameter, ParameterFrame
+from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
 from bluemira.builders.coil_supports import (
     ITERGravitySupportBuilder,
     OISBuilder,
@@ -69,7 +69,7 @@ def build_coil_structures_component(
     """
     Build the coil structures super-component.
     """
-    params = CoilStructuresParameters.from_frame(params)
+    params = make_parameter_frame(params, CoilStructuresParameters)
     ois_designer = StraightOISDesigner(
         params, build_config, tf_coil_xz_face, pf_coil_keep_out_zones
     )

--- a/eudemo/eudemo/reactor.py
+++ b/eudemo/eudemo/reactor.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
     )
 
     reactor.plasma = build_plasma(
-        reactor_config.params_for("Plasma").global_params,
+        reactor_config.params_for("Plasma"),
         reactor_config.config_for("Plasma"),
         reference_eq,
     )

--- a/tests/base/reactor_config/data/reactor_params.global.json
+++ b/tests/base/reactor_config/data/reactor_params.global.json
@@ -1,0 +1,6 @@
+{
+    "height": { "value": 180, "unit": "cm" },
+    "age": { "value": 30, "unit": "years" },
+    "only_global": { "value": 1, "unit": "years" },
+    "extra_global": { "value": 1, "unit": "s" }
+}

--- a/tests/base/reactor_config/test_reactor_config.py
+++ b/tests/base/reactor_config/test_reactor_config.py
@@ -37,6 +37,7 @@ class TestCompADesignerParams(ParameterFrame):
 
 test_config_path = Path(__file__).parent / "data" / "reactor_config.test.json"
 empty_config_path = Path(__file__).parent / "data" / "reactor_config.empty.json"
+global_params_path = Path(__file__).parent / "data" / "reactor_params.global.json"
 
 
 class TestReactorConfigClass:
@@ -44,14 +45,24 @@ class TestReactorConfigClass:
     Tests for the Reactor Config class functionality.
     """
 
-    def test_file_loading_with_empty_config(self):
+    def test_file_loading_with_empty_config(
+        self,
+        caplog,
+    ):
         reactor_config = ReactorConfig(empty_config_path.as_posix(), EmptyFrame)
 
         # want to know explicitly if it is an EmptyFrame
         assert type(reactor_config.global_params) is EmptyFrame
-        with pytest.raises(KeyError):
-            reactor_config.params_for("dne")
-            reactor_config.config_for("dne")
+
+        p_dne = reactor_config.params_for("dne")
+        c_dne = reactor_config.config_for("dne")
+
+        assert len(caplog.records) == 2
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
+
+        assert len(p_dne.local_params) == 0
+        assert len(c_dne) == 0
 
     def test_incorrect_global_config_type_empty_config(self):
         with pytest.raises(ValueError):
@@ -60,6 +71,36 @@ class TestReactorConfigClass:
     def test_incorrect_global_config_type_non_empty_config(self):
         with pytest.raises(ValueError):
             ReactorConfig(test_config_path.as_posix(), EmptyFrame)
+
+    def test_set_global_params(
+        self,
+        caplog,
+    ):
+        reactor_config = ReactorConfig(
+            test_config_path.as_posix(),
+            TestGlobalParams,
+            global_params_path=global_params_path.as_posix(),
+        )
+
+        cp = reactor_config.params_for("comp A", "designer")
+
+        assert len(caplog.records) == 1
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
+
+        cpf = make_parameter_frame(cp, TestCompADesignerParams)
+
+        # value checks
+        assert cpf.only_global.value == raw_uc(1, "years", "s")
+        assert cpf.height.value == 1.8
+        assert cpf.age.value == raw_uc(30, "years", "s")
+        assert cpf.name.value == "Comp A"
+        assert cpf.location.value == "here"
+
+        # instance checks
+        assert cpf.only_global is reactor_config.global_params.only_global
+        assert cpf.height is reactor_config.global_params.height
+        assert cpf.age is reactor_config.global_params.age
 
     def test_params_for_warnings_make_param_frame_type_value_overrides(
         self,
@@ -110,21 +151,6 @@ class TestReactorConfigClass:
         assert cf_comp_a["config_b"] == cf_comp_a_des["config_b"]
         assert cf_comp_a_des["config_c"]["c_value"] == "c_value"
 
-    def test_no_arg_in_config_error(self):
-        reactor_config = ReactorConfig(
-            {
-                "comp A": {
-                    "designer": {},
-                },
-            },
-            EmptyFrame,
-        )
-
-        with pytest.raises(KeyError):
-            reactor_config.params_for("comp A", "dne")
-        with pytest.raises(KeyError):
-            reactor_config.config_for("comp A", "dne")
-
     def test_no_params_warning(self, caplog):
         reactor_config = ReactorConfig(
             {
@@ -136,12 +162,14 @@ class TestReactorConfigClass:
         )
 
         cp = reactor_config.params_for("comp A", "designer")
+        cp_dne = reactor_config.params_for("comp A", "designer", "dne")
 
-        assert len(caplog.records) == 1
+        assert len(caplog.records) == 2
         for record in caplog.records:
             assert record.levelname == "WARNING"
 
         assert len(cp.local_params) == 0
+        assert len(cp_dne.local_params) == 0
 
     def test_no_config_warning(self, caplog):
         reactor_config = ReactorConfig(
@@ -155,13 +183,15 @@ class TestReactorConfigClass:
 
         cf_comp_a = reactor_config.config_for("comp A")
         cf_comp_a_des = reactor_config.config_for("comp A", "designer")
+        cf_comp_a_des_dne = reactor_config.config_for("comp A", "designer", "dne")
 
-        assert len(caplog.records) == 1
+        assert len(caplog.records) == 2
         for record in caplog.records:
             assert record.levelname == "WARNING"
 
         assert len(cf_comp_a) == 1
         assert len(cf_comp_a_des) == 0
+        assert len(cf_comp_a_des_dne) == 0
 
     def test_invalid_rc_initialization(
         self,


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1991 

## Description

Moves EUDEMO reactor.py to using the new ReactorConfig object.

The ReactorConfig class was changed a bit to make it more ergonomic to use. It no longer throws if you try to access keys that don't exist and only warns if return objects are empty.

This fits in with the way things were done in EUDEMO and makes sense because those parameters/configs might be added in the future.

A path to a json file holding global_params can now optionally be given. This lets one separate global params from the build config which is how EUDEMO has been laid out.

In the future, we could isolate params per component. See Issue #2086.

Options to silence the warnings were also added.

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

ReactorConfig

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
