### PR TITLE
Unbreak `show_cad` api

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1929,9 +1929,9 @@ class DefaultDisplayOptions:
 
 
 def show_cad(
-    labels: List[str],
     parts: Union[BluemiraGeo, List[BluemiraGeo]],  # noqa: F821
-    options: Optional[Union[Dict, List[Optional[Dict]]]] = None,
+    options: Union[Dict, List[Optional[Dict]]],
+    labels: List[str],
     **kwargs,
 ):
     """

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1943,6 +1943,8 @@ def show_cad(
         The parts to display.
     options
         The options to use to display the parts.
+    labels
+        labels to use for each part object
     """
     if options is None:
         options = [None]

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -64,6 +64,8 @@ def show_cad(
         The parts to display.
     part_options
         The options to use to display the parts.
+    labels
+        Labels to use for each part object
     **kwargs
         options passed to polyscope
     """

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import matplotlib.colors as colors
 import numpy as np
@@ -50,9 +50,9 @@ class DefaultDisplayOptions:
 
 
 def show_cad(
-    labels: List[str],
     parts: Union[BluemiraGeo, List[BluemiraGeo]],  # noqa: F821
-    part_options: Optional[Union[Dict, List[Dict]]] = None,
+    part_options: List[Dict],
+    labels: List[str],
     **kwargs,
 ):
     """

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -153,7 +153,7 @@ def _validate_display_inputs(parts, options, labels):
             "If options for plot are provided then there must be as many options as "
             "there are parts to plot."
         )
-    return parts, options
+    return parts, options, labels
 
 
 def show_cad(
@@ -186,7 +186,7 @@ def show_cad(
             bluemira_warn(f"Unknown viewer backend '{backend}' defaulting to FreeCAD")
             backend = ViewerBackend.FREECAD
 
-    parts, options = _validate_display_inputs(parts, options, labels)
+    parts, options, labels = _validate_display_inputs(parts, options, labels)
 
     new_options = []
     for o in options:

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -134,7 +134,7 @@ def _validate_display_inputs(parts, options, labels):
     """
     if parts is None:
         bluemira_debug("No new parts to display")
-        return [], []
+        return [], [], []
 
     if not isinstance(parts, list):
         parts = [parts]

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -174,6 +174,8 @@ def show_cad(
         The parts to display.
     options
         The options to use to display the parts.
+    labels
+        Labels to use for each part object
     backend
         Viewer backend
     kwargs

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -22,6 +22,7 @@
 """
 Tests for the displayer module.
 """
+import logging
 from dataclasses import asdict
 from unittest.mock import Mock, patch
 
@@ -203,6 +204,21 @@ class TestGeometryDisplayer:
         return extrude_shape(circle_face, vec=(0, 0, 10), label="my_solid")
 
     @pytest.mark.parametrize(
+        "labels, result",
+        [
+            ("name", ["name", "name"]),
+            (["name", "name"], ["name", "name"]),
+            ("", ["", ""]),
+            (None, ["", ""]),
+        ],
+    )
+    def test_labels_passed_in_correctly(self, labels, result):
+        with patch(f"{_FREECAD_REF}.show_cad") as show_cad_mock:
+            displayer.show_cad([self._make_shape(), self._make_shape()], labels=labels)
+
+        assert show_cad_mock.call_args_list[0][0][2] == result
+
+    @pytest.mark.parametrize(
         "viewer",
         [
             "freecad",
@@ -231,5 +247,7 @@ class TestGeometryDisplayer:
         assert len(caplog.messages) == 1
 
     def test_unknown_displayer(self, caplog):
+        caplog.set_level(logging.WARNING)
         displayer.show_cad(self._make_shape(), backend="mybackend")
+
         assert len(caplog.messages) == 1

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -159,22 +159,20 @@ class TestGeometryDisplayer:
         wire1 = make_polygon(self.square_points, label="wire1", closed=False)
         box1 = extrude_shape(wire1, vec=(0.0, 0.0, 1.0), label="box1")
 
-        displayer.show_cad("name", wire1, backend=viewer)
+        displayer.show_cad(wire1, backend=viewer)
         displayer.show_cad(
-            "name",
             box1,
             displayer.DisplayCADOptions(colour=(1.0, 0.0, 1.0)),
             backend=viewer,
         )
-        displayer.show_cad("name", [wire1, box1], backend=viewer)
+        displayer.show_cad([wire1, box1], backend=viewer)
         displayer.show_cad(
-            "name",
             [wire1, box1],
             displayer.DisplayCADOptions(colour=(1.0, 0.0, 1.0)),
+            ["name", "name2"],
             backend=viewer,
         )
         displayer.show_cad(
-            "name",
             [wire1, box1],
             [
                 displayer.DisplayCADOptions(colour=(1.0, 0.0, 0.0)),
@@ -183,7 +181,6 @@ class TestGeometryDisplayer:
             backend=viewer,
         )
         displayer.show_cad(
-            "name",
             [wire1, box1],
             color=(1.0, 0.0, 0.0),
             transparency=0.2,
@@ -192,7 +189,6 @@ class TestGeometryDisplayer:
 
         with pytest.raises(DisplayError):
             displayer.show_cad(
-                "name",
                 wire1,
                 [
                     displayer.DisplayCADOptions(colour=(1.0, 0.0, 0.0)),
@@ -217,7 +213,7 @@ class TestGeometryDisplayer:
         ],
     )
     def test_3d_cad_displays_shape(self, viewer):
-        displayer.show_cad("name", self._make_shape(), backend=viewer)
+        displayer.show_cad(self._make_shape(), backend=viewer)
 
     @pytest.mark.parametrize(
         "mock",
@@ -228,12 +224,12 @@ class TestGeometryDisplayer:
     )
     def test_no_displayer(self, mock, caplog):
         with patch("bluemira.display.displayer.get_module", mock):
-            displayer.show_cad("name", self._make_shape(), backend="polyscope")
+            displayer.show_cad(self._make_shape(), backend="polyscope")
         assert len(caplog.messages) == 1
         with patch("bluemira.display.displayer.get_module", mock):
-            displayer.show_cad("name", self._make_shape(), backend="polyscope")
+            displayer.show_cad(self._make_shape(), backend="polyscope")
         assert len(caplog.messages) == 1
 
     def test_unknown_displayer(self, caplog):
-        displayer.show_cad("name", self._make_shape(), backend="mybackend")
+        displayer.show_cad(self._make_shape(), backend="mybackend")
         assert len(caplog.messages) == 1


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
I broke the show_cad API when #1033 was merged this should unbreak it

@CoronelBuendia 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
