### PR TITLE
Make keep-out zones more customisable

### DIFF
--- a/bluemira/optimisation/__init__.py
+++ b/bluemira/optimisation/__init__.py
@@ -21,7 +21,7 @@
 """Public functions and classes for the optimisation module."""
 
 from bluemira.optimisation._algorithm import Algorithm
-from bluemira.optimisation._geometry.optimise import optimise_geometry
+from bluemira.optimisation._geometry.optimise import KeepOutZone, optimise_geometry
 from bluemira.optimisation._geometry.problem import GeomOptimisationProblem
 from bluemira.optimisation._optimise import optimise
 from bluemira.optimisation.problem import OptimisationProblem
@@ -29,6 +29,7 @@ from bluemira.optimisation.problem import OptimisationProblem
 __all__ = [
     "Algorithm",
     "GeomOptimisationProblem",
+    "KeepOutZone",
     "OptimisationProblem",
     "optimise",
     "optimise_geometry",

--- a/bluemira/optimisation/_geometry/_tools.py
+++ b/bluemira/optimisation/_geometry/_tools.py
@@ -46,10 +46,15 @@ class KeepOutZone:
     """Definition of a keep-out zone for a geometry optimisation."""
 
     wire: BluemiraWire
+    """Closed wire defining the keep-out zone."""
     byedges: bool = True
+    """Whether to discretize the wire by edges or not."""
     dl: Optional[int] = None
+    """Set the discretization length, this overrides ``n_discr`` if given."""
     n_discr: int = 100
+    """Set the number of points to discretise the wire into."""
     tol: float = 1e-8
+    """Set the tolerance for the keep-out zone constraint."""
 
 
 def to_objective(

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -84,10 +84,15 @@ class KeepOutZoneDict(TypedDict):
     """Typing for a dict representing a keep-out zone for a geometry optimisation."""
 
     wire: BluemiraWire
+    """Closed wire defining the keep-out zone."""
     byedges: NotRequired[bool]
+    """Whether to discretize the wire by edges or not."""
     dl: NotRequired[Optional[int]]
+    """Set the discretization length, this overrides ``n_discr`` if given."""
     n_discr: NotRequired[int]
+    """Set the number of points to discretise the wire into."""
     tol: NotRequired[float]
+    """Set the tolerance for the keep-out zone constraint."""
 
 
 def optimise_geometry(

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -86,13 +86,19 @@ class KeepOutZoneDict(TypedDict):
     wire: BluemiraWire
     """Closed wire defining the keep-out zone."""
     byedges: NotRequired[bool]
-    """Whether to discretize the wire by edges or not."""
-    dl: NotRequired[Optional[int]]
-    """Set the discretization length, this overrides ``n_discr`` if given."""
+    """Whether to discretize the keep-out zone by edges or not."""
+    dl: NotRequired[Optional[float]]
+    """
+    The discretization length for the keep-out zone.
+
+    This overrides ``n_discr`` if given.
+    """
     n_discr: NotRequired[int]
-    """Set the number of points to discretise the wire into."""
+    """The number of points to discretise the wire into."""
+    shape_n_discr: NotRequired[int]
+    """The number of points to discretise the keep-out zone into."""
     tol: NotRequired[float]
-    """Set the tolerance for the keep-out zone constraint."""
+    """The number of points to discretise the geometry being optimised into."""
 
 
 def optimise_geometry(

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -80,7 +80,7 @@ class GeomOptimiserResult(Generic[_GeomT]):
     """
 
 
-class KeepOutZoneT(TypedDict):
+class KeepOutZoneDict(TypedDict):
     """Typing for a dict representing a keep-out zone for a geometry optimisation."""
 
     wire: BluemiraWire
@@ -95,7 +95,7 @@ def optimise_geometry(
     f_objective: GeomOptimiserObjective,
     df_objective: Optional[GeomOptimiserCallable] = None,
     *,
-    keep_out_zones: Iterable[Union[BluemiraWire, KeepOutZoneT, KeepOutZone]] = (),
+    keep_out_zones: Iterable[Union[BluemiraWire, KeepOutZoneDict, KeepOutZone]] = (),
     algorithm: Union[Algorithm, str] = Algorithm.SLSQP,
     opt_conditions: Optional[Mapping[str, Union[int, float]]] = None,
     opt_parameters: Optional[Mapping[str, Any]] = None,
@@ -244,7 +244,7 @@ def optimise_geometry(
     return GeomOptimiserResult(**asdict(result), geom=geom)
 
 
-def _to_koz(koz: Union[BluemiraWire, KeepOutZoneT, KeepOutZone]) -> KeepOutZone:
+def _to_koz(koz: Union[BluemiraWire, KeepOutZoneDict, KeepOutZone]) -> KeepOutZone:
     """Convert ``koz`` to a ``KeepOutZone``."""
     if isinstance(koz, BluemiraWire):
         return KeepOutZone(koz)

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -19,15 +19,27 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 from dataclasses import asdict, dataclass, field
-from itertools import repeat
-from typing import Any, Generic, Iterable, List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
+from typing_extensions import NotRequired
 
 from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.optimisation._algorithm import Algorithm
 from bluemira.optimisation._geometry import _tools
+from bluemira.optimisation._geometry._tools import KeepOutZone
 from bluemira.optimisation._geometry.typing import (
     GeomConstraintT,
     GeomOptimiserCallable,
@@ -36,6 +48,8 @@ from bluemira.optimisation._geometry.typing import (
 from bluemira.optimisation._optimise import optimise
 
 _GeomT = TypeVar("_GeomT", bound=GeometryParameterisation)
+
+__all__ = ["GeomOptimiserResult", "optimise_geometry", "KeepOutZone"]
 
 
 @dataclass
@@ -66,19 +80,28 @@ class GeomOptimiserResult(Generic[_GeomT]):
     """
 
 
+class KeepOutZoneT(TypedDict):
+    """Typing for a dict representing a keep-out zone for a geometry optimisation."""
+
+    wire: BluemiraWire
+    byedges: NotRequired[bool]
+    dl: NotRequired[Optional[int]]
+    n_discr: NotRequired[int]
+    tol: NotRequired[float]
+
+
 def optimise_geometry(
     geom: _GeomT,
     f_objective: GeomOptimiserObjective,
     df_objective: Optional[GeomOptimiserCallable] = None,
     *,
-    keep_out_zones: Iterable[BluemiraWire] = (),
+    keep_out_zones: Iterable[Union[BluemiraWire, KeepOutZoneT, KeepOutZone]] = (),
     algorithm: Union[Algorithm, str] = Algorithm.SLSQP,
     opt_conditions: Optional[Mapping[str, Union[int, float]]] = None,
     opt_parameters: Optional[Mapping[str, Any]] = None,
     eq_constraints: Iterable[GeomConstraintT] = (),
     ineq_constraints: Iterable[GeomConstraintT] = (),
     keep_history: bool = False,
-    koz_discretisation: Union[int, Iterable[int]] = 100,
     check_constraints: bool = True,
     check_constraints_warn: bool = True,
 ) -> GeomOptimiserResult[_GeomT]:
@@ -101,8 +124,11 @@ def optimise_geometry(
         This argument is ignored if a non-gradient based algorithm is
         used.
     keep_out_zones:
-        An iterable of closed wires, defining areas the geometry must
-        not intersect.
+        An iterable of keep-out zones: closed wires that the geometry
+        must not intersect.
+        Each item can be given as a :class:`.KeepOutZone`, or a
+        dictionary with keys the same as the properties of the
+        `:class:`.KeepOutZone` class, or just a :class:`.BluemiraWire`.
     algorithm:
         The optimisation algorithm to use, by default ``Algorithm.SLSQP``.
     opt_conditions:
@@ -124,11 +150,11 @@ def optimise_geometry(
         The equality constraints for the optimiser.
         A dict with keys:
 
-            * f_constraint: the constraint function.
-            * tolerance: the tolerances in each constraint dimension.
-            * df_constraint (optional): the derivative of the constraint
-              function. If not given, a numerical approximation of the
-              gradient is made (if a gradient is required).
+        * f_constraint: the constraint function.
+        * tolerance: the tolerances in each constraint dimension.
+        * df_constraint (optional): the derivative of the constraint
+            function. If not given, a numerical approximation of the
+            gradient is made (if a gradient is required).
 
         A constraint is a vector-valued, non-linear, equality
         constraint of the form $f_{c}(x) \eq 0$.
@@ -138,9 +164,9 @@ def optimise_geometry(
 
             * `g` is a geometry parameterisation.
             * `y` is a numpy array containing the values of the
-              constraint at the current parameterisation of ``g``.
-              It must have size $m$, where $m$ is the dimensionality of
-              the constraint.
+                constraint at the current parameterisation of ``g``.
+                It must have size $m$, where $m$ is the dimensionality of
+                the constraint.
 
         The tolerance array must have the same dimensionality as the
         constraint.
@@ -171,13 +197,6 @@ def optimise_geometry(
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
         (default: False)
-    koz_discretisation:
-        The number of points to discretise the keep-out zone(s) over.
-        If this is an int, all keep-out zones will be discretised with
-        the same number of points. If this is an iterable, each i-th
-        keep-out zone is discretised using value in the i-th item.
-        The iterable should have the same number of items as
-        ``keep_out_zones``.
     check_constraints:
         Whether to check all constraints have been satisfied at the end
         of the optimisation, and warn if they have not. Note that, if
@@ -201,10 +220,8 @@ def optimise_geometry(
     ineq_constraints_list = _tools.get_shape_ineq_constraint(geom)
     for constraint in ineq_constraints:
         ineq_constraints_list.append(constraint)
-    for koz, discr in zip_with_scalar(keep_out_zones, koz_discretisation):
-        ineq_constraints_list.append(
-            _tools.make_keep_out_zone_constraint(koz, n_discr=discr)
-        )
+    for zone in keep_out_zones:
+        ineq_constraints_list.append(_tools.make_keep_out_zone_constraint(_to_koz(zone)))
 
     result = optimise(
         f_obj,
@@ -227,14 +244,12 @@ def optimise_geometry(
     return GeomOptimiserResult(**asdict(result), geom=geom)
 
 
-_T1 = TypeVar("_T1")
-_T2 = TypeVar("_T2")
-
-
-def zip_with_scalar(
-    it1: Iterable[_T1], it2: Union[Iterable[_T2], _T2]
-) -> Iterable[Tuple[_T1, _T2]]:
-    """Return an iterator that zips an iterable with another, or with a scalar."""
-    if not isinstance(it2, Iterable):
-        it2 = repeat(it2)
-    return zip(it1, it2)
+def _to_koz(koz: Union[BluemiraWire, KeepOutZoneT, KeepOutZone]) -> KeepOutZone:
+    """Convert ``koz`` to a ``KeepOutZone``."""
+    if isinstance(koz, BluemiraWire):
+        return KeepOutZone(koz)
+    if isinstance(koz, dict):
+        return KeepOutZone(**koz)
+    if isinstance(koz, KeepOutZone):
+        return koz
+    raise TypeError(f"Type '{type(koz).__name__}' is not a valid keep-out zone.")

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -248,7 +248,7 @@ def _to_koz(koz: Union[BluemiraWire, KeepOutZoneDict, KeepOutZone]) -> KeepOutZo
     """Convert ``koz`` to a ``KeepOutZone``."""
     if isinstance(koz, BluemiraWire):
         return KeepOutZone(koz)
-    if isinstance(koz, dict):
+    if isinstance(koz, Mapping):
         return KeepOutZone(**koz)
     if isinstance(koz, KeepOutZone):
         return koz

--- a/bluemira/optimisation/_geometry/problem.py
+++ b/bluemira/optimisation/_geometry/problem.py
@@ -21,15 +21,17 @@
 """Interface for defining a geometry-based optimisation problem."""
 
 import abc
-from typing import Any, Iterable, List, Mapping, Optional, TypeVar, Union
+from typing import Any, List, Mapping, Optional, TypeVar, Union
 
 import numpy as np
 
 from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.optimisation._algorithm import Algorithm
+from bluemira.optimisation._geometry._tools import KeepOutZone
 from bluemira.optimisation._geometry.optimise import (
     GeomOptimiserResult,
+    KeepOutZoneT,
     optimise_geometry,
 )
 from bluemira.optimisation._geometry.typing import GeomConstraintT
@@ -79,12 +81,12 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
         """
         return []
 
-    def keep_out_zones(self) -> List[BluemiraWire]:
+    def keep_out_zones(self) -> List[Union[BluemiraWire, KeepOutZoneT, KeepOutZone]]:
         """
         List of geometric keep-out zones.
 
-        An iterable of closed wires, defining areas the geometry must
-        not intersect.
+        An iterable of keep-out zones: closed wires that the geometry
+        must not intersect.
         """
         return []
 
@@ -96,7 +98,6 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
         opt_conditions: Optional[Mapping[str, Union[int, float]]] = None,
         opt_parameters: Optional[Mapping[str, Any]] = None,
         keep_history: bool = False,
-        koz_discretisation: Union[int, Iterable[int]] = 100,
         check_constraints: bool = True,
         check_constraints_warn: bool = True,
     ) -> GeomOptimiserResult[_GeomT]:
@@ -124,7 +125,6 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
             eq_constraints=self.eq_constraints(),
             ineq_constraints=self.ineq_constraints(),
             keep_history=keep_history,
-            koz_discretisation=koz_discretisation,
             check_constraints=check_constraints,
             check_constraints_warn=check_constraints_warn,
         )

--- a/bluemira/optimisation/_geometry/problem.py
+++ b/bluemira/optimisation/_geometry/problem.py
@@ -26,12 +26,10 @@ from typing import Any, List, Mapping, Optional, TypeVar, Union
 import numpy as np
 
 from bluemira.geometry.parameterisations import GeometryParameterisation
-from bluemira.geometry.wire import BluemiraWire
 from bluemira.optimisation._algorithm import Algorithm
-from bluemira.optimisation._geometry._tools import KeepOutZone
 from bluemira.optimisation._geometry.optimise import (
     GeomOptimiserResult,
-    KeepOutZoneT,
+    KeepOutZone,
     optimise_geometry,
 )
 from bluemira.optimisation._geometry.typing import GeomConstraintT
@@ -81,7 +79,7 @@ class GeomOptimisationProblem(abc.ABC, OptimisationProblemBase):
         """
         return []
 
-    def keep_out_zones(self) -> List[Union[BluemiraWire, KeepOutZoneT, KeepOutZone]]:
+    def keep_out_zones(self) -> List[KeepOutZone]:
         """
         List of geometric keep-out zones.
 

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -206,9 +206,15 @@ class TestGeometry:
         with mock.patch.object(zone, "discretize", wraps=zone.discretize) as discr_mock:
             optimise_geometry(
                 parameterisation,
-                lambda x: x.create_shape().length,
+                lambda _: 1.0,
                 keep_out_zones=[
-                    {"wire": zone, "n_discr": 20, "byedges": False, "dl": None}
+                    {
+                        "wire": zone,
+                        "n_discr": 20,
+                        "byedges": False,
+                        "dl": None,
+                        "shape_n_discr": 30,
+                    }
                 ],
                 opt_conditions={"max_eval": 1},
             )

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -32,6 +32,7 @@ from bluemira.geometry.parameterisations import (
 )
 from bluemira.geometry.tools import make_circle, make_polygon, signed_distance
 from bluemira.optimisation import optimise_geometry
+from bluemira.optimisation._geometry.optimise import KeepOutZone
 from bluemira.optimisation.error import GeometryOptimisationError
 
 
@@ -198,44 +199,87 @@ class TestGeometry:
         # The maximisation should mean the angles approximately sum to 360
         assert sum(angles) == pytest.approx(360, rel=1e-2)
 
-    def test_koz_discretisation_is_set_with_int(self):
+    # @pytest.mark.parametrize(
+    #     "zone",
+    #     [
+    #         {
+    #             "wire": make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0)),
+    #             "n_discr": 20,
+    #             "byedges": False,
+    #             "dl": None,
+    #         },
+    #         KeepOutZone(
+    #             wire=make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0)),
+    #             n_discr=20,
+    #             byedges=False,
+    #             dl=None,
+    #         ),
+    #     ],
+    # )
+    # def test_koz_settings_passed_to_discretize(self, zone):
+    #     parameterisation = PictureFrame()
+    #     discr = (
+    #         zone.wire.discretize if isinstance(zone, KeepOutZone) else zone.discretize
+    #     )
+
+    #     with mock.patch.object(zone, "discretize", wraps=discr) as discr_mock:
+    #         optimise_geometry(
+    #             parameterisation,
+    #             lambda x: x.create_shape().length,
+    #             keep_out_zones=[
+    #                 {"wire": zone, "n_discr": 20, "byedges": False, "dl": None}
+    #             ],
+    #             opt_conditions={"max_eval": 1},
+    #         )
+
+    #     discr_mock.assert_called_once_with(20, byedges=False, dl=None)
+
+    def test_dict_koz_settings_passed_to_discretize(self):
         parameterisation = PictureFrame()
-        zone = make_circle(radius=4.5, center=[100, 0, 0], axis=[0, 1, 0])
-        discr = 20
-        kwargs = {
-            "keep_out_zones": [zone],
-            "koz_discretisation": discr,
-            "opt_conditions": {"max_eval": 1},
-        }
+        zone = make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0))
 
         with mock.patch.object(zone, "discretize", wraps=zone.discretize) as discr_mock:
             optimise_geometry(
-                parameterisation, lambda x: x.create_shape().length, **kwargs
+                parameterisation,
+                lambda x: x.create_shape().length,
+                keep_out_zones=[
+                    {"wire": zone, "n_discr": 20, "byedges": False, "dl": None}
+                ],
+                opt_conditions={"max_eval": 1},
             )
 
-        discr_mock.assert_called_once_with(20, byedges=True)
+        discr_mock.assert_called_once_with(20, byedges=False, dl=None)
 
-    def test_zone_discretisation_is_set_with_iterable(self):
+    def test_koz_settings_passed_to_discretize(self):
         parameterisation = PictureFrame()
-        zone = make_circle(radius=4.5, center=[100, 0, 0], axis=[0, 1, 0])
-        zones = [zone, zone]
-        discr = (20, 30)
-        kwargs = {
-            "keep_out_zones": zones,
-            "koz_discretisation": discr,
-            "opt_conditions": {"max_eval": 1},
-        }
+        zone = make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0))
+        koz = KeepOutZone(wire=zone, n_discr=20, byedges=False, dl=None)
 
         with mock.patch.object(zone, "discretize", wraps=zone.discretize) as discr_mock:
             optimise_geometry(
-                parameterisation, lambda x: x.create_shape().length, **kwargs
+                parameterisation,
+                lambda x: x.create_shape().length,
+                keep_out_zones=[koz],
+                opt_conditions={"max_eval": 1},
             )
 
-        assert discr_mock.call_count == 2
-        assert discr_mock.call_args_list[0] == mock.call(20, byedges=True)
-        assert discr_mock.call_args_list[1] == mock.call(30, byedges=True)
+        discr_mock.assert_called_once_with(20, byedges=False, dl=None)
 
-    def test_ineq_constraint(self):
+    @pytest.mark.parametrize(
+        "bad_koz", [{"n_discr": 20, "byedges": False, "dl": None}, 10, None]
+    )
+    def test_TypeError_given_invalid_koz(self, bad_koz):
+        parameterisation = PictureFrame()
+
+        with pytest.raises(TypeError):
+            optimise_geometry(
+                parameterisation,
+                lambda _: 1,
+                keep_out_zones=[bad_koz],
+                opt_conditions={"max_eval": 1},
+            )
+
+    def test_eq_constraint(self):
         def square_constraint(geom: PictureFrame) -> np.ndarray:
             """Constraint to make a PictureFrame a square."""
             x1, x2, z1, z2, _, _ = geom.variables.values

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -199,41 +199,6 @@ class TestGeometry:
         # The maximisation should mean the angles approximately sum to 360
         assert sum(angles) == pytest.approx(360, rel=1e-2)
 
-    # @pytest.mark.parametrize(
-    #     "zone",
-    #     [
-    #         {
-    #             "wire": make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0)),
-    #             "n_discr": 20,
-    #             "byedges": False,
-    #             "dl": None,
-    #         },
-    #         KeepOutZone(
-    #             wire=make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0)),
-    #             n_discr=20,
-    #             byedges=False,
-    #             dl=None,
-    #         ),
-    #     ],
-    # )
-    # def test_koz_settings_passed_to_discretize(self, zone):
-    #     parameterisation = PictureFrame()
-    #     discr = (
-    #         zone.wire.discretize if isinstance(zone, KeepOutZone) else zone.discretize
-    #     )
-
-    #     with mock.patch.object(zone, "discretize", wraps=discr) as discr_mock:
-    #         optimise_geometry(
-    #             parameterisation,
-    #             lambda x: x.create_shape().length,
-    #             keep_out_zones=[
-    #                 {"wire": zone, "n_discr": 20, "byedges": False, "dl": None}
-    #             ],
-    #             opt_conditions={"max_eval": 1},
-    #         )
-
-    #     discr_mock.assert_called_once_with(20, byedges=False, dl=None)
-
     def test_dict_koz_settings_passed_to_discretize(self):
         parameterisation = PictureFrame()
         zone = make_circle(radius=4.5, center=(100, 0, 0), axis=(0, 1, 0))


### PR DESCRIPTION
## Linked Issues

Refs #2189 
Addresses issues flagged in https://github.com/Fusion-Power-Plant-Framework/bluemira/pull/2238#issuecomment-1564046300

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Expose more keep-out zone features through the `optimise_geometry` and `GeomOptimisationProblem` API.

This is done using a new class `KeepOutZone` which is constructed using a `BluemiraWire` and, optionally, discretization configuration and constraint tolerance.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
