### PR TITLE
Remove typing from optimisation module's docstrings

### DIFF
--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -63,28 +63,28 @@ def optimise_geometry(
 
     Parameters
     ----------
-    geom: GeometryParameterisation
+    geom
         The geometry to optimise the parameters of. The existing
         parameterisation is used as the initial guess in the
         optimisation.
-    f_objective: GeomOptimiserObjective
+    f_objective
         The objective function to minimise. Must take as an argument a
         `GeometryParameterisation` and return a float.
-    df_objective: Optional[GeomOptimiserCallable], optional
+    df_objective
         The derivative of the objective function, by default None. If
         not given, an approximation of the derivative is made using
         the 'central differences' method.
         This argument is ignored if a non-gradient based algorithm is
         used.
-    keep_out_zones: Iterable[BluemiraWire], optional
+    keep_out_zones
         An iterable of closed wires, defining areas the geometry must
         not intersect.
-    keep_in_zones: Iterable[BluemiraWire], optional
+    keep_in_zones
         An iterable list of closed wires, defining areas the geometry
         must wholly lie within.
-    algorithm : Union[Algorithm, str], optional
+    algorithm
         The optimisation algorithm to use, by default ``Algorithm.SLSQP``.
-    opt_conditions: Optional[Mapping[str, Union[int, float]]]
+    opt_conditions
         The stopping conditions for the optimiser. Supported conditions
         are:
 
@@ -97,12 +97,12 @@ def optimise_geometry(
             * stop_val: float
 
         (default: {"max_eval": 2000})
-    opt_parameters: Optional[Mapping[str, Any]]
+    opt_parameters
         The algorithm-specific optimisation parameters.
-    bounds: Tuple[np.ndarray, np.ndarray]
+    bounds
         The upper and lower bounds for the optimisation parameters.
         The first array being the lower bounds, the second the upper.
-    eq_constraints: Iterable[GeomConstraintT]
+    eq_constraints
         The equality constraints for the optimiser.
         A dict with keys:
 
@@ -137,7 +137,7 @@ def optimise_geometry(
             * COBYLA
             * ISRES
 
-    ineq_constraints: Iterable[GeomConstraintT]
+    ineq_constraints
         The geometric inequality constraints for the optimiser.
         This argument has the same form as the `eq_constraint` argument,
         but each constraint is of the form $f_{c}(x) \le 0$.
@@ -148,7 +148,7 @@ def optimise_geometry(
             * COBYLA
             * ISRES
 
-    keep_history: bool
+    keep_history
         Whether or not to record the history of the optimisation
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
@@ -156,7 +156,7 @@ def optimise_geometry(
 
     Returns
     -------
-    GeomOptimiserResult
+    result
         The result of the optimisation.
     """
     dimensions = geom.variables.n_free_variables

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -63,28 +63,28 @@ def optimise_geometry(
 
     Parameters
     ----------
-    geom
+    geom:
         The geometry to optimise the parameters of. The existing
         parameterisation is used as the initial guess in the
         optimisation.
-    f_objective
+    f_objective:
         The objective function to minimise. Must take as an argument a
         `GeometryParameterisation` and return a float.
-    df_objective
+    df_objective:
         The derivative of the objective function, by default None. If
         not given, an approximation of the derivative is made using
         the 'central differences' method.
         This argument is ignored if a non-gradient based algorithm is
         used.
-    keep_out_zones
+    keep_out_zones:
         An iterable of closed wires, defining areas the geometry must
         not intersect.
-    keep_in_zones
+    keep_in_zones:
         An iterable list of closed wires, defining areas the geometry
         must wholly lie within.
-    algorithm
+    algorithm:
         The optimisation algorithm to use, by default ``Algorithm.SLSQP``.
-    opt_conditions
+    opt_conditions:
         The stopping conditions for the optimiser. Supported conditions
         are:
 
@@ -97,12 +97,12 @@ def optimise_geometry(
             * stop_val: float
 
         (default: {"max_eval": 2000})
-    opt_parameters
+    opt_parameters:
         The algorithm-specific optimisation parameters.
-    bounds
+    bounds:
         The upper and lower bounds for the optimisation parameters.
         The first array being the lower bounds, the second the upper.
-    eq_constraints
+    eq_constraints:
         The equality constraints for the optimiser.
         A dict with keys:
 
@@ -137,7 +137,7 @@ def optimise_geometry(
             * COBYLA
             * ISRES
 
-    ineq_constraints
+    ineq_constraints:
         The geometric inequality constraints for the optimiser.
         This argument has the same form as the `eq_constraint` argument,
         but each constraint is of the form $f_{c}(x) \le 0$.
@@ -148,7 +148,7 @@ def optimise_geometry(
             * COBYLA
             * ISRES
 
-    keep_history
+    keep_history:
         Whether or not to record the history of the optimisation
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
@@ -156,8 +156,7 @@ def optimise_geometry(
 
     Returns
     -------
-    result
-        The result of the optimisation.
+    The result of the optimisation.
     """
     dimensions = geom.variables.n_free_variables
     f_obj = _tools.to_objective(f_objective, geom)

--- a/bluemira/optimisation/_geometry/parameterisations/tools.py
+++ b/bluemira/optimisation/_geometry/parameterisations/tools.py
@@ -29,15 +29,14 @@ def get_x_norm_index(variables: OptVariables, name: str):
 
     Parameters
     ----------
-    variables
+    variables:
         Bounded optimisation variables
-    name
+    name:
         Variable name for which to get the index
 
     Returns
     -------
-    idx_x_norm: int
-        Index of the variable name in the modified-length x_norm vector
+    Index of the variable name in the modified-length x_norm vector
     """
     fixed_idx = variables._fixed_variable_indices
     idx_actual = variables.names.index(name)
@@ -59,15 +58,14 @@ def process_x_norm_fixed(variables: OptVariables, x_norm: np.ndarray):
 
     Parameters
     ----------
-    variables
+    variables:
         Bounded optimisation variables
-    x_norm
+    x_norm:
         Normalised vector of variable values
 
     Returns
     -------
-    x_actual: list
-        List of ordered actual (un-normalised) values
+    List of ordered actual (un-normalised) values
     """
     fixed_idx = variables._fixed_variable_indices
 

--- a/bluemira/optimisation/_geometry/parameterisations/tools.py
+++ b/bluemira/optimisation/_geometry/parameterisations/tools.py
@@ -18,6 +18,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+import numpy as np
+
 from bluemira.utilities.opt_variables import OptVariables
 
 
@@ -27,9 +29,9 @@ def get_x_norm_index(variables: OptVariables, name: str):
 
     Parameters
     ----------
-    variables: OptVariables
+    variables
         Bounded optimisation variables
-    name: str
+    name
         Variable name for which to get the index
 
     Returns
@@ -50,16 +52,16 @@ def get_x_norm_index(variables: OptVariables, name: str):
     return idx_actual - count
 
 
-def process_x_norm_fixed(variables: OptVariables, x_norm):
+def process_x_norm_fixed(variables: OptVariables, x_norm: np.ndarray):
     """
     Utility for processing a set of free, normalised variables, and folding the fixed
     un-normalised variables back into a single list of all actual values.
 
     Parameters
     ----------
-    variables: OptVariables
+    variables
         Bounded optimisation variables
-    x_norm: np.ndarray
+    x_norm
         Normalised vector of variable values
 
     Returns

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -56,7 +56,7 @@ class NloptOptimiser(Optimiser):
 
     Parameters
     ----------
-    algorithm
+    algorithm:
         The optimisation algorithm to use. Available algorithms are:
 
             * SLSQP
@@ -69,18 +69,18 @@ class NloptOptimiser(Optimiser):
             * CRS
             * ISRES
 
-    n_variables
+    n_variables:
         The number of optimisation parameters.
-    f_objective
+    f_objective:
         The objective function to minimise. This function must take one
         argument (a numpy array), and return a numpy array or float.
-    df_objective
+    df_objective:
         The derivative of the objective function. This must take the
         form: `f(x) -> y` where `x` is a numpy array containing the
         optimization parameters, and `y` is a numpy array where each
         element `i` is the partial derivative `\partialf/\partialdx_{i}`.
         If not given, a numerical approximation of the gradient is used.
-    opt_conditions
+    opt_conditions:
         The stopping conditions for the optimiser. At least one stopping
         condition is required. Supported conditions are:
 
@@ -92,10 +92,10 @@ class NloptOptimiser(Optimiser):
             * max_time: float
             * stop_val: float
 
-    opt_parameters
+    opt_parameters:
         Parameters specific to the algorithm being used. Consult NLopt
         documentation for these.
-    keep_history
+    keep_history:
         Whether to record the history of each step of the optimisation.
         (default: False)
     """

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -56,7 +56,7 @@ class NloptOptimiser(Optimiser):
 
     Parameters
     ----------
-    algorithm: Union[str, Algorithm]
+    algorithm
         The optimisation algorithm to use. Available algorithms are:
 
             * SLSQP
@@ -69,18 +69,18 @@ class NloptOptimiser(Optimiser):
             * CRS
             * ISRES
 
-    n_variables: int
+    n_variables
         The number of optimisation parameters.
-    f_objective: Callable[[Arg(np.ndarray, 'x')], float]
+    f_objective
         The objective function to minimise. This function must take one
         argument (a numpy array), and return a numpy array or float.
-    df_objective: Optional[Callable[[Arg(np.ndarray, 'x')], np.ndarray]]
+    df_objective
         The derivative of the objective function. This must take the
         form: `f(x) -> y` where `x` is a numpy array containing the
         optimization parameters, and `y` is a numpy array where each
         element `i` is the partial derivative `\partialf/\partialdx_{i}`.
         If not given, a numerical approximation of the gradient is used.
-    opt_conditions: Mapping[str, Union[int, float]]
+    opt_conditions
         The stopping conditions for the optimiser. At least one stopping
         condition is required. Supported conditions are:
 
@@ -92,10 +92,10 @@ class NloptOptimiser(Optimiser):
             * max_time: float
             * stop_val: float
 
-    opt_parameters: Optional[Mapping[str, Any]]
+    opt_parameters
         Parameters specific to the algorithm being used. Consult NLopt
         documentation for these.
-    keep_history: bool
+    keep_history
         Whether to record the history of each step of the optimisation.
         (default: False)
     """

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -52,21 +52,21 @@ def optimise(
 
     Parameters
     ----------
-    f_objective
+    f_objective:
         The objective function to minimise.
-    dimensions
+    dimensions:
         The dimensionality of the problem. This or `x0` must be given.
-    x0
+    x0:
         The initial guess for the optimisation parameters. This or
         `dimensions` must be given, if both are given, `x0.size` must be
         equal to `dimensions`.
-    df_objective
+    df_objective:
         The derivative of the objective function.
-    algorithm
+    algorithm:
         The optimisation algorithm to use. See enum
         :obj:`optimisation.Algorithm` for supported algorithms.
         (default: "SLSQP")
-    opt_conditions
+    opt_conditions:
         The stopping conditions for the optimiser. Supported conditions
         are:
 
@@ -79,12 +79,12 @@ def optimise(
             * stop_val: float
 
         (default: {"max_eval": 2000})
-    opt_parameters
+    opt_parameters:
         The algorithm-specific optimisation parameters.
-    bounds
+    bounds:
         The upper and lower bounds for the optimisation parameters.
         The first array being the lower bounds, the second the upper.
-    eq_constraints
+    eq_constraints:
         The equality constraints for the optimiser.
         A dict with keys:
 
@@ -118,7 +118,7 @@ def optimise(
             * COBYLA
             * ISRES
 
-    ineq_constraints
+    ineq_constraints:
         The inequality constraints for the optimiser.
         This argument has the same form as the `eq_constraint` argument,
         but each constraint is in the form $f_{c}(x) \le 0$.
@@ -130,6 +130,7 @@ def optimise(
             * ISRES
 
     """
+    # TODO(hsaunders1904): finish this docstring!
     if dimensions is None:
         if x0 is not None:
             dimensions = x0.size

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -129,8 +129,15 @@ def optimise(
             * COBYLA
             * ISRES
 
+    keep_history:
+        Whether to record the history of each step of the optimisation.
+        (default: False)
+
+    Returns
+    -------
+    The result of the optimisation; including the optimised parameters
+    and the number of iterations.
     """
-    # TODO(hsaunders1904): finish this docstring!
     if dimensions is None:
         if x0 is not None:
             dimensions = x0.size

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -52,21 +52,21 @@ def optimise(
 
     Parameters
     ----------
-    f_objective: Callable[[Arg(np.ndarray, 'x')], np.ndarray]
+    f_objective
         The objective function to minimise.
-    dimensions: Optional[int]
+    dimensions
         The dimensionality of the problem. This or `x0` must be given.
-    x0: Optional[np.ndarray]
+    x0
         The initial guess for the optimisation parameters. This or
         `dimensions` must be given, if both are given, `x0.size` must be
         equal to `dimensions`.
-    df_objective: Optional[Callable[[Arg(np.ndarray, 'x')], np.ndarray]]
+    df_objective
         The derivative of the objective function.
-    algorithm: Optional[Union[Algorithm, str]]
+    algorithm
         The optimisation algorithm to use. See enum
         :obj:`optimisation.Algorithm` for supported algorithms.
         (default: "SLSQP")
-    opt_conditions: Optional[Mapping[str, Union[int, float]]]
+    opt_conditions
         The stopping conditions for the optimiser. Supported conditions
         are:
 
@@ -79,12 +79,12 @@ def optimise(
             * stop_val: float
 
         (default: {"max_eval": 2000})
-    opt_parameters: Optional[Mapping[str, Any]]
+    opt_parameters
         The algorithm-specific optimisation parameters.
-    bounds: Tuple[np.ndarray, np.ndarray]
+    bounds
         The upper and lower bounds for the optimisation parameters.
         The first array being the lower bounds, the second the upper.
-    eq_constraints: Iterable[ConstraintT]
+    eq_constraints
         The equality constraints for the optimiser.
         A dict with keys:
 
@@ -118,7 +118,7 @@ def optimise(
             * COBYLA
             * ISRES
 
-    ineq_constraints: Iterable[ConstraintT]
+    ineq_constraints
         The inequality constraints for the optimiser.
         This argument has the same form as the `eq_constraint` argument,
         but each constraint is in the form $f_{c}(x) \le 0$.

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -64,11 +64,11 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        f_constraint
+        f_constraint:
             The constraint function, with form as described above.
-        tolerance
+        tolerance:
             The tolerances for each optimisation parameter.
-        df_constraint
+        df_constraint:
             The gradient of the constraint function. This should have the
             same form as the constraint function, however its output
             array should have dimensions `m x n_variables` where `m` is
@@ -107,11 +107,11 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        f_constraint
+        f_constraint:
             The constraint function, with form as described above.
-        tolerance
+        tolerance:
             The tolerances for each optimisation parameter.
-        df_constraint
+        df_constraint:
             The gradient of the constraint function. This should have the
             same form as the constraint function, however its output
             array should have dimensions `m x n_variables` where `m` is
@@ -134,7 +134,7 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        x0
+        x0:
             The initial guess for each of the optimisation parameters.
             If not given, each parameter is set to the average of its
             lower and upper bound. If no bounds exist, the initial guess
@@ -142,10 +142,9 @@ class Optimiser(abc.ABC):
 
         Returns
         -------
-        result
-            The result of the optimisation, containing the optimised
-            parameters `x`, as well as other information about the
-            optimisation.
+        The result of the optimisation, containing the optimised
+        parameters `x`, as well as other information about the
+        optimisation.
         """
 
     @abc.abstractmethod

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -64,11 +64,11 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        f_constraint: Callable[[Arg(np.ndarray, 'x')], np.ndarray]
+        f_constraint
             The constraint function, with form as described above.
-        tolerance: np.ndarray
+        tolerance
             The tolerances for each optimisation parameter.
-        df_constraint: Optional[Callable[[Arg(np.ndarray, 'x')], np.ndarray]]
+        df_constraint
             The gradient of the constraint function. This should have the
             same form as the constraint function, however its output
             array should have dimensions `m x n_variables` where `m` is
@@ -107,11 +107,11 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        f_constraint: Callable[[Arg(np.ndarray, 'x')], np.ndarray]
+        f_constraint
             The constraint function, with form as described above.
-        tolerance: Union[float, np.ndarray]
+        tolerance
             The tolerances for each optimisation parameter.
-        df_constraint: Optional[Callable[[Arg(np.ndarray, 'x')], np.ndarray]]
+        df_constraint
             The gradient of the constraint function. This should have the
             same form as the constraint function, however its output
             array should have dimensions `m x n_variables` where `m` is
@@ -134,7 +134,7 @@ class Optimiser(abc.ABC):
 
         Parameters
         ----------
-        x0: Optional[np.ndarray]
+        x0
             The initial guess for each of the optimisation parameters.
             If not given, each parameter is set to the average of its
             lower and upper bound. If no bounds exist, the initial guess
@@ -142,7 +142,7 @@ class Optimiser(abc.ABC):
 
         Returns
         -------
-        result: OptimiserResult
+        result
             The result of the optimisation, containing the optimised
             parameters `x`, as well as other information about the
             optimisation.

--- a/bluemira/optimisation/_tools.py
+++ b/bluemira/optimisation/_tools.py
@@ -20,7 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Collection of utility functions for the module."""
 
-from typing import Callable, Iterable, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Tuple, Union
 
 import numpy as np
 from scipy.optimize._numdiff import approx_derivative as _approx_derivative
@@ -35,27 +35,27 @@ def approx_derivative(
     rel_step: Optional[_FloatOrArray] = None,
     f0: Optional[_FloatOrArray] = None,
     bounds: Optional[Iterable[_FloatOrArray]] = (-np.inf, np.inf),
-    args=(),
+    args: Optional[Tuple[Any, ...]] = (),
 ) -> np.ndarray:
     """
     Approximate the gradient of a function about a point.
 
     Parameters
     ----------
-    func: Callable
+    func
         Function for which to calculate the gradient.
-    x0: np.ndarray
+    x0
         Point about which to calculate the gradient.
-    method: str
+    method
         Finite difference method to use.
-    rel_step: Optional[float, np.ndarray]
+    rel_step
         Relative step size to use.
-    f0: Optional[float, np.ndarray]
+    f0
         Result of func(x0). If None, this is recomputed.
-    bounds: Optional[Iterable]
+    bounds
         Lower and upper bounds on individual variables.
-    args: tuple
-        Additional arguments to func.
+    args
+        Additional positional arguments to ``func``.
     """
     return _approx_derivative(
         func, x0, method=method, rel_step=rel_step, f0=f0, bounds=bounds, args=args

--- a/bluemira/optimisation/_tools.py
+++ b/bluemira/optimisation/_tools.py
@@ -42,19 +42,19 @@ def approx_derivative(
 
     Parameters
     ----------
-    func
+    func:
         Function for which to calculate the gradient.
-    x0
+    x0:
         Point about which to calculate the gradient.
-    method
+    method:
         Finite difference method to use.
-    rel_step
+    rel_step:
         Relative step size to use.
-    f0
+    f0:
         Result of func(x0). If None, this is recomputed.
-    bounds
+    bounds:
         Lower and upper bounds on individual variables.
-    args
+    args:
         Additional positional arguments to ``func``.
     """
     return _approx_derivative(


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2190 
Part of #2189 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Removes typing from the docstrings of functions/classes in the `optimisation` module.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Nope

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
