### PR TITLE
Add another way to get bounding boxes that is more accurate.

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -667,22 +667,31 @@ def bounding_box(obj: apiShape) -> Tuple[float, float, float, float, float, floa
     return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax
 
 
-def tesselated_bounding_box(
-    obj: apiShape, tolerance: float = 1.0
-) -> Tuple[float, float, float, float, float, float]:
+def tessellate(obj: apiShape, tolerance: float) -> None:
     """
-    Object's bounding box passing through tesselation
+    Tessellate a geometry object.
+
+    Parameters
+    ----------
+    obj:
+        Shape to tessellate
+    tolerance:
+        Tolerance with which to perform the operation
+
+    Raises
+    ------
+    ValueError:
+        If the tolerance is <= 0.0
 
     Notes
     -----
-    Tesselating less trivial geometry objects is the only way to get a more
-    accurate bounding box. Once tesselated, various attributes are modified
-    according to the the tolerance used.
-
-    Lower tolerances will not update the tesselation.
+    Once tesselated an object's properties may change. Tesselation cannot be reverted
+    to a previous lower value, but can be increased (irreversibly).
     """
+    if tolerance <= 0.0:
+        raise ValueError("Cannot have a tolerance that is less than or equal to 0.0")
+
     obj.tessellate(tolerance)
-    return bounding_box(obj)
 
 
 def start_point(obj: apiShape) -> np.ndarray:

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -667,6 +667,24 @@ def bounding_box(obj: apiShape) -> Tuple[float, float, float, float, float, floa
     return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax
 
 
+def tesselated_bounding_box(
+    obj: apiShape, tolerance: float = 1.0
+) -> Tuple[float, float, float, float, float, float]:
+    """
+    Object's bounding box passing through tesselation
+
+    Notes
+    -----
+    Tesselating less trivial geometry objects is the only way to get a more
+    accurate bounding box. Once tesselated, various attributes are modified
+    according to the the tolerance used.
+
+    Lower tolerances will not update the tesselation.
+    """
+    obj.tessellate(tolerance)
+    return bounding_box(obj)
+
+
 def start_point(obj: apiShape) -> np.ndarray:
     """The start point of the object"""
     point = obj.Edges[0].firstVertex().Point

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -212,8 +212,28 @@ class BluemiraGeo(ABC, GeoMeshable):
     @property
     def bounding_box(self) -> BoundingBox:
         """
-        The bounding box of the shape."""
+        The bounding box of the shape.
+        """
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.bounding_box(self.shape)
+        return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
+
+    def get_optimal_bounding_box(self, tolerance: float = 1.0) -> BoundingBox:
+        """
+        Get the optimised bounding box of the shape, via tesselation of the underlying
+        geometry.
+
+        Parameters
+        ----------
+        tolerance:
+            Tolerance with which to tesselate the BluemiraGeo before calculating the
+            bounding box.
+        """
+        if tolerance <= 0.0:
+            raise ValueError("Cannot have a tolerance that is less than or equal to 0.0")
+
+        x_min, y_min, z_min, x_max, y_max, z_max = cadapi.tesselated_bounding_box(
+            self.shape, tolerance=tolerance
+        )
         return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
 
     def is_null(self) -> bool:

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -228,13 +228,8 @@ class BluemiraGeo(ABC, GeoMeshable):
             Tolerance with which to tesselate the BluemiraGeo before calculating the
             bounding box.
         """
-        if tolerance <= 0.0:
-            raise ValueError("Cannot have a tolerance that is less than or equal to 0.0")
-
-        x_min, y_min, z_min, x_max, y_max, z_max = cadapi.tesselated_bounding_box(
-            self.shape, tolerance=tolerance
-        )
-        return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
+        self._tessellate(tolerance)
+        return self.bounding_box
 
     def is_null(self) -> bool:
         """
@@ -300,6 +295,22 @@ class BluemiraGeo(ABC, GeoMeshable):
             else:
                 cadapi.scale_shape(o, factor)
         cadapi.scale_shape(self.shape, factor)
+
+    def _tessellate(self, tolerance: float = 1.0) -> None:
+        """
+        Tessellate the geometry object.
+
+        Parameters
+        ----------
+        tolerance:
+            Tolerance with which to tessellate the geometry
+
+        Notes
+        -----
+        Once tesselated an object's properties may change. Tesselation cannot be reverted
+        to a previous lower value, but can be increased (irreversibly).
+        """
+        cadapi.tessellate(self.shape, tolerance)
 
     def translate(self, vector) -> None:
         """

--- a/tests/geometry/test_bound_box.py
+++ b/tests/geometry/test_bound_box.py
@@ -72,4 +72,14 @@ class TestHardBoundingBox:
 
     @pytest.mark.xfail
     def test_bad_bounding_box(self):
-        assert not np.isclose(self.wire.bounding_box.z_min, -5)
+        assert np.isclose(self.wire.bounding_box.z_min, -5.0)
+
+    @pytest.mark.parametrize("tol", [10.0, 1.0, 0.1, 0.001])
+    def test_opt_bounding_box(self, tol):
+        bb = self.wire.get_optimal_bounding_box(tolerance=tol)
+        assert np.isclose(bb.z_min, -5.0)
+
+    @pytest.mark.parametrize("tol", [0.0, -1e-9])
+    def test_bad_tolerace(self, tol):
+        with pytest.raises(ValueError):
+            self.wire.get_optimal_bounding_box(tolerance=tol)

--- a/tests/geometry/test_bound_box.py
+++ b/tests/geometry/test_bound_box.py
@@ -20,8 +20,12 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
 from bluemira.geometry.bound_box import BoundingBox
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.parameterisations import PolySpline
+from bluemira.geometry.tools import boolean_cut, make_polygon
 
 
 class TestBoundingBox:
@@ -43,3 +47,29 @@ class TestBoundingBox:
         assert np.allclose(xb, np.array([-2, -2, -2, -2, 2, 2, 2, 2]))
         assert np.allclose(yb, np.array([-2, -2, 2, 2, -2, -2, 2, 2]))
         assert np.allclose(zb, np.array([-2, 2, -2, 2, -2, 2, -2, 2]))
+
+
+class TestHardBoundingBox:
+    ps = PolySpline(
+        {
+            "bottom": {"value": 0.509036},
+            "flat": {"value": 1},
+            "height": {"value": 10.1269},
+            "lower": {"value": 0.2},
+            "tilt": {"value": 19.6953},
+            "top": {"value": 0.46719},
+            "upper": {"value": 0.326209},
+            "x1": {"value": 5},
+            "x2": {"value": 11.8222},
+            "z2": {"value": -0.170942},
+        }
+    )
+
+    cut_box = BluemiraFace(
+        make_polygon({"x": [0, 15, 15, 0], "z": [-7, -7, -5, -5], "y": 0}, closed=True)
+    )
+    wire = boolean_cut(ps.create_shape(), cut_box)[0]
+
+    @pytest.mark.xfail
+    def test_bad_bounding_box(self):
+        assert not np.isclose(self.wire.bounding_box.z_min, -5)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2162 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Adds a method onto `BluemiraGeo` to get an optimised bounding box. We haven't discussed the API of this @ivanmaione, I was just looking into making a MWE and found an easy solution. Happy to switch this around if necessary.

I have played with some 3-D solids and it works too but obviously the tesselation is much slower.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
