### PR TITLE
Update a couple of obsolete vars in PROCESS mapping

### DIFF
--- a/bluemira/codes/process/mapping.py
+++ b/bluemira/codes/process/mapping.py
@@ -89,7 +89,7 @@ IN_mappings = {
     "tk_vv_top": ("d_vv_top", "m"),
     "tk_vv_bot": ("d_vv_bot", "m"),
     "tk_cr_vv": ("ddwex", "m"),
-    "tk_tf_front_ib": ("casthi", "m"),
+    "tk_tf_front_ib": ("dr_tf_case_out", "m"),
     "tk_tf_side": ("casths", "m"),
     "PsepB_qAR_max": ("psepbqarmax", "MW.T/m"),
 }
@@ -122,7 +122,7 @@ OUT_mappings = {
     "tk_fw_in": ("fwith", "m"),
     "tk_fw_out": ("fwoth", "m"),
     "tk_tf_inboard": ("tfcth", "m"),
-    "tk_tf_nose": ("thkcas", "m"),
+    "tk_tf_nose": ("dr_tf_case_in", "m"),
     "tf_wp_width": ("dr_tf_wp", "m"),
     "tf_wp_depth": ("wwp1", "m"),
     "tk_tf_ins": ("tinstf", "m"),


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

Gets rid of a couple of warnings, but I am concerned that PROCESS no longer seems to be outputting `thkcas`. We've been implicitly using this for a while but it's been being set to 0.0. Now that it is a None, we get an error in the TF coil build, and I can no longer be certain that we are correctly interpreting the radial build from PROCESS (at least as far as the TF coil is concerned).
@je-cook
@ajpearcey
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
