### PR TITLE
More obsolete PROCESS variables in inputs

### DIFF
--- a/bluemira/codes/process/_inputs.py
+++ b/bluemira/codes/process/_inputs.py
@@ -84,7 +84,6 @@ class ProcessInputs:
     bore: float = 2.3322
     bscfmax: float = 0.99
     bt: float = 5.3292
-    casthi: float = 0.06
     casths: float = 0.05
     cfactr: float = 0.75
     coheof: float = 20726000.0
@@ -107,6 +106,8 @@ class ProcessInputs:
     divdum: int = 1
     divfix: float = 0.621
     dnbeta: float = 3.0
+    dr_tf_case_in: float = 0.52465
+    dr_tf_case_out: float = 0.06
     emult: float = 1.35
     enbeam: float = 1e3
     epsvmc: float = 1e-08
@@ -245,7 +246,6 @@ class ProcessInputs:
     tftmp: float = 4.75
     tftsgap: float = 0.05
     thicndut: float = 0.002
-    thkcas: float = 0.52465
     thshield: float = 0
     thwcndut: float = 0.008
     tinstf: float = 0.008


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
