### PR TITLE
Make `Builder` and `Designer` consistent when handling `build_config` in `__init__`

### DIFF
--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -26,7 +26,7 @@ Interfaces for builder classes.
 from __future__ import annotations
 
 import abc
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Optional, Type, Union
 
 from bluemira.base.components import Component
 from bluemira.base.parameter_frame import ParameterFrame, make_parameter_frame
@@ -103,14 +103,14 @@ class Builder(abc.ABC):
     def __init__(
         self,
         params: Union[Dict, ParameterFrame, ConfigParams, None],
-        build_config: Dict,
+        build_config: Optional[Dict] = None,
     ):
         super().__init__()
         self.name = build_config.get(
             "name", _remove_suffix(self.__class__.__name__, "Builder")
         )
         self.params = make_parameter_frame(params, self.param_cls)
-        self.build_config = build_config
+        self.build_config = build_config if build_config is not None else {}
 
     @abc.abstractproperty
     def param_cls(self) -> Union[Type[ParameterFrame], None]:

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -108,7 +108,7 @@ class Builder(abc.ABC):
         super().__init__()
         self.params = make_parameter_frame(params, self.param_cls)
         self.build_config = build_config if build_config is not None else {}
-        self.name = build_config.get(
+        self.name = self.build_config.get(
             "name", _remove_suffix(self.__class__.__name__, "Builder")
         )
 

--- a/bluemira/base/builder.py
+++ b/bluemira/base/builder.py
@@ -106,11 +106,11 @@ class Builder(abc.ABC):
         build_config: Optional[Dict] = None,
     ):
         super().__init__()
+        self.params = make_parameter_frame(params, self.param_cls)
+        self.build_config = build_config if build_config is not None else {}
         self.name = build_config.get(
             "name", _remove_suffix(self.__class__.__name__, "Builder")
         )
-        self.params = make_parameter_frame(params, self.param_cls)
-        self.build_config = build_config if build_config is not None else {}
 
     @abc.abstractproperty
     def param_cls(self) -> Union[Type[ParameterFrame], None]:

--- a/tests/base/test_builder.py
+++ b/tests/base/test_builder.py
@@ -51,6 +51,11 @@ class TestBuilder:
 
         assert builder.name == "Stub"
 
+    def test_default_name_is_class_name_sans_build_config(self):
+        builder = StubBuilder(self._params, None)
+
+        assert builder.name == "Stub"
+
     def test_component_tree(self):
         builder = StubBuilder(self._params, {})
         component = builder.component_tree(


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2015 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
