### PR TITLE
🎨 Improve freecad saving, examples and tests

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1415,7 +1415,7 @@ def save_cad(
         elif formatt is CADFileType.AUTOCAD:
             mesg += " FreeCAD requires `LibreDWG` to save in this format."
 
-        raise FileNotFoundError(
+        raise FreeCADError(
             f"{mesg} Not able to save object with format: '{formatt.value}'"
         )
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1193,17 +1193,17 @@ class CADFileType(enum.Enum):
     """
 
     # Commented out currently don't function
-    ACSII_STEREO_MESH = ("ast", "Mesh")
+    ASCII_STEREO_MESH = ("ast", "Mesh")
     ADDITIVE_MANUFACTURING = ("amf", "Mesh")
-    # ASC = ("asc", "Points")
-    # AUTOCAD = ("dwg", "importDWG")
+    ASC = ("asc", "Points")
+    AUTOCAD = ("dwg", "importDWG")
     AUTOCAD_DXF = ("dxf", "importDXF")
     # BDF = ("bdf", "feminout.exportNastranMesh")
     BINMESH = ("bms", "Mesh")
     BREP = ("brep", "Part")
     BREP_2 = ("brp", "Part")
     CSG = ("csg", "exportCSG")
-    # DAE = ("dae", "importDAE")
+    DAE = ("dae", "importDAE")
     # DAT = ("dat", "Fem")
     FREECAD = ("FCStd", None)
     # FENICS_FEM = ("xdmf", "feminout.importFenicsMesh")
@@ -1227,29 +1227,29 @@ class CADFileType(enum.Enum):
     OFF = ("off", "Mesh")
     OPENSCAD = ("scad", "exportCSG")
     # PCD = ("pcd", "Points")
-    PDF = ("pdf", "FreeCADGui")
+    # PDF = ("pdf", "FreeCADGui")
     # PLY = ("ply", "Points")
     PLY_STANFORD = ("ply", "Mesh")
     SIMPLE_MODEL = ("smf", "Mesh")
     STEP = ("stp", "ImportGui")
     STEP_2 = ("step", "ImportGui")
-    # STEP_ZIP = ("stpz", "stepZ")
+    STEP_ZIP = ("stpZ", "stepZ")
     STL = ("stl", "Mesh")
     # SVG = ("svg", "DrawingGui")
     # SVG_FLAT = ("svg", "importSVG")
     # TETGEN_FEM = ("poly", "feminout.convert2TetGen")
     THREED_MANUFACTURING = ("3mf", "Mesh")
     # UNV = ("unv", "Fem")
-    VRML = ("vrml", "FreeCADGui")
-    VRML_2 = ("wrl", "FreeCADGui")
-    VRML_ZIP = ("wrl.gz", "FreeCADGui")
-    VRML_ZIP_2 = ("wrz", "FreeCADGui")
+    # VRML = ("vrml", "FreeCADGui")
+    # VRML_2 = ("wrl", "FreeCADGui")
+    # VRML_ZIP = ("wrl.gz", "FreeCADGui")
+    # VRML_ZIP_2 = ("wrz", "FreeCADGui")
     # VTK = ("vtk", "Fem")
     # VTU = ("vtu", "Fem")
     # WEBGL = ("html", "importWebGL")
-    WEBGL_X3D = ("xhtml", "FreeCADGui")
-    X3D = ("x3d", "FreeCADGui")
-    X3DZ = ("x3dz", "FreeCADGui")
+    # WEBGL_X3D = ("xhtml", "FreeCADGui")
+    # X3D = ("x3d", "FreeCADGui")
+    # X3DZ = ("x3dz", "FreeCADGui")
     # YAML = ("yaml", "feminout.importYamlJsonMesh")
     # Z88_FEM_MESH = ("z88", "Fem")
     # Z88_FEM_MESH_2 = ("i1.txt", "feminout.importZ88Mesh")
@@ -1402,9 +1402,21 @@ def save_cad(
         ) from imp_err
 
     if not os.path.exists(filename):
+        mesg = f"{filename} not created, filetype not written by FreeCAD."
+        if formatt is CADFileType.IFC_BIM:
+            mesg += " FreeCAD requires `ifcopenshell` to save in this format."
+        elif formatt is CADFileType.DAE:
+            mesg += " FreeCAD requires `pycollada` to save in this format."
+        elif formatt is CADFileType.IFC_BIM_JSON:
+            mesg += (
+                " FreeCAD requires `ifcopenshell` and"
+                " IFCJSON module to save in this format."
+            )
+        elif formatt is CADFileType.AUTOCAD:
+            mesg += " FreeCAD requires `LibreDWG` to save in this format."
+
         raise FileNotFoundError(
-            f"{filename} not created, filetype not written by FreeCAD."
-            f"Possibly no object compatible with '{formatt.value}'"
+            f"{mesg} Not able to save object with format: '{formatt.value}'"
         )
 
 

--- a/examples/geometry/geometry_tutorial.ex.py
+++ b/examples/geometry/geometry_tutorial.ex.py
@@ -86,7 +86,7 @@ from bluemira.geometry.tools import (
     make_circle,
     make_polygon,
     revolve_shape,
-    save_as_STP,
+    save_cad,
     sweep_shape,
 )
 from bluemira.geometry.wire import BluemiraWire
@@ -406,8 +406,8 @@ show_cad([cut_box_1, new_cut_box_1], options=blue_red_options)
 # %% [markdown]
 # ## Exporting geometry
 #
-# At present, only the STEP Assembly format is supported
-# for exporting geometry.
+# Many different CAD file types can be written,
+# for a full list see the `CADFileType` class.
 
 # %%
 # Try saving any shape or group of shapes created above
@@ -416,10 +416,10 @@ show_cad([cut_box_1, new_cut_box_1], options=blue_red_options)
 my_shapes = [cut_box_1]
 # Modify this file path to where you want to save the data.
 my_file_path = "my_tutorial_assembly.STP"
-save_as_STP(
+save_cad(
     my_shapes,
     filename=os.path.join(
         get_bluemira_path("", subfolder="generated_data"), my_file_path
     ),
-    scale=1,
+    unit_scale="metre",
 )

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -80,12 +80,18 @@ def file_exists(good_file_path: str, isfile_ref: str):
 
 def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
     """Create skipif marker for unimportable modules"""
+    skip = []
     for m in module_name:
         try:
             __import__(m)
-            skip = False
+            skip.append(False)
         except ImportError:
-            skip = True
-            break
+            skip.append(True)
 
-    return pytest.mark.skipif(skip, reason=f"{module_name} dependency not found")
+    if len(module_name) == 1:
+        reason = f"dependency {module_name[0]} not found"
+    else:
+        modules = ", ".join(module_name[no] for no, i in enumerate(skip) if i)
+        reason = f"dependencies {modules} not found"
+
+    return pytest.mark.skipif(skip, reason=reason)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -28,6 +28,8 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 
 def combine_text_mock_write_calls(open_mock: mock.MagicMock) -> str:
     """
@@ -74,3 +76,16 @@ def file_exists(good_file_path: str, isfile_ref: str):
 
     with mock.patch(isfile_ref, new=new_isfile) as is_file_mock:
         yield is_file_mock
+
+
+def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
+    """Create skipif marker for unimportable modules"""
+    for m in module_name:
+        try:
+            __import__(m)
+            skip = False
+        except ImportError:
+            skip = True
+            break
+
+    return pytest.mark.skipif(skip, reason=f"{module_name} dependency not found")

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -94,4 +94,4 @@ def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
         modules = ", ".join(module_name[no] for no, i in enumerate(skip) if i)
         reason = f"dependencies {modules} not found"
 
-    return pytest.mark.skipif(skip, reason=reason)
+    return pytest.mark.skipif(any(skip), reason=reason)

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -31,6 +31,7 @@ from FreeCAD import Base, newDocument
 import bluemira.codes._freecadapi as cadapi
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import D_TOLERANCE
+from tests._helpers import skipif_import_error
 
 
 class TestFreecadapi:
@@ -306,27 +307,12 @@ class TestCADFiletype:
         assert cadapi.CADFileType[name] == ftype
         assert cadapi.CADFileType(ftype.value) == ftype
 
-    @pytest.mark.parametrize(
-        "name",
-        ("PDF", "VRML", "VRML_2", "VRML_ZIP", "VRML_ZIP_2", "WEBGL_X3D", "X3D", "X3DZ"),
-    )
-    def test_exporter_raised_FreeCADError(self, name, tmp_path):
-        """
-        These extensions require more of FreeCAD than we set up
-        Just tracking them.
-        Some of them may work if other packages are installed.
-        """
-
-        with pytest.raises(FreeCADError):
-            filetype = cadapi.CADFileType[name]
-            filetype.exporter([self.shape], f"{tmp_path/'tst'}.{filetype.value}")
-
     # Commented out CADFileTypes dont work with basic shapes tested or needed more
     # FreeCAD imported, should be reviewed in future
     @pytest.mark.parametrize(
         "name",
         (
-            "ACSII_STEREO_MESH",
+            "ASCII_STEREO_MESH",
             "ADDITIVE_MANUFACTURING",
             "AUTOCAD_DXF",
             "BINMESH",
@@ -349,39 +335,27 @@ class TestCADFiletype:
             "SIMPLE_MODEL",
             "STEP",
             "STEP_2",
+            "STEP_ZIP",  # Case sensitive extension
             "STL",
             "THREED_MANUFACTURING",
-            # ifcopenshell package required
-            pytest.param("IFC_BIM", marks=[pytest.mark.xfail]),
-            pytest.param("IFC_BIM_JSON", marks=[pytest.mark.xfail]),
+            pytest.param("IFC_BIM", marks=[skipif_import_error("ifcopenshell")]),
+            pytest.param(
+                "IFC_BIM_JSON",  # github.com/buildingSMART/ifcJSON
+                marks=[skipif_import_error("ifcopenshell", "ifcjson")],
+            ),
+            pytest.param("DAE", marks=[skipif_import_error("collada")]),
+            pytest.param("AUTOCAD", marks=[pytest.mark.xfail]),  # LibreDWG required
             # # Part.Feature has no compatible object type, find compatible object type
-            # pytest.param("ASC", marks=[pytest.mark.xfail]),
-            # pytest.param("BDF", marks=[pytest.mark.xfail]),
-            # pytest.param("DAT", marks=[pytest.mark.xfail]),
-            # pytest.param("FENICS_FEM", marks=[pytest.mark.xfail]),
-            # pytest.param("FENICS_FEM_XML", marks=[pytest.mark.xfail]),
-            # pytest.param("INP", marks=[pytest.mark.xfail]),
-            # pytest.param("MED", marks=[pytest.mark.xfail]),
-            # pytest.param("MESHJSON", marks=[pytest.mark.xfail]),
-            # pytest.param("MESHPY", marks=[pytest.mark.xfail]),
-            # pytest.param("MESHYAML", marks=[pytest.mark.xfail]),
-            # pytest.param("PCD", marks=[pytest.mark.xfail]),
-            # pytest.param("PLY", marks=[pytest.mark.xfail]),
-            # pytest.param("TETGEN_FEM", marks=[pytest.mark.xfail]),
-            # pytest.param("UNV", marks=[pytest.mark.xfail]),
-            # pytest.param("VTK", marks=[pytest.mark.xfail]),
-            # pytest.param("VTU", marks=[pytest.mark.xfail]),
-            # pytest.param("YAML", marks=[pytest.mark.xfail]),
-            # pytest.param("Z88_FEM_MESH", marks=[pytest.mark.xfail]),
-            # pytest.param("Z88_FEM_MESH_2", marks=[pytest.mark.xfail]),
-            # # No file created probably same problem as above block
-            # pytest.param("AUTOCAD", marks=[pytest.mark.xfail]),
-            # pytest.param("DAE", marks=[pytest.mark.xfail]),
-            # pytest.param("SVG_FLAT", marks=[pytest.mark.xfail]),
-            # pytest.param("STEP_ZIP", marks=[pytest.mark.xfail]),
-            # pytest.param("SVG", marks=[pytest.mark.xfail]),
+            # "ASC", "BDF", "DAT", "FENICS_FEM", "FENICS_FEM_XML", "INP", "MED",
+            # "MESHJSON", "MESHPY", "MESHYAML", "PCD", "PLY", "TETGEN_FEM", "UNV",
+            # "VTK", "VTU", "YAML", "Z88_FEM_MESH", "Z88_FEM_MESH_2",
             # # More FreeCAD than we import, fails differently on each import
-            # pytest.param("WEBGL", marks=[pytest.mark.xfail]),
+            # "WEBGL",
+            # # No file output
+            # "SVG, "SVG_FLAT",
+            # # Requires TechDrawGui import which requires a GUI
+            # "PDF", "VRML", "VRML_2", "VRML_ZIP", "VRML_ZIP_2",
+            # "WEBGL_X3D", "X3D", "X3DZ"
         ),
     )
     def test_exporter_function_exists_and_creates_a_file(self, name, tmp_path):


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Fixes some FreeCAD saving methods, checks in the test for skip on dependency availability and removes some tests that will never pass.
Adds the new saving to the examples.

~TODO check for other occurances of old saving examples~ cant find any

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
