### PR TITLE
Add deprecation warnings to old optimisation modules

### DIFF
--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -921,4 +921,3 @@ class OISBuilder(Builder):
             apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
 
         return components
-        return components

--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -23,8 +23,9 @@
 Coil support builders
 """
 
+import warnings
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -56,6 +57,7 @@ from bluemira.geometry.tools import (
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.optimisation import OptimisationProblem
 from bluemira.optimisation.typing import ConstraintT
+from bluemira.utilities.optimiser import Optimiser as _DeprecatedOptimiser
 
 
 @dataclass
@@ -575,6 +577,7 @@ class StraightOISOptimisationProblem(OptimisationProblem):
         self,
         wire: BluemiraWire,
         keep_out_zone: BluemiraFace,
+        optimiser: Optional[_DeprecatedOptimiser] = None,
         n_koz_discr: int = 100,
     ):
         self.wire = wire
@@ -582,6 +585,17 @@ class StraightOISOptimisationProblem(OptimisationProblem):
         self.koz_points = (
             keep_out_zone.boundary[0].discretize(byedges=True, ndiscr=n_koz_discr).xz.T
         )
+        if optimiser is not None:
+            warnings.warn(
+                "Use of StraightOISOptimisationProblem's 'optimiser' argument is "
+                "deprecated and it will be removed in version 2.0.0.\n"
+                "See "
+                "https://bluemira.readthedocs.io/en/latest/optimisation/"
+                "optimisation.html "
+                "for documentation of the new optimisation module.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def objective(self, x: np.ndarray) -> float:
         """Objective function to maximise length."""
@@ -906,4 +920,5 @@ class OISBuilder(Builder):
         for component in components:
             apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
 
+        return components
         return components

--- a/bluemira/equilibria/opt_constraint_funcs.py
+++ b/bluemira/equilibria/opt_constraint_funcs.py
@@ -56,12 +56,22 @@ in derivative based algorithms, such as those utilising gradient descent.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from bluemira.equilibria.equilibrium import Equilibrium
 
 import numpy as np
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def objective_constraint(

--- a/bluemira/equilibria/opt_constraints.py
+++ b/bluemira/equilibria/opt_constraints.py
@@ -24,6 +24,7 @@ Equilibrium optimisation constraint classes
 """
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
@@ -44,6 +45,15 @@ from bluemira.equilibria.plotting import ConstraintPlotter
 from bluemira.geometry.coordinates import interpolate_points
 from bluemira.utilities.opt_problems import OptimisationConstraint
 from bluemira.utilities.tools import abs_rel_difference, is_num
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def _get_dummy_equilibrium(equilibrium: Equilibrium):

--- a/bluemira/equilibria/opt_objectives.py
+++ b/bluemira/equilibria/opt_objectives.py
@@ -37,7 +37,7 @@ Note that the gradient of the objective function is of the form:
 
 :math:`\\nabla f = \\bigg[\\dfrac{\\partial f}{\\partial x_0}, \\dfrac{\\partial f}{\\partial x_1}, ...\\bigg]`
 """  # noqa (W505)
-
+import warnings
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
@@ -45,6 +45,15 @@ import numpy as np
 from bluemira.base.look_and_feel import bluemira_print_flush
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.utilities.optimiser import approx_derivative
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def ad_objective(

--- a/bluemira/equilibria/opt_problems.py
+++ b/bluemira/equilibria/opt_problems.py
@@ -37,6 +37,7 @@ the method used to map the coilset object to the state vector
 """
 
 import abc
+import warnings
 from typing import List, Tuple
 
 import numpy as np
@@ -67,6 +68,15 @@ __all__ = [
     "CoilsetPositionCOP",
     "NestedCoilsetPositionCOP",
 ]
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class CoilsetOptimisationProblem(OptimisationProblem):

--- a/bluemira/geometry/optimisation/_optimisation_old.py
+++ b/bluemira/geometry/optimisation/_optimisation_old.py
@@ -23,7 +23,7 @@
 Geometry optimisation classes and tools
 """
 
-
+import warnings
 from typing import List
 
 import numpy as np
@@ -41,6 +41,15 @@ from bluemira.utilities.opt_problems import (
 from bluemira.utilities.optimiser import Optimiser, approx_derivative
 
 __all__ = ["GeometryOptimisationProblem", "minimise_length", "MinimiseLengthGOP"]
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def calculate_length(vector, parameterisation):

--- a/bluemira/utilities/opt_problems.py
+++ b/bluemira/utilities/opt_problems.py
@@ -23,12 +23,23 @@
 Generic OptimisationProblem, OptimisationConstraint and OptimisationObjective interfaces.
 """
 import inspect
+import warnings
 from abc import ABC, abstractmethod
 from typing import List
 
 import numpy as np
 
 from bluemira.utilities.optimiser import Optimiser
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in v2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["OptimisationProblem", "OptimisationObjective", "OptimisationConstraint"]
 

--- a/bluemira/utilities/optimiser.py
+++ b/bluemira/utilities/optimiser.py
@@ -22,6 +22,7 @@
 """
 Static API to optimisation library
 """
+import warnings
 from pprint import pformat
 from typing import Union
 
@@ -33,6 +34,15 @@ from bluemira.codes._nlopt_api import NLOPTOptimiser
 from bluemira.utilities.tools import is_num
 
 __all__ = ["approx_derivative", "Optimiser"]
+
+warnings.warn(
+    f"The module '{__name__}' is deprecated and will be removed in version 2.0.0.\n"
+    "See "
+    "https://bluemira.readthedocs.io/en/latest/optimisation/optimisation.html "
+    "for documentation of the new optimisation module.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def approx_derivative(


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2337 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Adds deprecation warnings to the old optimisation modules and to some other bits of code whose usage will change due to the new optimisation module.

Leaving this as draft for now, as there may be more to add before the feature branch is ready, e.g., there may be some `kwarg` changes in `CoilsetOptimisationProblem`.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
