### PR TITLE
📝 Add reactor docs to introduction

### DIFF
--- a/documentation/source/base/components.rst
+++ b/documentation/source/base/components.rst
@@ -1,18 +1,18 @@
 Reactors, Components and Managers
 =================================
 
-:py:class:`Components` are the fundamental building blocks of a bluemira design.
-A :py:class:`Component` is a physical object or a group of physical objects, organised in a tree structure.
-A user may want access to some properties associated with a :py:class:`Component` that are related
+:py:class:`~bluemira.base.components.Component`\s are the fundamental building blocks of a bluemira design.
+A :py:class:`~bluemira.base.components.Component` is a physical object or a group of physical objects, organised in a tree structure.
+A user may want access to some properties associated with a :py:class:`~bluemira.base.components.Component` that are related
 but not directly connected to the physical object.
-For this reason we have :py:class:`ComponentManagers` which can provide helper functions for common operations or
-have extra information stored such as the equilibira in a plasma :py:class:`ComponentManager`.
-To manage a set of :py:class:`ComponentManagers` a `Reactor` class is used which represents the full reactor object.
+For this reason we have :py:class:`~bluemira.base.reactor.ComponentManager`\s which can provide helper functions for common operations or
+have extra information stored such as the equilibira in a plasma :py:class:`~bluemira.base.reactor.ComponentManager`.
+To manage a set of :py:class:`~bluemira.base.reactor.ComponentManager`\s a :py:class:`~bluemira.base.reactor.Reactor` class is used which represents the full reactor object.
 
 The Component class
 -------------------
 
-Two types of :py:class:`Component` classes are defined that can be used to represent different parts of a design:
+Two types of :py:class:`~bluemira.base.components.Component` classes are defined that can be used to represent different parts of a design:
 
 - :py:class:`bluemira.base.components.Component` is the base class and defines the
   framework on which other components can be defined within bluemira.
@@ -24,7 +24,7 @@ Two types of :py:class:`Component` classes are defined that can be used to repre
   As implementations of :py:class:`bluemira.base.components.PhysicalComponent` correspond to a physical object,
   instances of that class can be defined with a shape and a material.
 
-A :py:class:`Component` can be used as shown below:
+A :py:class:`~bluemira.base.components.Component` can be used as shown below:
 
 .. code-block:: pycon
 
@@ -45,8 +45,8 @@ A :py:class:`Component` can be used as shown below:
 ComponentManagers
 -----------------
 
-:py:class:`ComponentManagers` are designed to be created by the :ref:`Reactor Designer <how to use>`.
-The aim is to make it easier to access logically associated properties of a :py:class:`Component` that may not be directly connected to the physical object.
+:py:class:`~bluemira.base.reactor.ComponentManager`\s are designed to be created by the :ref:`Reactor Designer <how to use>`.
+The aim is to make it easier to access logically associated properties of a :py:class:`~bluemira.base.components.Component` that may not be directly connected to the physical object.
 It also can contain helper methods to ease access of specific sections of geometry,
 for instance the separatrix of a plasma.
 
@@ -64,15 +64,15 @@ for instance the separatrix of a plasma.
                 .shape.boundary[0]
             )
 
-A :py:class:`ComponentManager` should be how a :py:class:`Component` is used after creation within the top level of the reactor design.
+A :py:class:`~bluemira.base.reactor.ComponentManager` should be how a :py:class:`~bluemira.base.components.Component` is used after creation within the top level of the reactor design.
 
 Reactor
 -------
 
-:py:class:`Reactors` are again designed to be created by the :ref:`Reactor Designer <how to use>`.
+:py:class:`~bluemira.base.reactor.Reactor`\s are again designed to be created by the :ref:`Reactor Designer <how to use>`.
 This object is the complete reactor and is a container that allows easy access to any part of it.
-Methods on the :py:class:`Reactor` object have access to all parts of the reactor
-enabling functionality that needs to interact with multiple :py:class:`ComponentManagers`.
+Methods on the :py:class:`~bluemira.base.reactor.Reactor` object have access to all parts of the reactor
+enabling functionality that needs to interact with multiple :py:class:`~bluemira.base.reactor.ComponentManager`\s.
 
 .. code-block:: python
 
@@ -90,9 +90,8 @@ enabling functionality that needs to interact with multiple :py:class:`Component
     reactor.tf_coils = build_tf_coils()
     reactor.show_cad()
 
-A :py:class:`Reactor` interacts dynamically with :py:class:`ComponentManagers`.
-All the default methods on :py:class:`Reactor` such as :py:meth:`show_cad` will act
-on the currently available :py:class:`ComponentManagers` ignoring unavailable parts
-of the reactor. If a :py:class:`Component` is directly added to a :py:class:`Reactor`
-and not wrapped in a :py:class:`ComponentManagers` it will be ignored by the
-:py:class:`Reactor` methods.
+A :py:class:`~bluemira.base.reactor.Reactor` interacts dynamically with :py:class:`~bluemira.base.reactor.ComponentManager`\s.
+All the default methods on :py:class:`~bluemira.base.reactor.Reactor` such as :py:meth:`show_cad` will act
+on the currently available :py:class:`~bluemira.base.reactor.ComponentManager`\s ignoring unavailable parts
+of the reactor. If a :py:class:`~bluemira.base.components.Component` is directly added to a :py:class:`~bluemira.base.reactor.Reactor`
+and not wrapped in a :py:class:`~bluemira.base.reactor.ComponentManager`\s it will be ignored by the :py:class:`~bluemira.base.reactor.Reactor` methods.

--- a/documentation/source/base/components.rst
+++ b/documentation/source/base/components.rst
@@ -7,6 +7,7 @@ A user may want access to some properties associated with a :py:class:`Component
 but not directly connected to the physical object.
 For this reason we have :py:class:`ComponentManagers` which can provide helper functions for common operations or
 have extra information stored such as the equilibira in a plasma :py:class:`ComponentManager`.
+To manage a set of :py:class:`ComponentManagers` a `Reactor` class is used which represents the full reactor object.
 
 The Component class
 -------------------
@@ -67,3 +68,31 @@ A :py:class:`ComponentManager` should be how a :py:class:`Component` is used aft
 
 Reactor
 -------
+
+:py:class:`Reactors` are again designed to be created by the :ref:`Reactor Designer <how to use>`.
+This object is the complete reactor and is a container that allows easy access to any part of it.
+Methods on the :py:class:`Reactor` object have access to all parts of the reactor
+enabling functionality that need to interact with multiple :py:class:`ComponentManagers`.
+
+.. code-block:: python
+
+    class MyReactor(Reactor):
+        '''An example of how to declare a reactor structure.'''
+
+        plasma: MyPlasma
+        tf_coils: MyTfCoils
+
+        def get_ripple(self):
+            '''Calculate the ripple in the TF coils.'''
+
+    reactor = MyReactor("My Reactor")
+    reactor.plasma = build_plasma()
+    reactor.tf_coils = build_tf_coils()
+    reactor.show_cad()
+
+A :py:class:`Reactor` interacts dynamically with :py:class:`ComponentManagers`.
+All the default methods on :py:class:`Reactor` such as :py:method:`show_cad` will act
+on the currently available :py:class:`ComponentManagers` ignoring unavailable parts
+of the reactor. If a :py:class:`Component` is directly added to a :py:class:`Reactor`
+and not wrapped in a :py:class:`ComponentManagers` it will be ignored by the :py:class
+:`Reactor` methods.

--- a/documentation/source/base/components.rst
+++ b/documentation/source/base/components.rst
@@ -1,5 +1,5 @@
-Components
-==========
+Reactors, Components and Managers
+=================================
 
 :py:class:`Components` are the fundamental building blocks of a bluemira design.
 A :py:class:`Component` is a physical object or a group of physical objects, organised in a tree structure.
@@ -64,3 +64,6 @@ for instance the separatrix of a plasma.
             )
 
 A :py:class:`ComponentManager` should be how a :py:class:`Component` is used after creation within the top level of the reactor design.
+
+Reactor
+-------

--- a/documentation/source/base/components.rst
+++ b/documentation/source/base/components.rst
@@ -91,7 +91,7 @@ enabling functionality that need to interact with multiple :py:class:`ComponentM
     reactor.show_cad()
 
 A :py:class:`Reactor` interacts dynamically with :py:class:`ComponentManagers`.
-All the default methods on :py:class:`Reactor` such as :py:method:`show_cad` will act
+All the default methods on :py:class:`Reactor` such as :py:meth:`show_cad` will act
 on the currently available :py:class:`ComponentManagers` ignoring unavailable parts
 of the reactor. If a :py:class:`Component` is directly added to a :py:class:`Reactor`
 and not wrapped in a :py:class:`ComponentManagers` it will be ignored by the :py:class

--- a/documentation/source/base/components.rst
+++ b/documentation/source/base/components.rst
@@ -72,7 +72,7 @@ Reactor
 :py:class:`Reactors` are again designed to be created by the :ref:`Reactor Designer <how to use>`.
 This object is the complete reactor and is a container that allows easy access to any part of it.
 Methods on the :py:class:`Reactor` object have access to all parts of the reactor
-enabling functionality that need to interact with multiple :py:class:`ComponentManagers`.
+enabling functionality that needs to interact with multiple :py:class:`ComponentManagers`.
 
 .. code-block:: python
 
@@ -94,5 +94,5 @@ A :py:class:`Reactor` interacts dynamically with :py:class:`ComponentManagers`.
 All the default methods on :py:class:`Reactor` such as :py:meth:`show_cad` will act
 on the currently available :py:class:`ComponentManagers` ignoring unavailable parts
 of the reactor. If a :py:class:`Component` is directly added to a :py:class:`Reactor`
-and not wrapped in a :py:class:`ComponentManagers` it will be ignored by the :py:class
-:`Reactor` methods.
+and not wrapped in a :py:class:`ComponentManagers` it will be ignored by the
+:py:class:`Reactor` methods.

--- a/documentation/source/base/design_build.dot
+++ b/documentation/source/base/design_build.dot
@@ -86,9 +86,14 @@ digraph {
 
     }
     a -> d [group=g1, ltail=cluster_0, lhead=cluster_1, minlen=2];
-    d -> f [ltail=cluster_1, lhead=cluster_3, minlen=2];
+    d -> f [ltail=cluster_1, minlen=2];
     e -> reac [ltail=cluster_2, minlen=2];
     f -> reac [ltail=cluster_3, minlen=2];
 
-    reac[label="Reactor", tooltip="Reactor"]
+    reac[
+           label="Reactor", tooltip="Reactor",
+           href="../base/components.html#reactor",
+           target="_parent",
+           fontcolor="#2980b9"
+    ]
 }

--- a/documentation/source/base/design_build.dot
+++ b/documentation/source/base/design_build.dot
@@ -63,7 +63,7 @@ digraph {
         e[
             label="Component",
             tooltip="Component",
-            href="../base/components.html#components",
+            href="../base/components.html#reactors-components-and-managers",
             target="_parent",
             fontcolor="#2980b9"
         ]
@@ -79,7 +79,7 @@ digraph {
         f[
             label="Component",
             tooltip="Component",
-            href="../base/components.html#components",
+            href="../base/components.html#reactors-components-and-managers",
             target="_parent",
             fontcolor="#2980b9"
         ]


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Adds documentation of the Reactor object to the base module docs and links to it from the introduction.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
