### PR TITLE
Reorganise logging and add back banner

### DIFF
--- a/bluemira/base/logs.py
+++ b/bluemira/base/logs.py
@@ -104,7 +104,7 @@ def logger_setup(
     recorded_handler.setLevel(logging.DEBUG)
     recorded_handler.setFormatter(recorded_formatter)
 
-    root_logger.setLevel(logging.NOTSET)
+    root_logger.setLevel(logging.DEBUG)
     root_logger.addHandler(recorded_handler)
 
     bm_logger.setLevel(logging.DEBUG)

--- a/bluemira/base/logs.py
+++ b/bluemira/base/logs.py
@@ -46,7 +46,7 @@ class LevelFilter(logging.Filter):
     Filter out some logging levels
     """
 
-    def __init__(self, *filtered: str):
+    def __init__(self, *filtered: LogLevel):
         self.filter_list = filtered
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/bluemira/gen_params.py
+++ b/bluemira/gen_params.py
@@ -36,12 +36,7 @@ from typing import Dict, Optional, Set
 from setuptools import find_packages
 
 from bluemira.base.logs import set_log_level
-from bluemira.base.look_and_feel import (
-    bluemira_debug,
-    bluemira_print,
-    bluemira_warn,
-    print_banner,
-)
+from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.base.parameter_frame import ParameterFrame
 from bluemira.base.parameter_frame._parameter import ParamDictT
 from bluemira.utilities.tools import get_module, json_writer
@@ -144,7 +139,6 @@ def parse_args():
     args.directory = str(Path(args.directory).resolve())
 
     set_log_level(min(max(0, 2 + args.q - args.v), 5))
-    print_banner()
     return args
 
 

--- a/tests/base/test_look_and_feel.py
+++ b/tests/base/test_look_and_feel.py
@@ -36,9 +36,9 @@ from bluemira.base.look_and_feel import (
     bluemira_print_flush,
     bluemira_warn,
     count_slocs,
+    get_banner,
     get_git_branch,
     get_git_version,
-    print_banner,
     user_banner,
     version_banner,
 )
@@ -157,9 +157,8 @@ def test_bluemira_print_flush(caplog):
 # mess up this test's 'len' assertion
 @mock.patch("bluemira.base.look_and_feel.get_git_branch", lambda _: "develop")
 @mock.patch("bluemira.base.look_and_feel.count_slocs", lambda _, __: {"total": 1})
-def test_print_banner(caplog):
-    result = capture_output(caplog, print_banner)
+def test_get_banner():
+    result = get_banner()
 
-    assert len(result) == 15
     assert ANSI_COLOR["blue"] in result[0]
-    assert EXIT_COLOR in result[-1]
+    assert EXIT_COLOR in result[0]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

This adds the opportunity to solve #181 if we organise a place to save data

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This change means we would log INFO and more verbose to stdout and WARNING and less verbose to stderr instead of all to stderr.

It also adds back the banner printing on the program initialisation (well if anything from look and feel is imported). It feels a bit hacky but it works. Possible future downsides it its current form you cant disable all logging before we output text. 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
