### PR TITLE
Fix docstring indentation

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -853,17 +853,17 @@ class SextupleArc(GeometryParameterisation):
         self, constraint: np.ndarray, x_norm: np.ndarray, grad: np.ndarray
     ) -> np.ndarray:
         """
-                Inequality constraint function for the variable vector of the geometry
-                parameterisation.
+        Inequality constraint function for the variable vector of the geometry
+        parameterisation.
 
-                Parameters
-                ----------
-                constraint:
-                    Constraint vector (assign in place)
-                x_norm:
-                    Normalised vector of free variables
-                grad:
-                    Gradient matrix of the constraint (assign in place)
+        Parameters
+        ----------
+        constraint:
+            Constraint vector (assign in place)
+        x_norm:
+            Normalised vector of free variables
+        grad:
+            Gradient matrix of the constraint (assign in place)
         """
         x_actual = self._process_x_norm_fixed(x_norm)
 

--- a/examples/geometry/optimisation_tutorial.ex.py
+++ b/examples/geometry/optimisation_tutorial.ex.py
@@ -57,10 +57,7 @@ import numpy as np
 
 from bluemira.geometry.optimisation import GeometryOptimisationProblem, minimise_length
 from bluemira.geometry.parameterisations import PrincetonD
-from bluemira.utilities.opt_problems import (
-    OptimisationConstraint,
-    OptimisationObjective,
-)
+from bluemira.utilities.opt_problems import OptimisationConstraint, OptimisationObjective
 from bluemira.utilities.optimiser import Optimiser, approx_derivative
 from bluemira.utilities.tools import set_random_seed
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Docstring indentation got mangled by me somehow. Needs fixing, as all the other `feature/new_optimisation_module` PRs are failing!

This commit exists in #2331, but let's get this in on its own.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
