### PR TITLE
Add selection strategies for the points at which TF ripple is constrained

### DIFF
--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -23,7 +23,7 @@
 Built-in build steps for making parameterised TF coils.
 """
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Optional

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -182,7 +182,7 @@ class RipplePointSelector(ABC):
             f_constraint_args={
                 "parameterisation": parameterisation,
                 "solver": solver,
-                "points": self.get_ripple_points(),
+                "points": self.points,
                 "TF_ripple_limit": TF_ripple_limit,
             },
             tolerance=rip_con_tol * np.ones(len(self.points)),

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -507,6 +507,10 @@ class MaximiseSelector(RipplePointSelector):
 
 @dataclass
 class RippleConstrainedLengthGOPParams(ParameterFrame):
+    """
+    Parameters for the RippleConstrainedLengthGOP
+    """
+
     n_TF: Parameter[int]
     R_0: Parameter[float]
     z_0: Parameter[float]

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -410,7 +410,7 @@ class MaximiseSelector(RipplePointSelector):
                 func,
                 vector,
                 f0=constraint,
-                args=(parameterisation, solver, TF_ripple_limit),
+                args=(parameterisation, solver, lcfs_wire, alpha_0, TF_ripple_limit),
                 **ad_args,
             )
 

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -167,7 +167,7 @@ class RipplePointSelector(ABC):
     """
 
     def __init__(self):
-        self.wire: BluemiraWire = None
+        self._wire: BluemiraWire = None
         self.points: Coordinates = None
 
     def set_wire(self, wire: BluemiraWire):
@@ -179,7 +179,7 @@ class RipplePointSelector(ABC):
         wire
             Wire along which the points will be selected
         """
-        self.wire = wire
+        self._wire = wire
 
     def make_ripple_constraint(
         self, parameterisation, solver, TF_ripple_limit, rip_con_tol
@@ -404,7 +404,7 @@ class MaximiseSelector(RipplePointSelector):
                 "parameterisation": parameterisation,
                 "solver": solver,
                 "TF_ripple_limit": TF_ripple_limit,
-                "lcfs_wire": self.wire,
+                "lcfs_wire": self._wire,
                 "alpha_0": self._alpha_0,
                 # I'm sorry...
                 "this": self,

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -447,7 +447,7 @@ class MaximiseSelector(RipplePointSelector):
         """
         func = MaximiseSelector.calculate_max_ripple
         constraint[:] = func(
-            vector, parameterisation, solver, lcfs_wire, TF_ripple_limit
+            vector, parameterisation, solver, lcfs_wire, alpha_0, TF_ripple_limit
         )
         if grad.size > 0:
             grad[:] = approx_derivative(

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -344,16 +344,12 @@ class ExtremaSelector(RipplePointSelector):
         """
         super().set_wire(wire)
         coords = wire.discretize(byedges=True, ndiscr=2000)
-        arg_x_min = np.argmin(coords.x)
-        arg_x_max = np.argmax(coords.x)
-        arg_z_min = np.argmin(coords.z)
-        arg_z_max = np.argmax(coords.z)
         self.points = Coordinates(
             [
-                coords.points[arg_x_min],
-                coords.points[arg_x_max],
-                coords.points[arg_z_min],
-                coords.points[arg_z_max],
+                coords.points[np.argmin(coords.x)],
+                coords.points[np.argmax(coords.x)],
+                coords.points[np.argmin(coords.z)],
+                coords.points[np.argmax(coords.z)],
             ]
         )
 

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -442,6 +442,11 @@ class MaximiseSelector(RipplePointSelector):
             TF ripple solver
         TF_ripple_limit: float
             Maximum allowable TF ripple
+        this: MaximiseSelector
+            Need to pass this in sadly as need to set the points property
+            dynamically because it is not know a priori
+        ad_args: Optional[dict]
+            Automatic differentiation arguments
         """
         func = MaximiseSelector._calculate_max_ripple
         constraint[:] = func(
@@ -489,6 +494,9 @@ class MaximiseSelector(RipplePointSelector):
             TF ripple solver
         TF_ripple_limit: float
             Maximum allowable TF ripple
+        this: MaximiseSelector
+            Need to pass this in sadly as need to set the points property
+            dynamically because it is not know a priori
 
         Returns
         -------

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -72,8 +72,6 @@ class ParameterisedRippleSolver:
         Vertical coordinate at which to calculate B_0
     B_0: float
         Toroidal field at (R_0, z_0)
-    ripple_points: np.ndarray
-        Points at which to calculate TF ripple
     """
 
     def __init__(self, wp_xs, nx, ny, n_TF, R_0, z_0, B_0):
@@ -190,7 +188,7 @@ class RipplePointSelector(ABC):
         Make the ripple OptimisationConstraint
         """
         return OptimisationConstraint(
-            self.constrain_ripple,
+            self._constrain_ripple,
             f_constraint_args={
                 "parameterisation": parameterisation,
                 "solver": solver,
@@ -201,7 +199,7 @@ class RipplePointSelector(ABC):
         )
 
     @staticmethod
-    def constrain_ripple(
+    def _constrain_ripple(
         constraint,
         vector,
         grad,
@@ -231,7 +229,7 @@ class RipplePointSelector(ABC):
         TF_ripple_limit: float
             Maximum allowable TF ripple
         """
-        func = RipplePointSelector.calculate_ripple
+        func = RipplePointSelector._calculate_ripple
         constraint[:] = func(vector, parameterisation, solver, points, TF_ripple_limit)
         if grad.size > 0:
             grad[:] = approx_derivative(
@@ -246,7 +244,7 @@ class RipplePointSelector(ABC):
         return constraint
 
     @staticmethod
-    def calculate_ripple(vector, parameterisation, solver, points, TF_ripple_limit):
+    def _calculate_ripple(vector, parameterisation, solver, points, TF_ripple_limit):
         """
         Calculate ripple constraint
 
@@ -401,7 +399,7 @@ class MaximiseSelector(RipplePointSelector):
         Make the ripple OptimisationConstraint
         """
         return OptimisationConstraint(
-            self.constrain_max_ripple,
+            self._constrain_max_ripple,
             f_constraint_args={
                 "parameterisation": parameterisation,
                 "solver": solver,
@@ -415,7 +413,7 @@ class MaximiseSelector(RipplePointSelector):
         )
 
     @staticmethod
-    def constrain_max_ripple(
+    def _constrain_max_ripple(
         constraint,
         vector,
         grad,
@@ -445,7 +443,7 @@ class MaximiseSelector(RipplePointSelector):
         TF_ripple_limit: float
             Maximum allowable TF ripple
         """
-        func = MaximiseSelector.calculate_max_ripple
+        func = MaximiseSelector._calculate_max_ripple
         constraint[:] = func(
             vector, parameterisation, solver, lcfs_wire, alpha_0, TF_ripple_limit, this
         )
@@ -469,7 +467,7 @@ class MaximiseSelector(RipplePointSelector):
         return constraint
 
     @staticmethod
-    def calculate_max_ripple(
+    def _calculate_max_ripple(
         vector,
         parameterisation,
         solver,

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -172,9 +172,14 @@ class RipplePointSelector(ABC):
         self.wire: BluemiraWire = None
         self.points: Coordinates = None
 
-    def set_wire(self, wire):
+    def set_wire(self, wire: BluemiraWire):
         """
         Set the wire along which the points will be selected
+
+        Parameters
+        ----------
+        wire
+            Wire along which the points will be selected
         """
         self.wire = wire
 
@@ -284,6 +289,14 @@ class EquispacedSelector(RipplePointSelector):
         self.n_rip_points = n_rip_points
 
     def set_wire(self, wire):
+        """
+        Set the wire along which the points will be selected
+
+        Parameters
+        ----------
+        wire
+            Wire along which the points will be selected
+        """
         super().set_wire(wire)
         self.points = wire.discretize(byedges=True, ndiscr=self.n_rip_points)
 
@@ -308,6 +321,14 @@ class OutboardEquispacedSelector(RipplePointSelector):
         self.x_min = x_min
 
     def set_wire(self, wire):
+        """
+        Set the wire along which the points will be selected
+
+        Parameters
+        ----------
+        wire
+            Wire along which the points will be selected
+        """
         super().set_wire(wire)
         bb = wire.bounding_box
         if self.x_min is None:
@@ -362,6 +383,14 @@ class MaximiseSelector(RipplePointSelector):
         self.points = None
 
     def set_wire(self, wire):
+        """
+        Set the wire along which the points will be selected
+
+        Parameters
+        ----------
+        wire
+            Wire along which the points will be selected
+        """
         super().set_wire(wire)
         points = wire.discretize(byedges=True, ndiscr=200)
         arg_x_max = np.argmax(points.x)

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -168,7 +168,6 @@ class RipplePointSelector(ABC):
     ABC for ripple point selection strategies.
     """
 
-    @abstractmethod
     def __init__(self):
         self.wire: BluemiraWire = None
         self.points: Coordinates = None
@@ -329,9 +328,6 @@ class ExtremaSelector(RipplePointSelector):
     """
     Select the extrema of the wire and constrain ripple there.
     """
-
-    def __init__(self):
-        super().__init__()
 
     def set_wire(self, wire: BluemiraWire):
         """

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -555,9 +555,9 @@ class RippleConstrainedLengthGOP(GeometryOptimisationProblem):
             bluemira_warn(
                 "RippleConstrainedLengthGOP API has changed, please specify how you want "
                 "to constrain TF ripple by using one of the available RipplePointSelector "
-                f"classes. Defaulting to an EquispacedSelector with {n_rip_points} for now."
+                f"classes. Defaulting to an EquispacedSelector with {n_rip_points=} for now."
             )
-            ripple_selector = EquispacedSelector(separatrix, n_rip_points)
+            ripple_selector = EquispacedSelector(n_rip_points)
 
         ripple_selector.set_wire(self.separatrix)
         self.ripple_values = None

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -334,6 +334,14 @@ class ExtremaSelector(RipplePointSelector):
         super().__init__()
 
     def set_wire(self, wire: BluemiraWire):
+        """
+        Set the wire along which the points will be selected
+
+        Parameters
+        ----------
+        wire
+            Wire along which the points will be selected
+        """
         super().set_wire(wire)
         coords = wire.discretize(byedges=True, ndiscr=2000)
         arg_x_min = np.argmin(coords.x)

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -31,6 +31,7 @@ from typing import Optional
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy.optimize import minimize
 
 from bluemira.base.constants import EPS
 from bluemira.base.look_and_feel import bluemira_debug_flush, bluemira_warn
@@ -503,7 +504,6 @@ class MaximiseSelector(RipplePointSelector):
         parameterisation.variables.set_values_from_norm(vector)
         tf_wire = parameterisation.create_shape()
         solver.update_cage(tf_wire)
-        from scipy.optimize import minimize
 
         def f_max_ripple(alpha):
             point = lcfs_wire.value_at(alpha)

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -325,6 +325,31 @@ class EquispacedSelector(RipplePointSelector):
         self.points = wire.discretize(byedges=True, ndiscr=self.n_rip_points)
 
 
+class ExtremaSelector(RipplePointSelector):
+    """
+    Select the extrema of the wire and constrain ripple there.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def set_wire(self, wire: BluemiraWire):
+        super().set_wire(wire)
+        coords = wire.discretize(byedges=True, ndiscr=2000)
+        arg_x_min = np.argmin(coords.x)
+        arg_x_max = np.argmax(coords.x)
+        arg_z_min = np.argmin(coords.z)
+        arg_z_max = np.argmax(coords.z)
+        self.points = Coordinates(
+            [
+                coords.points[arg_x_min],
+                coords.points[arg_x_max],
+                coords.points[arg_z_min],
+                coords.points[arg_z_max],
+            ]
+        )
+
+
 class FixedSelector(RipplePointSelector):
     """
     Specified points at which to constrain the ripple, overrides any information

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -33,7 +33,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from bluemira.base.constants import EPS
-from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_debug_flush, bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
 from bluemira.display import plot_2d

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -74,7 +74,7 @@ class ParameterisedRippleSolver:
         Points at which to calculate TF ripple
     """
 
-    def __init__(self, wp_xs, nx, ny, n_TF, R_0, z_0, B_0, ripple_points):
+    def __init__(self, wp_xs, nx, ny, n_TF, R_0, z_0, B_0):
         self.wp_xs = wp_xs
         self.nx = nx
         self.ny = ny
@@ -82,7 +82,6 @@ class ParameterisedRippleSolver:
         self.R_0 = R_0
         self.z_0 = z_0
         self.B_0 = B_0
-        self.ripple_points = ripple_points
         self.cage = None
 
     def update_cage(self, wire):
@@ -265,7 +264,6 @@ class RippleConstrainedLengthGOP(GeometryOptimisationProblem):
             params.R_0.value,
             params.z_0.value,
             params.B_0.value,
-            self.ripple_points,
         )
         ripple_constraint = OptimisationConstraint(
             self.constrain_ripple,
@@ -404,7 +402,7 @@ class RippleConstrainedLengthGOP(GeometryOptimisationProblem):
         """
         parameterisation = super().optimise(x0=x0)
         self.solver.update_cage(parameterisation.create_shape())
-        self.ripple_values = self.solver.ripple()
+        self.ripple_values = self.solver.ripple(*self.ripple_points)
         return parameterisation
 
     def plot(self, ax=None):

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -411,6 +411,7 @@ class MaximiseSelector(RipplePointSelector):
                 "TF_ripple_limit": TF_ripple_limit,
                 "lcfs_wire": self.wire,
                 "alpha_0": self._alpha_0,
+                # I'm sorry...
                 "this": self,
             },
             tolerance=rip_con_tol * np.ones(2),

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -229,11 +229,11 @@ class HelmholtzCage(SourceGroup):
 
         Parameters
         ----------
-        x
+        x:
             The x coordinate(s) of the points at which to calculate the ripple
-        y
+        y:
             The y coordinate(s) of the points at which to calculate the ripple
-        z
+        z:
             The z coordinate(s) of the points at which to calculate the ripple
 
         Returns

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -1,0 +1,34 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from bluemira.builders.tf_coils import (
+    EquispacedSelector,
+    FixedSelector,
+    MaximiseSelector,
+    OutboardEquispacedSelector,
+    RippleConstrainedLengthGOP,
+)
+from bluemira.geometry.parameterisations import PrincetonD
+from bluemira.geometry.tools import make_polygon
+
+
+class TestRippleConstrainedLengthGOP:
+    pass

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -82,7 +82,12 @@ class TestRippleConstrainedLengthGOP:
         )
         problem.optimise()
         problem.plot()
-        assert np.all(problem.ripple_values < self.params.TF_ripple_limit.value + 1e-3)
+        assert np.isclose(
+            max(problem.ripple_values),
+            self.params.TF_ripple_limit.value,
+            rtol=0,
+            atol=1e-3,
+        )
 
     @pytest.mark.parametrize(
         "selector",

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -28,7 +28,6 @@ from bluemira.builders.tf_coils import (
     EquispacedSelector,
     FixedSelector,
     MaximiseSelector,
-    OutboardEquispacedSelector,
     RippleConstrainedLengthGOP,
     RippleConstrainedLengthGOPParams,
 )
@@ -93,7 +92,8 @@ class TestRippleConstrainedLengthGOP:
         "selector",
         [
             EquispacedSelector(3),
-            OutboardEquispacedSelector(3, x_min=9),
+            EquispacedSelector(3, x_frac=0.5),
+            EquispacedSelector(3, x_frac=1.0),
             FixedSelector(Coordinates({"x": [12, 6, 6], "z": [0, -4, 4]})),
             MaximiseSelector(),
         ],

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -64,6 +64,7 @@ class TestRippleConstrainedLengthGOP:
     @classmethod
     def teardown_method(cls):
         plt.show()
+        plt.close()
 
     def _make_optimiser(self):
         return Optimiser("SLSQP", opt_conditions={"max_eval": 100, "ftol_rel": 1e-6})

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -93,7 +93,7 @@ class TestRippleConstrainedLengthGOP:
             MaximiseSelector(),
         ],
     )
-    def test_outboard_equispaced(self, selector):
+    def test_selector_setup(self, selector):
         optimiser = self._make_optimiser()
         problem = RippleConstrainedLengthGOP(
             self.princeton,
@@ -107,4 +107,9 @@ class TestRippleConstrainedLengthGOP:
         )
         problem.optimise()
         problem.plot()
-        assert np.all(problem.ripple_values < self.params.TF_ripple_limit.value + 1e-3)
+        assert np.isclose(
+            max(problem.ripple_values),
+            self.params.TF_ripple_limit.value,
+            rtol=0,
+            atol=1e-3,
+        )

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
+from bluemira.base.parameter_frame import make_parameter_frame
 from bluemira.builders.tf_coils import (
     EquispacedSelector,
     FixedSelector,
@@ -90,6 +90,7 @@ class TestRippleConstrainedLengthGOP:
             EquispacedSelector(3),
             OutboardEquispacedSelector(3, x_min=9),
             FixedSelector(Coordinates({"x": [12, 6, 6], "z": [0, -4, 4]})),
+            MaximiseSelector(),
         ],
     )
     def test_outboard_equispaced(self, selector):

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -78,7 +78,7 @@ class TestRippleConstrainedLengthGOP:
             self.lcfs,
             keep_out_zone=None,
             rip_con_tol=1e-3,
-            n_rip_points=10,
+            n_rip_points=3,
         )
         problem.optimise()
         problem.plot()
@@ -87,7 +87,8 @@ class TestRippleConstrainedLengthGOP:
     @pytest.mark.parametrize(
         "selector",
         [
-            OutboardEquispacedSelector(5, x_min=9),
+            EquispacedSelector(3),
+            OutboardEquispacedSelector(3, x_min=9),
             FixedSelector(Coordinates({"x": [12, 6, 6], "z": [0, -4, 4]})),
         ],
     )

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -26,6 +26,7 @@ import pytest
 from bluemira.base.parameter_frame import make_parameter_frame
 from bluemira.builders.tf_coils import (
     EquispacedSelector,
+    ExtremaSelector,
     FixedSelector,
     MaximiseSelector,
     RippleConstrainedLengthGOP,
@@ -94,6 +95,7 @@ class TestRippleConstrainedLengthGOP:
             EquispacedSelector(3),
             EquispacedSelector(3, x_frac=0.5),
             EquispacedSelector(3, x_frac=1.0),
+            ExtremaSelector(),
             FixedSelector(Coordinates({"x": [12, 6, 6], "z": [0, -4, 4]})),
             MaximiseSelector(),
         ],


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Requires #2065 
Closes #1735 

OK, I've had a quick bash at this, but before I go much further, I'd like to just summarise what I'm going for, and check it will do what you want, @bielsnohr.

I've added an argument to the `RippleConstrainedLengthGOP` `__init__` in which a `RipplePointSelector` can be provided. This is not the nicest API, and I'm sure there are nicer ways to instantiate these things which I will improve on later.

I kind of need a class or protocol to capture the following options:

* Equi-spaced points at which the ripple shall be calculated
* Equi-spaced points above a certain minimum radius (could be combined with the above)
* Direct specification of the points at which ripple should be calculated (your use case?)
* Finding the point of maximum ripple along a wire

Please run:
```bash
pytest tests/builders/test_tf_coils.py --plotting-on
```

and have a look at the API of the aforementioned strategies to see if they are going to deliver what you need.


## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
