### PR TITLE
🐛 Fix show cad and rearrange typing

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -32,11 +32,7 @@ import sys
 from copy import deepcopy
 from dataclasses import dataclass, field
 from types import DynamicClassAttribute
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
-
-if TYPE_CHECKING:
-    from bluemira.geometry.base import BluemiraGeo
-
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 from warnings import warn
 
 import FreeCAD
@@ -2310,7 +2306,7 @@ class DefaultDisplayOptions:
 
 
 def show_cad(
-    parts: Union[BluemiraGeo, List[BluemiraGeo]],
+    parts: Union[apiShape, List[apiShape]],
     options: Union[Dict, List[Optional[Dict]]],
     labels: List[str],
     **kwargs,

--- a/bluemira/codes/_polyscope.py
+++ b/bluemira/codes/_polyscope.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
-
-if TYPE_CHECKING:
-    from bluemira.geometry.base import BluemiraGeo
+from typing import Dict, List, Tuple, Union
 
 import matplotlib.colors as colors
 import numpy as np
@@ -53,7 +50,7 @@ class DefaultDisplayOptions:
 
 
 def show_cad(
-    parts: Union[BluemiraGeo, List[BluemiraGeo]],
+    parts: Union[cadapi.apiShape, List[cadapi.apiShape]],
     part_options: List[Dict],
     labels: List[str],
     **kwargs,
@@ -159,7 +156,7 @@ def _init_polyscope():
 
 def add_features(
     labels: List[str],
-    parts: Union[BluemiraGeo, List[BluemiraGeo]],
+    parts: Union[cadapi.apiShape, List[cadapi.apiShape]],
     options: Union[Dict, List[Dict]],
 ) -> Tuple[List[ps.SurfaceMesh], List[ps.CurveNetwork]]:
     """
@@ -184,7 +181,7 @@ def add_features(
     for shape_i, (label, part, option) in enumerate(
         zip(labels, parts, options),
     ):
-        verts, faces = cadapi.collect_verts_faces(part._shape, option["tesselation"])
+        verts, faces = cadapi.collect_verts_faces(part, option["tesselation"])
 
         if not (verts is None or faces is None):
             m = ps.register_surface_mesh(
@@ -199,7 +196,7 @@ def add_features(
             meshes.append(m)
 
         if option["wires_on"] or (verts is None or faces is None):
-            verts, edges = cadapi.collect_wires(part._shape, Deflection=0.01)
+            verts, edges = cadapi.collect_wires(part, Deflection=0.01)
             c = ps.register_curve_network(
                 clean_name(label, f"{shape_i}_wire"),
                 verts,

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -199,9 +199,12 @@ def show_cad(
         else:
             new_options.append(DisplayCADOptions(**kwargs, backend=backend))
 
-    part_options = [o.as_dict() for o in new_options]
-
-    backend.get_module().show_cad(parts, part_options, labels, **kwargs)
+    backend.get_module().show_cad(
+        [part.shape for part in parts],
+        [o.as_dict() for o in new_options],
+        labels,
+        **kwargs,
+    )
 
 
 class BaseDisplayer(ABC):


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
The merge of #1918 missed a bit of show cad mechanics. It was not caught by our CI because  we patch out viewing of CAD because its headless. Caught by @oliverfunk in https://github.com/Fusion-Power-Plant-Framework/bluemira/pull/2276#discussion_r1205802348.

Bonus it removes the type checking geometry `BluemiraGeo` import from the FreeCAD api.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
It does slightly change the `_freecadapi` interface but nothing user level.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
