### PR TITLE
Allow `"df_constraint": None` in optimise geometry

### DIFF
--- a/bluemira/optimisation/_geometry/_tools.py
+++ b/bluemira/optimisation/_geometry/_tools.py
@@ -81,9 +81,12 @@ def to_constraint(
         "tolerance": geom_constraint["tolerance"],
     }
     if "df_constraint" in geom_constraint:
-        constraint["df_constraint"] = to_optimiser_callable(
-            geom_constraint["df_constraint"], geom
-        )
+        if geom_constraint["df_constraint"] is None:
+            constraint["df_constraint"] = None
+        else:
+            constraint["df_constraint"] = to_optimiser_callable(
+                geom_constraint["df_constraint"], geom
+            )
 
     return constraint
 

--- a/bluemira/optimisation/_geometry/_tools.py
+++ b/bluemira/optimisation/_geometry/_tools.py
@@ -78,16 +78,11 @@ def to_constraint(
     """Convert a geometry constraint to a normal one."""
     constraint: ConstraintT = {
         "f_constraint": to_optimiser_callable(geom_constraint["f_constraint"], geom),
+        "df_constraint": None,
         "tolerance": geom_constraint["tolerance"],
     }
-    if "df_constraint" in geom_constraint:
-        if geom_constraint["df_constraint"] is None:
-            constraint["df_constraint"] = None
-        else:
-            constraint["df_constraint"] = to_optimiser_callable(
-                geom_constraint["df_constraint"], geom
-            )
-
+    if df_constraint := geom_constraint.get("df_constraint", None):
+        constraint["df_constraint"] = to_optimiser_callable(df_constraint, geom)
     return constraint
 
 

--- a/bluemira/optimisation/_geometry/_typing.py
+++ b/bluemira/optimisation/_geometry/_typing.py
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
-from typing import Protocol, TypedDict
+from typing import Optional, Protocol, TypedDict
 
 import numpy as np
 from typing_extensions import NotRequired
@@ -47,4 +47,4 @@ class GeomConstraintT(TypedDict):
 
     f_constraint: GeomOptimiserCallable
     tolerance: np.ndarray
-    df_constraint: NotRequired[GeomOptimiserCallable]
+    df_constraint: NotRequired[Optional[GeomOptimiserCallable]]

--- a/bluemira/optimisation/_typing.py
+++ b/bluemira/optimisation/_typing.py
@@ -20,7 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Types for the optimisation module."""
 
-from typing import Protocol, TypedDict
+from typing import Optional, Protocol, TypedDict
 
 import numpy as np
 from typing_extensions import NotRequired
@@ -47,4 +47,4 @@ class ConstraintT(TypedDict):
 
     f_constraint: OptimiserCallable
     tolerance: np.ndarray
-    df_constraint: NotRequired[OptimiserCallable]
+    df_constraint: NotRequired[Optional[OptimiserCallable]]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}
At present, you get an error if you specify a constraint dict with  `"df_constraint": None` in `optimise_geometry` which is not the case in `optimise`.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
