### PR TITLE
🐛 Fix quad padding for coil circuits

### DIFF
--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -365,7 +365,11 @@ class CoilGroup(CoilGroupFieldsMixin):
         self._pad_discretisation(_quad_list)
 
         for i, d in enumerate(self._pad_size):
-            _quad_list[i] = np.pad(_quad_list[i], (0, d))
+            if _quad_list[i].ndim > 1:
+                pad = tuple((0, 0) for _ in range(_quad_list[i].ndim - 1)) + ((0, d),)
+            else:
+                pad = (0, d)
+            _quad_list[i] = np.pad(_quad_list[i], pad)
 
         return np.vstack(_quad_list)
 

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -438,6 +438,13 @@ class TestCoilSet:
 
         cls.coilset = CoilSet(coil, circuit)
 
+    def test_padding_of_quads(self):
+        cs = copy.deepcopy(self.coilset)
+        cs._coils[0].discretisation = 0.5
+
+        # if padding is done on multiple axes this shape will be (10, 8)
+        assert cs._quad_x.shape == (3, 8)
+
     def test_group_vecs(self):
         x, z, dx, dz, currents = self.coilset.to_group_vecs()
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When repadding a `Circuit` the padding was being added to all axes of the array whereas we only want to pad the end of the last axis

~TODO a test~ Done

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
