### PR TITLE
🐛 Fix FETCH_HEAD bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         flake8 --count
         black --check .
         if [ $COPYRIGHT ]; then
-           git fetch origin $GITHUB_BASE_REF $GITHUB_REF
+           git fetch origin $GITHUB_REF $GITHUB_BASE_REF
            pre-commit run update_copyright --from-ref origin/$GITHUB_BASE_REF --to-ref FETCH_HEAD
         fi
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
FETCH_HEAD refers to the first branch in a git fetch not the last

tested on this CI run https://github.com/Fusion-Power-Plant-Framework/bluemira/actions/runs/5401454617/jobs/9811280435 see the passed on the copyright check

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
