### PR TITLE
🎨 Add pytest XPASS to output and fix tests for parallel running

### DIFF
--- a/eudemo/eudemo_tests/test_blanket.py
+++ b/eudemo/eudemo_tests/test_blanket.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+from functools import partial
 from random import uniform
 
 import pytest
@@ -52,11 +53,11 @@ class TestDivertorBuilder:
             )
         )
 
-    @pytest.mark.parametrize("cut_angle", [uniform(0, 90) for _ in range(2)])
-    @pytest.mark.parametrize("r_inner_cut", [uniform(2, 4) for _ in range(2)])
+    @pytest.mark.parametrize("cut_angle", [partial(uniform, 0, 90) for _ in range(2)])
+    @pytest.mark.parametrize("r_inner_cut", [partial(uniform, 2, 4) for _ in range(2)])
     def test_components_and_segments(self, r_inner_cut, cut_angle):
         builder = BlanketBuilder(
-            self.params, {}, self.silhouette, r_inner_cut, cut_angle
+            self.params, {}, self.silhouette, r_inner_cut(), cut_angle()
         )
         blanket = builder.build()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ markers = [
     "reactor",
     "private"
 ]
-addopts = "--html=report.html --self-contained-html --strict-markers"
+addopts = "--html=report.html --self-contained-html --strict-markers -r fEX"
 filterwarnings = ['ignore:Matplotlib is currently using agg:UserWarning']
 
 [tool.versioneer]


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
To keep track of expected failures that pass this adds it to the default pytest output. 
Secondly modified a couple of tests so pytest-xdist can be used again. I could use a fixture but this seemed easier...

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
