### PR TITLE
Remove bad tuples in `BluemiraGeo` subclasses.

### DIFF
--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -193,7 +193,7 @@ class BluemiraFace(BluemiraGeo):
         """
         The faces of the wire. By definition an empty list.
         """
-        return tuple(self)
+        return tuple([self])
 
     @property
     def shells(self) -> tuple:

--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -170,41 +170,41 @@ class BluemiraFace(BluemiraGeo):
     @property
     def vertexes(self) -> Coordinates:
         """
-        The vertexes of the wire.
+        The vertexes of the face.
         """
         return Coordinates(cadapi.vertexes(self.shape))
 
     @property
     def edges(self) -> Tuple[BluemiraWire]:
         """
-        The edges of the wire.
+        The edges of the face.
         """
         return tuple([BluemiraWire(cadapi.apiWire(o)) for o in cadapi.edges(self.shape)])
 
     @property
     def wires(self) -> Tuple[BluemiraWire]:
         """
-        The wires of the wire. By definition a list of itself.
+        The wires of the face.
         """
         return tuple([BluemiraWire(o) for o in cadapi.wires(self.shape)])
 
     @property
     def faces(self) -> Tuple[BluemiraFace]:
         """
-        The faces of the wire. By definition an empty list.
+        The faces of the face. By definition a tuple of itself.
         """
         return tuple([self])
 
     @property
     def shells(self) -> tuple:
         """
-        The shells of the wire. By definition an empty list.
+        The shells of the face. By definition an empty tuple.
         """
         return ()
 
     @property
     def solids(self) -> tuple:
         """
-        The solids of the wire. By definition an empty list.
+        The solids of the face. By definition an empty tuple.
         """
         return ()

--- a/bluemira/geometry/shell.py
+++ b/bluemira/geometry/shell.py
@@ -110,7 +110,7 @@ class BluemiraShell(BluemiraGeo):
         """
         The shells of the shell. By definition a list of itself.
         """
-        return tuple(self)
+        return tuple([self])
 
     @property
     def solids(self) -> tuple:

--- a/bluemira/geometry/shell.py
+++ b/bluemira/geometry/shell.py
@@ -108,13 +108,13 @@ class BluemiraShell(BluemiraGeo):
     @property
     def shells(self) -> tuple:
         """
-        The shells of the shell. By definition a list of itself.
+        The shells of the shell. By definition a tuple of itself.
         """
         return tuple([self])
 
     @property
     def solids(self) -> tuple:
         """
-        The solids of the shell. By definition an empty list.
+        The solids of the shell. By definition an empty tuple.
         """
         return ()

--- a/bluemira/geometry/solid.py
+++ b/bluemira/geometry/solid.py
@@ -134,6 +134,6 @@ class BluemiraSolid(BluemiraGeo):
     @property
     def solids(self) -> Tuple[BluemiraSolid]:
         """
-        The solids of the solid. By definition a list of itself.
+        The solids of the solid. By definition a tuple of itself.
         """
         return tuple([self])

--- a/bluemira/geometry/solid.py
+++ b/bluemira/geometry/solid.py
@@ -136,4 +136,4 @@ class BluemiraSolid(BluemiraGeo):
         """
         The solids of the solid. By definition a list of itself.
         """
-        return tuple(self)
+        return tuple([self])

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -247,7 +247,7 @@ class BluemiraWire(BluemiraGeo):
         """
         The wires of the wire. By definition a list of itself.
         """
-        return tuple(self)
+        return tuple([self])
 
     @property
     def faces(self) -> tuple:

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -245,27 +245,27 @@ class BluemiraWire(BluemiraGeo):
     @property
     def wires(self) -> Tuple[BluemiraWire]:
         """
-        The wires of the wire. By definition a list of itself.
+        The wires of the wire. By definition a tuple of itself.
         """
         return tuple([self])
 
     @property
     def faces(self) -> tuple:
         """
-        The faces of the wire. By definition an empty list.
+        The faces of the wire. By definition an empty tuple.
         """
         return ()
 
     @property
     def shells(self) -> tuple:
         """
-        The shells of the wire. By definition an empty list.
+        The shells of the wire. By definition an empty tuple.
         """
         return ()
 
     @property
     def solids(self) -> tuple:
         """
-        The solids of the wire. By definition an empty list.
+        The solids of the wire. By definition an empty tuple.
         """
         return ()


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

Bug when getting the list of thing that is a thing..

```python
>>> from bluemira.geometry.tools import make_circle
>>> c = make_circle()
>>> c.wires
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/matti/code/bluemira/bluemira/geometry/wire.py", line 250, in wires
    return tuple(self)
TypeError: 'BluemiraWire' object is not iterable

```
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
