### PR TITLE
✨ Max column size for tabulated ParameterFrame

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -254,7 +254,7 @@ ANGLE_UNITS = [
     "arcsecond",
     "milliarcsecond",
     "grade",
-    "mil",
+    # "mil",  # this break milli conversion with current implementation
     "steradian",
     "square_degree",
 ]

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -4,6 +4,7 @@ import copy
 import json
 from contextlib import suppress
 from dataclasses import dataclass, fields
+from operator import itemgetter
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -289,6 +290,9 @@ class ParameterFrame:
         -------
         The tabulated data
         """
+        column_widths = dict(
+            zip(list(ParamDictT.__annotations__.keys()), [20, None, 20, 20, 20, 20])
+        )
         columns = list(ParamDictT.__annotations__.keys()) if keys is None else keys
         rec_col = copy.deepcopy(columns)
         rec_col.pop(columns.index("name"))
@@ -309,6 +313,7 @@ class ParameterFrame:
             tablefmt=tablefmt,
             showindex=False,
             numalign="right",
+            maxcolwidths=list(itemgetter(*columns)(column_widths)),
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Hard limits the table size of a printed parameterframe

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
