### PR TITLE
🚸 Force type of max eval

### DIFF
--- a/bluemira/optimisation/_nlopt/conditions.py
+++ b/bluemira/optimisation/_nlopt/conditions.py
@@ -42,6 +42,9 @@ class NLOptConditions:
             raise OptimisationConditionsError(
                 "Must specify at least one stopping condition for the optimiser."
             )
+        if self.max_eval is not None and isinstance(self.max_eval, float):
+            bluemira_warn("optimisation: max_eval must be an integer, forcing type.")
+            self.max_eval = int(self.max_eval)
 
     def _no_stopping_condition_set(self) -> bool:
         return all(

--- a/tests/optimisation/test_nlopt.py
+++ b/tests/optimisation/test_nlopt.py
@@ -104,6 +104,14 @@ class TestNloptOptimiser:
         with pytest.raises(OptimisationConditionsError):
             NloptOptimiser("SLSQP", 5, no_op)
 
+    def test_warning_raised_if_max_eval_is_float(self, caplog):
+        NloptOptimiser("SLSQP", 5, no_op, opt_conditions={"ftol_abs": 1, "max_eval": 5})
+        assert len(caplog.records) == 0
+        NloptOptimiser(
+            "SLSQP", 5, no_op, opt_conditions={"ftol_abs": 1, "max_eval": 1e6}
+        )
+        assert len(caplog.records) == 1
+
     @pytest.mark.parametrize(
         "string, enum_value, nlopt_enum",
         [


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When setting the stopping conditions eg `{"max_eval": 1e6}` this will try and convert floats to ints (with a warning). It feels a bit more user friendly to me.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
