### PR TITLE
🔥 remove BluemiraClock

### DIFF
--- a/bluemira/base/look_and_feel.py
+++ b/bluemira/base/look_and_feel.py
@@ -23,13 +23,11 @@
 Aesthetic and ambiance functions.
 """
 
-import datetime
 import logging
 import os
 import platform
 import shutil
 import subprocess  # noqa :S404
-import time
 from getpass import getuser
 from textwrap import dedent, wrap
 
@@ -412,74 +410,6 @@ def bluemira_error_clean(string):
         The string to colour print
     """
     _terminator_handler(LOGGER.error, _print_color(string, "red"))
-
-
-class BluemiraClock:
-    """
-    A printed progress bar.
-
-    Parameters
-    ----------
-    n_iter: int
-        The number of iterations
-    print_rate: int
-        The update rate
-    width: int
-        The width of the progress bar
-    """
-
-    def __init__(self, n_iter, print_rate=1, width=73):
-        self.rate = print_rate
-        self.elapsed = " elapsed"
-        self.left = " left"
-
-        self.width = (
-            width - len(self.elapsed) - len(self.left) - 2 * (9 + len(str(n_iter))) - 17
-        )
-
-        # Constructors
-        self.i = 0
-        self.t_start = None
-        self.n_iter = None
-
-        self.start(n_iter)
-
-    def start(self, n_iter):
-        """
-        Start the clock.
-        """
-        self.i = 0
-        self.t_start = time.time()
-        self.n_iter = n_iter
-
-    def stop(self):
-        """
-        Stop the clock.
-        """
-        return time.time() - self.t_start
-
-    def tock(self):
-        """
-        Tick the iterations of the clock over.
-        """
-        self.i += 1
-        if self.i % self.rate == 0 and self.i > 0:
-            elapsed = time.time() - self.t_start
-            remain = elapsed * (self.n_iter - self.i) / self.i
-            prog_str = f"{self.i:1d}/{self.n_iter:1d}"
-
-            str_elapsed = str(datetime.timedelta(seconds=int(elapsed)))
-            str_left = str(datetime.timedelta(seconds=int(remain)))
-            prog_str += f" {str_elapsed:0>8}s{self.elapsed}"
-            prog_str += f" {str_left:0>8}s{self.left}"
-            prog_str += f" {1e2 * self.i / self.n_iter:1.1f}%"
-            nh = int((self.i / self.n_iter) * self.width)
-            prog_str += " |" + nh * "#" + (self.width - nh) * "-" + "|"
-
-            bluemira_print_flush(prog_str)
-
-        if self.i == self.n_iter:
-            print("\n")
 
 
 # =============================================================================

--- a/bluemira/fuel_cycle/analysis.py
+++ b/bluemira/fuel_cycle/analysis.py
@@ -26,8 +26,9 @@ from collections.abc import Iterable
 
 import matplotlib.pyplot as plt
 import numpy as np
+from rich.progress import track
 
-from bluemira.base.look_and_feel import BluemiraClock, bluemira_warn
+from bluemira.base.look_and_feel import bluemira_warn
 
 __all__ = ["FuelCycleAnalysis"]
 
@@ -88,10 +89,8 @@ class FuelCycleAnalysis:
         if not isinstance(timelines, Iterable):  # Single timeline
             timelines = [timelines]
 
-        clock = BluemiraClock(len(timelines))
-        for timeline in timelines:
+        for timeline in track(timelines):
             self.model.run(timeline)
-            clock.tock()
             self.m_T_req.append(self.model.m_T_req)
             self.t_d.append(self.model.t_d)
             self.m_dot_release.append(self.model.m_dot_release)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

As mentioned in https://github.com/Fusion-Power-Plant-Framework/bluemira/pull/2058#discussion_r1146178193

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
 We dont need this anymore as it can be replaced by rich's `progress.track`. This is the only use of it in the whole codebase

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
BluemiraClock is gone

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `flake8` and `black .`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
