### PR TITLE
Allow customisation of keep in/out zone discretisation

### DIFF
--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -19,7 +19,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 from dataclasses import asdict, dataclass
-from typing import Any, Generic, Iterable, Mapping, Optional, TypeVar, Union
+from itertools import repeat
+from typing import Any, Generic, Iterable, Mapping, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -58,6 +59,8 @@ def optimise_geometry(
     eq_constraints: Iterable[GeomConstraintT] = (),
     ineq_constraints: Iterable[GeomConstraintT] = (),
     keep_history: bool = False,
+    koz_discretisation: Union[int, Iterable[int]] = 100,
+    kiz_discretisation: Union[int, Iterable[int]] = 100,
 ) -> GeomOptimiserResult[_GeomT]:
     r"""
     Minimise the given objective function for a geometry parameterisation.
@@ -154,6 +157,20 @@ def optimise_geometry(
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
         (default: False)
+    koz_discretisation
+        The number of points to discretise the keep-out zone(s) over.
+        If this is an int, all keep-out zones will be discretised with
+        the same number of points. If this is an iterable, each i-th
+        keep-out zone is discretised using value in the i-th item.
+        The iterable should have the same number of items as
+        ``keep_out_zones``.
+    kiz_discretisation
+        The number of points to discretise the keep-in zone(s) over.
+        If this is an int, all keep-in zones will be discretised with
+        the same number of points. If this is an iterable, each i-th
+        keep-in zone is discretised using value in the i-th item.
+        The iterable should have the same number of items as
+        ``keep_in_zones``.
 
     Returns
     -------
@@ -168,10 +185,14 @@ def optimise_geometry(
     ineq_constraints_list = _tools.get_shape_ineq_constraint(geom)
     for constraint in ineq_constraints:
         ineq_constraints_list.append(constraint)
-    for koz in keep_out_zones:
-        ineq_constraints_list.append(_tools.make_keep_out_zone_constraint(koz))
-    for kiz in keep_in_zones:
-        ineq_constraints_list.append(_tools.make_keep_in_zone_constraint(kiz))
+    for koz, discr in zip_with_scalar(keep_out_zones, koz_discretisation):
+        ineq_constraints_list.append(
+            _tools.make_keep_out_zone_constraint(koz, n_discr=discr)
+        )
+    for kiz, discr in zip_with_scalar(keep_in_zones, kiz_discretisation):
+        ineq_constraints_list.append(
+            _tools.make_keep_in_zone_constraint(kiz, n_discr=discr)
+        )
 
     result = optimise(
         f_obj,
@@ -190,3 +211,16 @@ def optimise_geometry(
     # geometry update may not have been with the optimum result
     geom.variables.set_values_from_norm(result.x)
     return GeomOptimiserResult(**asdict(result), geom=geom)
+
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+
+
+def zip_with_scalar(
+    it1: Iterable[_T1], it2: Union[Iterable[_T2], _T2]
+) -> Iterable[Tuple[_T1, _T2]]:
+    """Return an iterator that zips an iterable with another, or with a scalar."""
+    if not isinstance(it2, Iterable):
+        it2 = repeat(it2)
+    return zip(it1, it2)

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -49,6 +49,7 @@ def optimise_geometry(
     geom: _GeomT,
     f_objective: GeomOptimiserObjective,
     df_objective: Optional[GeomOptimiserCallable] = None,
+    *,
     keep_out_zones: Iterable[BluemiraWire] = (),
     keep_in_zones: Iterable[BluemiraWire] = (),
     algorithm: Union[Algorithm, str] = Algorithm.SLSQP,

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -157,14 +157,14 @@ def optimise_geometry(
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
         (default: False)
-    koz_discretisation
+    koz_discretisation:
         The number of points to discretise the keep-out zone(s) over.
         If this is an int, all keep-out zones will be discretised with
         the same number of points. If this is an iterable, each i-th
         keep-out zone is discretised using value in the i-th item.
         The iterable should have the same number of items as
         ``keep_out_zones``.
-    kiz_discretisation
+    kiz_discretisation:
         The number of points to discretise the keep-in zone(s) over.
         If this is an int, all keep-in zones will be discretised with
         the same number of points. If this is an iterable, each i-th

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -138,6 +138,7 @@ def optimise(
     The result of the optimisation; including the optimised parameters
     and the number of iterations.
     """
+    # TODO(hsaunders1904): finish this docstring!
     if dimensions is None:
         if x0 is not None:
             dimensions = x0.size

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -36,9 +36,10 @@ from bluemira.optimisation._typing import (
 
 def optimise(
     f_objective: ObjectiveCallable,
-    dimensions: Optional[int] = None,
-    x0: Optional[np.ndarray] = None,
     df_objective: Optional[OptimiserCallable] = None,
+    *,
+    x0: Optional[np.ndarray] = None,
+    dimensions: Optional[int] = None,
     algorithm: Union[Algorithm, str] = Algorithm.SLSQP,
     opt_conditions: Optional[Mapping[str, Union[int, float]]] = None,
     opt_parameters: Optional[Mapping[str, Any]] = None,

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -138,7 +138,6 @@ def optimise(
     The result of the optimisation; including the optimised parameters
     and the number of iterations.
     """
-    # TODO(hsaunders1904): finish this docstring!
     if dimensions is None:
         if x0 is not None:
             dimensions = x0.size

--- a/tests/optimisation/test_geometry.py
+++ b/tests/optimisation/test_geometry.py
@@ -295,16 +295,3 @@ class TestGeometry:
         assert discr_mock.call_count == 2
         assert discr_mock.call_args_list[0] == mock.call(20, byedges=True)
         assert discr_mock.call_args_list[1] == mock.call(30, byedges=True)
-
-
-def make_picture_frame() -> PictureFrame:
-    return PictureFrame(
-        {
-            "x1": {"value": 4.5, "upper_bound": 6, "lower_bound": 3},
-            "x2": {"value": 16, "upper_bound": 17.5, "lower_bound": 14.0},
-            "z1": {"value": 8, "upper_bound": 15, "lower_bound": 2.5},
-            "z2": {"value": -6, "upper_bound": -2.5, "lower_bound": -15},
-            "ri": {"value": 0, "fixed": True},
-            "ro": {"value": 0, "fixed": True},
-        }
-    )


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2203 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Add `koz_discretisation` and `kiz_discretisation` arguments to `optimise_geometry`. This allows users to set the discretisation of the given keep-in/out zones in geometry optimisations.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
