### PR TITLE
ReactorConfig warnings defaults

### DIFF
--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Tuple, Type, TypeVar, Union
 
 from bluemira.base.error import ReactorConfigError
-from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.base.look_and_feel import bluemira_debug, bluemira_warn
 from bluemira.base.parameter_frame import ParameterFrame, make_parameter_frame
 
 
@@ -89,9 +89,9 @@ class ReactorConfig:
         self,
         config_path: Union[str, Path, dict],
         global_params_type: Type[_PfT],
-        warn_on_duplicate_keys: bool = True,
-        warn_on_empty_local_params: bool = True,
-        warn_on_empty_config: bool = True,
+        warn_on_duplicate_keys: bool = False,
+        warn_on_empty_local_params: bool = False,
+        warn_on_empty_config: bool = False,
     ):
         self.warn_on_duplicate_keys = warn_on_duplicate_keys
         self.warn_on_empty_local_params = warn_on_empty_local_params
@@ -150,8 +150,11 @@ class ReactorConfig:
         self._check_args_are_strings(args)
 
         local_params = self._extract(args, is_config=False)
-        if not local_params and self.warn_on_empty_local_params:
-            bluemira_warn(f"Empty local params for args: {args}")
+        if not local_params:
+            if self.warn_on_empty_local_params:
+                bluemira_warn(f"Empty local params for args: {args}")
+            else:
+                bluemira_debug(f"Empty local params for args: {args}")
 
         return ConfigParams(
             global_params=self.global_params,
@@ -188,8 +191,11 @@ class ReactorConfig:
         self._check_args_are_strings(args)
 
         _return = self._extract(args, is_config=True)
-        if not _return and self.warn_on_empty_config:
-            bluemira_warn(f"Empty config for args: {args}")
+        if not _return:
+            if self.warn_on_empty_config:
+                bluemira_warn(f"Empty config for args: {args}")
+            else:
+                bluemira_debug(f"Empty config for args: {args}")
 
         return _return
 
@@ -219,6 +225,11 @@ class ReactorConfig:
     ):
         if self.warn_on_duplicate_keys:
             bluemira_warn(
+                "duplicate config key: "
+                f"'{shared_key}' in {arg} wil be overwritten with {existing_value}"
+            )
+        else:
+            bluemira_debug(
                 "duplicate config key: "
                 f"'{shared_key}' in {arg} wil be overwritten with {existing_value}"
             )

--- a/bluemira/base/reactor_config.py
+++ b/bluemira/base/reactor_config.py
@@ -98,7 +98,7 @@ class ReactorConfig:
         self.warn_on_empty_config = warn_on_empty_config
 
         config_data = self._read_or_return(config_path)
-        if not isinstance(config_path, dict):
+        if isinstance(config_path, (Path, str)):
             self._expand_paths_in_dict(config_data, Path(config_path).parent)
 
         self.config_data = config_data

--- a/eudemo/eudemo/reactor.py
+++ b/eudemo/eudemo/reactor.py
@@ -249,9 +249,7 @@ def build_radiation_shield(params, build_config, cryostat_koz) -> RadiationShiel
 
 if __name__ == "__main__":
     set_log_level("INFO")
-    reactor_config = ReactorConfig(
-        BUILD_CONFIG_FILE_PATH, EUDEMOReactorParams, warn_on_empty_config=False
-    )
+    reactor_config = ReactorConfig(BUILD_CONFIG_FILE_PATH, EUDEMOReactorParams)
     reactor = EUDEMO(
         "EUDEMO",
         n_sectors=reactor_config.global_params.n_TF.value,

--- a/tests/base/reactor_config/test_reactor_config.py
+++ b/tests/base/reactor_config/test_reactor_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from bluemira.base.constants import raw_uc
 from bluemira.base.error import ReactorConfigError
+from bluemira.base.logs import set_log_level
 from bluemira.base.parameter_frame import (
     EmptyFrame,
     Parameter,
@@ -49,6 +50,9 @@ class TestReactorConfigClass:
     Tests for the Reactor Config class functionality.
     """
 
+    def setup_method(self):
+        set_log_level("DEBUG")
+
     def test_file_loading_with_empty_config(self, caplog):
         reactor_config = ReactorConfig(empty_config_path, EmptyFrame)
 
@@ -60,7 +64,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 2
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         assert len(p_dne.local_params) == 0
         assert len(c_dne) == 0
@@ -86,7 +90,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 1
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         cpf = make_parameter_frame(cp, TestCompADesignerParams)
 
@@ -119,7 +123,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 1
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         cpf = make_parameter_frame(cp, TestCompADesignerParams)
 
@@ -141,7 +145,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 1
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         assert cf_comp_a["config_a"] == cf_comp_a_des["config_a"]
         assert cf_comp_a["config_b"] == cf_comp_a_des["config_b"]
@@ -162,7 +166,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 2
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         assert len(cp.local_params) == 0
         assert len(cp_dne.local_params) == 0
@@ -183,7 +187,7 @@ class TestReactorConfigClass:
 
         assert len(caplog.records) == 2
         for record in caplog.records:
-            assert record.levelname == "WARNING"
+            assert record.levelname == "DEBUG"
 
         assert len(cf_comp_a) == 1
         assert len(cf_comp_a_des) == 0


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2280

## Description

The warnings printed when using ReactorConfig have been unhelpfully loud. This PR switches the defaults to not print to  warn, instead to debug.

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
