### PR TITLE
minor quickfix, MultiMaterial should be Material

### DIFF
--- a/bluemira/materials/mixtures.py
+++ b/bluemira/materials/mixtures.py
@@ -44,7 +44,7 @@ from bluemira.materials.error import MaterialsError
 from bluemira.materials.material import SerialisedMaterial
 
 
-class HomogenisedMixture(SerialisedMaterial, nmm.MultiMaterial):
+class HomogenisedMixture(SerialisedMaterial, nmm.Material):
     """
     Inherits and does some dropping of 0 fractions (avoid touching nmm)
     """


### PR DESCRIPTION
Issue: 
`File "/media/bap/Fusion/bluemira/bluemira/materials/mixtures.py", line 47, in <module>
    class HomogenisedMixture(SerialisedMaterial, nmm.MultiMaterial):
                                                 ^^^^^^^^^^^^^^^^^
AttributeError: module 'neutronics_material_maker' has no attribute 'MultiMaterial'
`

This is caused by nmm not having a MultiMaterial class. I changed it to Material

