### PR TITLE
🎨 Add Building to docker compose and cleanup docker file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,15 +1,21 @@
 services:
   bluemira:
-    image: bluemira:latest
+    build:
+      context: ../
+      dockerfile: ./docker/env.Dockerfile
+      target: release
+    image: bluemira:release
     volumes:
         - /tmp/.X11-unix:/tmp/.X11-unix  # X11 forwarding
-        - $HOME/.Xauthority:/user/.Xauthority  # X11 forwarding
+        - $HOME/.Xauthority:/home/user/.Xauthority  # X11 forwarding
         - /dev/dri/card0:/dev/dri/card0  # Removes cad viewer warning for me
     environment:
       DISPLAY: $DISPLAY
     network_mode: host
 
   bluemira-develop:
+   build:
+      target: develop
    image: bluemira:develop
    extends:
      service: bluemira

--- a/docker/env.Dockerfile
+++ b/docker/env.Dockerfile
@@ -99,7 +99,9 @@ RUN apt-get install git -y
 USER user
 COPY requirements-develop.txt .
 RUN pip install --no-cache-dir -r requirements-develop.txt && rm requirements-develop.txt
-
+RUN echo "echo -n 'Installing bluemira development version...' &&  \
+          pip install -U -e /home/user/bluemira --quiet --quiet && \
+          echo 'Done'"  >> .bashrc
 
 FROM user_base as release
 RUN pip install git+https://github.com/Fusion-Power-Plant-Framework/bluemira.git@main


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Adds building to docker compose so we don't have to remember the commands for the release and develop images.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
On the develop image bluemira is now installed when the container is started by having the install command in the .bashrc

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
