### PR TITLE
Fix inline latex not rendering in optimise docstring

### DIFF
--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -127,10 +127,10 @@ def optimise_geometry(
         optimisation.
     f_objective:
         The objective function to minimise. Must take as an argument a
-        `GeometryParameterisation` and return a float.
+        ``GeometryParameterisation`` and return a ``float``.
     df_objective:
-        The derivative of the objective function, by default None. If
-        not given, an approximation of the derivative is made using
+        The derivative of the objective function, by default ``None``.
+        If not given, an approximation of the derivative is made using
         the 'central differences' method.
         This argument is ignored if a non-gradient based algorithm is
         used.
@@ -141,7 +141,7 @@ def optimise_geometry(
         dictionary with keys the same as the properties of the
         `:class:`.KeepOutZone` class, or just a :class:`.BluemiraWire`.
     algorithm:
-        The optimisation algorithm to use, by default ``Algorithm.SLSQP``.
+        The optimisation algorithm to use, by default :obj:`.Algorithm.SLSQP`.
     opt_conditions:
         The stopping conditions for the optimiser. Supported conditions
         are:
@@ -167,24 +167,25 @@ def optimise_geometry(
             function. If not given, a numerical approximation of the
             gradient is made (if a gradient is required).
 
-        A constraint is a vector-valued, non-linear, equality
-        constraint of the form $f_{c}(x) \eq 0$.
+        The constraint is a vector-valued, non-linear, inequality
+        constraint of the form :math:`f_{c}(g) = 0`.
 
-        The constraint function should have the form ``f(g) -> y``,
-        where:
+        The constraint function should have the form
+        :math:`f(g) \rightarrow y`, where:
 
-            * `g` is a geometry parameterisation.
-            * `y` is a numpy array containing the values of the
-                constraint at the current parameterisation of ``g``.
-                It must have size $m$, where $m$ is the dimensionality of
-                the constraint.
+            * :math:`g` is a geometry parameterisation.
+            * :math:`y` is a numpy array containing the values of the
+              constraint at :math:`g`, with size :math:`m`, where
+              :math:`m` is the dimensionality of the constraint.
+
 
         The tolerance array must have the same dimensionality as the
         constraint.
 
         The gradient function should have the same form as the
         constraint function, however its output should have size
-        $n \cross m$ where $m$ is the dimensionality of the constraint.
+        :math:`n \times m` where :math:`m` is the dimensionality of the
+        constraint.
 
         Equality constraints are only supported by algorithms:
 
@@ -194,8 +195,9 @@ def optimise_geometry(
 
     ineq_constraints:
         The geometric inequality constraints for the optimiser.
-        This argument has the same form as the `eq_constraint` argument,
-        but each constraint is of the form $f_{c}(x) \le 0$.
+        This argument has the same form as the ``eq_constraint``
+        argument, but each constraint is of the form
+        :math:`f_{c}(g) \le 0`.
 
         Inequality constraints are only supported by algorithms:
 
@@ -207,7 +209,7 @@ def optimise_geometry(
         Whether or not to record the history of the optimisation
         parameters at each iteration. Note that this can significantly
         impact the performance of the optimisation.
-        (default: False)
+        (default: ``False``)
     check_constraints:
         Whether to check all constraints have been satisfied at the end
         of the optimisation, and warn if they have not. Note that, if

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -184,8 +184,9 @@ def optimise_geometry(
 
         The gradient function should have the same form as the
         constraint function, however its output should have size
-        :math:`n \times m` where :math:`m` is the dimensionality of the
-        constraint.
+        :math:`n \times m` where, again, :math:`m` is the dimensionality
+        of the constraint and :math:`n` is the number of parameters in
+        the geometry parameterisation.
 
         Equality constraints are only supported by algorithms:
 

--- a/bluemira/optimisation/_geometry/optimise.py
+++ b/bluemira/optimisation/_geometry/optimise.py
@@ -167,7 +167,7 @@ def optimise_geometry(
             function. If not given, a numerical approximation of the
             gradient is made (if a gradient is required).
 
-        The constraint is a vector-valued, non-linear, inequality
+        The constraint is a vector-valued, non-linear, equality
         constraint of the form :math:`f_{c}(g) = 0`.
 
         The constraint function should have the form

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -77,10 +77,12 @@ class NloptOptimiser(Optimiser):
         argument (a numpy array), and return a numpy array or float.
     df_objective:
         The derivative of the objective function. This must take the
-        form: `f(x) -> y` where `x` is a numpy array containing the
-        optimization parameters, and `y` is a numpy array where each
-        element `i` is the partial derivative `\partialf/\partialdx_{i}`.
-        If not given, a numerical approximation of the gradient is used.
+        form: :math:`f(x) \rightarrow y` where :math:`x` is a numpy
+        array containing the optimization parameters, and :math:`y` is a
+        numpy array where each element :math:`i` is the partial
+        derivative :math:`\frac{\partial f(x)}{\partial x_{i}}`.
+        If not given, and a gradient based algorithm is used, a
+        numerical approximation of the gradient will be made.
     opt_conditions:
         The stopping conditions for the optimiser. At least one stopping
         condition is required. Supported conditions are:
@@ -94,22 +96,12 @@ class NloptOptimiser(Optimiser):
             * stop_val: float
 
     opt_parameters:
-        Parameters specific to the algorithm being used. Consult NLopt
-        documentation for these.
+        Parameters specific to the algorithm being used. Consult the
+        NLopt documentation for these.
     keep_history:
         Whether to record the history of each step of the optimisation.
-        (default: False)
+        (default: ``False``)
     """
-
-    SLSQP = "SLSQP"
-    COBYLA = "COBYLA"
-    SBPLX = "SBPLX"
-    MMA = "MMA"
-    BFGS = "BFGS"
-    DIRECT = "DIRECT"
-    DIRECT_L = "DIRECT_L"
-    CRS = "CRS"
-    ISRES = "ISRES"
 
     def __init__(
         self,
@@ -164,13 +156,6 @@ class NloptOptimiser(Optimiser):
         tolerance: np.ndarray,
         df_constraint: Optional[OptimiserCallable] = None,
     ) -> None:
-        """
-        Add an equality constraint to the optimiser.
-
-        See docs of
-        :obj:`optimisation._optimiser.Optimiser.add_eq_constraint` for
-        details of the form the arguments should take.
-        """
         if self.algorithm not in [Algorithm.SLSQP, Algorithm.COBYLA, Algorithm.ISRES]:
             raise OptimisationError(
                 f"Algorithm '{self.algorithm.name}' does not support equality "
@@ -192,13 +177,6 @@ class NloptOptimiser(Optimiser):
         tolerance: np.ndarray,
         df_constraint: Optional[OptimiserCallable] = None,
     ) -> None:
-        r"""
-        Add an inequality constraint to the optimiser.
-
-        See docs of
-        :obj:`optimisation._optimiser.Optimiser.add_ineq_constraint` for
-        details of the form the arguments should take.
-        """
         if self.algorithm not in [Algorithm.SLSQP, Algorithm.COBYLA, Algorithm.ISRES]:
             raise OptimisationError(
                 f"Algorithm '{self.algorithm.name}' does not support inequality "
@@ -215,13 +193,6 @@ class NloptOptimiser(Optimiser):
         self._ineq_constraints.append(constraint)
 
     def optimise(self, x0: Optional[np.ndarray] = None) -> OptimiserResult:
-        """
-        Run the optimiser.
-
-        See docs of
-        :obj:`optimisation._optimiser.Optimiser.optimise` for details of
-        the form the arguments should take.
-        """
         if x0 is None:
             x0 = _initial_guess_from_bounds(self.lower_bounds, self.upper_bounds)
 
@@ -256,11 +227,6 @@ class NloptOptimiser(Optimiser):
         )
 
     def set_lower_bounds(self, bounds: np.ndarray) -> None:
-        """
-        Set the lower bound for each optimisation parameter.
-
-        Set to `-np.inf` to unbound the parameter's minimum.
-        """
         bounds = np.array(bounds)
         _check_bounds(self._opt.get_dimension(), bounds)
         self._opt.set_lower_bounds(bounds)
@@ -272,11 +238,6 @@ class NloptOptimiser(Optimiser):
             constraint.set_approx_derivative_lower_bound(bounds)
 
     def set_upper_bounds(self, bounds: Union[np.ndarray, float]) -> None:
-        """
-        Set the upper bound for each optimisation parameter.
-
-        Set to `np.inf` to unbound the parameter's minimum.
-        """
         bounds = np.array(bounds)
         _check_bounds(self._opt.get_dimension(), bounds)
         self._opt.set_upper_bounds(bounds)

--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import nlopt
 import numpy as np
+import numpy.typing as npt
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.optimisation._algorithm import Algorithm
@@ -156,6 +157,11 @@ class NloptOptimiser(Optimiser):
         tolerance: np.ndarray,
         df_constraint: Optional[OptimiserCallable] = None,
     ) -> None:
+        """
+        Add an equality constraint.
+
+        See :meth:`~bluemira.optimisation._optimiser.Optimiser.add_eq_constraint`.
+        """
         if self.algorithm not in [Algorithm.SLSQP, Algorithm.COBYLA, Algorithm.ISRES]:
             raise OptimisationError(
                 f"Algorithm '{self.algorithm.name}' does not support equality "
@@ -177,6 +183,11 @@ class NloptOptimiser(Optimiser):
         tolerance: np.ndarray,
         df_constraint: Optional[OptimiserCallable] = None,
     ) -> None:
+        """
+        Add an inequality constraint.
+
+        See :meth:`~bluemira.optimisation._optimiser.Optimiser.add_ineq_constraint`.
+        """
         if self.algorithm not in [Algorithm.SLSQP, Algorithm.COBYLA, Algorithm.ISRES]:
             raise OptimisationError(
                 f"Algorithm '{self.algorithm.name}' does not support inequality "
@@ -193,6 +204,11 @@ class NloptOptimiser(Optimiser):
         self._ineq_constraints.append(constraint)
 
     def optimise(self, x0: Optional[np.ndarray] = None) -> OptimiserResult:
+        """
+        Run the optimisation.
+
+        See :meth:`~bluemira.optimisation._optimiser.Optimiser.optimise`.
+        """
         if x0 is None:
             x0 = _initial_guess_from_bounds(self.lower_bounds, self.upper_bounds)
 
@@ -226,7 +242,12 @@ class NloptOptimiser(Optimiser):
             history=self._objective.history,
         )
 
-    def set_lower_bounds(self, bounds: np.ndarray) -> None:
+    def set_lower_bounds(self, bounds: npt.ArrayLike) -> None:
+        """
+        Set the lower bound for each optimisation parameter.
+
+        See :meth:`~bluemira.optimisation._optimiser.Optimiser.set_lower_bounds`.
+        """
         bounds = np.array(bounds)
         _check_bounds(self._opt.get_dimension(), bounds)
         self._opt.set_lower_bounds(bounds)
@@ -237,7 +258,12 @@ class NloptOptimiser(Optimiser):
         for constraint in self._eq_constraints + self._ineq_constraints:
             constraint.set_approx_derivative_lower_bound(bounds)
 
-    def set_upper_bounds(self, bounds: Union[np.ndarray, float]) -> None:
+    def set_upper_bounds(self, bounds: npt.ArrayLike) -> None:
+        """
+        Set the upper bound for each optimisation parameter.
+
+        See :meth:`~bluemira.optimisation._optimiser.Optimiser.set_upper_bounds`.
+        """
         bounds = np.array(bounds)
         _check_bounds(self._opt.get_dimension(), bounds)
         self._opt.set_upper_bounds(bounds)

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -131,7 +131,8 @@ def optimise(
         The gradient function should have the same form as the
         constraint function, however its output should have size
         :math:`n \times m` where :math:`m` is the dimensionality of the
-        constraint.
+        constraint and :math:`n` is the number of optimisation
+        parameters.
 
         Equality constraints are only supported by algorithms:
 

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -141,7 +141,7 @@ def optimise(
 
     ineq_constraints:
         The inequality constraints for the optimiser.
-        This argument has the same form as the `eq_constraint` argument,
+        This argument has the same form as the ``eq_constraint`` argument,
         but each constraint is in the form :math:`f_{c}(x) \le 0`.
 
         Inequality constraints are only supported by algorithms:

--- a/bluemira/optimisation/_optimise.py
+++ b/bluemira/optimisation/_optimise.py
@@ -71,17 +71,17 @@ def optimise(
     f_objective:
         The objective function to minimise.
     dimensions:
-        The dimensionality of the problem. This or `x0` must be given.
+        The dimensionality of the problem. This or ``x0`` must be given.
     x0:
         The initial guess for the optimisation parameters. This or
-        `dimensions` must be given, if both are given, `x0.size` must be
-        equal to `dimensions`.
+        `dimensions` must be given, if both are given, ``x0.size`` must
+        be equal to ``dimensions``.
     df_objective:
         The derivative of the objective function.
     algorithm:
         The optimisation algorithm to use. See enum
-        :obj:`optimisation.Algorithm` for supported algorithms.
-        (default: "SLSQP")
+        :class:`.Algorithm` for supported algorithms.
+        (default: ``"SLSQP"``)
     opt_conditions:
         The stopping conditions for the optimiser. Supported conditions
         are:
@@ -94,7 +94,7 @@ def optimise(
             * max_time: float
             * stop_val: float
 
-        (default: {"max_eval": 2000})
+        (default: ``{"max_eval": 2000}``\)
     opt_parameters:
         The algorithm-specific optimisation parameters.
     bounds:
@@ -115,22 +115,23 @@ def optimise(
               gradient is made (if a gradient is required).
 
         A constraint is a vector-valued, non-linear, equality
-        constraint of the form $f_{c}(x) \eq 0$.
+        constraint of the form :math:`f_{c}(x) = 0`.
 
-        The constraint function should have the form `f(x) -> y`,
-        where:
+        The constraint function should have the form
+        :math:`f(x) \rightarrow y`, where:
 
-            * `x` is a numpy array of the optimisation parameters.
-            * `y` is a numpy array containing the values of the
-              constraint at `x`, with size $m$, where $m$ is the
-              dimensionality of the constraint.
+            * :math:`x` is a numpy array of the optimisation parameters.
+            * :math:`y` is a numpy array containing the values of the
+              constraint at :math:`x`, with size :math:`m`, where
+              :math:`m` is the dimensionality of the constraint.
 
         The tolerance array must have the same dimensionality as the
         constraint.
 
         The gradient function should have the same form as the
         constraint function, however its output should have size
-        $n \cross m$ where $m$ is the dimensionality of the constraint.
+        :math:`n \times m` where :math:`m` is the dimensionality of the
+        constraint.
 
         Equality constraints are only supported by algorithms:
 
@@ -141,7 +142,7 @@ def optimise(
     ineq_constraints:
         The inequality constraints for the optimiser.
         This argument has the same form as the `eq_constraint` argument,
-        but each constraint is in the form $f_{c}(x) \le 0$.
+        but each constraint is in the form :math:`f_{c}(x) \le 0`.
 
         Inequality constraints are only supported by algorithms:
 

--- a/bluemira/optimisation/_optimiser.py
+++ b/bluemira/optimisation/_optimiser.py
@@ -64,19 +64,19 @@ class Optimiser(abc.ABC):
         tolerance: np.ndarray,
         df_constraint: Optional[OptimiserCallable] = None,
     ) -> None:
-        """
+        r"""
         Add an equality constraint to the optimiser.
 
         The constraint is a vector-valued, non-linear, equality
-        constraint of the form $h(x) = 0$.
+        constraint of the form :math:`f_{c}(x) = 0`.
 
-        The constraint function must have the form `f(x) -> y`,
-        where:
+        The constraint function should have the form
+        :math:`f(x) \rightarrow y`, where:
 
-            * `x` is a numpy array of the optimisation parameters.
-            * `y` is a numpy array containing the values of the
-              constraint at `x`, with size $m$, where $m$ is the
-              dimensionality of the constraint.
+            * :math:`x` is a numpy array of the optimisation parameters.
+            * :math:`y` is a numpy array containing the values of the
+              constraint at :math:`x`, with size :math:`m`, where
+              :math:`m` is the dimensionality of the constraint.
 
         Parameters
         ----------
@@ -85,14 +85,15 @@ class Optimiser(abc.ABC):
         tolerance:
             The tolerances for each optimisation parameter.
         df_constraint:
-            The gradient of the constraint function. This should have the
-            same form as the constraint function, however its output
-            array should have dimensions `m x n_variables` where `m` is
-            the dimensionality of the constraint.
+            The gradient of the constraint function. This should have
+            the same form as the constraint function, however its output
+            array should have dimensions :math:`m \times n` where
+            :math`m` is the dimensionality of the constraint, and
+            :math:`n` is the number of optimisation parameters.
 
         Notes
         -----
-        Equality constraints are only supported by algorithms:
+        Inequality constraints are only supported by algorithms:
 
             * SLSQP
             * COBYLA
@@ -111,15 +112,15 @@ class Optimiser(abc.ABC):
         Add an inequality constrain to the optimiser.
 
         The constraint is a vector-valued, non-linear, inequality
-        constraint of the form $f_{c}(x) \le 0$.
+        constraint of the form :math:`f_{c}(x) \le 0`.
 
-        The constraint function should have the form `f(x) -> y`,
-        where:
+        The constraint function should have the form
+        :math:`f(x) \rightarrow y`, where:
 
-            * `x` is a numpy array of the optimisation parameters.
-            * `y` is a numpy array containing the values of the
-              constraint at `x`, with size $m$, where $m$ is the
-              dimensionality of the constraint.
+            * :math:`x` is a numpy array of the optimisation parameters.
+            * :math:`y` is a numpy array containing the values of the
+              constraint at :math:`x`, with size :math:`m`, where
+              :math:`m` is the dimensionality of the constraint.
 
         Parameters
         ----------
@@ -128,10 +129,11 @@ class Optimiser(abc.ABC):
         tolerance:
             The tolerances for each optimisation parameter.
         df_constraint:
-            The gradient of the constraint function. This should have the
-            same form as the constraint function, however its output
-            array should have dimensions `m x n_variables` where `m` is
-            the dimensionality of the constraint.
+            The gradient of the constraint function. This should have
+            the same form as the constraint function, however its output
+            array should have dimensions :math:`m \times n` where
+            :math`m` is the dimensionality of the constraint, and
+            :math:`n` is the number of optimisation parameters.
 
         Notes
         -----
@@ -159,7 +161,7 @@ class Optimiser(abc.ABC):
         Returns
         -------
         The result of the optimisation, containing the optimised
-        parameters `x`, as well as other information about the
+        parameters ``x``, as well as other information about the
         optimisation.
         """
 

--- a/documentation/source/optimisation/optimisation.rst
+++ b/documentation/source/optimisation/optimisation.rst
@@ -35,7 +35,8 @@ subject to constraints
 for parameters
 :math:`a_1 = 2`, :math:`b_1 = 0`, :math:`a_2 = -1`, :math:`b_2 = 1`.
 
-This problem expects a minimum at :math:`x = ( \frac{1}{3}, \frac{8}{27} )`.
+This problem expects a minimum at
+:math:`\boldsymbol{x} = ( \frac{1}{3}, \frac{8}{27} )`.
 
 .. note::
 
@@ -89,18 +90,19 @@ so the function can return a float, or,
 an array of length :math:`m`,
 where :math:`m` is the dimensionality of the constraint.
 
-Given a constraint function :math:`f_c`, and optimisation parameters :math:`x`,
+Given a constraint function :math:`f_c`, and optimisation parameters
+:math:`\boldsymbol{x}`,
 an equality constraint has the form
 
 .. math::
 
-    f_c(x) = 0
+    f_c(\boldsymbol{x}) = 0
 
 and an inequality constraint has the form
 
 .. math::
 
-    f_c(x) \le 0
+    f_c(\boldsymbol{x}) \le 0
 
 
 In our example, we have two inequality constraints.


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2252 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Fix up the docstrings in the optimisation module, as well as a small update to the optimisation RST docs to make vectors bold in the maths.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
