### PR TITLE
✨ Add dynamic file reading to ReactorConfig

### DIFF
--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -281,6 +281,10 @@ class ReactorConfig:
                 # if doing a params extraction,
                 # get the values from the _PARAMETERS_KEY
                 to_extract = current_layer.get(_PARAMETERS_KEY, {})
+                if isinstance(to_extract, str) and to_extract.endswith(".json"):
+                    to_extract = self._get_nested_filepaths(
+                        to_extract, _PARAMETERS_KEY, arg_keys, next_idx + 1
+                    )
 
             # add all keys not in extracted already
             # if doing a config, ignore the "params" (_PARAMETERS_KEY)

--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -267,6 +267,7 @@ class ReactorConfig:
         # this routine is designed not to copy any dict's while parsing
 
         current_layer = self.config_data
+
         for next_idx, current_arg_key in enumerate(arg_keys, start=1):
             current_layer = current_layer.get(current_arg_key, {})
             next_arg_key = arg_keys[next_idx] if next_idx < len(arg_keys) else None

--- a/tests/base/reactor_config/data/reactor_config.nested_config.json
+++ b/tests/base/reactor_config/data/reactor_config.nested_config.json
@@ -1,0 +1,3 @@
+{
+  "Tester": "reactor_config.test.json"
+}

--- a/tests/base/reactor_config/data/reactor_config.nested_params.json
+++ b/tests/base/reactor_config/data/reactor_config.nested_params.json
@@ -1,0 +1,3 @@
+{
+  "Tester": { "params": "reactor_params.global.json" }
+}

--- a/tests/base/reactor_config/test_reactor_config.py
+++ b/tests/base/reactor_config/test_reactor_config.py
@@ -235,9 +235,6 @@ class TestReactorConfigClass:
 
     def test_file_path_loading_in_json_nested_config(self):
         reactor_config = ReactorConfig(nested_config_path.as_posix(), EmptyFrame)
-        import ipdb
-
-        ipdb.set_trace()
 
         pf = make_parameter_frame(
             reactor_config.params_for("Tester", "comp A", "designer"),
@@ -247,6 +244,7 @@ class TestReactorConfigClass:
         self._compa_designer_param_value_checks(pf)
 
         assert reactor_config.config_for("Tester", "comp A", "designer") == {
+            # "comp B": {}, # Bug
             "config_a": {"a_value": "overridden_value"},
             "config_b": {"b_value": "b_value"},
             "config_c": {"c_value": "c_value"},


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This adds dynamic file reading to ReactorConfig eg:

```json
{ "Equilibria": "file.json",
  "PF": "stuff"
}
```

It will try and resolve the location of the file so relative will work if the file is in the cwd or is in the same directory as the base json file.

Need to write a test still.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
