### PR TITLE
🐛 enable dollarmaths in notebook example docs

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -132,6 +132,7 @@ nb_execution_mode = "off"
 nb_custom_formats = {
     ".ex.py": ["jupytext.reads", {"fmt": "py:percent"}],
 }
+myst_enable_extensions = ["amsmath", "dollarmath"]
 
 
 class ParamsDirective(Directive):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2227 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
There area few extension we can enable for our notebook renderer see a full list here: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-extensions

Seem to work:

![MicrosoftTeams-image (16)](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/81617086/34fb7fc4-46ad-44cd-b45a-8ea7cc122083)


## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
