### PR TITLE
Depricate filter_ and formatt

### DIFF
--- a/bluemira/base/components.py
+++ b/bluemira/base/components.py
@@ -92,7 +92,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
     def filter_components(
         self,
         names: Iterable[str],
-        filter_: Optional[Callable[[Component], bool]] = None,
+        component_filter: Optional[Callable[[Component], bool]] = None,
     ):
         """
         Removes all components from the tree, starting at this component,
@@ -103,7 +103,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
         ----------
         names:
             The list of names of each component to search for.
-        filter_:
+        component_filter:
             A callable to filter Components from the Component tree,
             returning True keeps the node False removes it
 
@@ -129,7 +129,7 @@ class Component(NodeMixin, Plottable, DisplayableCAD):
                         c_sib.parent = None
 
                 for c_child in c.descendants:
-                    if filter_ is not None and not filter_(c_child):
+                    if component_filter is not None and not component_filter(c_child):
                         c_child.parent = None
 
     def tree(self) -> str:

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -78,7 +78,7 @@ class BaseManager(abc.ABC):
         self,
         components: Union[Component, Iterable[Component]],
         filename: str,
-        formatt: Union[str, cadapi.CADFileType] = "stp",
+        cad_format: Union[str, cadapi.CADFileType] = "stp",
         **kwargs,
     ):
         """
@@ -90,16 +90,24 @@ class BaseManager(abc.ABC):
             components to save
         filename:
             the filename to save
-        formatt:
+        cad_format:
             CAD file format
         """
+        if kw_formatt := kwargs.pop("formatt", None):
+            warn(
+                "Using kwarg 'formatt' is no longer supported. "
+                "Use cad_format instead.",
+                category=DeprecationWarning,
+            )
+            cad_format = kw_formatt
+
         shape_name = get_properties_from_components(components, ("shape", "name"))
         if not isinstance(shape_name[0], tuple):
             shapes, names = [shape_name[0]], [shape_name[1]]
         else:
             shapes, names = shape_name
 
-        save_cad(shapes, filename, formatt, names, **kwargs)
+        save_cad(shapes, filename, cad_format, names, **kwargs)
 
     @abc.abstractmethod
     def show_cad(
@@ -307,7 +315,7 @@ class ComponentManager(BaseManager):
         *dims: str,
         filter_: Optional[Callable[[Component], bool]] = FilterMaterial(),
         filename: Optional[str] = None,
-        formatt: Union[str, cadapi.CADFileType] = "stp",
+        cad_format: Union[str, cadapi.CADFileType] = "stp",
         directory: Union[str, Path] = "",
         **kwargs,
     ):
@@ -324,7 +332,7 @@ class ComponentManager(BaseManager):
             returning True keeps the node False removes it
         filename:
             the filename to save, will default to the component name
-        formatt:
+        cad_format:
             CAD file format
         directory:
             Directory to save into, defaults to the current directory
@@ -338,7 +346,7 @@ class ComponentManager(BaseManager):
         super().save_cad(
             self._filter_tree(comp, self._validate_cad_dims(*dims, **kwargs), filter_),
             filename=Path(directory, filename).as_posix(),
-            formatt=formatt,
+            cad_format=cad_format,
             **kwargs,
         )
 
@@ -539,7 +547,7 @@ class Reactor(BaseManager):
         n_sectors: Optional[int] = None,
         filter_: Optional[Callable[[Component], bool]] = FilterMaterial(),
         filename: Optional[str] = None,
-        formatt: Union[str, cadapi.CADFileType] = "stp",
+        cad_format: Union[str, cadapi.CADFileType] = "stp",
         directory: Union[str, Path] = "",
         **kwargs,
     ):
@@ -562,7 +570,7 @@ class Reactor(BaseManager):
             returning True keeps the node False removes it
         filename:
             the filename to save, will default to the component name
-        formatt:
+        cad_format:
             CAD file format
         directory:
             Directory to save into, defaults to the current directory
@@ -577,7 +585,7 @@ class Reactor(BaseManager):
                 self._validate_cad_dims(*dims), with_components, n_sectors, filter_
             ),
             Path(directory, filename).as_posix(),
-            formatt,
+            cad_format,
             **kwargs,
         )
 

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1351,7 +1351,7 @@ def _scale_obj(objs, scale: float = 1000):
 def save_cad(
     shapes: Iterable[apiShape],
     filename: str,
-    formatt: Union[str, CADFileType] = "stp",
+    cad_format: Union[str, CADFileType] = "stp",
     labels: Optional[Iterable[str]] = None,
     unit_scale: str = "metre",
     **kwargs,
@@ -1364,9 +1364,9 @@ def save_cad(
     shapes:
         CAD shape objects to save
     filename:
-        filename (file extension will be forced base on `formatt`)
-    formatt:
-        file formatt
+        filename (file extension will be forced base on `cad_format`)
+    cad_format:
+        file cad_format
     labels:
         shape labels
     unit_scale:
@@ -1379,8 +1379,15 @@ def save_cad(
     Part builds in millimetres therefore we need to scale to metres to be
     consistent with our units
     """
-    formatt = CADFileType(formatt)
-    filename = force_file_extension(filename, f".{formatt.value}")
+    if kw_formatt := kwargs.pop("formatt", None):
+        warn(
+            "Using kwarg 'formatt' is no longer supported. Use cad_format instead.",
+            category=DeprecationWarning,
+        )
+        cad_format = kw_formatt
+
+    cad_format = CADFileType(cad_format)
+    filename = force_file_extension(filename, f".{cad_format.value}")
 
     _freecad_save_config(**kwargs)
 
@@ -1392,28 +1399,28 @@ def save_cad(
     # Some exporters need FreeCADGui to be setup before their import,
     # this is achieved in _setup_document
     try:
-        formatt.exporter(objs, filename)
+        cad_format.exporter(objs, filename)
     except ImportError as imp_err:
         raise FreeCADError(
-            f"Unable to save to {formatt.value} please try through the main FreeCAD GUI"
+            f"Unable to save to {cad_format.value} please try through the main FreeCAD GUI"
         ) from imp_err
 
     if not os.path.exists(filename):
         mesg = f"{filename} not created, filetype not written by FreeCAD."
-        if formatt is CADFileType.IFC_BIM:
+        if cad_format is CADFileType.IFC_BIM:
             mesg += " FreeCAD requires `ifcopenshell` to save in this format."
-        elif formatt is CADFileType.DAE:
+        elif cad_format is CADFileType.DAE:
             mesg += " FreeCAD requires `pycollada` to save in this format."
-        elif formatt is CADFileType.IFC_BIM_JSON:
+        elif cad_format is CADFileType.IFC_BIM_JSON:
             mesg += (
                 " FreeCAD requires `ifcopenshell` and"
                 " IFCJSON module to save in this format."
             )
-        elif formatt is CADFileType.AUTOCAD:
+        elif cad_format is CADFileType.AUTOCAD:
             mesg += " FreeCAD requires `LibreDWG` to save in this format."
 
         raise FreeCADError(
-            f"{mesg} Not able to save object with format: '{formatt.value}'"
+            f"{mesg} Not able to save object with format: '{cad_format.value}'"
         )
 
 

--- a/bluemira/equilibria/fem_fixed_boundary/file.py
+++ b/bluemira/equilibria/fem_fixed_boundary/file.py
@@ -23,6 +23,7 @@
 """
 File saving for fixed boundary equilibrium
 """
+from logging import warn
 from typing import Dict, Optional
 
 import numpy as np
@@ -66,8 +67,9 @@ def save_fixed_boundary_to_file(
     equilibrium: FixedBoundaryEquilibrium,
     nx: int,
     nz: int,
-    formatt: str = "json",
+    file_format: str = "json",
     json_kwargs: Optional[Dict] = None,
+    **kwargs,
 ):
     """
     Save a fixed boundary equilibrium to a file.
@@ -84,11 +86,18 @@ def save_fixed_boundary_to_file(
         Number of radial points to use in the psi map
     nz:
         Number of vertical points to use in the psi map
-    formatt:
+    file_format:
         Format of the file
     json_kwargs:
         kwargs to use if saving to JSON
     """
+    if kw_formatt := kwargs.pop("formatt", None):
+        warn(
+            "Using kwarg 'formatt' is no longer supported. Use file_format instead.",
+            category=DeprecationWarning,
+        )
+        file_format = kw_formatt
+
     xbdry, zbdry = get_mesh_boundary(equilibrium.mesh)
     xbdry = np.append(xbdry, xbdry[0])
     zbdry = np.append(zbdry, zbdry[0])
@@ -175,5 +184,5 @@ def save_fixed_boundary_to_file(
         psinorm=psi_norm,
         qpsi=np.array([]),
     )
-    data.write(file_path, format=formatt, json_kwargs=json_kwargs)
+    data.write(file_path, format=file_format, json_kwargs=json_kwargs)
     return data

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -29,6 +29,7 @@ import inspect
 import json
 import os
 from copy import deepcopy
+from logging import warn
 from typing import (
     Any,
     Callable,
@@ -1048,7 +1049,7 @@ def save_as_STP(
 def save_cad(
     shapes: Union[BluemiraGeo, List[BluemiraGeo]],
     filename: str,
-    formatt: Union[str, cadapi.CADFileType] = "stp",
+    cad_format: Union[str, cadapi.CADFileType] = "stp",
     names: Optional[Union[str, Iterable[str]]] = None,
     **kwargs,
 ):
@@ -1061,16 +1062,27 @@ def save_cad(
         shapes to save
     filename:
         Full path filename of the STP assembly
-    formatt:
+    cad_format:
         file format to save as
     kwargs:
         arguments passed to cadapi save function
     """
+    if kw_formatt := kwargs.pop("formatt", None):
+        warn(
+            "Using kwarg 'formatt' is no longer supported. Use cad_format instead.",
+            category=DeprecationWarning,
+        )
+        cad_format = kw_formatt
+
     if not isinstance(shapes, list):
         shapes = [shapes]
 
     cadapi.save_cad(
-        [s.shape for s in shapes], filename, formatt=formatt, labels=names, **kwargs
+        [s.shape for s in shapes],
+        filename,
+        cad_format=cad_format,
+        labels=names,
+        **kwargs,
     )
 
 

--- a/bluemira/utilities/plot_tools.py
+++ b/bluemira/utilities/plot_tools.py
@@ -25,6 +25,7 @@ A collection of plotting tools.
 
 import os
 import re
+from logging import warn
 from typing import Optional, Union
 
 import imageio
@@ -92,7 +93,9 @@ def str_to_latex(string: str) -> str:
     return "$" + s[0] + ss + "}" * (len(s) - 1) + "$"
 
 
-def make_gif(folder: str, figname: str, formatt: str = "png", clean: bool = True):
+def make_gif(
+    folder: str, figname: str, file_format: str = "png", clean: bool = True, **kwargs
+):
     """
     Make a GIF image from a set of images with similar names in a folder.
     Figures are sorted in increasing order based on a trailing number, e.g.
@@ -106,14 +109,21 @@ def make_gif(folder: str, figname: str, formatt: str = "png", clean: bool = True
         Full path folder name
     figname:
         Figure name prefix
-    formatt:
+    file_format:
         Figure filename extension
     clean:
         Delete figures after completion?
     """
+    if kw_formatt := kwargs.pop("formatt", None):
+        warn(
+            "Using kwarg 'formatt' is no longer supported. Use file_format instead.",
+            category=DeprecationWarning,
+        )
+        file_format = kw_formatt
+
     ims = []
     for filename in os.listdir(folder):
-        if filename.startswith(figname) and filename.endswith(formatt):
+        if filename.startswith(figname) and filename.endswith(file_format):
             fp = os.path.join(folder, filename)
             ims.append(fp)
 
@@ -128,17 +138,26 @@ def make_gif(folder: str, figname: str, formatt: str = "png", clean: bool = True
     imageio.mimsave(gifname, images, "GIF-FI", **kwargs)
 
 
-def save_figure(fig, name, save=False, folder=None, dpi=600, formatt="png", **kwargs):
+def save_figure(
+    fig, name, save=False, folder=None, dpi=600, file_format="png", **kwargs
+):
     """
     Saves a figure to the directory if save flag active
     """
+    if kw_formatt := kwargs.pop("formatt", None):
+        warn(
+            "Using kwarg 'formatt' is no longer supported. Use file_format instead.",
+            category=DeprecationWarning,
+        )
+        file_format = kw_formatt
+
     if save is True:
         if folder is None:
             folder = get_bluemira_path("plots", subfolder="data")
-        name = os.sep.join([folder, name]) + "." + formatt
+        name = os.sep.join([folder, name]) + "." + file_format
         if os.path.isfile(name):
             os.remove(name)  # f.savefig will otherwise not overwrite
-        fig.savefig(name, dpi=dpi, bbox_inches="tight", format=formatt, **kwargs)
+        fig.savefig(name, dpi=dpi, bbox_inches="tight", format=file_format, **kwargs)
 
 
 def ring_coding(n: int) -> np.ndarray:

--- a/examples/codes/equilibrium_plasmod_example.ex.py
+++ b/examples/codes/equilibrium_plasmod_example.ex.py
@@ -236,7 +236,7 @@ data = save_fixed_boundary_to_file(
     equilibrium,
     100,
     110,
-    formatt="json",
+    file_format="json",
 )
 
 # %% [markdown]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2314

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Deprecates the use of filter_ and formatt parameters throughout the codebase.

filter_ is changed to component_filter
formatt is changed to cad_format or file_formatt (for images mostly)

## Interface Changes

A number of interfaces have changed but deprecation notices have been used so the same interface can be used.

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
