### PR TITLE
Add `BetaLiIpProfile` to free boundary equilibrium solver

### DIFF
--- a/bluemira/equilibria/constants.py
+++ b/bluemira/equilibria/constants.py
@@ -54,11 +54,6 @@ I_MIN = 1e-20
 # Minimum current density in toroidal current density array
 J_TOR_MIN = 1e-36
 
-# Relative tolerance on normalised internal inductance constraint
-#       Used when optimising flux function shape parameters and StopIteration
-#       condition for the SLSQP optimiser.
-LI_REL_TOL = 0.015
-
 # Breakdown field limit [T]
 #       Used when calculating plasma breakdowns
 B_BREAKDOWN = 3e-3

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -58,7 +58,7 @@ from bluemira.equilibria.plotting import (
     CorePlotter2,
     EquilibriumPlotter,
 )
-from bluemira.equilibria.profiles import CustomProfile
+from bluemira.equilibria.profiles import BetaLiIpProfile, CustomProfile
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.utilities.opt_tools import process_scipy_result
 from bluemira.utilities.tools import abs_rel_difference
@@ -507,8 +507,6 @@ class Equilibrium(MHDState):
         Limiter conditions to apply to equilibrium
     psi: None or 2-D numpy array (optional) default = None
         Magnetic flux [V.s] applied to X, Z grid
-    li: None or float (default None)
-        Normalised plasma internal inductance [-]
     jtor: np.array or None
         The toroidal current density array of the plasma. Default = None will
         cause the jtor array to be constructed later as necessary.
@@ -525,7 +523,6 @@ class Equilibrium(MHDState):
         vcontrol=None,
         limiter=None,
         psi=None,
-        li=None,
         jtor=None,
         filename=None,
     ):
@@ -537,9 +534,13 @@ class Equilibrium(MHDState):
         self._x_points = None
         self._solver = None
         self._eqdsk = None
-        self._li = li  # target plasma normalised inductance
-        self._li_iter = 0  # li iteration count
-        self._li_temp = None
+
+        self._li_flag = False
+        if isinstance(profiles, BetaLiIpProfile):
+            self._li_flag = True
+            self._li = profiles.l_i_target  # target plasma normalised inductance
+            self._li_iter = 0  # li iteration count
+            self._li_temp = None
 
         self.plasma = None
 
@@ -834,10 +835,8 @@ class Equilibrium(MHDState):
             ._I_p
             ._Jtor
         """
-        if self._li is None:
-            raise EquilibriaError(
-                "Need to specify a normalised internal inductance to solve an Equilibrium with solve_li."
-            )
+        if not self._li_flag:
+            raise EquilibriaError("Cannot use solve_li without the BetaLiIpProfile.")
         self._clear_OX_points()
         if psi is None:
             psi = self.psi()
@@ -872,7 +871,7 @@ class Equilibrium(MHDState):
             )
             self._li_temp = li
             self._jtor = jtor_opt
-            if abs_rel_difference(self._li_temp, self._li) <= LI_REL_TOL:
+            if abs_rel_difference(self._li_temp, self._li) <= self.profiles.rel_tol:
                 # Scipy's callback argument doesn't seem to work, so we do this
                 # instead...
                 raise StopIteration

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -838,6 +838,7 @@ class Equilibrium(MHDState):
         if not self._li_flag:
             raise EquilibriaError("Cannot use solve_li without the BetaLiIpProfile.")
         self._clear_OX_points()
+        self._li_iter = 0
         if psi is None:
             psi = self.psi()
         # Speed optimisations

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -35,7 +35,7 @@ from bluemira.base.file import get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_print_flush
 from bluemira.equilibria.boundary import FreeBoundary, apply_boundary
 from bluemira.equilibria.coils import CoilSet, symmetrise_coilset
-from bluemira.equilibria.constants import LI_REL_TOL, PSI_NORM_TOL
+from bluemira.equilibria.constants import PSI_NORM_TOL
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.file import EQDSKInterface
 from bluemira.equilibria.find import (
@@ -538,7 +538,7 @@ class Equilibrium(MHDState):
         self._li_flag = False
         if isinstance(profiles, BetaLiIpProfile):
             self._li_flag = True
-            self._li = profiles.l_i_target  # target plasma normalised inductance
+            self._li = profiles._l_i_target  # target plasma normalised inductance
             self._li_iter = 0  # li iteration count
             self._li_temp = None
 
@@ -871,7 +871,7 @@ class Equilibrium(MHDState):
             )
             self._li_temp = li
             self._jtor = jtor_opt
-            if abs_rel_difference(self._li_temp, self._li) <= self.profiles.rel_tol:
+            if abs_rel_difference(self._li_temp, self._li) <= self.profiles._l_i_rel_tol:
                 # Scipy's callback argument doesn't seem to work, so we do this
                 # instead...
                 raise StopIteration

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -287,7 +287,7 @@ def calc_li3(eq):
     mask = in_plasma(eq.x, eq.z, eq.psi())
     Bp = eq.Bp()
     bpavg = volume_integral(Bp**2 * mask, eq.x, eq.dx, eq.dz)
-    return 2 * bpavg / (eq._R_0 * (MU_0 * eq._I_p) ** 2)
+    return 2 * bpavg / (eq.profiles.R_0 * (MU_0 * eq.profiles.I_p) ** 2)
 
 
 def calc_li3minargs(

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -479,7 +479,7 @@ class BetaIpProfile(Profile):
     betap: float
         Plasma poloidal beta constraint
     I_p: float
-        Plasma current constraint [Amps]
+        Plasma current constraint [A]
     R_0: float
         Reactor major radius [m] (used in p' and ff' components)
 
@@ -596,6 +596,23 @@ class BetaLiIpProfile(BetaIpProfile):
     """
     This is what BLUEPRINT used to do, and Fabrizio told me he had done
     something similar, at one point.
+
+    Parameters
+    ----------
+    betap: float
+        Plasma poloidal beta constraint
+    l_i: float
+        Normalised internal inductance constraint
+    I_p: float
+        Plasma current constraint [Amps]
+    R_0: float
+        Reactor major radius [m] (used in p' and ff' components)
+    B_0: float
+        Toroidal field [T]
+    shape: Optional[ShapeFunction]
+        The shape function to use for the flux functions
+    li_rel_tol: float
+        Absolute relative tolerance for the internal inductance constraint
     """
 
     def __init__(self, betap, l_i, I_p, R_0, B_0, shape=None, li_rel_tol=0.015):

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -626,7 +626,7 @@ class BetaLiIpProfile(BetaIpProfile):
         super().__init__(betap, I_p, R_0, B_0, shape=shape)
         self._l_i_target = l_i
         self._l_i_rel_tol = li_rel_tol
-        self._l_i_min_iter
+        self._l_i_min_iter = li_min_iter
 
 
 class CustomProfile(Profile):

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -592,6 +592,18 @@ class BetaIpProfile(Profile):
         return MU_0 * self.lambd * (1 - self.beta0) * self.R_0 * self.shape(pn)
 
 
+class BetaLiIpProfile(BetaIpProfile):
+    """
+    This is what BLUEPRINT used to do, and Fabrizio told me he had done
+    something similar, at one point.
+    """
+
+    def __init__(self, betap, l_i, I_p, R_0, B_0, shape=None, li_rel_tol=0.015):
+        super().__init__(betap, I_p, R_0, B_0, shape=shape)
+        self.l_i_target = l_i
+        self.rel_tol = li_rel_tol
+
+
 class CustomProfile(Profile):
     """
     User-specified profile functions p'(psi), ff'(psi)

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -594,8 +594,8 @@ class BetaIpProfile(Profile):
 
 class BetaLiIpProfile(BetaIpProfile):
     """
-    This is what BLUEPRINT used to do, and Fabrizio told me he had done
-    something similar, at one point.
+    Profile is what BLUEPRINT used to do, and Fabrizio told me he had done
+    something similar in MIRA, at one point.
 
     Parameters
     ----------
@@ -613,12 +613,20 @@ class BetaLiIpProfile(BetaIpProfile):
         The shape function to use for the flux functions
     li_rel_tol: float
         Absolute relative tolerance for the internal inductance constraint
+    li_min_iter: int
+        Iteration at which the profile optimisation should start to be
+        carried out. Usually best not to start solving the equilibrium
+        with the profile constraint, and fold it in later, when the plasma
+        shape is more representative.
     """
 
-    def __init__(self, betap, l_i, I_p, R_0, B_0, shape=None, li_rel_tol=0.015):
+    def __init__(
+        self, betap, l_i, I_p, R_0, B_0, shape=None, li_rel_tol=0.015, li_min_iter=5
+    ):
         super().__init__(betap, I_p, R_0, B_0, shape=shape)
-        self.l_i_target = l_i
-        self.rel_tol = li_rel_tol
+        self._l_i_target = l_i
+        self._l_i_rel_tol = li_rel_tol
+        self._l_i_min_iter
 
 
 class CustomProfile(Profile):

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -601,7 +601,7 @@ class PicardIterator:
         """
         Solve for this iteration.
         """
-        if self.eq._li_flag and self.i > 5:
+        if self.eq._li_flag and self.i > self.eq.profiles._l_i_min_iter:
             self.eq.solve_li(psi=self.psi)
         else:
             self.eq.solve(psi=self.psi)

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -601,7 +601,10 @@ class PicardIterator:
         """
         Solve for this iteration.
         """
-        self.eq.solve(psi=self.psi)
+        if self.eq._li_flag and self.i > 5:
+            self.eq.solve_li(psi=self.psi)
+        else:
+            self.eq.solve(psi=self.psi)
 
     def _initial_optimise_coilset(self, **kwargs):
         self._optimise_coilset(**kwargs)

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -72,8 +72,13 @@ from bluemira.equilibria.opt_problems import (
     OutboardBreakdownZoneStrategy,
     UnconstrainedTikhonovCurrentGradientCOP,
 )
-from bluemira.equilibria.physics import calc_psib
-from bluemira.equilibria.profiles import CustomProfile
+from bluemira.equilibria.physics import calc_beta_p, calc_li3, calc_psib
+from bluemira.equilibria.profiles import (
+    BetaIpProfile,
+    BetaLiIpProfile,
+    CustomProfile,
+    DoublePowerFunc,
+)
 from bluemira.equilibria.solve import PicardIterator
 from bluemira.utilities.optimiser import Optimiser
 
@@ -221,7 +226,15 @@ psi_eof -= 10
 # %% [markdown]
 #
 # Set up a parameterised profile
+# Here you can use a CustomProfile, by feeding in arrays describing
+# your p' and FF' flux functions which are linearly interpolated.
 
+# Or you can use either BetaIpProfile or BetaLiIpProfile to constrain
+# the plasma integrals, optimising the shape of the flux functions
+# to match these.
+
+# Comment out the relevant lines below to explore the different
+# behaviour.
 # %%
 profiles = CustomProfile(
     np.array([86856, 86506, 84731, 80784, 74159, 64576, 52030, 36918, 20314, 4807, 0.0]),
@@ -232,7 +245,6 @@ profiles = CustomProfile(
     B_0=B_0,
     I_p=I_p,
 )
-from bluemira.equilibria.profiles import BetaIpProfile, BetaLiIpProfile, DoublePowerFunc
 
 shape = DoublePowerFunc([2, 1])
 profiles = BetaIpProfile(beta_p, I_p, R_0, B_0, shape=shape)
@@ -349,13 +361,8 @@ eof_psi = 2 * np.pi * eof.psi(*eof._x_points[0][:2])
 ax[1].set_title("$\\psi_{b}$ = " + f"{sof_psi:.2f} V.s")
 ax[2].set_title("$\\psi_{b}$ = " + f"{eof_psi:.2f} V.s")
 
+
+bluemira_print(f"SOF: beta_p: {calc_beta_p(sof):.2f} l_i: {calc_li3(sof):.2f}")
+bluemira_print(f"EOF: beta_p: {calc_beta_p(eof):.2f} l_i: {calc_li3(eof):.2f}")
+
 plt.show()
-
-from bluemira.equilibria.physics import calc_beta_p, calc_li3
-
-bluemira_print()
-# TODO: Fix this example...
-msg = f"SOF: beta_p: {calc_beta_p(sof):.2f} l_i: {calc_li3(sof):.2f}"
-bluemira_print(msg)
-msg = f"EOF: beta_p: {calc_beta_p(eof):.2f} l_i: {calc_li3(eof):.2f}"
-bluemira_print(msg)

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -232,7 +232,13 @@ profiles = CustomProfile(
     B_0=B_0,
     I_p=I_p,
 )
-# profile = BetaIpProfile(beta_p, I_p, R_0, B_0, shape=shape)
+from bluemira.equilibria.profiles import BetaIpProfile, BetaLiIpProfile, DoublePowerFunc
+
+shape = DoublePowerFunc([2, 1])
+profiles = BetaIpProfile(beta_p, I_p, R_0, B_0, shape=shape)
+profiles = BetaLiIpProfile(
+    beta_p, l_i, I_p, R_0, B_0, shape=shape, li_min_iter=0, li_rel_tol=0.001
+)
 
 
 # %% [markdown]
@@ -251,9 +257,12 @@ reference_eq = Equilibrium(
 #   * Field null at lower X-point
 #   * divertor legs are not treated, but could easily be added
 
+sof_xbdry = np.array(sof_xbdry)[::15]
+sof_zbdry = np.array(sof_zbdry)[::15]
+
 isoflux = IsofluxConstraint(
-    np.array(sof_xbdry)[::10],
-    np.array(sof_zbdry)[::10],
+    sof_xbdry,
+    sof_zbdry,
     sof_xbdry[0],
     sof_zbdry[0],
     tolerance=1e-3,
@@ -278,10 +287,10 @@ program()
 
 
 sof_psi_boundary = PsiBoundaryConstraint(
-    np.array(sof_xbdry)[::10],
-    np.array(sof_zbdry)[::10],
+    sof_xbdry,
+    sof_zbdry,
     psi_sof / (2 * np.pi),
-    tolerance=1.0,
+    tolerance=0.5,
 )
 
 optimiser = Optimiser("SLSQP", opt_conditions={"max_eval": 1000, "ftol_rel": 1e-6})
@@ -302,10 +311,10 @@ iterator()
 
 
 eof_psi_boundary = PsiBoundaryConstraint(
-    np.array(sof_xbdry)[::10],
-    np.array(sof_zbdry)[::10],
+    sof_xbdry,
+    sof_zbdry,
     psi_eof / (2 * np.pi),
-    tolerance=1.0,
+    tolerance=0.5,
 )
 
 eof = deepcopy(reference_eq)

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -351,9 +351,11 @@ ax[2].set_title("$\\psi_{b}$ = " + f"{eof_psi:.2f} V.s")
 
 plt.show()
 
-# TODO: Fix this example...
-# bluemira_print(
-#     "SOF:\n" f"beta_p: {calc_beta_p_approx(sof):.2f}\n" f"l_i: {calc_li(sof):.2f}"
-# )
+from bluemira.equilibria.physics import calc_beta_p, calc_li3
 
-# bluemira_print("EOF:\n" f"beta_p: {calc_beta_p(eof):.2f}\n" f"l_i: {calc_li(sof):.2f}")
+bluemira_print()
+# TODO: Fix this example...
+msg = f"SOF: beta_p: {calc_beta_p(sof):.2f} l_i: {calc_li3(sof):.2f}"
+bluemira_print(msg)
+msg = f"EOF: beta_p: {calc_beta_p(eof):.2f} l_i: {calc_li3(eof):.2f}"
+bluemira_print(msg)

--- a/tests/equilibria/setup_methods.py
+++ b/tests/equilibria/setup_methods.py
@@ -86,8 +86,10 @@ def _coilset_setup(self, materials=False):
 
     if materials:
         # Max PF currents / sizes don't stack up in the CREATE document...
-        self.coilset.assign_coil_materials("PF", j_max=12.5, b_max=12.5)
-        self.coilset.assign_coil_materials("CS", j_max=12.5, b_max=12.5)
+        self.coilset.get_coiltype("PF").b_max = 12.5
+        self.coilset.get_coiltype("PF").j_max = 12.5e6
+        self.coilset.get_coiltype("CS").b_max = 12.5
+        self.coilset.get_coiltype("CS").j_max = 12.5e6
         self.coilset.fix_sizes()
 
     self.no_coils = len(names)

--- a/tests/equilibria/setup_methods.py
+++ b/tests/equilibria/setup_methods.py
@@ -86,10 +86,8 @@ def _coilset_setup(self, materials=False):
 
     if materials:
         # Max PF currents / sizes don't stack up in the CREATE document...
-        self.coilset.get_coiltype("PF").b_max = 12.5
-        self.coilset.get_coiltype("PF").j_max = 12.5e6
-        self.coilset.get_coiltype("CS").b_max = 12.5
-        self.coilset.get_coiltype("CS").j_max = 12.5e6
+        self.coilset.assign_material("PF", j_max=12.5e6, b_max=12.5)
+        self.coilset.assign_material("CS", j_max=12.5e6, b_max=12.5)
         self.coilset.fix_sizes()
 
     self.no_coils = len(names)

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -37,7 +37,7 @@ from bluemira.equilibria.opt_constraints import (
     MagneticConstraintSet,
 )
 from bluemira.equilibria.opt_problems import UnconstrainedTikhonovCurrentGradientCOP
-from bluemira.equilibria.physics import calc_beta_p, calc_li3
+from bluemira.equilibria.physics import calc_li3
 from bluemira.equilibria.profiles import (
     BetaIpProfile,
     BetaLiIpProfile,
@@ -296,6 +296,7 @@ class TestSolveEquilibrium:
             gif=False,
         )
         program()
+        assert program.check_converged()
 
     @pytest.mark.parametrize("shape", shape_funcs)
     def test_betaip_profile(self, shape):
@@ -314,6 +315,7 @@ class TestSolveEquilibrium:
             gif=False,
         )
         program()
+        assert program.check_converged()
 
     @pytest.mark.parametrize("shape", shape_funcs)
     def test_betapliip_profile(self, shape):
@@ -343,6 +345,7 @@ class TestSolveEquilibrium:
         )
         program()
         assert abs_rel_difference(calc_li3(eq), self.l_i) <= rel_tol
+        assert program.check_converged()
 
 
 class TestEquilibrium:


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1042


## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->


Adds a `BetaLiIpProfile` to free boundary equilibrium solver, which is just resurrected stuff from BLUEPRINT. Turns out it works pretty great for EU-DEMO, at least for the example considered. It's not the most beautiful implementation, and uses scipy optimize at present, which I hate with a passion, but... it works out of the box.
## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
