### PR TITLE
Material filtering on Managers

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -92,7 +92,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
     def filter_components(
         self,
         names: Iterable[str],
-        filter_: Optional[Callable[[anytree.Node], bool]] = None,
+        filter_: Optional[Callable[[PhysicalComponent], bool]] = None,
     ):
         """
         Removes all components from the tree, starting at this component,
@@ -103,6 +103,8 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         ----------
         names:
             The list of names of each component to search for.
+        filter_:
+            A callable to filter PhysicalComponents from the Component tree
 
         Notes
         -----
@@ -201,7 +203,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def get_component(
         self, name: str, first: bool = True, full_tree: bool = False
-    ) -> Union[Component, Iterable[Component], None]:
+    ) -> Union[Component, Tuple[Component], None]:
         """
         Find the components with the specified name.
 
@@ -283,7 +285,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
 
     def _get_thing(
         self, filter_: Union[Callable, None], first: bool, full_tree: bool
-    ) -> Union[Component, Iterable[Component], None]:
+    ) -> Union[Component, Tuple[Component], None]:
         found_nodes = anytree.search.findall(
             self.root if full_tree else self, filter_=filter_
         )

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -89,7 +89,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         """
         return self.name + " (" + self.__class__.__name__ + ")"
 
-    def filter_components(self, names: Iterable[str], filter_: Union[Callable, None]):
+    def filter_components(self, names: Iterable[str], filter_: Optional[Callable[[anytree.Node], bool]] = None):
         """
         Removes all components from the tree, starting at this component,
         that are siblings of each component specified in `names`

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -92,7 +92,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
     def filter_components(
         self,
         names: Iterable[str],
-        filter_: Optional[Callable[[PhysicalComponent], bool]] = None,
+        filter_: Optional[Callable[[Component], bool]] = None,
     ):
         """
         Removes all components from the tree, starting at this component,
@@ -104,7 +104,8 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         names:
             The list of names of each component to search for.
         filter_:
-            A callable to filter PhysicalComponents from the Component tree
+            A callable to filter Components from the Component tree,
+            returning True keeps the node False removes it
 
         Notes
         -----
@@ -128,11 +129,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
                         c_sib.parent = None
 
                 for c_child in c.descendants:
-                    if (
-                        isinstance(c_child, PhysicalComponent)
-                        and filter_ is not None
-                        and not filter_(c_child)
-                    ):
+                    if filter_ is not None and not filter_(c_child):
                         c_child.parent = None
 
     def tree(self) -> str:

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -269,7 +269,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
             ]
             return tuple(map(list, zip(*node_properties)))
 
-    def _get_thing(self, filter_: Callable, first: bool, full_tree: bool):
+    def _get_thing(self, filter_: Union[Callable, None], first: bool, full_tree: bool):
         found_nodes = anytree.search.findall(
             self.root if full_tree else self, filter_=filter_
         )

--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -89,7 +89,11 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         """
         return self.name + " (" + self.__class__.__name__ + ")"
 
-    def filter_components(self, names: Iterable[str], filter_: Optional[Callable[[anytree.Node], bool]] = None):
+    def filter_components(
+        self,
+        names: Iterable[str],
+        filter_: Optional[Callable[[anytree.Node], bool]] = None,
+    ):
         """
         Removes all components from the tree, starting at this component,
         that are siblings of each component specified in `names`

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -22,7 +22,7 @@
 
 import abc
 import time
-from typing import Callable, Iterable, List, Optional, Tuple, Type, Union
+from typing import Callable, List, Optional, Tuple, Type, Union
 from warnings import warn
 
 import anytree
@@ -164,6 +164,18 @@ class BaseManager(abc.ABC):
 
 
 class FilterMaterial:
+    """
+    Filter nodes by material
+
+    Parameters
+    ----------
+    material:
+       materials to include
+    not_material:
+       materials to exclude
+
+    """
+
     def __init__(
         self,
         material: Union[
@@ -176,7 +188,8 @@ class FilterMaterial:
         self.material = material
         self.not_material = not_material
 
-    def __call__(self, node: anytree.Node):
+    def __call__(self, node: anytree.Node) -> bool:
+        """Filter node based on material include and exclude rules"""
         return hasattr(node, "material") and self._filterer(node.material)
 
     def _filterer(

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -175,9 +175,9 @@ class FilterMaterial:
 
     Parameters
     ----------
-    material:
+    keep_material:
        materials to include
-    not_material:
+    reject_material:
        materials to exclude
 
     """

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -22,7 +22,7 @@
 
 import abc
 import time
-from typing import Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 from warnings import warn
 
 import anytree
@@ -191,12 +191,23 @@ class FilterMaterial:
             Type[SerialisedMaterial], Tuple[Type[SerialisedMaterial]], None
         ] = Void,
     ):
-        self.material = material
-        self.not_material = not_material
+        super().__setattr__("material", material)
+        super().__setattr__("not_material", not_material)
 
     def __call__(self, node: anytree.Node) -> bool:
         """Filter node based on material include and exclude rules"""
         return hasattr(node, "material") and self._filterer(node.material)
+
+    def __setattr__(self, name: str, value: Any):
+        """
+        Override setattr to force immutability
+
+        This method makes the class nearly immutable as no new attributes
+        can be modified or added by standard methods.
+
+        See #2236 discussion_r1191246003 for further details
+        """
+        raise AttributeError(f"{type(self).__name__} is immutable")
 
     def _filterer(
         self, material: Union[SerialisedMaterial, Tuple[SerialisedMaterial]]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2207 
Closes #2163 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This PR adds some filtering opportunities to the `ComponentManager` and `Reactor` it doesn't use the  `Component._get_thing` filtering mechanism that I add last year (and forgot about) so that the tree is kept intact in the filtering. 

At the moment you can only filter on `PhysicalComponent` properties which I will try and find a way around but as `Component` doesnt hold and information and is just a node linker that may be acceptable. We can already filter by node with the combination of `with_component` and `dims`.

UPDATE: restriction removed

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
