### PR TITLE
Check constraints in optimisations

### DIFF
--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -1145,7 +1145,7 @@ def signed_distance_2D_polygon(
 
     Parameters
     ----------
-    subject_poly
+    subject_poly:
         Subject 2-D polygon
     target_poly:
         Target 2-D polygon

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -33,14 +33,13 @@ from bluemira.optimisation._geometry.typing import (
     GeomOptimiserCallable,
     GeomOptimiserObjective,
 )
-from bluemira.optimisation._optimise import optimise
-from bluemira.optimisation._optimiser import OptimiserResult
+from bluemira.optimisation._optimise import OptimisationResult, optimise
 
 _GeomT = TypeVar("_GeomT", bound=GeometryParameterisation)
 
 
 @dataclass
-class GeomOptimiserResult(OptimiserResult, Generic[_GeomT]):
+class GeomOptimiserResult(OptimisationResult, Generic[_GeomT]):
     """Container for the result of a geometry optimisation."""
 
     geom: _GeomT

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -20,7 +20,6 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Definition of the generic `optimise` function."""
 
-from dataclasses import asdict, dataclass
 from pprint import pformat
 from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 
@@ -38,18 +37,6 @@ from bluemira.optimisation.typing import (
 )
 
 
-@dataclass
-class OptimisationResult(OptimiserResult):
-    """The result of a call to :func:`.optimise`."""
-
-    constraints_satisfied: Union[bool, None]
-    """
-    Whether all constraints have been satisfied to within the required tolerance.
-
-    Is ``None`` if constraints have not been checked.
-    """
-
-
 def optimise(
     f_objective: ObjectiveCallable,
     df_objective: Optional[OptimiserCallable] = None,
@@ -64,7 +51,7 @@ def optimise(
     ineq_constraints: Iterable[ConstraintT] = (),
     keep_history: bool = False,
     check_constraints: bool = True,
-) -> OptimisationResult:
+) -> OptimiserResult:
     r"""
     Find the parameters that minimise the given objective function.
 
@@ -194,12 +181,9 @@ def optimise(
         keep_history,
     )
     result = optimiser.optimise(x0)
-    constraints_satisfied = None
     if check_constraints:
-        constraints_satisfied = _check_constraints(result.x, ineq_constraints)
-    return OptimisationResult(
-        **asdict(result), constraints_satisfied=constraints_satisfied
-    )
+        result.constraints_satisfied = _check_constraints(result.x, ineq_constraints)
+    return result
 
 
 def _make_optimiser(

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -142,10 +142,10 @@ def optimise(
         Whether to record the history of each step of the optimisation.
         (default: False)
     check_constraints:
-        Whether to check whether all constraints have been
-        satisfied at the end of the optimisation, and warn if they have
-        not. Note that, if this is set to False, the result's
-        ``constraints_satisfied`` attribute will be set to ``None``.
+        Whether to check all constraints have been satisfied at the end
+        of the optimisation, and warn if they have not. Note that, if
+        this is set to False, the result's ``constraints_satisfied``
+        attribute will be set to ``None``.
 
     Returns
     -------

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -164,8 +164,8 @@ def optimise(
     if opt_conditions is None:
         opt_conditions = {"max_eval": 2000}
     bounds = _process_bounds(bounds, dimensions)
-    # Convert to list, as it could be an iterable, and we may need to
-    # consume it more than once.
+    # Convert to lists, as these could be generators, and we may need to
+    # consume them more than once.
     eq_constraints = list(eq_constraints)
     ineq_constraints = list(ineq_constraints)
 

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Definition of the generic `optimise` function."""
 
+from dataclasses import asdict, dataclass
 from pprint import pformat
 from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 
@@ -37,6 +38,11 @@ from bluemira.optimisation.typing import (
 )
 
 
+@dataclass
+class OptimisationResult(OptimiserResult):
+    constraints_satisfied: Union[bool, None]
+
+
 def optimise(
     f_objective: ObjectiveCallable,
     df_objective: Optional[OptimiserCallable] = None,
@@ -51,7 +57,7 @@ def optimise(
     ineq_constraints: Iterable[ConstraintT] = (),
     keep_history: bool = False,
     check_constraints: bool = True,
-) -> OptimiserResult:
+) -> OptimisationResult:
     r"""
     Find the parameters that minimise the given objective function.
 
@@ -181,9 +187,12 @@ def optimise(
         keep_history,
     )
     result = optimiser.optimise(x0)
+    constraints_satisfied = None
     if check_constraints:
-        _check_constraints(result.x, ineq_constraints)
-    return result
+        constraints_satisfied = _check_constraints(result.x, ineq_constraints)
+    return OptimisationResult(
+        **asdict(result), constraints_satisfied=constraints_satisfied
+    )
 
 
 def _make_optimiser(

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -40,7 +40,14 @@ from bluemira.optimisation.typing import (
 
 @dataclass
 class OptimisationResult(OptimiserResult):
+    """The result of a call to :func:`.optimise`."""
+
     constraints_satisfied: Union[bool, None]
+    """
+    Whether all constraints have been satisfied to within the required tolerance.
+
+    Is ``None`` if constraints have not been checked.
+    """
 
 
 def optimise(
@@ -148,10 +155,10 @@ def optimise(
         Whether to record the history of each step of the optimisation.
         (default: False)
     check_constraints:
-        Whether to check, and warn, whether all constraints have been
-        satisfied at the end of the optimisation. Note that, if this
-        is set to False, the result will mark constraints as satisfied.
-        Default is True.
+        Whether to check whether all constraints have been
+        satisfied at the end of the optimisation, and warn if they have
+        not. Note that, if this is set to False, the result's
+        ``constraints_satisfied`` attribute will be set to ``None``.
 
     Returns
     -------

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -22,7 +22,7 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -41,6 +41,12 @@ class OptimiserResult:
     """The number of evaluations of the objective function in the optimisation."""
     history: List[Tuple[np.ndarray, float]] = field(repr=False)
     """The history of the parametrisation at each iteration."""
+    constraints_satisfied: Union[bool, None] = None
+    """
+    Whether all constraints have been satisfied to within the required tolerance.
+
+    Is ``None`` if constraints have not been checked.
+    """
 
 
 class Optimiser(abc.ABC):

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -22,7 +22,7 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -34,9 +34,13 @@ class OptimiserResult:
     """Container for optimiser results."""
 
     f_x: float
+    """The evaluation of the optimised parameterisation."""
     x: np.ndarray
+    """The optimised parameterisation."""
     n_evals: int
-    history: List[np.ndarray] = field(repr=False)
+    """The number of evaluations of the objective function in the optimisation."""
+    history: List[Tuple[np.ndarray, float]] = field(repr=False)
+    """The history of the parametrisation at each iteration."""
 
 
 class Optimiser(abc.ABC):

--- a/tests/optimisation/test_optimise.py
+++ b/tests/optimisation/test_optimise.py
@@ -244,3 +244,30 @@ class TestOptimise:
 
         assert result.constraints_satisfied is None
         assert bm_warn_mock.call_count == 0
+
+    @mock.patch("bluemira.optimisation._optimise.bluemira_warn")
+    def test_no_warnings_given_constraints_satisfied(self, bm_warn_mock):
+        def f_objective(x):
+            return np.sqrt(x[1])
+
+        def f_ineq_constraint(x):
+            return np.sum(x) - 5
+
+        def f_eq_constraint(x):
+            return abs(x[0] - x[1])
+
+        result = optimise(
+            f_objective,
+            x0=np.array([1, 1]),
+            opt_conditions={"max_eval": 1},
+            eq_constraints=[
+                {"f_constraint": f_eq_constraint, "tolerance": np.array([1e-8])}
+            ],
+            ineq_constraints=[
+                {"f_constraint": f_ineq_constraint, "tolerance": np.array([1e-8])}
+            ],
+            check_constraints=True,
+        )
+
+        assert result.constraints_satisfied is True
+        assert bm_warn_mock.call_count == 0

--- a/tests/optimisation/test_optimise.py
+++ b/tests/optimisation/test_optimise.py
@@ -18,7 +18,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
-import re
 from unittest import mock
 
 import numpy as np
@@ -211,8 +210,9 @@ class TestOptimise:
 
         bm_warn_mock.assert_called_once()
         message = bm_warn_mock.call_args[0][0].lower()
-        assert re.search(r"constraints .*not .*satisfied", message)
-        assert constraint_type in message
+        assert all(
+            m in message for m in ["constraints", "not", "satisfied", constraint_type]
+        )
         assert result.constraints_satisfied is False
 
     @mock.patch("bluemira.optimisation._optimise.bluemira_warn")

--- a/tests/optimisation/test_optimise.py
+++ b/tests/optimisation/test_optimise.py
@@ -210,9 +210,9 @@ class TestOptimise:
 
         bm_warn_mock.assert_called_once()
         message = bm_warn_mock.call_args[0][0].lower()
-        assert all(
-            m in message for m in ["constraints", "not", "satisfied", constraint_type]
-        )
+        comp_str = "!<" if constraint_type == "ineq" else "!="
+        msg_strs = ["constraints", "not", "satisfied", constraint_type, comp_str]
+        assert all(m in message for m in msg_strs)
         assert result.constraints_satisfied is False
 
     @mock.patch("bluemira.optimisation._optimise.bluemira_warn")


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Partly addresses #2256.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Adds code to `optimise` that checks whether inequality constraints have been satisfied within tolerance, and prints a warning if not.

I've changed the warning message ever so slightly, it now shows the constraint type and number, and the index into that constraint vector when warning of a violated constraint - instead of concatenating all the constraints into one long vector. I think this makes it a bit clearer which constraints are being violated - we could even consider adding the ability to label a constraint in the future.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
