### PR TITLE
Fix returning initial value and not previous iteration on round-off error

### DIFF
--- a/bluemira/optimisation/_nlopt/functions.py
+++ b/bluemira/optimisation/_nlopt/functions.py
@@ -94,18 +94,23 @@ class ObjectiveFunction(_NloptFunction):
         """Execute the NLOpt objective function."""
         if not np.any(np.isnan(x)):
             self._store_x(x)
+        return self._call_inner(x, grad)
+
+    def call_with_history(self, x: np.ndarray, grad: np.ndarray) -> float:
+        """Execute the NLOpt objective function, recording the iteration history."""
+        f_x = self._call_inner(x, grad)
+        self.history.append((np.copy(x), f_x))
+        self.prev_iter = self.history[-1][0]
+        return f_x
+
+    def _call_inner(self, x: np.ndarray, grad: np.ndarray) -> float:
+        """Execute the objective function in the form required by NLOpt."""
         # Cache f(x) so we do not need to recalculate it if we're using
         # an approximate gradient
         self.f0 = self.f(x)
         if grad.size > 0:
             grad[:] = self.df(x)
         return self.f0
-
-    def call_with_history(self, x: np.ndarray, grad: np.ndarray) -> float:
-        """Execute the NLOpt objective function, recording the iteration history."""
-        f_x = self.call(x, grad)
-        self.history.append((np.copy(x), f_x))
-        return f_x
 
     def _store_x(self, x: np.ndarray) -> None:
         """Store ``x`` in ``self.prev_iter``."""

--- a/bluemira/optimisation/_nlopt/functions.py
+++ b/bluemira/optimisation/_nlopt/functions.py
@@ -77,6 +77,8 @@ class ObjectiveFunction(_NloptFunction):
     based, a numerical approximation of the gradient is calculated.
     """
 
+    f: ObjectiveCallable
+
     def __init__(
         self,
         f: ObjectiveCallable,

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -229,16 +229,22 @@ class NloptOptimiser(Optimiser):
             f_x = self._objective.f(x_star)
         except nlopt.RoundoffLimited:
             # It's likely that the last call was still a reasonably good solution.
-            bluemira_warn(
-                "optimisation: round-off error occurred, returning last optimisation "
-                "parameterisation."
-            )
+            round_off_msg = "optimisation: round-off error occurred"
             if self._objective.history:
+                # TODO(hsaunders1904): Is this really what we want to
+                # return? Can't the minimum have been something that
+                # wildly violates constraints?
+                bluemira_warn(
+                    f"{round_off_msg}. Returning best parameterisation found so far."
+                )
                 fx_values = np.array(self._objective.history).T[1]
-                f_x = np.min(fx_values)
                 arg_min_fx = np.argmin(fx_values)
+                f_x = fx_values[arg_min_fx]
                 x_star = self._objective.history[arg_min_fx][0]
             else:
+                bluemira_warn(
+                    f"{round_off_msg}. Returning last optimisation parameterisation."
+                )
                 x_star = self._objective.prev_iter
                 f_x = np.infty
 

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -126,7 +126,7 @@ class NloptOptimiser(Optimiser):
 
         self._set_algorithm(algorithm)
         self._opt = nlopt.opt(_NLOPT_ALG_MAPPING[self.algorithm], n_variables)
-        self._set_objective_function(f_objective, df_objective)
+        self._set_objective_function(f_objective, df_objective, n_variables)
         self._set_termination_conditions(opt_conditions)
         self._set_algorithm_parameters(opt_parameters)
         self._eq_constraints: List[Constraint] = []
@@ -302,11 +302,14 @@ class NloptOptimiser(Optimiser):
         self._algorithm = _check_algorithm(alg)
 
     def _set_objective_function(
-        self, func: ObjectiveCallable, df: Union[None, OptimiserCallable]
+        self,
+        func: ObjectiveCallable,
+        df: Union[None, OptimiserCallable],
+        n_variables: int,
     ) -> None:
         """Wrap and set the objective function."""
         self._objective = ObjectiveFunction(
-            func, df, bounds=(self.lower_bounds, self.upper_bounds)
+            func, df, n_variables, bounds=(self.lower_bounds, self.upper_bounds)
         )
         if self._keep_history:
             self._opt.set_min_objective(self._objective.call_with_history)

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -285,7 +285,7 @@ class NloptOptimiser(Optimiser):
             bluemira_warn(
                 f"{round_off_msg}. Returning best parameterisation found so far."
             )
-            fx_values = np.array(self._objective.history).T[1]
+            fx_values = [h[1] for h in self._objective.history]
             arg_min_fx = np.argmin(fx_values)
             f_x = fx_values[arg_min_fx]
             x_star = self._objective.history[arg_min_fx][0]

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -239,7 +239,7 @@ class NloptOptimiser(Optimiser):
                 arg_min_fx = np.argmin(fx_values)
                 x_star = self._objective.history[arg_min_fx][0]
             else:
-                x_star = x0
+                x_star = self._objective.prev_iter
                 f_x = np.infty
 
         return OptimiserResult(

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -246,7 +246,10 @@ class NloptOptimiser(Optimiser):
                     f"{round_off_msg}. Returning last optimisation parameterisation."
                 )
                 x_star = self._objective.prev_iter
-                f_x = self._objective.f(x_star)
+                if x_star.size:
+                    f_x = self._objective.f(x_star)
+                else:
+                    f_x = np.inf
 
         return OptimiserResult(
             f_x=f_x,

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -246,7 +246,7 @@ class NloptOptimiser(Optimiser):
                     f"{round_off_msg}. Returning last optimisation parameterisation."
                 )
                 x_star = self._objective.prev_iter
-                f_x = np.infty
+                f_x = self._objective.f(x_star)
 
         return OptimiserResult(
             f_x=f_x,

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -277,21 +277,12 @@ class NloptOptimiser(Optimiser):
         It's likely the last call was a decent solution, so return that
         (with a warning).
         """
-        round_off_msg = "optimisation: round-off error occurred"
-        if self._objective.history:
-            bluemira_warn(
-                f"{round_off_msg}. Returning best parameterisation found so far."
-            )
-            fx_values = [h[1] for h in self._objective.history]
-            arg_min_fx = np.argmin(fx_values)
-            f_x = fx_values[arg_min_fx]
-            x_star = self._objective.history[arg_min_fx][0]
-        else:
-            bluemira_warn(
-                f"{round_off_msg}. Returning last optimisation parameterisation."
-            )
-            x_star = self._objective.prev_iter
-            f_x = self._objective.f(x_star) if x_star.size else np.inf
+        bluemira_warn(
+            "optimisation: round-off error occurred. "
+            "Returning last optimisation parameterisation."
+        )
+        x_star = self._objective.prev_iter
+        f_x = self._objective.f(x_star) if x_star.size else np.inf
         return x_star, f_x
 
     def _set_algorithm(self, alg: Union[str, Algorithm]) -> None:

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -279,9 +279,6 @@ class NloptOptimiser(Optimiser):
         """
         round_off_msg = "optimisation: round-off error occurred"
         if self._objective.history:
-            # TODO(hsaunders1904): Is this really what we want to
-            # return? Can't the minimum have been something that
-            # wildly violates constraints?
             bluemira_warn(
                 f"{round_off_msg}. Returning best parameterisation found so far."
             )

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -40,7 +40,12 @@ class OptimiserResult:
     n_evals: int
     """The number of evaluations of the objective function in the optimisation."""
     history: List[Tuple[np.ndarray, float]] = field(repr=False)
-    """The history of the parametrisation at each iteration."""
+    """
+    The history of the parametrisation at each iteration.
+
+    The first element of each tuple is the parameterisation (x), the
+    second is the evaluation of the objective function at x (f(x)).
+    """
     constraints_satisfied: Union[bool, None] = None
     """
     Whether all constraints have been satisfied to within the required tolerance.

--- a/tests/optimisation/test_nlopt.py
+++ b/tests/optimisation/test_nlopt.py
@@ -355,11 +355,7 @@ class TestNloptOptimiser:
         error_on = 4
         erroring_objective = ErroringObjective(error_on)
         err_opt = NloptOptimiser(
-            "COBYLA",
-            2,
-            erroring_objective,
-            opt_conditions={"max_eval": 5},
-            keep_history=True,
+            "COBYLA", 2, erroring_objective, opt_conditions={"max_eval": 5}
         )
         err_res = err_opt.optimise(np.array([0, 0]))
 

--- a/tests/optimisation/test_nlopt.py
+++ b/tests/optimisation/test_nlopt.py
@@ -321,20 +321,50 @@ class TestNloptOptimiser:
         with pytest.raises(OptimisationError):
             getattr(opt, f"add_{t}_constraint")(no_op, np.array([1e-4, 1e-4]))
 
-    @mock.patch(f"{NLOPT_OPT_REF}.optimize")
     @mock.patch("bluemira.optimisation._nlopt.optimiser.bluemira_warn")
-    def test_warning_and_prev_iter_result_given_round_off_error(
-        self, bm_warn, nlopt_mock
-    ):
-        nlopt_mock.side_effect = nlopt.RoundoffLimited
-        x0 = np.array([1, 2])
-        opt = NloptOptimiser("SLSQP", 2, no_op, opt_conditions={"max_eval": 200})
+    def test_warning_and_prev_iter_result_given_round_off_error(self, bm_warn):
+        # This is a bit of tricky one to test, so this is also a little
+        # bit hacky, sorry!
+        # Run a deterministic optimisation once, keeping the history.
+        # Then run that optimisation again, but throw a round-off error
+        # a set no. of iterations in. Then check, in the history, that
+        # we return the parameterisation from the iteration previous to
+        # the one we threw the round-off error in.
+        def objective(x):
+            return -np.sum(x)
 
-        res = opt.optimise(x0)
+        class ErroringObjective:
+            def __init__(self, error_on_iter: int) -> None:
+                self.iter_num = 0
+                self.error_on_iter = error_on_iter
+
+            def __call__(self, x):
+                self.iter_num += 1
+                if self.iter_num == self.error_on_iter:
+                    raise nlopt.RoundoffLimited()
+                return objective(x)
+
+        # Run the first optimisation
+        opt = NloptOptimiser(
+            "COBYLA", 2, objective, opt_conditions={"max_eval": 5}, keep_history=True
+        )
+        hist = opt.optimise(np.array([0, 0])).history
+
+        # Now run it again, but throw an error on iteration 4 of the
+        # optimisation loop
+        error_on = 4
+        erroring_objective = ErroringObjective(error_on)
+        err_opt = NloptOptimiser(
+            "COBYLA",
+            2,
+            erroring_objective,
+            opt_conditions={"max_eval": 5},
+            keep_history=True,
+        )
+        err_res = err_opt.optimise(np.array([0, 0]))
 
         bm_warn.assert_called_once()
-        assert res.n_evals == 0
-        np.testing.assert_allclose(res.x, x0)
+        np.testing.assert_allclose(err_res.x, hist[error_on - 1][0])
 
     @pytest.mark.parametrize("bad_alg", [0, ["SLSQP"]])
     def test_TypeError_setting_alg_with_invalid_type(self, bad_alg):

--- a/tests/optimisation/test_nlopt.py
+++ b/tests/optimisation/test_nlopt.py
@@ -362,31 +362,6 @@ class TestNloptOptimiser:
         bm_warn.assert_called_once()
         np.testing.assert_allclose(err_res.x, hist[error_on - 1][0])
 
-    @mock.patch("bluemira.optimisation._nlopt.optimiser.bluemira_warn")
-    def test_warning_and_min_previous_result_given_round_off_error_and_history(
-        self, bm_warn
-    ):
-        class ErroringObjective:
-            def __init__(self, error_on_iter: int) -> None:
-                self.iter_num = 0
-                self.error_on_iter = error_on_iter
-                self.fs = [0.0, 4.0, -2.0, -1.0, 0.0]
-
-            def __call__(self, x):
-                self.iter_num += 1
-                if self.iter_num == self.error_on_iter:
-                    raise nlopt.RoundoffLimited()
-                return self.fs[min(self.iter_num, len(self.fs) - 1)]
-
-        objective = ErroringObjective(error_on_iter=5)
-        opt = NloptOptimiser(
-            "COBYLA", 1, objective, opt_conditions={"max_eval": 5}, keep_history=True
-        )
-        res = opt.optimise(np.array([0.0]))
-
-        bm_warn.assert_called_once()
-        assert res.f_x == -2.0
-
     @pytest.mark.parametrize("bad_alg", [0, ["SLSQP"]])
     def test_TypeError_setting_alg_with_invalid_type(self, bad_alg):
         with pytest.raises(TypeError):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2335 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
On a round-off error, we were actually returning the _initial_ parameterisation, not the parameterisation from the previous iteration 😱.

I'm a little dubious of the way this was being handled in the old optimiser. I found it necessary to copy the NLOpt array to get the documented behaviour (at least what I thought the documented behaviour meant). This was not being done in the old optimiser classes.

I thought we were intending to return the parameterisation from the iteration _before_ we got the round-off error (this is what I've implemented). But it occurs to me now that maybe we wanted the iteration that actually caused the round-off error (I believe this is the behaviour the old optimiser has. Couldn't this mean we get a bunch of `NaN`s?, though).

@CoronelBuendia any thoughts on what behaviour we're actually after?

Also, thoughts on this [TODO](https://github.com/Fusion-Power-Plant-Framework/bluemira/pull/2336/files#diff-7c6c17eb9e2800ef1b3be1e40569f1c8c9ab22c63f789c02eeda0e1744d48b72R234) would be appreciated.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
