### PR TITLE
Remove keep in zones

### DIFF
--- a/bluemira/optimisation/_geometry/_tools.py
+++ b/bluemira/optimisation/_geometry/_tools.py
@@ -125,29 +125,6 @@ def make_keep_out_zone_constraint(
     return {"f_constraint": _f_constraint, "tolerance": np.full(real_n_discr, tol)}
 
 
-def make_keep_in_zone_constraint(
-    kiz: BluemiraWire,
-    n_discr: int = _DEFAULT_ZONE_DISCR,
-    tol: float = _DEFAULT_ZONE_TOL,
-) -> GeomConstraintT:
-    """Make a keep-in zone inequality constraint from a wire."""
-    if not kiz.is_closed():
-        raise GeometryOptimisationError(
-            f"Keep-in zone with label '{kiz.label}' is not closed."
-        )
-    kiz_points = kiz.discretize(n_discr, byedges=True).xz
-    # As we're discretizing by edges, we may not get exactly the number
-    # of points we ask for, especially if n_discr is small.
-    real_n_discr = kiz_points.shape[1]
-
-    def _f_constraint(geom: GeometryParameterisation) -> np.ndarray:
-        return -calculate_signed_distance(
-            geom, n_shape_discr=real_n_discr, zone_points=kiz_points
-        )
-
-    return {"f_constraint": _f_constraint, "tolerance": np.full(real_n_discr, tol)}
-
-
 def get_shape_ineq_constraint(geom: GeometryParameterisation) -> List[GeomConstraintT]:
     """
     Retrieve the inequality constraints registered for the given parameterisation.

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -72,7 +72,6 @@ def optimise_geometry(
     df_objective: Optional[GeomOptimiserCallable] = None,
     *,
     keep_out_zones: Iterable[BluemiraWire] = (),
-    keep_in_zones: Iterable[BluemiraWire] = (),
     algorithm: Union[Algorithm, str] = Algorithm.SLSQP,
     opt_conditions: Optional[Mapping[str, Union[int, float]]] = None,
     opt_parameters: Optional[Mapping[str, Any]] = None,
@@ -80,7 +79,6 @@ def optimise_geometry(
     ineq_constraints: Iterable[GeomConstraintT] = (),
     keep_history: bool = False,
     koz_discretisation: Union[int, Iterable[int]] = 100,
-    kiz_discretisation: Union[int, Iterable[int]] = 100,
 ) -> GeomOptimiserResult[_GeomT]:
     r"""
     Minimise the given objective function for a geometry parameterisation.
@@ -103,9 +101,6 @@ def optimise_geometry(
     keep_out_zones:
         An iterable of closed wires, defining areas the geometry must
         not intersect.
-    keep_in_zones:
-        An iterable list of closed wires, defining areas the geometry
-        must wholly lie within.
     algorithm:
         The optimisation algorithm to use, by default ``Algorithm.SLSQP``.
     opt_conditions:
@@ -184,13 +179,6 @@ def optimise_geometry(
         keep-out zone is discretised using value in the i-th item.
         The iterable should have the same number of items as
         ``keep_out_zones``.
-    kiz_discretisation:
-        The number of points to discretise the keep-in zone(s) over.
-        If this is an int, all keep-in zones will be discretised with
-        the same number of points. If this is an iterable, each i-th
-        keep-in zone is discretised using value in the i-th item.
-        The iterable should have the same number of items as
-        ``keep_in_zones``.
 
     Returns
     -------
@@ -208,10 +196,6 @@ def optimise_geometry(
     for koz, discr in zip_with_scalar(keep_out_zones, koz_discretisation):
         ineq_constraints_list.append(
             _tools.make_keep_out_zone_constraint(koz, n_discr=discr)
-        )
-    for kiz, discr in zip_with_scalar(keep_in_zones, kiz_discretisation):
-        ineq_constraints_list.append(
-            _tools.make_keep_in_zone_constraint(kiz, n_discr=discr)
         )
 
     result = optimise(

--- a/bluemira/optimisation/_geometry/problem.py
+++ b/bluemira/optimisation/_geometry/problem.py
@@ -88,15 +88,6 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
         """
         return []
 
-    def keep_in_zones(self) -> List[BluemiraWire]:
-        """
-        List of geometric keep-in zones.
-
-        An iterable list of closed wires, defining areas the geometry
-        must wholly lie within.
-        """
-        return []
-
     def optimise(
         self,
         geom: _GeomT,
@@ -106,7 +97,6 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
         opt_parameters: Optional[Mapping[str, Any]] = None,
         keep_history: bool = False,
         koz_discretisation: Union[int, Iterable[int]] = 100,
-        kiz_discretisation: Union[int, Iterable[int]] = 100,
     ) -> GeomOptimiserResult[_GeomT]:
         """
         Run the geometry optimisation.
@@ -126,7 +116,6 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
             f_objective=self.objective,
             df_objective=df_objective,
             keep_out_zones=self.keep_out_zones(),
-            keep_in_zones=self.keep_in_zones(),
             algorithm=algorithm,
             opt_conditions=opt_conditions,
             opt_parameters=opt_parameters,
@@ -134,5 +123,4 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
             ineq_constraints=self.ineq_constraints(),
             keep_history=keep_history,
             koz_discretisation=koz_discretisation,
-            kiz_discretisation=kiz_discretisation,
         )

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -63,33 +63,6 @@ class TestGeometry:
                 PictureFrame(), f_objective=lambda _: 1, keep_out_zones=kozs
             )
 
-    @pytest.mark.parametrize(
-        "kizs",
-        [
-            [
-                make_polygon(
-                    np.array([[3, 13, 13, 3], [0, 0, 0, 0], [-5, -5, 6, 6]]),
-                    closed=False,
-                )
-            ],
-            [
-                make_polygon(
-                    np.array([[3, 13, 13, 3], [0, 0, 0, 0], [-5, -5, 6, 6]]),
-                    closed=True,
-                ),
-                make_polygon(
-                    np.array([[3, 13, 13, 3], [0, 0, 0, 0], [-5, -5, 6, 6]]),
-                    closed=False,
-                ),
-            ],
-        ],
-    )
-    def test_GeometryOptimisationError_given_unclosed_kiz(self, kizs):
-        with pytest.raises(GeometryOptimisationError):
-            optimise_geometry(
-                PictureFrame(), f_objective=lambda _: 1, keep_in_zones=kizs
-            )
-
     def test_simple_optimisation_with_keep_out_zone(self):
         def length(geom: GeometryParameterisation):
             return geom.create_shape().length
@@ -167,38 +140,6 @@ class TestGeometry:
         signed_dist = signed_distance(opt_shape, keep_out_zone)
         # The PrincetonD should fully enclose the keep-out zone
         np.testing.assert_array_less(signed_dist, np.zeros_like(signed_dist))
-
-    def test_maximise_length_with_keep_in_zone_with_TripleArc(self):
-        # Make a rectangular keep-in zone and check the TripleArc
-        # respects the bounds. Note that in this example we expect the
-        # height of the TripleArc to match the height of the keep-in
-        # zone, and the width of the TripleArc should be less than the
-        # width of the keep-in zone.
-        arc = TripleArc(
-            {
-                "x1": {"value": 3.5, "lower_bound": 2.75},
-                "dz": {"value": 0},
-            }
-        )
-        kiz = make_polygon(
-            np.array([[3, 13, 13, 3], [0, 0, 0, 0], [-5, -5, 6, 6]]), closed=True
-        )
-
-        result = optimise_geometry(
-            arc,
-            f_objective=lambda geom: -geom.create_shape().length,
-            keep_in_zones=(kiz,),
-            algorithm="SLSQP",
-            opt_conditions={"max_eval": 5000, "ftol_rel": 1e-6},
-        )
-
-        opt_shape = result.geom.create_shape()
-        assert opt_shape.center_of_mass[2] == pytest.approx(0.5, rel=0.01)
-        bbox = opt_shape.bounding_box
-        assert bbox.z_min == pytest.approx(-5, rel=0.01)
-        assert bbox.z_max == pytest.approx(6, rel=0.01)
-        assert bbox.x_min >= 3
-        assert bbox.x_max * 0.99905 <= 13
 
     def test_maximise_angles_with_TripleArc(self):
         # Maximise the sum of the angles in a TripleArc. The shape's


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2274 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Removes keep-in zones from `optimise_geometry` and `GeomOptimisationProblem`.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
