### PR TITLE
Catch `RuntimeError` which occasionally crops up in fixed boundary equilibrium solver.

### DIFF
--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -32,6 +32,7 @@ from matplotlib.tri import Triangulation
 from scipy.interpolate import interp1d
 
 from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.utilities.error import ExternalOptError
 from bluemira.utilities.opt_problems import OptimisationConstraint, OptimisationObjective
 from bluemira.utilities.optimiser import Optimiser, approx_derivative
 from bluemira.utilities.tools import is_num
@@ -462,7 +463,7 @@ def calculate_plasma_shape_params(
         optimiser.add_eq_constraints(f_constraint, tolerance=1e-10)
         try:
             x_star = optimiser.optimise(x0)
-        except Exception as e:
+        except ExternalOptError as e:
             bluemira_warn(
                 f"calculate_plasma_shape_params::find_extremum failing at {x0}, defaulting to mesh value: {e}"
             )

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -31,6 +31,7 @@ from matplotlib.axes._axes import Axes
 from matplotlib.tri import Triangulation
 from scipy.interpolate import interp1d
 
+from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.utilities.opt_problems import OptimisationConstraint, OptimisationObjective
 from bluemira.utilities.optimiser import Optimiser, approx_derivative
 from bluemira.utilities.tools import is_num
@@ -459,7 +460,14 @@ def calculate_plasma_shape_params(
         )
 
         optimiser.add_eq_constraints(f_constraint, tolerance=1e-10)
-        return optimiser.optimise(x0)
+        try:
+            x_star = optimiser.optimise(x0)
+        except Exception as e:
+            bluemira_warn(
+                f"calculate_plasma_shape_params::find_extremum failing at {x0}, defaulting to mesh value: {e}"
+            )
+            x_star = x0
+        return x_star
 
     pi_opt = find_extremum(_f_min_radius, pi)
     pl_opt = find_extremum(_f_min_vert, pl)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

For bad/difficult profiles, I've occasionally witnessed a RuntimeError, when calculating the plasma shape params. This fails hard, and the mesh point is a fair enough estimate of the extrema anyway, so we can just fall back to it softly with a warning.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
