### PR TITLE
Allow viewing of palette colours in terminal

### DIFF
--- a/bluemira/balance_of_plant/plotting.py
+++ b/bluemira/balance_of_plant/plotting.py
@@ -312,7 +312,7 @@ class BalanceOfPlantPlotter:
             connect=None,
             trunklength=trunk_length,
             pathlengths=[l_m, l_s / 1.5, l_s, l_s],
-            facecolor=BLUEMIRA_PALETTE["blue"],
+            facecolor=BLUEMIRA_PALETTE["blue"].as_hex(),
         )
         # 1: H&CD (first block)
         self.sankey.add(
@@ -324,7 +324,7 @@ class BalanceOfPlantPlotter:
             connect=(1, 1),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s / 1.5, l_s],
-            facecolor=BLUEMIRA_PALETTE["pink"],
+            facecolor=BLUEMIRA_PALETTE["pink"].as_hex(),
         )
         # 2: Neutrons
         self.sankey.add(
@@ -336,7 +336,7 @@ class BalanceOfPlantPlotter:
             connect=(2, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s, l_s, 3 * l_m, l_m],
-            facecolor=BLUEMIRA_PALETTE["orange"],
+            facecolor=BLUEMIRA_PALETTE["orange"].as_hex(),
         )
         # 3: Radiation and separatrix
         self.sankey.add(
@@ -348,7 +348,7 @@ class BalanceOfPlantPlotter:
             connect=(3, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s, l_s],
-            facecolor=BLUEMIRA_PALETTE["red"],
+            facecolor=BLUEMIRA_PALETTE["red"].as_hex(),
         )
         # 4: Blanket
         self.sankey.add(
@@ -360,7 +360,7 @@ class BalanceOfPlantPlotter:
             connect=(2, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s, l_s, l_s, l_s],
-            facecolor=BLUEMIRA_PALETTE["yellow"],
+            facecolor=BLUEMIRA_PALETTE["yellow"].as_hex(),
         )
         # 5: Divertor
         self.sankey.add(
@@ -372,7 +372,7 @@ class BalanceOfPlantPlotter:
             connect=(3, 0),
             trunklength=trunk_length,
             pathlengths=[l_m, l_s, l_s],
-            facecolor=BLUEMIRA_PALETTE["cyan"],
+            facecolor=BLUEMIRA_PALETTE["cyan"].as_hex(),
         )
         # 6: First wall
         self.sankey.add(
@@ -385,7 +385,7 @@ class BalanceOfPlantPlotter:
             connect=[(1, 0), (1, 2)],
             trunklength=trunk_length,
             pathlengths=[0, l_s, 0],
-            facecolor=BLUEMIRA_PALETTE["grey"],
+            facecolor=BLUEMIRA_PALETTE["grey"].as_hex(),
         )
         # 7: BoP
         self.sankey.add(
@@ -397,7 +397,7 @@ class BalanceOfPlantPlotter:
             connect=(4, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_m, l_m, 0],
-            facecolor=BLUEMIRA_PALETTE["purple"],
+            facecolor=BLUEMIRA_PALETTE["purple"].as_hex(),
         )
         # 8: Electricity
         # Check if we have net electric power
@@ -438,7 +438,7 @@ class BalanceOfPlantPlotter:
                 3 * l_m,
                 l_s,
             ],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 9: H&CD return leg
         self.sankey.add(
@@ -450,7 +450,7 @@ class BalanceOfPlantPlotter:
             connect=(5, 0),
             trunklength=trunk_length,
             pathlengths=[l_s / 2, 7 * l_m],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 10: Divertor (second block)
         self.sankey.add(
@@ -463,7 +463,7 @@ class BalanceOfPlantPlotter:
             connect=[(2, 0), (1, 1)],
             trunklength=trunk_length,
             pathlengths=[0, 0],
-            facecolor=BLUEMIRA_PALETTE["cyan"],
+            facecolor=BLUEMIRA_PALETTE["cyan"].as_hex(),
         )
         # 11: H&CD return leg (second half)
         self.sankey.add(
@@ -476,7 +476,7 @@ class BalanceOfPlantPlotter:
             connect=[(1, 0), (0, 1)],
             trunklength=trunk_length,
             pathlengths=[0, 0],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 12: Divertor back into BoP
         self.sankey.add(
@@ -489,7 +489,7 @@ class BalanceOfPlantPlotter:
             connect=[(2, 0), (1, 2)],
             trunklength=trunk_length,
             pathlengths=[0, l_s / 2, 0],
-            facecolor=BLUEMIRA_PALETTE["cyan"],
+            facecolor=BLUEMIRA_PALETTE["cyan"].as_hex(),
         )
         # 13: BB electrical pumping loss turn leg
         self.sankey.add(
@@ -501,7 +501,7 @@ class BalanceOfPlantPlotter:
             connect=(7, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s, l_m * 3],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 14: BB electrical pumping return leg into blanket
         self.sankey.add(
@@ -514,7 +514,7 @@ class BalanceOfPlantPlotter:
             connect=[(2, 0), (2, 1)],
             trunklength=trunk_length,
             pathlengths=[0, 0],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 15: Divertor electrical pumping loss turn leg
         self.sankey.add(
@@ -526,7 +526,7 @@ class BalanceOfPlantPlotter:
             connect=(6, 0),
             trunklength=trunk_length,
             pathlengths=[l_s, l_s / 2, l_m],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
         # 16: Divertor electrical pumping return into divertor
         self.sankey.add(
@@ -539,7 +539,7 @@ class BalanceOfPlantPlotter:
             connect=[(2, 0), (1, 1)],
             trunklength=trunk_length,
             pathlengths=[0, 0],
-            facecolor=BLUEMIRA_PALETTE["green"],
+            facecolor=BLUEMIRA_PALETTE["green"].as_hex(),
         )
 
     def _polish(self):

--- a/bluemira/builders/tools.py
+++ b/bluemira/builders/tools.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+from bluemira.display.palettes import ColorPalette
+
 if TYPE_CHECKING:
     from bluemira.geometry.solid import BluemiraSolid
     from bluemira.geometry.wire import BluemiraWire
@@ -71,12 +73,14 @@ __all__ = [
 
 def apply_component_display_options(
     phys_component: PhysicalComponent,
-    color: Iterable,
+    color: Union[Iterable, ColorPalette],
     transparency: Optional[float] = None,
 ):
     """
     Apply color and transparency to a PhysicalComponent for both plotting and CAD.
     """
+    if isinstance(color, ColorPalette):
+        color = color.as_hex()
     phys_component.plot_options.face_options["color"] = color
     phys_component.display_cad_options.color = color
     if transparency:

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -58,7 +58,6 @@ from bluemira.base.file import force_file_extension
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes._freecadconfig import _freecad_save_config
 from bluemira.codes.error import FreeCADError, InvalidCADInputsError
-from bluemira.display.palettes import ColorPalette
 from bluemira.geometry.constants import MINIMUM_LENGTH
 from bluemira.utilities.tools import ColourDescriptor
 
@@ -2307,7 +2306,9 @@ class DefaultDisplayOptions:
         return self.colour
 
     @color.setter
-    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
+    def color(
+        self, value: Union[str, Tuple[float, float, float], ColorPalette]  # noqa: F821
+    ):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -58,6 +58,7 @@ from bluemira.base.file import force_file_extension
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes._freecadconfig import _freecad_save_config
 from bluemira.codes.error import FreeCADError, InvalidCADInputsError
+from bluemira.display.palettes import ColorPalette
 from bluemira.geometry.constants import MINIMUM_LENGTH
 from bluemira.utilities.tools import ColourDescriptor
 
@@ -2306,7 +2307,7 @@ class DefaultDisplayOptions:
         return self.colour
 
     @color.setter
-    def color(self, value):
+    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -32,7 +32,7 @@ import sys
 from copy import deepcopy
 from dataclasses import dataclass
 from types import DynamicClassAttribute
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
 import FreeCAD
@@ -60,6 +60,9 @@ from bluemira.codes._freecadconfig import _freecad_save_config
 from bluemira.codes.error import FreeCADError, InvalidCADInputsError
 from bluemira.geometry.constants import MINIMUM_LENGTH
 from bluemira.utilities.tools import ColourDescriptor
+
+if TYPE_CHECKING:
+    from bluemira.display.palettes import ColorPalette
 
 apiVertex = Part.Vertex  # noqa :N816
 apiVector = Base.Vector  # noqa :N816
@@ -2306,9 +2309,7 @@ class DefaultDisplayOptions:
         return self.colour
 
     @color.setter
-    def color(
-        self, value: Union[str, Tuple[float, float, float], ColorPalette]  # noqa: F821
-    ):
+    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -32,7 +32,9 @@ class DefaultDisplayOptions:
         return self.colour
 
     @color.setter
-    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
+    def color(
+        self, value: Union[str, Tuple[float, float, float], ColorPalette]  # noqa: F821
+    ):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -11,6 +11,7 @@ import polyscope as ps
 import bluemira.codes._freecadapi as cadapi
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.utilities.tools import ColourDescriptor
+from bluemira.display.palettes import ColorPalette
 
 
 @dataclass
@@ -26,12 +27,12 @@ class DefaultDisplayOptions:
     smooth: bool = True
 
     @property
-    def color(self):
+    def color(self) -> str:
         """See colour"""
         return self.colour
 
     @color.setter
-    def color(self, value):
+    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -32,9 +32,7 @@ class DefaultDisplayOptions:
         return self.colour
 
     @color.setter
-    def color(
-        self, value: Union[str, Tuple[float, float, float], ColorPalette]  # noqa: F821
-    ):
+    def color(self, value: Union[str, Tuple[float, float, float], ColorPalette]):
         """See colour"""
         self.colour = value
 

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -10,8 +10,8 @@ import polyscope as ps
 
 import bluemira.codes._freecadapi as cadapi
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.utilities.tools import ColourDescriptor
 from bluemira.display.palettes import ColorPalette
+from bluemira.utilities.tools import ColourDescriptor
 
 
 @dataclass

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -162,9 +162,9 @@ class ColorPalette:
         try:
             g_ipy = get_ipython()
             if "terminal" in str(type(g_ipy)) or g_ipy is None:
-                return self._repr_colour_str(self._hex_horizontal())
+                return self._repr_colour_str(self._hex_horizontal()).strip(" \n")
         except NameError:
-            return self._repr_colour_str(self._hex_horizontal())
+            return self._repr_colour_str(self._hex_horizontal()).strip(" \n")
 
         from IPython.core.display import HTML, display
 

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -166,7 +166,7 @@ class ColorPalette:
         """Get the length of the ColorPalette"""
         return len(self._palette)
 
-    def as_hex(self) -> list:
+    def as_hex(self) -> Union[List[str], str]:
         """
         Get the hex representation of the palette
         """
@@ -181,7 +181,7 @@ class ColorPalette:
             hex_list.append(colors.to_hex(self._palette))
         else:
             hex_list.append(self._palette)
-        return hex_list
+        return hex_list[0] if len(hex_list) == 1 else hex_list
 
 
 def background_colour_string(hexstring: str) -> str:

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -24,7 +24,7 @@ Colour palettes
 """
 
 from itertools import cycle
-from typing import Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import matplotlib.colors as colors
 import numpy as np
@@ -147,25 +147,38 @@ class ColorPalette:
         display(HTML(self._repr_html()))
         return ""
 
-    def _repr_colour_str(self) -> str:
+    def _repr_colour_str(self, *, _hex: Optional[Union[str, List[str]]] = None) -> str:
         """Create colourful representation in terminal"""
-        if isinstance(self._palette, list):
-            string = ""
-            for en, pp in enumerate(self._palette):
-                if isinstance(pp, tuple):
-                    string += background_colour_string(colors.to_hex(pp))
-                elif isinstance(pp, type(self)):
-                    string += f"{pp._repr_colour_str()}\n"
-        elif isinstance(self._palette, tuple):
-            string = background_colour_string(colors.to_hex(self._palette))
-        else:
-            string = background_colour_string(self._palette)
-
-        return string
+        string = ""
+        if _hex is None:
+            _hex = self.as_hex()
+        for col in _hex:
+            if isinstance(col, list):
+                string += self._repr_colour_str(_hex=col)
+            else:
+                string += background_colour_string(col)
+        return f"{string}\n"
 
     def __len__(self) -> int:
         """Get the length of the ColorPalette"""
         return len(self._dict)
+
+    def as_hex(self) -> list:
+        """
+        Get the hex representation of the palette
+        """
+        hex_list = []
+        if isinstance(self._palette, list):
+            for pp in self._palette:
+                if isinstance(pp, tuple):
+                    hex_list.append(colors.to_hex(pp))
+                elif isinstance(pp, type(self)):
+                    hex_list.append(pp.as_hex())
+        elif isinstance(self._palette, tuple):
+            hex_list.append(colors.to_hex(self._palette))
+        else:
+            hex_list.append(self._palette)
+        return hex_list
 
 
 def background_colour_string(hexstring: str) -> str:

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -218,7 +218,7 @@ def make_rgb_alpha(
         Tuple of 3 RGB floats  (0<=float<=1)
     alpha:
         Transparency as a fraction  (0<=float<=1)
-    background_rgb
+    background_rgb:
         3 RGB floats (0<=float<=1), background colour (default = white)
 
     Returns
@@ -236,7 +236,7 @@ def make_alpha_palette(color, n_colors: int, background_rgb="white") -> ColorPal
     ----------
     color: Any
         Palette base color. Anything matplotlib will recognise as a color
-    n_colors
+    n_colors:
         Numer of colors to make in the palette
     background_rgb: Any
         Background color. Anything matplotlib will recognise as a color

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -136,7 +136,8 @@ class ColorPalette:
         Create a representation of the ColorPalette
         """
         try:
-            if "terminal" in str(type(get_ipython())):
+            g_ipy = get_ipython()
+            if "terminal" in str(type(g_ipy)) or g_ipy is None:
                 return self._repr_colour_str()
         except NameError:
             return self._repr_colour_str()

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -108,30 +108,31 @@ class ColorPalette:
             )
 
     def _repr_html(self) -> str:
-        def html_str(
-            _hex: List[str], i: int = 0, first: bool = False
-        ) -> Tuple[int, str]:
+        def html_str(_hex: List[str], c_no: int = 0, column=False) -> str:
             string = ""
-            if first := _hex is None:
-                _hex = self.as_hex()
-            for j, col in enumerate(_hex):
+            for no, col in enumerate(_hex):
                 if isinstance(col, list):
-                    i, str_ = html_str(_hex=col, i=i)
-                    string += str_
+                    string += html_str(_hex=col, c_no=no, column=True)
                 else:
+                    if column:
+                        x = c_no * s
+                        y = no * s
+                    else:
+                        x = no * s
+                        y = c_no * s
                     string += (
-                        f'<rect x="{i*s}" y="{0 if first else j * s}"'
+                        f'<rect x="{x}" y="{y}"'
                         f' width="{s}" height="{s}" style="fill:{col};'
                         'stroke-width:2;stroke:rgb(255,255,255)"/>'
                     )
-            return i + 1, string
+
+            return string
 
         s = 55
         hex_str = self.as_hex()
         m = max([len(sp) if isinstance(sp, list) else 1 for sp in hex_str])
-        colours = html_str(hex_str, first=True)[1]
-
-        return f'<svg  width="{len(self) * s}" height="{m * s}">{colours}</svg>'
+        colours = html_str(hex_str)
+        return f'<svg  width="{(len(self))* s}" height="{m * s}">{colours}</svg>'
 
     def __repr__(self) -> str:
         """
@@ -163,7 +164,7 @@ class ColorPalette:
 
     def __len__(self) -> int:
         """Get the length of the ColorPalette"""
-        return len(self._dict)
+        return len(self._palette)
 
     def as_hex(self) -> list:
         """

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -108,28 +108,30 @@ class ColorPalette:
             )
 
     def _repr_html(self) -> str:
-        def html_rect(x: int, y: int, size: int, fill: str) -> str:
-            return (
-                f'<rect x="{x}" y="{y}" width="{size}" height="{size}" style="fill:{fill};'
-                'stroke-width:2;stroke:rgb(255,255,255)"/>'
-            )
+        def html_str(
+            _hex: List[str], i: int = 0, first: bool = False
+        ) -> Tuple[int, str]:
+            string = ""
+            if first := _hex is None:
+                _hex = self.as_hex()
+            for j, col in enumerate(_hex):
+                if isinstance(col, list):
+                    i, str_ = html_str(_hex=col, i=i)
+                    string += str_
+                else:
+                    string += (
+                        f'<rect x="{i*s}" y="{0 if first else j * s}"'
+                        f' width="{s}" height="{s}" style="fill:{col};'
+                        'stroke-width:2;stroke:rgb(255,255,255)"/>'
+                    )
+            return i + 1, string
 
         s = 55
-        n = len(self)
-        sub_pals = [v for v in self._dict.values() if isinstance(v, type(self))]
-        m = max([len(sp) for sp in sub_pals]) if sub_pals else 1
+        hex_str = self.as_hex()
+        m = max([len(sp) if isinstance(sp, list) else 1 for sp in hex_str])
+        colours = html_str(hex_str, first=True)[1]
 
-        html = f'<svg  width="{n * s}" height="{m * s}">'
-
-        for i, c in enumerate(self._palette):
-            if isinstance(c, type(self)):
-                for j, sc in enumerate(c):
-                    html += html_rect(i * s, j * s, s, colors.to_hex(sc))
-            else:
-                html += html_rect(i * s, 0, s, colors.to_hex(c))
-
-        html += "</svg>"
-        return html
+        return f'<svg  width="{len(self) * s}" height="{m * s}">{colours}</svg>'
 
     def __repr__(self) -> str:
         """

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -22,6 +22,7 @@
 """
 A collection of miscellaneous tools.
 """
+from __future__ import annotations
 
 import operator
 import string
@@ -33,7 +34,7 @@ from itertools import permutations
 from json import JSONEncoder, dumps
 from os import listdir
 from types import ModuleType
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
 
 import matplotlib.colors as colors
 import nlopt
@@ -41,6 +42,9 @@ import numpy as np
 
 from bluemira.base.constants import E_I, E_IJ, E_IJK
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_warn
+
+if TYPE_CHECKING:
+    from bluemira.display.palettes import ColorPalette
 
 # =====================================================
 # JSON utilities
@@ -320,7 +324,7 @@ class ColourDescriptor:
 
         return colors.to_hex(getattr(obj, self._name, self._default))
 
-    def __set__(self, obj: Any, value: Union[str, Tuple[float, ...]]):
+    def __set__(self, obj: Any, value: Union[str, Tuple[float, ...], ColorPalette]):
         """
         Set the colour
 
@@ -328,6 +332,10 @@ class ColourDescriptor:
         -----
         The value can be anything accepted by matplotlib.colors.to_hex
         """
+        if hasattr(value, "as_hex"):
+            value = value.as_hex()
+            if isinstance(value, list):
+                value = value[0]
         setattr(obj, self._name, value)
 
 

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -33,6 +33,7 @@ import bluemira.codes._freecadapi as cadapi
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.display import displayer
 from bluemira.display.error import DisplayError
+from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import extrude_shape, make_circle, make_polygon
 
@@ -95,6 +96,7 @@ class TestDisplayCADOptions:
 
 
 class TestComponentDisplayer:
+    @pytest.mark.parametrize("colour", [(1.0, 0.0, 0.0), BLUE_PALETTE["VV"]])
     @pytest.mark.parametrize(
         "viewer",
         [
@@ -105,7 +107,7 @@ class TestComponentDisplayer:
             ),
         ],
     )
-    def test_display(self, viewer):
+    def test_display(self, colour, viewer):
         square_points = np.array(
             [
                 (0.0, 0.0, 0.0),
@@ -125,12 +127,10 @@ class TestComponentDisplayer:
 
         child1.show_cad(backend=viewer)
         group.show_cad(backend=viewer)
-        child2.display_cad_options = displayer.DisplayCADOptions(colour=(1.0, 0.0, 0.0))
+        child2.display_cad_options = displayer.DisplayCADOptions(colour=colour)
         group.show_cad(backend=viewer)
         group.show_cad(colour=(0.0, 0.0, 1.0), backend=viewer)
-        displayer.ComponentDisplayer().show_cad(
-            group, color=(1.0, 0.0, 0.0), backend=viewer
-        )
+        displayer.ComponentDisplayer().show_cad(group, color=colour, backend=viewer)
 
         with pytest.raises(DisplayError):
             child2.display_cad_options = (0.0, 0.0, 1.0)

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -50,7 +50,7 @@ class TestColorPalette:
         assert colors.to_hex(self.pal["C1"][0]) == "#aaaaaa"
 
         self.pal["C1"] = "#000000"
-        assert self.pal["C1"][0] == "#000000"
+        assert colors.to_hex(self.pal["C1"][0]) == "#000000"
 
     def test_repr_term(self):
         assert (
@@ -79,7 +79,7 @@ def test_make_rgb_alpha():
     assert make_rgb_alpha((1, 2, 3), 0.5, (0.5, 0.5, 0.5)) == (0.75, 1.25, 1.75)
 
 
-@pytest.mark.parametrize("color", [ColorPalette({"C1": "#000000"}), "#000000"])
+@pytest.mark.parametrize("pal", [ColorPalette({"C1": "#000000"}), "#000000"])
 def test_make_alpha_palette(pal):
     new_pal = make_alpha_palette(pal, 3)
     assert [colors.to_hex(p) for p in new_pal._palette] == [

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -55,7 +55,7 @@ class TestColorPalette:
     def test_repr_term(self):
         assert (
             self.pal._repr_colour_str()
-            == "\x1b[48:2::0:0:0m \x1b[49m\x1b[48:2::255:255:255m \x1b[49m"
+            == "\x1b[48:2::0:0:0m \x1b[49m\x1b[48:2::255:255:255m \x1b[49m\n"
         )
 
     def test_repr_html(self):
@@ -63,7 +63,7 @@ class TestColorPalette:
             '<svg  width="110" height="55">'
             '<rect x="0" y="0" width="55" height="55"'
             ' style="fill:#000000;stroke-width:2;stroke:rgb(255,255,255)"/>'
-            '<rect x="55" y="0" width="55" height="55"'
+            '<rect x="0" y="55" width="55" height="55"'
             ' style="fill:#ffffff;stroke-width:2;stroke:rgb(255,255,255)"/>'
             "</svg>"
         )

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -1,0 +1,95 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for palettes module
+"""
+import matplotlib.colors as colors
+import pytest
+
+from bluemira.display.palettes import (
+    ColorPalette,
+    background_colour_string,
+    make_alpha_palette,
+    make_rgb_alpha,
+)
+
+
+class TestColorPalette:
+    def setup_method(self):
+        self.pal = ColorPalette({"C1": "#000000", "C2": "#ffffff"})
+
+    def test_keys(self):
+        assert self.pal.keys() == set("C1", "C2")
+
+    def test_next(self):
+        assert next(self.pal) == "#000000"
+        assert next(self.pal) == "#ffffff"
+        assert next(self.pal) == "#000000"
+
+    def test_set_get_item(self):
+        self.pal[0] = "#aaaaaa"
+        assert colors.to_hex(self.pal["C1"]._palette[0]) == "#aaaaaa"
+
+        self.pal["C1"] = "#000000"
+        assert self.pal[0] == "#000000"
+
+    def test_repr_term(self):
+        assert (
+            self.pal._repr_colour_str()
+            == "\x1b[48:2::0:0:0m \x1b[49m\x1b[48:2::255:255:255m \x1b[49m"
+        )
+
+    def test_repr_html(self):
+        assert self.pal._repr_html() == (
+            '<svg  width="110" height="55">'
+            '<rect x="0" y="0" width="55" height="55"'
+            ' style="fill:#000000;stroke-width:2;stroke:rgb(255,255,255)"/>'
+            '<rect x="55" y="0" width="55" height="55"'
+            ' style="fill:#ffffff;stroke-width:2;stroke:rgb(255,255,255)"/>'
+            "</svg>"
+        )
+
+
+def test_background_colour_string():
+    assert background_colour_string("#123456") == "\x1b[48:2::18:52:86m \x1b[49m"
+    assert background_colour_string("#123") == "\x1b[48:2::1:2:3m \x1b[49m"
+
+
+def test_make_rgb_alpha():
+    assert make_rgb_alpha((1, 2, 3), 0.5) == (1.0, 1.5, 2.0)
+    assert make_rgb_alpha((1, 2, 3), 0.5, (0.5, 0.5, 0.5)) == (0.75, 1.25, 1.75)
+
+
+@pytest.mark.parametrize("color", [ColorPalette({"C1": "#000000"}), "#000000"])
+def test_make_alpha_palette(pal):
+    new_pal = make_alpha_palette(pal, 3)
+    assert [colors.to_hex(p) for p in new_pal._palette] == [
+        "#000000",
+        "#555555",
+        "#aaaaaa",
+    ]
+    new_pal = make_alpha_palette(pal, 3, "red")
+    assert [colors.to_hex(p) for p in new_pal._palette] == [
+        "#000000",
+        "#550000",
+        "#aa0000",
+    ]

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -61,8 +61,8 @@ class TestColorPalette:
 
     def test_repr_term(self):
         assert (
-            self.pal._repr_colour_str()
-            == "\x1b[48:2::0:0:0m \x1b[49m\x1b[48:2::255:255:255m \x1b[49m\n"
+            self.pal._repr_colour_str(self.pal._hex_horizontal())
+            == "\x1b[48:2::0:0:0m  \x1b[49m\x1b[48:2::255:255:255m  \x1b[49m\n"
         )
 
     def test_repr_html(self):
@@ -81,23 +81,23 @@ class TestColorPalette:
         assert pal._repr_html() == (
             '<svg  width="110" height="440">'
             + self.rect_str.format(0, 0, "#000000")
+            + self.rect_str.format(55, 0, "#ffffff")
             + self.rect_str.format(0, 55, "#202020")
+            + self.rect_str.format(55, 55, "#ffffff")
             + self.rect_str.format(0, 110, "#404040")
+            + self.rect_str.format(55, 110, "#ffffff")
             + self.rect_str.format(0, 165, "#606060")
             + self.rect_str.format(0, 220, "#808080")
             + self.rect_str.format(0, 275, "#9f9f9f")
             + self.rect_str.format(0, 330, "#bfbfbf")
             + self.rect_str.format(0, 385, "#dfdfdf")
-            + self.rect_str.format(55, 0, "#ffffff")
-            + self.rect_str.format(55, 55, "#ffffff")
-            + self.rect_str.format(55, 110, "#ffffff")
             + "</svg>"
         )
 
 
 def test_background_colour_string():
-    assert background_colour_string("#123456") == "\x1b[48:2::18:52:86m \x1b[49m"
-    assert background_colour_string("#123") == "\x1b[48:2::1:2:3m \x1b[49m"
+    assert background_colour_string("#123456") == "\x1b[48:2::18:52:86m  \x1b[49m"
+    assert background_colour_string("#123") == "\x1b[48:2::1:2:3m  \x1b[49m"
 
 
 def test_make_rgb_alpha():

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -28,7 +28,6 @@ import matplotlib.colors as colors
 import pytest
 
 from bluemira.display.palettes import (
-    BLUE_PALETTE,
     ColorPalette,
     background_colour_string,
     make_alpha_palette,
@@ -37,6 +36,11 @@ from bluemira.display.palettes import (
 
 
 class TestColorPalette:
+    rect_str = (
+        '<rect x="{}" y="{}" width="55" height="55"'
+        ' style="fill:{};stroke-width:2;stroke:rgb(255,255,255)"/>'
+    )
+
     def setup_method(self):
         self.pal = ColorPalette({"C1": "#000000", "C2": "#ffffff"})
 
@@ -64,18 +68,31 @@ class TestColorPalette:
     def test_repr_html(self):
         assert self.pal._repr_html() == (
             '<svg  width="110" height="55">'
-            '<rect x="0" y="0" width="55" height="55"'
-            ' style="fill:#000000;stroke-width:2;stroke:rgb(255,255,255)"/>'
-            '<rect x="55" y="0" width="55" height="55"'
-            ' style="fill:#ffffff;stroke-width:2;stroke:rgb(255,255,255)"/>'
-            "</svg>"
+            + self.rect_str.format(0, 0, "#000000")
+            + self.rect_str.format(55, 0, "#ffffff")
+            + "</svg>"
         )
 
-    def test_repr_html_BP(self):
+    def test_repr_html_with_alpha(self):
         pal = copy(self.pal)
         pal["C1"] = make_alpha_palette(pal["C1"], 8)
         pal["C2"] = make_alpha_palette(pal["C2"], 3)
-        assert pal._repr_html() == ""
+
+        assert pal._repr_html() == (
+            '<svg  width="110" height="440">'
+            + self.rect_str.format(0, 0, "#000000")
+            + self.rect_str.format(0, 55, "#202020")
+            + self.rect_str.format(0, 110, "#404040")
+            + self.rect_str.format(0, 165, "#606060")
+            + self.rect_str.format(0, 220, "#808080")
+            + self.rect_str.format(0, 275, "#9f9f9f")
+            + self.rect_str.format(0, 330, "#bfbfbf")
+            + self.rect_str.format(0, 385, "#dfdfdf")
+            + self.rect_str.format(55, 0, "#ffffff")
+            + self.rect_str.format(55, 55, "#ffffff")
+            + self.rect_str.format(55, 110, "#ffffff")
+            + "</svg>"
+        )
 
 
 def test_background_colour_string():

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -22,10 +22,13 @@
 """
 Tests for palettes module
 """
+from copy import copy
+
 import matplotlib.colors as colors
 import pytest
 
 from bluemira.display.palettes import (
+    BLUE_PALETTE,
     ColorPalette,
     background_colour_string,
     make_alpha_palette,
@@ -63,10 +66,16 @@ class TestColorPalette:
             '<svg  width="110" height="55">'
             '<rect x="0" y="0" width="55" height="55"'
             ' style="fill:#000000;stroke-width:2;stroke:rgb(255,255,255)"/>'
-            '<rect x="0" y="55" width="55" height="55"'
+            '<rect x="55" y="0" width="55" height="55"'
             ' style="fill:#ffffff;stroke-width:2;stroke:rgb(255,255,255)"/>'
             "</svg>"
         )
+
+    def test_repr_html_BP(self):
+        pal = copy(self.pal)
+        pal["C1"] = make_alpha_palette(pal["C1"], 8)
+        pal["C2"] = make_alpha_palette(pal["C2"], 3)
+        assert pal._repr_html() == ""
 
 
 def test_background_colour_string():

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -38,7 +38,7 @@ class TestColorPalette:
         self.pal = ColorPalette({"C1": "#000000", "C2": "#ffffff"})
 
     def test_keys(self):
-        assert self.pal.keys() == set("C1", "C2")
+        assert self.pal.keys() == set(("C1", "C2"))
 
     def test_next(self):
         assert next(self.pal) == "#000000"
@@ -47,10 +47,10 @@ class TestColorPalette:
 
     def test_set_get_item(self):
         self.pal[0] = "#aaaaaa"
-        assert colors.to_hex(self.pal["C1"]._palette[0]) == "#aaaaaa"
+        assert colors.to_hex(self.pal["C1"][0]) == "#aaaaaa"
 
         self.pal["C1"] = "#000000"
-        assert self.pal[0] == "#000000"
+        assert self.pal["C1"][0] == "#000000"
 
     def test_repr_term(self):
         assert (

--- a/tests/display/test_palettes.py
+++ b/tests/display/test_palettes.py
@@ -94,6 +94,22 @@ class TestColorPalette:
             + "</svg>"
         )
 
+    def test_repr_term_with_alpha(self):
+        pal = copy(self.pal)
+        pal["C1"] = make_alpha_palette(pal["C1"], 8)
+        pal["C2"] = make_alpha_palette(pal["C2"], 3)
+
+        assert pal._repr_colour_str(pal._hex_horizontal()) == (
+            "\x1b[48:2::0:0:0m  \x1b[49m\x1b[48:2::255:255:255m  \x1b[49m\n"
+            "\x1b[48:2::32:32:32m  \x1b[49m\x1b[48:2::255:255:255m  \x1b[49m\n"
+            "\x1b[48:2::64:64:64m  \x1b[49m\x1b[48:2::255:255:255m  \x1b[49m\n"
+            "\x1b[48:2::96:96:96m  \x1b[49m  \n"
+            "\x1b[48:2::128:128:128m  \x1b[49m  \n"
+            "\x1b[48:2::159:159:159m  \x1b[49m  \n"
+            "\x1b[48:2::191:191:191m  \x1b[49m  \n"
+            "\x1b[48:2::223:223:223m  \x1b[49m  \n\n"
+        )
+
 
 def test_background_colour_string():
     assert background_colour_string("#123456") == "\x1b[48:2::18:52:86m  \x1b[49m"


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
It was annoying me that I couldnt see the colours in the terminal but I could in a jupyter notebook. Now it works in both places.

![image](https://user-images.githubusercontent.com/81617086/233919035-f3113d2a-279b-489f-b985-f885b2869ddf.png)

![image](https://user-images.githubusercontent.com/81617086/233919865-8f1c5854-4a9b-4b6d-9439-f7e0f7b06361.png)

![image](https://user-images.githubusercontent.com/81617086/233925529-b75fe110-1d1c-4f21-97d4-815fbca00aba.png)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
`pallette.as_hex()` to view hex representation or just `print(pallette)` to view the colours

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
