### PR TITLE
🚨 Fix warnings in numba 0.57

### DIFF
--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -74,7 +74,7 @@ def fitfunc(func, data, order=None):
     return popt
 
 
-@nb.jit
+@nb.jit(nopython=True)
 def singlepowerfunc(x, *args):
     """
     Single power shape function defined e.g. CREATE stuff
@@ -85,7 +85,7 @@ def singlepowerfunc(x, *args):
     return 1 - x**n
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def doublepowerfunc(x, *args):
     """
     Double power shape function defined e.g. in Lao 1985
@@ -109,7 +109,7 @@ def pshape(shape, psinorm, psio, psix):
     return si
 
 
-@nb.jit(cache=False, forceobj=True)  # Cannot cache due to "lifted loops"
+@nb.jit(forceobj=True, looplift=True)  # Cannot cache due to "lifted loops"
 def speedy_pressure(psi_norm, psio, psix, shape):
     """
     Calculate the pressure map on the psi_norm array without any masking because
@@ -188,7 +188,7 @@ def laopoly(x, *args):
     return res
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def luxonexp(x, *args):
     """
     Exponential shape function defined in Luxon 1984

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -37,7 +37,7 @@ from bluemira.magnetostatics.tools import process_xyz_array
 __all__ = ["TrapezoidalPrismCurrentSource"]
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def primitive_sxn_bound(cos_theta, sin_theta, r, q, t):
     """
     Function primitive of Bx evaluated at a bound.
@@ -87,7 +87,7 @@ def primitive_sxn_bound(cos_theta, sin_theta, r, q, t):
     return result
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def primitive_sxn(theta, r, q, l1, l2):
     """
     Analytical integral of Bx function primitive.
@@ -116,7 +116,7 @@ def primitive_sxn(theta, r, q, l1, l2):
     )
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def primitive_szn_bound(cos_theta, sin_theta, r, ll, t):
     """
     Function primitive of Bz evaluated at a bound.
@@ -183,7 +183,7 @@ def primitive_szn_bound(cos_theta, sin_theta, r, ll, t):
     return result
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def primitive_szn(theta, r, ll, q1, q2):
     """
     Analytical integral of Bz function primitive.
@@ -212,7 +212,7 @@ def primitive_szn(theta, r, ll, q1, q2):
     )
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def Bx_analytical_prism(alpha, beta, l1, l2, q1, q2, r1, r2):
     """
     Calculate magnetic field in the local x coordinate direction due to a
@@ -250,7 +250,7 @@ def Bx_analytical_prism(alpha, beta, l1, l2, q1, q2, r1, r2):
     )
 
 
-@nb.jit(cache=True)
+@nb.jit(nopython=True, cache=True)
 def Bz_analytical_prism(alpha, beta, l1, l2, q1, q2, r1, r2):
     """
     Calculate magnetic field in the local z coordinate direction due to a


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Some warnings have been introduced as part of the numba 0.57 update. This should be reviewed thoroughly. I don't think any behaviour will change (and the tests still pass locally)

this is being merged into develop_dependencies so we have a few weeks

https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
