### PR TITLE
🐛 Fix collect verts and faces for polyscope viewing

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1997,7 +1997,7 @@ def collect_verts_faces(
         # tesselation is likely to be the most expensive part of this
         v, f = face.tessellate(tesselation)
 
-        if v != []:
+        if v != [] and f != []:
             verts.append(np.array(v))
             faces.append(np.array(f) + voffset)
             voffset += len(v)

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1997,9 +1997,10 @@ def collect_verts_faces(
         # tesselation is likely to be the most expensive part of this
         v, f = face.tessellate(tesselation)
 
-        if v != [] and f != []:
+        if v != []:
             verts.append(np.array(v))
-            faces.append(np.array(f) + voffset)
+            if f != []:
+                faces.append(np.array(f) + voffset)
             voffset += len(v)
 
     if len(solid.Faces) > 0:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When testing #2167 it would error with the polyscope backed because we were trying to stack empty arrays. 
This fixes that

my test line:
```python
from bluemira.base.reactor import FilterMaterial, Void

reactor.show_cad("xyz", n_sectors=3, filter_=FilterMaterial(keep_material=Void, reject_material=None), backend='polyscope')
```
## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
