### PR TITLE
Retrofit coilset optimisations to use new optimiser interface

### DIFF
--- a/bluemira/equilibria/opt_problems.py
+++ b/bluemira/equilibria/opt_problems.py
@@ -296,25 +296,25 @@ class CoilsetPositionCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    coilset: CoilSet
+    coilset:
         Coilset to optimise.
     eq: Equilibrium
         Equilibrium object used to update magnetic field targets.
-    targets: MagneticConstraintSet
+    targets:
         Set of magnetic field targets to use in objective function.
-    pfregions: dict(coil_name:Coordinates, coil_name:Coordinates, ...)
+    pfregions:
         Dictionary of Coordinates that specify convex hull regions inside which
         each PF control coil position is to be optimised.
         The Coordinates must be 2d in x,z in units of [m].
-    max_currents: float or np.ndarray (default = None)
+    max_currents:
         Maximum allowed current for each independent coil current in coilset [A].
         If specified as a float, the float will set the maximum allowed current
         for all coils.
-    gamma: float (default = 1e-8)
+    gamma:
         Tikhonov regularisation parameter in units of [A⁻¹].
-    optimiser: bluemira.utilities.optimiser.Optimiser
+    optimiser:
         Optimiser object to use for constrained optimisation.
-    constraints: List[OptimisationConstraint] (default: None)
+    constraints:
         Optional list of OptimisationConstraint objects storing
         information about constraints that must be satisfied
         during the coilset optimisation, to be provided to the
@@ -454,25 +454,25 @@ class CoilsetPositionCOP(CoilsetOptimisationProblem):
 
         Parameters
         ----------
-        vector: np.array
+        vector:
             State vector. Numpy array formed by concatenation of coil radial
             coordinates, coil vertical coordinates, and (scaled) coil currents.
-        grad: np.array
+        grad:
             Dummy variable for NLOpt calls. Not updated.
-        coilset: CoilSet
+        coilset:
             CoilSet to update using state vector.
-        eq: Equilibrium
+        eq:
             Equilibrium object used to update magnetic field targets.
-        targets: MagneticConstraintSet
+        targets:
             Set of magnetic field targets to optimise Equilibrium towards,
             using least-squares objective with Tikhonov regularisation.
-        region_mapper: RegionMapper
+        region_mapper
             RegionMapper mapping coil positions within the allowed optimisation
             regions.
-        current_scale: float
+        current_scale:
             Scale factor to scale currents in state vector up by to
             give currents in [A].
-        gamma: float
+        gamma:
             Tikhonov regularisation parameter in units of [A⁻¹].
 
         Returns
@@ -512,22 +512,22 @@ class NestedCoilsetPositionCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    sub_opt: CoilsetOP
+    sub_opt:
         Coilset OptimisationProblem to use for the optimisation of
         coil currents at each trial set of coil positions.
         sub_opt.coilset must exist, and will be modified
         during the optimisation.
-    eq: Equilibrium
+    eq:
         Equilibrium object used to update magnetic field targets.
-    targets: MagneticConstraintSet
+    targets:
         Set of magnetic field targets to use in objective function.
-    pfregions: dict(coil_name:Coordinates, coil_name:Coordinates, ...)
+    pfregions:
         Dictionary of Coordinates that specify convex hull regions inside which
         each PF control coil position is to be optimised.
         The Coordinates must be 2d in x,z in units of [m].
-    optimiser: bluemira.utilities.optimiser.Optimiser
+    optimiser:
         Optimiser object to use for constrained optimisation.
-    constraints: List[OptimisationConstraint] (default: None)
+    constraints:
         Optional list of OptimisationConstraint objects storing
         information about constraints that must be satisfied
         during the coilset optimisation, to be provided to the
@@ -634,32 +634,32 @@ class NestedCoilsetPositionCOP(CoilsetOptimisationProblem):
 
         Parameters
         ----------
-        vector: np.array(n_C)
+        vector:
             State vector of the array of coil positions.
-        grad: np.array
+        grad:
             Dummy variable for NLOpt calls. Not updated.
         coilset: CoilSet
             CoilSet to update using state vector.
-        eq: Equilibrium
+        eq:
             Equilibrium object used to update magnetic field targets.
-        targets: MagneticConstraintSet
+        targets:
             Set of magnetic field targets to update for use in sub_opt.
-        region_mapper: RegionMapper
+        region_mapper:
             RegionMapper mapping coil positions within the allowed optimisation
             regions.
-        current_scale: float
+        current_scale:
             Scale factor to scale currents in state vector up by to
             give currents in [A].
-        initial_currents: np.array
+        initial_currents:
             Array containing initial (scaled) coil currents prior to passing
             to sub_opt
-        sub_opt: CoilsetOP
+        sub_opt:
             Coilset OptimisationProblem used to optimise the array of coil
             currents at each trial position.
 
         Returns
         -------
-        fom: float
+        fom:
             Value of objective function (figure of merit).
         """
         region_mapper.set_Lmap(vector)
@@ -689,13 +689,13 @@ class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    coilset: CoilSet
+    coilset:
         CoilSet object to optimise with
-    eq: Equilibrium
+    eq:
         Equilibrium object to optimise for
-    targets: MagneticConstraintSet
+    targets:
         Set of magnetic constraints to minimise the error for
-    gamma: float
+    gamma:
         Tikhonov regularisation parameter [1/A]
     """
 
@@ -739,21 +739,21 @@ class TikhonovCurrentCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    coilset: CoilSet
+    coilset:
         Coilset to optimise.
     eq: Equilibrium
         Equilibrium object used to update magnetic field targets.
-    targets: MagneticConstraintSet
+    targets:
         Set of magnetic field targets to use in objective function.
-    gamma: float (default = 1e-8)
+    gamma:
         Tikhonov regularisation parameter in units of [A⁻¹].
     max_currents Union[float, np.ndarray] (default = None)
         Maximum allowed current for each independent coil current in coilset [A].
         If specified as a float, the float will set the maximum allowed current
         for all coils.
-    optimiser: bluemira.utilities.optimiser.Optimiser
+    optimiser:
         Optimiser object to use for constrained optimisation.
-    constraints: List[OptimisationConstraint] (default: None)
+    constraints:
         Optional list of OptimisationConstraint objects storing
         information about constraints that must be satisfied
         during the coilset optimisation, to be provided to the

--- a/bluemira/equilibria/optimisation/constraint_funcs.py
+++ b/bluemira/equilibria/optimisation/constraint_funcs.py
@@ -172,34 +172,40 @@ class FieldConstraints(ConstraintFunction):
         bzp_vec: np.ndarray,
         B_max: np.ndarray,
         scale: float,
-    ) -> None:
-        super().__init__()
+    ):
+        self.ax_mat = ax_mat
+        self.az_mat = az_mat
+        self.bxp_vec = bxp_vec
+        self.bzp_vec = bzp_vec
+        self.B_max = B_max
+        self.scale = scale
+
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        currents = self.scale * vector
+        Bx_a = self.ax_mat @ currents
+        Bz_a = self.az_mat @ currents
+
+        B = np.hypot(Bx_a + self.bxp_vec, Bz_a + self.bzp_vec)
+        return B - self.B_max
+
+    def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        currents = self.scale * vector
+        Bx_a = self.ax_mat @ currents
+        Bz_a = self.az_mat @ currents
+        B = np.hypot(Bx_a + self.bxp_vec, Bz_a + self.bzp_vec)
+        return (
+            Bx_a * (Bx_a @ currents + self.bxp_vec)
+            + Bz_a * (Bz_a @ currents + self.bzp_vec)
+        ) / (B * self.scale**2)
 
 
-# TODO: below
-
-
-def current_midplane_constraint(
-    constraint: np.ndarray,
-    vector: np.ndarray,
-    grad: np.ndarray,
-    eq: Equilibrium,
-    radius: float,
-    scale: float,
-    inboard: bool = True,
-) -> np.ndarray:
+class CurrentMidplanceConstraint(ConstraintFunction):
     """
     Constraint function to constrain the inboard or outboard midplane
     of the plasma during optimisation.
 
     Parameters
     ----------
-    constraint:
-        Constraint array (modified in place)
-    vector:
-        Current vector
-    grad:
-        Constraint Jacobian (modified in place)
     eq:
         Equilibrium to use to fetch last closed flux surface from.
     radius:
@@ -209,171 +215,106 @@ def current_midplane_constraint(
     inboard:
         Boolean controlling whether to constrain the inboard (if True) or
         outboard (if False) side of the plasma midplane.
-
-    Returns
-    -------
-    Updated constraint vector
     """
-    eq.coilset.set_control_currents(vector * scale)
-    lcfs = eq.get_LCFS()
-    if inboard:
-        constraint[:] = radius - min(lcfs.x)
-    else:
-        constraint[:] = max(lcfs.x) - radius
-    return constraint
+
+    def __init__(
+        self,
+        eq: Equilibrium,
+        radius: float,
+        scale: float,
+        inboard: bool,
+    ) -> None:
+        self.eq = eq
+        self.radius = radius
+        self.scale = scale
+        self.inboard = inboard
+
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        self.eq.coilset.set_control_currents(vector * self.scale)
+        lcfs = self.eq.get_LCFS()
+        if self.inboard:
+            return self.radius - min(lcfs.x)
+        return max(lcfs.x) - self.radius
 
 
-def coil_force_constraints(
-    constraint: np.ndarray,
-    vector: np.ndarray,
-    grad: np.ndarray,
-    a_mat: np.ndarray,
-    b_vec: np.ndarray,
-    n_PF: int,
-    n_CS: int,
-    PF_Fz_max: float,
-    CS_Fz_sum_max: float,
-    CS_Fz_sep_max: float,
-    scale: float,
-) -> np.ndarray:
-    """
-    Current optimisation force constraints on coils
+class CoilForceConstraint(ConstraintFunction):
+    def __init__(
+        self,
+        a_mat: np.ndarray,
+        b_vec: np.ndarray,
+        n_PF: int,
+        n_CS: int,
+        PF_Fz_max: float,
+        CS_Fz_sum_max: float,
+        CS_Fz_sep_max: float,
+        scale: float,
+    ) -> None:
+        self.a_mat = a_mat
+        self.b_vec = b_vec
+        self.n_PF = n_PF
+        self.n_CS = n_CS
+        self.PF_Fz_max = PF_Fz_max
+        self.CS_Fz_sum_max = CS_Fz_sum_max
+        self.CS_Fz_sep_max = CS_Fz_sep_max
+        self.scale = scale
 
-    Parameters
-    ----------
-    constraint:
-        Constraint array (modified in place)
-    vector:
-        Current vector
-    grad:
-        Constraint Jacobian (modified in place)
-    a_mat:
-        Response matrix block for Fx and Fz
-    b_vec:
-        Background value vector block for Fx and Fz
-    n_PF:
-        Number of PF coils
-    n_CS:
-        Number of CS coils
-    PF_Fz_max:
-        Maximum vertical force on each PF coil [N]
-    CS_Fz_sum_max:
-        Maximum total vertical force on the CS stack [N]
-    CS_Fz_sep_max:
-        Maximum vertical separation force in the CS stack [N]
-    scale:
-        Current scale with which to calculate the constraints
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        n_coils = len(vector)
+        currents = self.scale * vector
+        constraint = np.zeros(n_coils)
 
-    Returns
-    -------
-    Updated constraint vector
-    """
-    n_coils = len(vector)
-    currents = scale * vector
+        # get coil force and jacobian
+        F = np.zeros((n_coils, 2))
+        self.PF_Fz_max /= self.scale
+        self.CS_Fz_sep_max /= self.scale
+        self.CS_Fz_sum_max /= self.scale
 
-    # get coil force and jacobian
-    F = np.zeros((n_coils, 2))
-    PF_Fz_max /= scale
-    CS_Fz_sep_max /= scale
-    CS_Fz_sum_max /= scale
+        for i in range(2):  # coil force
+            # NOTE: * Hadamard matrix product
+            F[:, i] = currents * (self.a_mat[:, :, i] @ self.currents + self.b_vec[:, i])
 
-    for i in range(2):  # coil force
-        # NOTE: * Hadamard matrix product
-        F[:, i] = currents * (a_mat[:, :, i] @ currents + b_vec[:, i])
+        F /= self.scale  # Scale down to MN
 
-    F /= scale  # Scale down to MN
+        # Absolute vertical force constraint on PF coils
+        constraint[: self.n_PF] = F[: self.n_PF, 1] ** 2 - self.PF_Fz_max**2
 
-    # Absolute vertical force constraint on PF coils
-    constraint[:n_PF] = F[:n_PF, 1] ** 2 - PF_Fz_max**2
+        if self.n_CS != 0:
+            # vertical forces on CS coils
+            cs_fz = F[self.n_PF :, 1]
+            # vertical force on CS stack
+            cs_z_sum = np.sum(cs_fz)
+            # Absolute sum of vertical force constraint on entire CS stack
+            constraint[self.n_PF] = cs_z_sum**2 - self.CS_Fz_sum_max**2
+            for i in range(self.n_CS - 1):  # evaluate each gap in CS stack
+                # CS separation constraints
+                f_sep = np.sum(cs_fz[: i + 1]) - np.sum(cs_fz[i + 1 :])
+                constraint[self.n_PF + 1 + i] = f_sep - self.CS_Fz_sep_max
 
-    if n_CS != 0:
-        # vertical forces on CS coils
-        cs_fz = F[n_PF:, 1]
-        # vertical force on CS stack
-        cs_z_sum = np.sum(cs_fz)
-        # Absolute sum of vertical force constraint on entire CS stack
-        constraint[n_PF] = cs_z_sum**2 - CS_Fz_sum_max**2
-        for i in range(n_CS - 1):  # evaluate each gap in CS stack
-            # CS separation constraints
-            f_sep = np.sum(cs_fz[: i + 1]) - np.sum(cs_fz[i + 1 :])
-            constraint[n_PF + 1 + i] = f_sep - CS_Fz_sep_max
-
-    # calculate constraint jacobian
-    if grad.size > 0:
+    def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        n_coils = vector.size
+        grad = np.zeros((n_coils, n_coils))
         dF = np.zeros((n_coils, n_coils, 2))  # noqa: N806
+        currents = self.scale * vector
+
         im = currents.reshape(-1, 1) @ np.ones((1, n_coils))  # current matrix
         for i in range(2):
-            dF[:, :, i] = im * a_mat[:, :, i]
+            dF[:, :, i] = im * self.a_mat[:, :, i]
             diag = (
-                a_mat[:, :, i] @ currents
-                + currents * np.diag(a_mat[:, :, i])
-                + b_vec[:, i]
+                self.a_mat[:, :, i] @ currents
+                + currents * np.diag(self.a_mat[:, :, i])
+                + self.b_vec[:, i]
             )
             np.fill_diagonal(dF[:, :, i], diag)
 
         # Absolute vertical force constraint on PF coils
-        grad[:n_PF] = 2 * dF[:n_PF, :, 1]
+        grad[: self.n_PF] = 2 * dF[: self.n_PF, :, 1]
 
-        if n_CS != 0:
+        if self.n_CS != 0:
             # Absolute sum of vertical force constraint on entire CS stack
-            grad[n_PF] = 2 * np.sum(dF[n_PF:, :, 1], axis=0)
+            grad[self.n_PF] = 2 * np.sum(dF[self.n_PF :, :, 1], axis=0)
 
-            for i in range(n_CS - 1):  # evaluate each gap in CS stack
+            for i in range(self.n_CS - 1):  # evaluate each gap in CS stack
                 # CS separation constraint Jacobians
-                f_up = np.sum(dF[n_PF : n_PF + i + 1, :, 1], axis=0)
-                f_down = np.sum(dF[n_PF + i + 1 :, :, 1], axis=0)
-                grad[n_PF + 1 + i] = f_up - f_down
-    return constraint
-
-
-def field_constraints(
-    constraint: np.ndarray,
-    vector: np.ndarray,
-    grad: np.ndarray,
-    ax_mat: np.ndarray,
-    az_mat: np.ndarray,
-    bxp_vec: np.ndarray,
-    bzp_vec: np.ndarray,
-    B_max: np.ndarray,
-    scale: float,
-) -> np.ndarray:
-    """
-    Current optimisation poloidal field constraints at prescribed locations
-
-    Parameters
-    ----------
-    constraint:
-        Constraint array (modified in place)
-    vector:
-        Current vector
-    grad:
-        Constraint Jacobian (modified in place)
-    ax_mat:
-        Response matrix for Bx (active coil contributions)
-    az_mat:
-        Response matrix for Bz (active coil contributions)
-    bxp_vec:
-        Background vector for Bx (passive coil contributions)
-    bzp_vec:
-        Background vector for Bz (passive coil contributions)
-    B_max:
-        Maximum fields inside the coils
-    scale:
-        Current scale with which to calculate the constraints
-
-    Returns
-    -------
-    Updated constraint vector
-    """
-    currents = scale * vector
-    Bx_a = ax_mat @ currents
-    Bz_a = az_mat @ currents
-
-    B = np.hypot(Bx_a + bxp_vec, Bz_a + bzp_vec)
-    if grad.size > 0:
-        grad[:] = (
-            Bx_a * (Bx_a @ currents + bxp_vec) + Bz_a * (Bz_a @ currents + bzp_vec)
-        ) / (B * scale**2)
-
-    constraint[:] = B - B_max
-    return constraint
+                f_up = np.sum(dF[self.n_PF : self.n_PF + i + 1, :, 1], axis=0)
+                f_down = np.sum(dF[self.n_PF + i + 1 :, :, 1], axis=0)
+                grad[self.n_PF + 1 + i] = f_up - f_down

--- a/bluemira/equilibria/optimisation/constraint_funcs.py
+++ b/bluemira/equilibria/optimisation/constraint_funcs.py
@@ -59,13 +59,13 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING, Literal
 
+import numpy as np
+import numpy.typing as npt
+
 from bluemira.base.look_and_feel import bluemira_warn
 
 if TYPE_CHECKING:
     from bluemira.equilibria.equilibrium import Equilibrium
-
-import numpy as np
-import numpy.typing as npt
 
 
 class ConstraintFunction(abc.ABC):
@@ -77,6 +77,7 @@ class ConstraintFunction(abc.ABC):
 
     @property
     def constraint_type(self) -> Literal["inequality", "equality"]:
+        """The type of constraint"""
         try:
             return self._constraint_type
         except AttributeError:
@@ -118,9 +119,11 @@ class AxBConstraint(ConstraintFunction):
         self.scale = scale
 
     def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint function"""
         return np.dot(self.a_mat, self.scale * vector) - self.b_vec - self.value
 
     def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint derivative"""
         return self.scale * self.a_mat
 
 
@@ -132,7 +135,7 @@ class L2NormConstraint(ConstraintFunction):
 
     Parameters
     ----------
-    A_mat:
+    a_mat:
         Response matrix
     b_vec:
         Target value vector
@@ -153,11 +156,13 @@ class L2NormConstraint(ConstraintFunction):
         self.scale = scale
 
     def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint function"""
         vector = self.scale * vector
         residual = self.a_mat @ vector - self.b_vec
         return residual.T @ residual - self.value
 
     def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint derivative"""
         vector = self.scale * vector
         df = 2 * (self.a_mat.T @ self.a_mat @ vector - self.a_mat.T @ self.b_vec)
         return df * self.scale
@@ -200,6 +205,7 @@ class FieldConstraintFunction(ConstraintFunction):
         self.scale = scale
 
     def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint function"""
         currents = self.scale * vector
         Bx_a = self.ax_mat @ currents
         Bz_a = self.az_mat @ currents
@@ -208,6 +214,7 @@ class FieldConstraintFunction(ConstraintFunction):
         return B - self.B_max
 
     def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint derivative"""
         currents = self.scale * vector
         Bx_a = self.ax_mat @ currents
         Bz_a = self.az_mat @ currents
@@ -249,6 +256,7 @@ class CurrentMidplanceConstraint(ConstraintFunction):
         self.inboard = inboard
 
     def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint function"""
         self.eq.coilset.set_control_currents(vector * self.scale)
         lcfs = self.eq.get_LCFS()
         if self.inboard:
@@ -257,6 +265,29 @@ class CurrentMidplanceConstraint(ConstraintFunction):
 
 
 class CoilForceConstraint(ConstraintFunction):
+    """
+    Constraint function to constrain the force applied to the coils
+
+    Parameters
+    ----------
+    a_mat:
+        Response matrix
+    b_vec:
+        Target value vector
+    n_PF:
+        Number of PF coils
+    n_CS:
+        Number of CS coils
+    PF_Fz_max:
+        The maximum force in the z direction for a PF coil
+    CS_Fz_sum_max:
+        The total maximum force in the z direction for the CS coils
+    CS_Fz_sep_max:
+        The individual maximum force in the z direction for the CS coils
+    scale:
+        Current scale with which to calculate the constraints
+    """
+
     def __init__(
         self,
         a_mat: np.ndarray,
@@ -278,6 +309,7 @@ class CoilForceConstraint(ConstraintFunction):
         self.scale = scale
 
     def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint function"""
         n_coils = len(vector)
         currents = self.scale * vector
         constraint = np.zeros(n_coils)
@@ -311,6 +343,7 @@ class CoilForceConstraint(ConstraintFunction):
         return constraint
 
     def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """Constraint derivative"""
         n_coils = vector.size
         grad = np.zeros((n_coils, n_coils))
         dF = np.zeros((n_coils, n_coils, 2))  # noqa: N806

--- a/bluemira/equilibria/optimisation/constraint_funcs.py
+++ b/bluemira/equilibria/optimisation/constraint_funcs.py
@@ -1,0 +1,379 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Equilibrium optimisation constraint functions.
+for use in NLOpt constrained
+optimisation problems.
+
+Constraint functions must be of the form:
+
+.. code-block:: python
+
+    def f_constraint(constraint, x, grad, args):
+        constraint[:] = my_constraint_calc(x)
+        if grad.size > 0:
+            grad[:] = my_gradient_calc(x)
+        return constraint
+
+The constraint function convention is such that c <= 0 is sought. I.e. all constraint
+values must be negative.
+
+Note that the gradient (Jacobian) of the constraint function is of the form:
+
+.. math::
+
+    \\nabla \\mathbf{c} = \\begin{bmatrix}
+            \\dfrac{\\partial c_{0}}{\\partial x_0} & \\dfrac{\\partial c_{0}}{\\partial x_1} & ... \n
+            \\dfrac{\\partial c_{1}}{\\partial x_0} & \\dfrac{\\partial c_{1}}{\\partial x_1} & ... \n
+            ... & ... & ... \n
+            \\end{bmatrix}
+
+The grad and constraint matrices must be assigned in place.
+
+If grad is not updated, the constraint can still be used for derivative-free
+optimisation algorithms, but will need to be updated or approximated for use
+in derivative based algorithms, such as those utilising gradient descent.
+"""  # noqa: W505
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bluemira.equilibria.equilibrium import Equilibrium
+
+import numpy as np
+import numpy.typing as npt
+
+
+class ConstraintFunction(abc.ABC):
+    """Override to define a numerical constraint for a coilset optimisation."""
+
+    @abc.abstractmethod
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        """The constraint function."""
+
+
+class AxBConstraint(ConstraintFunction):
+    """
+    Constraint function of the form:
+        A.x - b < value
+
+    Parameters
+    ----------
+    a_mat:
+        Response matrix
+    b_vec:
+        Target value vector
+    value:
+        Target constraint value
+    scale:
+        Current scale with which to calculate the constraints
+    """
+
+    def __init__(
+        self, a_mat: np.ndarray, b_vec: np.ndarray, value: float, scale: float
+    ) -> None:
+        self.a_mat = a_mat
+        self.b_vec = b_vec
+        self.value = value
+        self.scale = scale
+
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        return np.dot(self.a_mat, self.scale * vector) - self.b_vec - self.value
+
+    def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        return self.scale * self.a_mat
+
+
+class L2NormConstraint(ConstraintFunction):
+    """
+    Constrain the L2 norm of an Ax = b system of equations.
+
+    ||(Ax - b)||² < value
+
+    Parameters
+    ----------
+    A_mat:
+        Response matrix
+    b_vec:
+        Target value vector
+    scale:
+        Current scale with which to calculate the constraints
+    """
+
+    def __init__(
+        self,
+        a_mat: npt.NDArray,
+        b_vec: npt.NDArray,
+        value: float,
+        scale: float,
+    ) -> None:
+        self.a_mat = a_mat
+        self.b_vec = b_vec
+        self.value = value
+        self.scale = scale
+
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        vector = self.scale * vector
+        residual = self.a_mat @ vector - self.b_vec
+        return residual.T @ residual - self.value
+
+    def df_constraint(self, vector: npt.NDArray) -> npt.NDArray:
+        df = 2 * (self.a_mat.T @ self.a_mat @ vector - self.a_mat.T @ self.b_vec)
+        return df * self.scale
+
+
+class FieldConstraints(ConstraintFunction):
+    """
+    Current optimisation poloidal field constraints at prescribed locations
+
+    Parameters
+    ----------
+    ax_mat:
+        Response matrix for Bx (active coil contributions)
+    az_mat:
+        Response matrix for Bz (active coil contributions)
+    bxp_vec:
+        Background vector for Bx (passive coil contributions)
+    bzp_vec:
+        Background vector for Bz (passive coil contributions)
+    B_max:
+        Maximum fields inside the coils
+    scale:
+        Current scale with which to calculate the constraints
+    """
+
+    def __init__(
+        self,
+        ax_mat: np.ndarray,
+        az_mat: np.ndarray,
+        bxp_vec: np.ndarray,
+        bzp_vec: np.ndarray,
+        B_max: np.ndarray,
+        scale: float,
+    ) -> None:
+        super().__init__()
+
+
+# TODO: below
+
+
+def current_midplane_constraint(
+    constraint: np.ndarray,
+    vector: np.ndarray,
+    grad: np.ndarray,
+    eq: Equilibrium,
+    radius: float,
+    scale: float,
+    inboard: bool = True,
+) -> np.ndarray:
+    """
+    Constraint function to constrain the inboard or outboard midplane
+    of the plasma during optimisation.
+
+    Parameters
+    ----------
+    constraint:
+        Constraint array (modified in place)
+    vector:
+        Current vector
+    grad:
+        Constraint Jacobian (modified in place)
+    eq:
+        Equilibrium to use to fetch last closed flux surface from.
+    radius:
+        Toroidal radius at which to constrain the plasma midplane.
+    scale:
+        Current scale with which to calculate the constraints
+    inboard:
+        Boolean controlling whether to constrain the inboard (if True) or
+        outboard (if False) side of the plasma midplane.
+
+    Returns
+    -------
+    Updated constraint vector
+    """
+    eq.coilset.set_control_currents(vector * scale)
+    lcfs = eq.get_LCFS()
+    if inboard:
+        constraint[:] = radius - min(lcfs.x)
+    else:
+        constraint[:] = max(lcfs.x) - radius
+    return constraint
+
+
+def coil_force_constraints(
+    constraint: np.ndarray,
+    vector: np.ndarray,
+    grad: np.ndarray,
+    a_mat: np.ndarray,
+    b_vec: np.ndarray,
+    n_PF: int,
+    n_CS: int,
+    PF_Fz_max: float,
+    CS_Fz_sum_max: float,
+    CS_Fz_sep_max: float,
+    scale: float,
+) -> np.ndarray:
+    """
+    Current optimisation force constraints on coils
+
+    Parameters
+    ----------
+    constraint:
+        Constraint array (modified in place)
+    vector:
+        Current vector
+    grad:
+        Constraint Jacobian (modified in place)
+    a_mat:
+        Response matrix block for Fx and Fz
+    b_vec:
+        Background value vector block for Fx and Fz
+    n_PF:
+        Number of PF coils
+    n_CS:
+        Number of CS coils
+    PF_Fz_max:
+        Maximum vertical force on each PF coil [N]
+    CS_Fz_sum_max:
+        Maximum total vertical force on the CS stack [N]
+    CS_Fz_sep_max:
+        Maximum vertical separation force in the CS stack [N]
+    scale:
+        Current scale with which to calculate the constraints
+
+    Returns
+    -------
+    Updated constraint vector
+    """
+    n_coils = len(vector)
+    currents = scale * vector
+
+    # get coil force and jacobian
+    F = np.zeros((n_coils, 2))
+    PF_Fz_max /= scale
+    CS_Fz_sep_max /= scale
+    CS_Fz_sum_max /= scale
+
+    for i in range(2):  # coil force
+        # NOTE: * Hadamard matrix product
+        F[:, i] = currents * (a_mat[:, :, i] @ currents + b_vec[:, i])
+
+    F /= scale  # Scale down to MN
+
+    # Absolute vertical force constraint on PF coils
+    constraint[:n_PF] = F[:n_PF, 1] ** 2 - PF_Fz_max**2
+
+    if n_CS != 0:
+        # vertical forces on CS coils
+        cs_fz = F[n_PF:, 1]
+        # vertical force on CS stack
+        cs_z_sum = np.sum(cs_fz)
+        # Absolute sum of vertical force constraint on entire CS stack
+        constraint[n_PF] = cs_z_sum**2 - CS_Fz_sum_max**2
+        for i in range(n_CS - 1):  # evaluate each gap in CS stack
+            # CS separation constraints
+            f_sep = np.sum(cs_fz[: i + 1]) - np.sum(cs_fz[i + 1 :])
+            constraint[n_PF + 1 + i] = f_sep - CS_Fz_sep_max
+
+    # calculate constraint jacobian
+    if grad.size > 0:
+        dF = np.zeros((n_coils, n_coils, 2))  # noqa: N806
+        im = currents.reshape(-1, 1) @ np.ones((1, n_coils))  # current matrix
+        for i in range(2):
+            dF[:, :, i] = im * a_mat[:, :, i]
+            diag = (
+                a_mat[:, :, i] @ currents
+                + currents * np.diag(a_mat[:, :, i])
+                + b_vec[:, i]
+            )
+            np.fill_diagonal(dF[:, :, i], diag)
+
+        # Absolute vertical force constraint on PF coils
+        grad[:n_PF] = 2 * dF[:n_PF, :, 1]
+
+        if n_CS != 0:
+            # Absolute sum of vertical force constraint on entire CS stack
+            grad[n_PF] = 2 * np.sum(dF[n_PF:, :, 1], axis=0)
+
+            for i in range(n_CS - 1):  # evaluate each gap in CS stack
+                # CS separation constraint Jacobians
+                f_up = np.sum(dF[n_PF : n_PF + i + 1, :, 1], axis=0)
+                f_down = np.sum(dF[n_PF + i + 1 :, :, 1], axis=0)
+                grad[n_PF + 1 + i] = f_up - f_down
+    return constraint
+
+
+def field_constraints(
+    constraint: np.ndarray,
+    vector: np.ndarray,
+    grad: np.ndarray,
+    ax_mat: np.ndarray,
+    az_mat: np.ndarray,
+    bxp_vec: np.ndarray,
+    bzp_vec: np.ndarray,
+    B_max: np.ndarray,
+    scale: float,
+) -> np.ndarray:
+    """
+    Current optimisation poloidal field constraints at prescribed locations
+
+    Parameters
+    ----------
+    constraint:
+        Constraint array (modified in place)
+    vector:
+        Current vector
+    grad:
+        Constraint Jacobian (modified in place)
+    ax_mat:
+        Response matrix for Bx (active coil contributions)
+    az_mat:
+        Response matrix for Bz (active coil contributions)
+    bxp_vec:
+        Background vector for Bx (passive coil contributions)
+    bzp_vec:
+        Background vector for Bz (passive coil contributions)
+    B_max:
+        Maximum fields inside the coils
+    scale:
+        Current scale with which to calculate the constraints
+
+    Returns
+    -------
+    Updated constraint vector
+    """
+    currents = scale * vector
+    Bx_a = ax_mat @ currents
+    Bz_a = az_mat @ currents
+
+    B = np.hypot(Bx_a + bxp_vec, Bz_a + bzp_vec)
+    if grad.size > 0:
+        grad[:] = (
+            Bx_a * (Bx_a @ currents + bxp_vec) + Bz_a * (Bz_a @ currents + bzp_vec)
+        ) / (B * scale**2)
+
+    constraint[:] = B - B_max
+    return constraint

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -193,6 +193,7 @@ class FieldConstraints(UpdateableConstraint):
         return Bx, Bz
 
     def f_constraint(self) -> FieldConstraintFunction:
+        """Calculate the constraint function"""
         f_constraint = FieldConstraintFunction(**self._args)
         f_constraint.constraint_type = self.f_constraint_type
         return f_constraint
@@ -364,6 +365,7 @@ class CoilForceConstraints(UpdateableConstraint):
         return fp
 
     def f_constraint(self) -> CoilForceConstraintFunction:
+        """Calculate the constraint function"""
         return CoilForceConstraintFunction(**self._args)
 
 

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -1,0 +1,929 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Equilibrium optimisation constraint classes
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, Union
+
+if TYPE_CHECKING:
+    from bluemira.equilibria.coils import CoilSet
+    from bluemira.equilibria.equilibrium import Equilibrium
+
+import numpy as np
+
+from bluemira.equilibria.opt_constraint_funcs import (
+    Ax_b_constraint,
+    L2_norm_constraint,
+    coil_force_constraints,
+    field_constraints,
+)
+from bluemira.equilibria.optimisation.constraint_funcs import (
+    AxBConstraint,
+    ConstraintFunction,
+    L2NormConstraint,
+)
+from bluemira.equilibria.plotting import ConstraintPlotter
+from bluemira.geometry.coordinates import interpolate_points
+from bluemira.utilities.tools import abs_rel_difference, is_num
+
+
+def _get_dummy_equilibrium(equilibrium: Equilibrium):
+    """
+    Get a dummy equilibrium for current optimisation where the background response is
+    solely due to the plasma and passive coils.
+
+    Notes
+    -----
+    When we do dI (current gradient) optimisation, the background vector includes the
+    contributions from the whole coilset (including active coils).
+
+    When we do I (current vector) optimisation, the background vector only includes
+    contributions from the passive coils (plasma).
+    """
+    # TODO: Add passive coil contributions here
+    dummy = equilibrium.plasma
+    dummy.coilset = deepcopy(equilibrium.coilset)
+    return dummy
+
+
+class UpdateableConstraint(ABC):
+    """
+    Abstract base mixin class for an equilibrium optimisation constraint that is
+    updateable.
+    """
+
+    @abstractmethod
+    def prepare(self, equilibrium: Equilibrium, I_not_dI=False, fixed_coils=False):
+        """
+        Prepare the constraint for use in an equilibrium optimisation problem.
+        """
+        pass
+
+    @abstractmethod
+    def control_response(self, coilset: CoilSet):
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        pass
+
+    @abstractmethod
+    def evaluate(self, equilibrium: Equilibrium):
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        pass
+
+
+class FieldConstraints(UpdateableConstraint):
+    """
+    Inequality constraints for the poloidal field at certain locations.
+
+    Parameters
+    ----------
+    x:
+        Radial coordinate(s) at which to constrain the poloidal field
+    z:
+        Vertical coordinate(s) at which to constrain the poloidal field
+    B_max:
+        Maximum poloidal field value(s) at location(s)
+    tolerance:
+        Tolerance with which the constraint(s) will be met
+    constraint_type:
+        Type of constraint
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        B_max: Union[float, np.ndarray],
+        tolerance: Union[float, np.ndarray] = 1.0e-6,
+        constraint_type: str = "inequality",
+    ):
+        if is_num(x):
+            x = np.array([x])
+        if is_num(z):
+            z = np.array([z])
+
+        if is_num(B_max):
+            B_max = B_max * np.ones(len(x))
+        if len(B_max) != len(x):
+            raise ValueError(
+                "Maximum field vector length not equal to the number of points."
+            )
+
+        if is_num(tolerance):
+            tolerance = tolerance * np.ones(len(x))
+        if len(tolerance) != len(x):
+            raise ValueError("Tolerance vector length not equal to the number of coils.")
+
+        self.x = x
+        self.z = z
+        super().__init__(
+            f_constraint=field_constraints,
+            f_constraint_args={
+                "ax_mat": None,
+                "az_mat": None,
+                "bxp_vec": None,
+                "bzp_vec": None,
+                "B_max": B_max,
+                "scale": 1.0,
+            },
+            tolerance=tolerance,
+            constraint_type=constraint_type,
+        )
+
+    def prepare(
+        self, equilibrium: Equilibrium, I_not_dI: bool = False, fixed_coils: bool = False
+    ):
+        """
+        Prepare the constraint for use in an equilibrium optimisation problem.
+        """
+        if I_not_dI:
+            equilibrium = _get_dummy_equilibrium(equilibrium)
+
+        # Re-build control response matrix
+        if not fixed_coils or (fixed_coils and self._args["ax_mat"] is None):
+            ax_mat, az_mat = self.control_response(equilibrium.coilset)
+            self._args["ax_mat"] = ax_mat
+            self._args["az_mat"] = az_mat
+
+        bxp_vec, bzp_vec = self.evaluate(equilibrium)
+        self._args["bxp_vec"] = bxp_vec
+        self._args["bzp_vec"] = bzp_vec
+
+    def control_response(self, coilset: CoilSet) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return (
+            coilset.Bx_response(self.x, self.z, control=True),
+            coilset.Bz_response(self.x, self.z, control=True),
+        )
+
+    def evaluate(self, equilibrium: Equilibrium) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        Bx, Bz = np.zeros(len(self)), np.zeros(len(self))
+        Bx = equilibrium.Bx(self.x, self.z)
+        Bz = equilibrium.Bz(self.x, self.z)
+        return Bx, Bz
+
+    def __len__(self) -> int:
+        """
+        Length of field constraints.
+        """
+        return len(self.x)
+
+
+class CoilFieldConstraints(FieldConstraints):
+    """
+    Inequality constraints on the poloidal field at the middle of the inside edge
+    of the coils, where the field is usually highest.
+
+    Parameters
+    ----------
+    coilset:
+        Coilset for which to constrain the fields in the coils
+    B_max:
+        Maximum field allowed in the coils
+    tolerance:
+        Tolerance with which the inequality constraints will be met
+
+    Notes
+    -----
+    This is a fast approximation constraint, and does not solve for the peak field
+    at all points in the coils. Use with caution.
+    TODO: Presently only handles CoilSets with Coils (SymmetricCircuits not yet
+    supported)
+    TODO: Presently only accounts for poloidal field contributions from PF coils and
+    plasma (TF from TF coils not accounted for if PF coils are inside the TF coils.)
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        B_max: Union[float, np.ndarray],
+        tolerance: Union[float, np.ndarray] = 1.0e-6,
+    ):
+        n_coils = coilset.n_coils()
+        if is_num(B_max):
+            B_max = B_max * np.ones(n_coils)
+        if len(B_max) != n_coils:
+            raise ValueError(
+                "Maximum field vector length not equal to the number of coils."
+            )
+
+        if is_num(tolerance):
+            tolerance = tolerance * np.ones(n_coils)
+        if len(tolerance) != n_coils:
+            raise ValueError("Tolerance vector length not equal to the number of coils.")
+
+        x, z = self._get_constraint_points(coilset)
+
+        super().__init__(x, z, B_max, tolerance=tolerance, constraint_type="inequality")
+
+    @staticmethod
+    def _get_constraint_points(coilset):
+        return coilset.x - coilset.dx, coilset.z
+
+    def prepare(
+        self, equilibrium: Equilibrium, I_not_dI: bool = False, fixed_coils: bool = False
+    ):
+        """
+        Prepare the constraint for use in an equilibrium optimisation problem.
+        """
+        if I_not_dI:
+            equilibrium = _get_dummy_equilibrium(equilibrium)
+
+        # Re-build control response matrix
+        if not fixed_coils or (fixed_coils and self._args["ax_mat"] is None):
+            # Update the target points for the constraints (the coils may be moving)
+            self.x, self.z = self._get_constraint_points(equilibrium.coilset)
+            ax_mat, az_mat = self.control_response(equilibrium.coilset)
+            self._args["ax_mat"] = ax_mat
+            self._args["az_mat"] = az_mat
+
+        bxp_vec, bzp_vec = self.evaluate(equilibrium)
+        self._args["bxp_vec"] = bxp_vec
+        self._args["bzp_vec"] = bzp_vec
+
+
+class CoilForceConstraints(UpdateableConstraint):
+    """
+    Inequality constraints on the vertical forces in the PF and CS coils.
+
+    Parameters
+    ----------
+    coilset:
+        Coilset for which to constrain the fields in the coils
+    PF_Fz_max:
+        Maximum absolute vertical force in a PF coil [MN]
+    CS_Fz_sum_max:
+        Maximum absolute vertical force sum in the CS stack [MN]
+    CS_Fz_sep_max:
+        Maximum separation vertical force between two CS modules [MN]
+    tolerance:
+        Tolerance with which the inequality constraints will be met
+
+    Notes
+    -----
+    TODO: Presently only handles CoilSets with Coils (SymmetricCircuits not yet
+    supported)
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        PF_Fz_max: float,
+        CS_Fz_sum_max: float,
+        CS_Fz_sep_max: float,
+        tolerance: Union[float, np.ndarray] = 1.0e-6,
+    ):
+        n_PF = coilset.n_coils("PF")
+        n_CS = coilset.n_coils("CS")
+        n_f_constraints = n_PF + n_CS
+
+        if is_num(tolerance):
+            tolerance = tolerance * np.ones(n_f_constraints)
+        elif len(tolerance) != n_f_constraints:
+            raise ValueError(f"Tolerance vector not of length {n_f_constraints}")
+
+        super().__init__(
+            f_constraint=coil_force_constraints,
+            f_constraint_args={
+                "a_mat": None,
+                "b_vec": None,
+                "scale": 1.0,
+                "PF_Fz_max": PF_Fz_max,
+                "CS_Fz_sum_max": CS_Fz_sum_max,
+                "CS_Fz_sep_max": CS_Fz_sep_max,
+                "n_PF": n_PF,
+                "n_CS": n_CS,
+            },
+            tolerance=tolerance,
+        )
+
+    def prepare(
+        self, equilibrium: Equilibrium, I_not_dI: bool = False, fixed_coils: bool = False
+    ):
+        """
+        Prepare the constraint for use in an equilibrium optimisation problem.
+        """
+        if I_not_dI:
+            equilibrium = _get_dummy_equilibrium(equilibrium)
+
+        # Re-build control response matrix
+        if not fixed_coils or (fixed_coils and self._args["a_mat"] is None):
+            self._args["a_mat"] = self.control_response(equilibrium.coilset)
+
+        self._args["b_vec"] = self.evaluate(equilibrium)
+
+    def control_response(self, coilset: CoilSet) -> np.ndarray:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return coilset.control_F(coilset)
+
+    def evaluate(self, equilibrium: Equilibrium) -> np.ndarray:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        fp = np.zeros((equilibrium.coilset.n_coils(), 2))
+        current = equilibrium.coilset.current
+        non_zero = np.where(current != 0)[0]
+        if non_zero.size:
+            fp[non_zero] = (
+                equilibrium.coilset.F(equilibrium)[non_zero] / current[non_zero][:, None]
+            )
+        return fp
+
+
+class MagneticConstraint(UpdateableConstraint):
+    """
+    Abstract base class for a magnetic optimisation constraint.
+
+    Can be used as a standalone constraint for use in an optimisation problem. In which
+    case the constraint is of the form: ||(Ax - b)||² < target_value
+
+    Can be used in a MagneticConstraintSet
+    """
+
+    def __init__(
+        self,
+        target_value: float = 0.0,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: Union[float, np.ndarray] = 1e-6,
+        f_constraint: Type[ConstraintFunction] = L2NormConstraint,
+        constraint_type: str = "inequality",
+    ):
+        self.target_value = target_value * np.ones(len(self))
+        if is_num(tolerance):
+            if f_constraint == L2NormConstraint:
+                tolerance = tolerance * np.ones(1)
+            else:
+                tolerance = tolerance * np.ones(len(self))
+        self.weights = weights
+        self.f_constraint = f_constraint
+        self._args = {"a_mat": None, "b_vec": None, "value": 0.0, "scale": 1.0}
+        self.tolerance = tolerance
+        self.constraint_type = constraint_type
+
+    def prepare(
+        self, equilibrium: Equilibrium, I_not_dI: bool = False, fixed_coils: bool = False
+    ):  # noqa :N803
+        """
+        Prepare the constraint for use in an equilibrium optimisation problem.
+        """
+        if I_not_dI:
+            equilibrium = _get_dummy_equilibrium(equilibrium)
+
+        # Re-build control response matrix
+        if not fixed_coils or (fixed_coils and self._args["a_mat"] is None):
+            self._args["a_mat"] = self.control_response(equilibrium.coilset)
+
+        self.update_target(equilibrium)
+        self._args["b_vec"] = self.target_value - self.evaluate(equilibrium)
+
+    def update_target(self, equilibrium: Equilibrium):
+        """
+        Update the target value of the magnetic constraint.
+        """
+        pass
+
+    @abstractmethod
+    def plot(self, ax):
+        """
+        Plot the constraint onto an Axes.
+        """
+        pass
+
+    def __len__(self) -> int:
+        """
+        The mathematical size of the constraint.
+
+        Notes
+        -----
+        Length of the array if an array is specified, otherwise 1 for a float.
+        """
+        return len(self.x) if hasattr(self.x, "__len__") else 1
+
+
+class AbsoluteMagneticConstraint(MagneticConstraint):
+    """
+    Abstract base class for absolute magnetic constraints, where the target
+    value is prescribed in absolute terms.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        target_value: float,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: Union[float, np.ndarray] = 1e-6,
+        f_constraint: Type[ConstraintFunction] = AxBConstraint,
+        constraint_type: str = "equality",
+    ):
+        self.x = x
+        self.z = z
+        super().__init__(
+            target_value,
+            weights,
+            tolerance=tolerance,
+            f_constraint=f_constraint,
+            constraint_type=constraint_type,
+        )
+
+
+class RelativeMagneticConstraint(MagneticConstraint):
+    """
+    Abstract base class for relative magnetic constraints, where the target
+    value is prescribed with respect to a reference point.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        ref_x: float,
+        ref_z: float,
+        constraint_value: float = 0.0,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: Union[float, np.ndarray] = 1e-6,
+        f_constraint: Type[ConstraintFunction] = L2NormConstraint,
+        constraint_type: str = "inequality",
+    ):
+        self.x = x
+        self.z = z
+        self.ref_x = ref_x
+        self.ref_z = ref_z
+        super().__init__(
+            0.0,
+            weights,
+            tolerance=tolerance,
+            f_constraint=f_constraint,
+            constraint_type=constraint_type,
+        )
+        self._args["value"] = constraint_value
+
+    @abstractmethod
+    def update_target(self, equilibrium: Equilibrium):
+        """
+        Update the target value of the magnetic constraint.
+        """
+        pass
+
+
+class FieldNullConstraint(AbsoluteMagneticConstraint):
+    """
+    Magnetic field null constraint. In practice sets the Bx and Bz field components
+    to be 0 at the specified location.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: float = 1e-6,
+    ):
+        super().__init__(
+            x,
+            z,
+            target_value=0.0,
+            weights=weights,
+            tolerance=tolerance,
+            constraint_type="inequality",
+            f_constraint=L2_norm_constraint,
+        )
+
+    def control_response(self, coilset: CoilSet) -> np.ndarray:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return np.vstack(
+            [
+                coilset.Bx_response(self.x, self.z, control=True),
+                coilset.Bz_response(self.x, self.z, control=True),
+            ]
+        )
+
+    def evaluate(self, eq: Equilibrium) -> np.ndarray:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        return np.array([eq.Bx(self.x, self.z), eq.Bz(self.x, self.z)])
+
+    def plot(self, ax):
+        """
+        Plot the constraint onto an Axes.
+        """
+        kwargs = {
+            "marker": "X",
+            "color": "b",
+            "markersize": 10,
+            "zorder": 45,
+            "linestyle": "None",
+        }
+        ax.plot(self.x, self.z, **kwargs)
+
+    def __len__(self) -> int:
+        """
+        The mathematical size of the constraint.
+        """
+        return 2
+
+
+class PsiConstraint(AbsoluteMagneticConstraint):
+    """
+    Absolute psi value constraint.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        target_value: float,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: Union[float, np.ndarray] = 1e-6,
+    ):
+        super().__init__(
+            x,
+            z,
+            target_value,
+            weights=weights,
+            tolerance=tolerance,
+            f_constraint=Ax_b_constraint,
+            constraint_type="equality",
+        )
+
+    def control_response(self, coilset: CoilSet) -> np.ndarray:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return coilset.psi_response(self.x, self.z, control=True)
+
+    def evaluate(self, eq: Equilibrium) -> np.ndarray:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        return eq.psi(self.x, self.z)
+
+    def plot(self, ax):
+        """
+        Plot the constraint onto an Axes.
+        """
+        kwargs = {"marker": "s", "markersize": 8, "color": "b", "linestyle": "None"}
+        ax.plot(self.x, self.z, **kwargs)
+
+
+class IsofluxConstraint(RelativeMagneticConstraint):
+    """
+    Isoflux constraint for a set of points relative to a reference point.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        ref_x: float,
+        ref_z: float,
+        constraint_value: float = 0.0,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: float = 1e-6,
+    ):
+        super().__init__(
+            x,
+            z,
+            ref_x,
+            ref_z,
+            constraint_value,
+            weights=weights,
+            f_constraint=L2NormConstraint,
+            tolerance=tolerance,
+            constraint_type="inequality",
+        )
+
+    def control_response(self, coilset: CoilSet) -> np.ndarray:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return coilset.psi_response(self.x, self.z, control=True) - coilset.psi_response(
+            self.ref_x, self.ref_z, control=True
+        )
+
+    def evaluate(self, eq: Equilibrium) -> np.ndarray:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        return eq.psi(self.x, self.z)
+
+    def update_target(self, eq: Equilibrium):
+        """
+        We need to update the target value, as it is a relative constraint.
+        """
+        self.target_value = float(eq.psi(self.ref_x, self.ref_z))
+
+    def plot(self, ax):
+        """
+        Plot the constraint onto an Axes.
+        """
+        kwargs = {
+            "marker": "o",
+            "markeredgewidth": 3,
+            "markeredgecolor": "b",
+            "markersize": 10,
+            "linestyle": "None",
+            "markerfacecolor": "None",
+            "zorder": 45,
+        }
+        ax.plot(self.x, self.z, **kwargs)
+        kwargs["markeredgewidth"] = 5
+        ax.plot(self.ref_x, self.ref_z, **kwargs)
+
+
+class PsiBoundaryConstraint(AbsoluteMagneticConstraint):
+    """
+    Absolute psi value constraint on the plasma boundary. Gets updated when
+    the plasma boundary flux value is changed.
+    """
+
+    def __init__(
+        self,
+        x: Union[float, np.ndarray],
+        z: Union[float, np.ndarray],
+        target_value: float,
+        weights: Union[float, np.ndarray] = 1.0,
+        tolerance: Union[float, np.ndarray] = 1e-6,
+    ):
+        super().__init__(
+            x,
+            z,
+            target_value,
+            weights,
+            tolerance,
+            f_constraint=L2_norm_constraint,
+            constraint_type="inequality",
+        )
+
+    def control_response(self, coilset: CoilSet) -> np.ndarray:
+        """
+        Calculate control response of a CoilSet to the constraint.
+        """
+        return coilset.psi_response(self.x, self.z, control=True)
+
+    def evaluate(self, eq: Equilibrium) -> np.ndarray:
+        """
+        Calculate the value of the constraint in an Equilibrium.
+        """
+        return eq.psi(self.x, self.z)
+
+    def plot(self, ax):
+        """
+        Plot the constraint onto an Axes.
+        """
+        kwargs = {"marker": "o", "markersize": 8, "color": "b", "linestyle": "None"}
+        ax.plot(self.x, self.z, **kwargs)
+
+
+class MagneticConstraintSet(ABC):
+    """
+    A set of magnetic constraints to be applied to an equilibrium. The optimisation
+    problem is of the form:
+
+        [A][x] = [b]
+
+    where:
+
+        [b] = [target] - [background]
+
+    The target vector is the vector of desired values. The background vector
+    is the vector of values due to uncontrolled current terms (plasma and passive
+    coils).
+
+
+    Use of class:
+
+        - Inherit from this class
+        - Add a __init__(args) method
+        - Populate constraints with super().__init__(List[MagneticConstraint])
+    """
+
+    __slots__ = ["constraints", "eq", "coilset", "A", "w", "target", "background"]
+
+    def __init__(self, constraints: List[MagneticConstraint]):
+        self.constraints = constraints
+        self.eq = None
+        self.A = None
+        self.target = None
+        self.background = None
+
+    def __call__(
+        self, equilibrium: Equilibrium, I_not_dI: bool = False, fixed_coils: bool = False
+    ):  # noqa :N803
+        """
+        Update the MagneticConstraintSet
+        """
+        if I_not_dI:
+            equilibrium = _get_dummy_equilibrium(equilibrium)
+
+        self.eq = equilibrium
+        self.coilset = equilibrium.coilset
+
+        # Update relative magnetic constraints without updating A matrix
+        for constraint in self.constraints:
+            if isinstance(constraint, RelativeMagneticConstraint):
+                constraint.update_target(equilibrium)
+
+        # Re-build control response matrix
+        if not fixed_coils or (fixed_coils and self.A is None):
+            self.build_control_matrix()
+            self.build_target()
+
+        self.build_background()
+        self.build_weight_matrix()
+
+    def __len__(self) -> int:
+        """
+        The mathematical size of the constraint set.
+        """
+        return sum([len(c) for c in self.constraints])
+
+    def get_weighted_arrays(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Get [A] and [b] scaled by weight matrix.
+        Weight matrix assumed to be diagonal.
+        """
+        weights = self.w
+        weighted_a = weights[:, np.newaxis] * self.A
+        weighted_b = weights * self.b
+        return weights, weighted_a, weighted_b
+
+    def build_weight_matrix(self):
+        """
+        Build the weight matrix used in optimisation.
+        Assumed to be diagonal.
+        """
+        self.w = np.zeros(len(self))
+
+        i = 0
+        for constraint in self.constraints:
+            n = len(constraint)
+            self.w[i : i + n] = constraint.weights
+            i += n
+
+    def build_control_matrix(self):
+        """
+        Build the control response matrix used in optimisation.
+        """
+        self.A = np.zeros((len(self), len(self.coilset.control)))
+
+        i = 0
+        for constraint in self.constraints:
+            n = len(constraint)
+            self.A[i : i + n, :] = constraint.control_response(self.coilset)
+            i += n
+
+    def build_target(self):
+        """
+        Build the target value vector.
+        """
+        self.target = np.zeros(len(self))
+
+        i = 0
+        for constraint in self.constraints:
+            n = len(constraint)
+            self.target[i : i + n] = constraint.target_value * np.ones(n)
+            i += n
+
+    def build_background(self):
+        """
+        Build the background value vector.
+        """
+        self.background = np.zeros(len(self))
+
+        i = 0
+        for constraint in self.constraints:
+            n = len(constraint)
+            self.background[i : i + n] = constraint.evaluate(self.eq)
+            i += n
+
+    @property
+    def b(self) -> np.ndarray:
+        """
+        The b vector of target - background values.
+        """
+        return self.target - self.background
+
+    def update_psi_boundary(self, psi_bndry: float):
+        """
+        Update the target value for all PsiBoundaryConstraints.
+
+        Parameters
+        ----------
+        psi_bndry:
+            The target psi boundary value [V.s/rad]
+        """
+        for constraint in self.constraints:
+            if isinstance(constraint, PsiBoundaryConstraint):
+                constraint.target_value = psi_bndry
+        self.build_target()
+
+    def plot(self, ax=None):
+        """
+        Plots constraints
+        """
+        return ConstraintPlotter(self, ax=ax)
+
+
+class AutoConstraints(MagneticConstraintSet):
+    """
+    Utility class for crude reconstruction of magnetic constraints from a
+    specified LCFS set of coordinates.
+
+    Parameters
+    ----------
+    x:
+        The x coordinates of the LCFS
+    z:
+        The z coordinates of the LCFS
+    psi_boundary:
+        The psi boundary value to use as a constraint. If None, an
+        isoflux constraint is used.
+    n_points:
+        The number of interpolated points to use
+    """
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        z: np.ndarray,
+        psi_boundary: Optional[float] = None,
+        n_points: int = 40,
+    ):
+        x = np.array(x)
+        z = np.array(z)
+        z_max = max(z)
+        z_min = min(z)
+        x_z_max = x[np.argmax(z)]
+        x_z_min = x[np.argmin(z)]
+
+        # Determine if we are dealing with SN or DN
+        single_null = abs_rel_difference(abs(z_min), z_max) > 0.05
+
+        if single_null:
+            # Determine if it is an upper or lower SN
+            lower = abs(z_min) > z_max
+
+            if lower:
+                constraints = [FieldNullConstraint(x_z_min, z_min)]
+            else:
+                constraints = [FieldNullConstraint(x_z_max, z_max)]
+
+        else:
+            constraints = [
+                FieldNullConstraint(x_z_min, z_min),
+                FieldNullConstraint(x_z_max, z_max),
+            ]
+
+        # Interpolate some points on the LCFS
+        x_boundary, _, z_boundary = interpolate_points(x, np.zeros_like[x], z, n_points)
+
+        # Apply an appropriate constraint on the LCFS
+        if psi_boundary is None:
+            arg_inner = np.argmin(x_boundary**2 + z_boundary**2)
+            ref_x = x_boundary[arg_inner]
+            ref_z = z_boundary[arg_inner]
+
+            constraints.append(IsofluxConstraint(x_boundary, z_boundary, ref_x, ref_z))
+
+        else:
+            constraints.append(
+                PsiBoundaryConstraint(x_boundary, z_boundary, psi_boundary)
+            )
+        super().__init__(constraints)

--- a/bluemira/equilibria/optimisation/objectives.py
+++ b/bluemira/equilibria/optimisation/objectives.py
@@ -1,0 +1,178 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Equilibrium optimisation objective functions.
+
+Objective functions must be of the form:
+
+.. code-block:: python
+
+    def f_objective(x, grad, args):
+        if grad.size > 0:
+            grad[:] = my_gradient_calc(x)
+        return my_objective_calc(x)
+
+The objective function is minimised, so lower values are "better".
+
+Note that the gradient of the objective function is of the form:
+
+:math:`\\nabla f = \\bigg[\\dfrac{\\partial f}{\\partial x_0}, \\dfrac{\\partial f}{\\partial x_1}, ...\\bigg]`
+"""  # noqa (W505)
+
+import abc
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.error import EquilibriaError
+
+
+class ObjectiveFunction(abc.ABC):
+    @abc.abstractmethod
+    def f_objective(self, vector: npt.NDArray) -> float:
+        """Objective function for an optimisation."""
+
+    def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        """Gradient of the objective function for an optimisation."""
+
+
+class RegularisedLsqObjective(ObjectiveFunction):
+    """
+    Least-squares objective with Tikhonov regularisation term.
+
+    Parameters
+    ----------
+    scale:
+        Scaling factor for the vector
+    a_mat:
+        The 2-D a_mat control matrix A (n, m)
+    b_vec:
+        The 1-D b vector of target values (n)
+    gamma:
+        The Tikhonov regularisation parameter.
+    """
+
+    def __init__(
+        self,
+        scale: float,
+        a_mat: npt.NDArray,
+        b_vec: npt.NDArray,
+        gamma: float,
+    ) -> None:
+        self.scale = scale
+        self.a_mat = a_mat
+        self.b_vec = b_vec
+        self.gamma = gamma
+
+    def f_objective(self, x: npt.NDArray) -> float:
+        x = x * self.scale
+        fom, _ = regularised_lsq_fom(x, self.a_mat, self.b_vec, self.gamma)
+        if fom <= 0:
+            raise EquilibriaError(
+                "Optimiser least-squares objective function less than zero or nan."
+            )
+        return fom
+
+    def df_objective(self, x: npt.NDArray) -> npt.NDArray:
+        x = x * self.scale
+        jac = 2 * self.a_mat.T @ self.a_mat @ x / float(len(self.b_vec))
+        jac -= 2 * self.a_mat.T @ self.b_vec / float(len(self.b_vec))
+        jac += 2 * self.gamma * self.gamma * x
+        return self.scale * jac
+
+
+class CoilCurrentsObjective(ObjectiveFunction):
+    """Objective function for the minimisation of the sum of coil currents squared."""
+
+    def f_objective(self, vector: npt.NDArray) -> float:
+        return np.sum(vector**2)
+
+    def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        return 2 * vector
+
+
+class MaximiseFluxObjective(ObjectiveFunction):
+    """
+    Objective function to maximise flux
+
+    Parameters
+    ----------
+    c_psi_mat:
+        Response matrix of the coil psi contributions to the point at which the flux
+        should be maximised
+    scale:
+        Scaling factor for the vector
+    """
+
+    def __init__(self, c_psi_mat: npt.NDArray, scale: float):
+        self.c_psi_mat = c_psi_mat
+        self.scale = scale
+
+    def f_objective(self, vector: npt.NDArray) -> float:
+        return -self.scale * self.c_psi_mat @ vector
+
+    def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        return -self.scale * self.c_psi_mat
+
+
+# =============================================================================
+# Figures of merit
+# =============================================================================
+
+
+def regularised_lsq_fom(
+    x: np.ndarray, a_mat: np.ndarray, b_vec: np.ndarray, gamma: float
+) -> Tuple[float, np.ndarray]:
+    """
+    Figure of merit for the least squares problem Ax = b, with
+    Tikhonov regularisation term. Normalised for the number of
+    targets.
+
+    ||(Ax - b)||²/ len(b)] + ||Γx||²
+
+    Parameters
+    ----------
+    x :
+        The 1-D x state vector (m)
+    a_mat:
+        The 2-D a_mat control matrix A (n, m)
+    b_vec:
+        The 1-D b vector of target values (n)
+    gamma:
+        The Tikhonov regularisation parameter.
+
+    Returns
+    -------
+    fom:
+        Figure of merit, explicitly given by
+        ||(Ax - b)||²/ len(b)] + ||Γx||²
+    residual:
+        Residual vector (Ax - b)
+    """
+    residual = np.dot(a_mat, x) - b_vec
+    number_of_targets = float(len(residual))
+    fom = residual.T @ residual / number_of_targets + gamma * gamma * x.T @ x
+
+    if fom <= 0:
+        raise EquilibriaError("Least-squares objective function less than zero or nan.")
+    return fom, residual

--- a/bluemira/equilibria/optimisation/objectives.py
+++ b/bluemira/equilibria/optimisation/objectives.py
@@ -48,12 +48,22 @@ from bluemira.equilibria.error import EquilibriaError
 
 
 class ObjectiveFunction(abc.ABC):
+    """
+    Base class for ObjectiveFunctions
+
+    Notes
+    -----
+    Optionally the function 'df_objective' can be implemented on any child
+    classes to calculate the gradient of the objective function.
+    The function should take an `npt.NDArray` as its only argument and
+    return only an `npt.NDArray`.
+    If the `df_objective` function is not provided and the optimisation algorithm
+    is gradient based the approximate derivate is calculated.
+    """
+
     @abc.abstractmethod
     def f_objective(self, vector: npt.NDArray) -> float:
         """Objective function for an optimisation."""
-
-    def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
-        """Gradient of the objective function for an optimisation."""
 
 
 class RegularisedLsqObjective(ObjectiveFunction):
@@ -85,6 +95,7 @@ class RegularisedLsqObjective(ObjectiveFunction):
         self.gamma = gamma
 
     def f_objective(self, x: npt.NDArray) -> float:
+        """Objective function for an optimisation."""
         x = x * self.scale
         fom, _ = regularised_lsq_fom(x, self.a_mat, self.b_vec, self.gamma)
         if fom <= 0:
@@ -94,6 +105,7 @@ class RegularisedLsqObjective(ObjectiveFunction):
         return fom
 
     def df_objective(self, x: npt.NDArray) -> npt.NDArray:
+        """Gradient of the objective function for an optimisation."""
         x = x * self.scale
         jac = 2 * self.a_mat.T @ self.a_mat @ x / float(len(self.b_vec))
         jac -= 2 * self.a_mat.T @ self.b_vec / float(len(self.b_vec))
@@ -105,9 +117,11 @@ class CoilCurrentsObjective(ObjectiveFunction):
     """Objective function for the minimisation of the sum of coil currents squared."""
 
     def f_objective(self, vector: npt.NDArray) -> float:
+        """Objective function for an optimisation."""
         return np.sum(vector**2)
 
     def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        """Gradient of the objective function for an optimisation."""
         return 2 * vector
 
 
@@ -129,9 +143,11 @@ class MaximiseFluxObjective(ObjectiveFunction):
         self.scale = scale
 
     def f_objective(self, vector: npt.NDArray) -> float:
+        """Objective function for an optimisation."""
         return -self.scale * self.c_psi_mat @ vector
 
     def df_objective(self, vector: npt.NDArray) -> npt.NDArray:
+        """Gradient of the objective function for an optimisation."""
         return -self.scale * self.c_psi_mat
 
 

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -23,6 +23,7 @@
 from bluemira.equilibria.optimisation.problem._minimal_current import MinimalCurrentCOP
 from bluemira.equilibria.optimisation.problem._nested_position import (
     NestedCoilsetPositionCOP,
+    PulsedNestedPositionCOP,
 )
 from bluemira.equilibria.optimisation.problem._position import CoilsetPositionCOP
 from bluemira.equilibria.optimisation.problem._tikhonov import (
@@ -36,6 +37,7 @@ __all__ = [
     "CoilsetPositionCOP",
     "MinimalCurrentCOP",
     "NestedCoilsetPositionCOP",
+    "PulsedNestedPositionCOP",
     "TikhonovCurrentCOP",
     "UnconstrainedTikhonovCurrentGradientCOP",
 ]

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -18,6 +18,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+"""Coilset optimisation problem classes and tools."""
+
+from bluemira.equilibria.optimisation.problem._nested_position import (
+    NestedCoilsetPositionCOP,
+)
 from bluemira.equilibria.optimisation.problem._position import CoilsetPositionCOP
 from bluemira.equilibria.optimisation.problem._tikhonov import TikhonovCurrentCOP
 from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
@@ -25,5 +30,6 @@ from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationPro
 __all__ = [
     "CoilsetOptimisationProblem",
     "CoilsetPositionCOP",
+    "NestedCoilsetPositionCOP",
     "TikhonovCurrentCOP",
 ]

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -1,0 +1,27 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+from bluemira.equilibria.optimisation.problem._tikhonov import TikhonovCurrentCOP
+from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
+
+__all__ = [
+    "CoilsetOptimisationProblem",
+    "TikhonovCurrentCOP",
+]

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -25,7 +25,10 @@ from bluemira.equilibria.optimisation.problem._nested_position import (
     NestedCoilsetPositionCOP,
 )
 from bluemira.equilibria.optimisation.problem._position import CoilsetPositionCOP
-from bluemira.equilibria.optimisation.problem._tikhonov import TikhonovCurrentCOP
+from bluemira.equilibria.optimisation.problem._tikhonov import (
+    TikhonovCurrentCOP,
+    UnconstrainedTikhonovCurrentGradientCOP,
+)
 from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
 
 __all__ = [
@@ -34,4 +37,5 @@ __all__ = [
     "MinimalCurrentCOP",
     "NestedCoilsetPositionCOP",
     "TikhonovCurrentCOP",
+    "UnconstrainedTikhonovCurrentGradientCOP",
 ]

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -18,10 +18,12 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+from bluemira.equilibria.optimisation.problem._position import CoilsetPositionCOP
 from bluemira.equilibria.optimisation.problem._tikhonov import TikhonovCurrentCOP
 from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
 
 __all__ = [
     "CoilsetOptimisationProblem",
+    "CoilsetPositionCOP",
     "TikhonovCurrentCOP",
 ]

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -20,6 +20,14 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Coilset optimisation problem classes and tools."""
 
+from bluemira.equilibria.optimisation.problem._breakdown import (
+    BreakdownCOP,
+    BreakdownZoneStrategy,
+    CircularZoneStrategy,
+    InboardBreakdownZoneStrategy,
+    InputBreakdownZoneStrategy,
+    OutboardBreakdownZoneStrategy,
+)
 from bluemira.equilibria.optimisation.problem._minimal_current import MinimalCurrentCOP
 from bluemira.equilibria.optimisation.problem._nested_position import (
     NestedCoilsetPositionCOP,
@@ -33,10 +41,16 @@ from bluemira.equilibria.optimisation.problem._tikhonov import (
 from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
 
 __all__ = [
+    "BreakdownCOP",
+    "BreakdownZoneStrategy",
+    "CircularZoneStrategy",
     "CoilsetOptimisationProblem",
     "CoilsetPositionCOP",
+    "InboardBreakdownZoneStrategy",
+    "InputBreakdownZoneStrategy",
     "MinimalCurrentCOP",
     "NestedCoilsetPositionCOP",
+    "OutboardBreakdownZoneStrategy",
     "PulsedNestedPositionCOP",
     "TikhonovCurrentCOP",
     "UnconstrainedTikhonovCurrentGradientCOP",

--- a/bluemira/equilibria/optimisation/problem/__init__.py
+++ b/bluemira/equilibria/optimisation/problem/__init__.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 """Coilset optimisation problem classes and tools."""
 
+from bluemira.equilibria.optimisation.problem._minimal_current import MinimalCurrentCOP
 from bluemira.equilibria.optimisation.problem._nested_position import (
     NestedCoilsetPositionCOP,
 )
@@ -30,6 +31,7 @@ from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationPro
 __all__ = [
     "CoilsetOptimisationProblem",
     "CoilsetPositionCOP",
+    "MinimalCurrentCOP",
     "NestedCoilsetPositionCOP",
     "TikhonovCurrentCOP",
 ]

--- a/bluemira/equilibria/optimisation/problem/_breakdown.py
+++ b/bluemira/equilibria/optimisation/problem/_breakdown.py
@@ -44,11 +44,11 @@ class BreakdownZoneStrategy(abc.ABC):
 
     Parameters
     ----------
-    R_0: float
+    R_0:
         Major radius of the reference plasma
-    A: float
+    A:
         Aspect ratio of the reference plasma
-    tk_sol: float
+    tk_sol:
         Thickness of the scrape-off layer
     """
 
@@ -58,15 +58,15 @@ class BreakdownZoneStrategy(abc.ABC):
         self.tk_sol = tk_sol
 
     @abc.abstractproperty
-    def breakdown_point(self) -> Tuple[float]:
+    def breakdown_point(self) -> Tuple[float, float]:
         """
         The location of the breakdown point.
 
         Returns
         -------
-        x_c: float
+        x_c:
             Radial coordinate of the breakdown point
-        z_c: float
+        z_c:
             Vertical coordinate of the breakdown point
         """
         pass
@@ -111,7 +111,17 @@ class InboardBreakdownZoneStrategy(CircularZoneStrategy):
     """
 
     @property
-    def breakdown_point(self) -> Tuple[float]:
+    def breakdown_point(self) -> Tuple[float, float]:
+        """
+        The location of the breakdown point.
+
+        Returns
+        -------
+        x_c:
+            Radial coordinate of the breakdown point
+        z_c:
+            Vertical coordinate of the breakdown point
+        """
         r_c = self.breakdown_radius
         x_c = self.R_0 - self.R_0 / self.A - self.tk_sol + r_c
         z_c = 0.0
@@ -119,6 +129,9 @@ class InboardBreakdownZoneStrategy(CircularZoneStrategy):
 
     @property
     def breakdown_radius(self) -> float:
+        """
+        The radius of the breakdown zone.
+        """
         return 0.5 * self.R_0 / self.A
 
 
@@ -128,7 +141,17 @@ class OutboardBreakdownZoneStrategy(CircularZoneStrategy):
     """
 
     @property
-    def breakdown_point(self) -> Tuple[float]:
+    def breakdown_point(self) -> Tuple[float, float]:
+        """
+        The location of the breakdown point.
+
+        Returns
+        -------
+        x_c:
+            Radial coordinate of the breakdown point
+        z_c:
+            Vertical coordinate of the breakdown point
+        """
         r_c = self.breakdown_radius
         x_c = self.R_0 + self.R_0 / self.A + self.tk_sol - r_c
         z_c = 0.0
@@ -136,6 +159,9 @@ class OutboardBreakdownZoneStrategy(CircularZoneStrategy):
 
     @property
     def breakdown_radius(self) -> float:
+        """
+        The radius of the breakdown zone.
+        """
         return 0.7 * self.R_0 / self.A
 
 
@@ -144,20 +170,30 @@ class InputBreakdownZoneStrategy(CircularZoneStrategy):
     User input breakdown zone strategy.
     """
 
-    def __call__(self, *args, **kwargs):
-        return self
-
     def __init__(self, x_c, z_c, r_c):
         self.x_c = x_c
         self.z_c = z_c
         self.r_c = r_c
 
     @property
-    def breakdown_point(self) -> Tuple[float]:
+    def breakdown_point(self) -> Tuple[float, float]:
+        """
+        The location of the breakdown point.
+
+        Returns
+        -------
+        x_c:
+            Radial coordinate of the breakdown point
+        z_c:
+            Vertical coordinate of the breakdown point
+        """
         return self.x_c, self.z_c
 
     @property
     def breakdown_radius(self) -> float:
+        """
+        The radius of the breakdown zone.
+        """
         return self.r_c
 
 

--- a/bluemira/equilibria/optimisation/problem/_breakdown.py
+++ b/bluemira/equilibria/optimisation/problem/_breakdown.py
@@ -1,0 +1,231 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+import abc
+from typing import List, Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.coils import CoilSet
+from bluemira.equilibria.equilibrium import Breakdown
+from bluemira.equilibria.optimisation.constraints import (
+    FieldConstraints,
+    UpdateableConstraint,
+)
+from bluemira.equilibria.optimisation.objectives import MaximiseFluxObjective
+from bluemira.equilibria.optimisation.problem.base import (
+    CoilsetOptimisationProblem,
+    CoilsetOptimiserResult,
+)
+from bluemira.optimisation import optimise
+
+
+class BreakdownZoneStrategy(abc.ABC):
+    """
+    Abstract base class for the definition of a breakdown zone strategy.
+
+    Parameters
+    ----------
+    R_0: float
+        Major radius of the reference plasma
+    A: float
+        Aspect ratio of the reference plasma
+    tk_sol: float
+        Thickness of the scrape-off layer
+    """
+
+    def __init__(self, R_0, A, tk_sol, **kwargs):
+        self.R_0 = R_0
+        self.A = A
+        self.tk_sol = tk_sol
+
+    @abc.abstractproperty
+    def breakdown_point(self) -> Tuple[float]:
+        """
+        The location of the breakdown point.
+
+        Returns
+        -------
+        x_c: float
+            Radial coordinate of the breakdown point
+        z_c: float
+            Vertical coordinate of the breakdown point
+        """
+        pass
+
+    @abc.abstractproperty
+    def breakdown_radius(self) -> float:
+        """
+        The radius of the breakdown zone.
+        """
+        pass
+
+    @abc.abstractmethod
+    def calculate_zone_points(self, n_points: int) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate the discretised set of points representing the breakdown zone.
+        """
+        pass
+
+
+class CircularZoneStrategy(BreakdownZoneStrategy):
+    """
+    Circular breakdown zone strategy.
+    """
+
+    def calculate_zone_points(self, n_points: int) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate the discretised set of points representing the breakdown zone.
+        """
+        x_c, z_c = self.breakdown_point
+        r_c = self.breakdown_radius
+        theta = np.linspace(0, 2 * np.pi, n_points - 1, endpoint=False)
+        x = x_c + r_c * np.cos(theta)
+        z = z_c + r_c * np.sin(theta)
+        x = np.append(x, x_c)
+        z = np.append(z, z_c)
+        return x, z
+
+
+class InboardBreakdownZoneStrategy(CircularZoneStrategy):
+    """
+    Inboard breakdown zone strategy.
+    """
+
+    @property
+    def breakdown_point(self) -> Tuple[float]:
+        r_c = self.breakdown_radius
+        x_c = self.R_0 - self.R_0 / self.A - self.tk_sol + r_c
+        z_c = 0.0
+        return x_c, z_c
+
+    @property
+    def breakdown_radius(self) -> float:
+        return 0.5 * self.R_0 / self.A
+
+
+class OutboardBreakdownZoneStrategy(CircularZoneStrategy):
+    """
+    Outboard breakdown zone strategy.
+    """
+
+    @property
+    def breakdown_point(self) -> Tuple[float]:
+        r_c = self.breakdown_radius
+        x_c = self.R_0 + self.R_0 / self.A + self.tk_sol - r_c
+        z_c = 0.0
+        return x_c, z_c
+
+    @property
+    def breakdown_radius(self) -> float:
+        return 0.7 * self.R_0 / self.A
+
+
+class InputBreakdownZoneStrategy(CircularZoneStrategy):
+    """
+    User input breakdown zone strategy.
+    """
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __init__(self, x_c, z_c, r_c):
+        self.x_c = x_c
+        self.z_c = z_c
+        self.r_c = r_c
+
+    @property
+    def breakdown_point(self) -> Tuple[float]:
+        return self.x_c, self.z_c
+
+    @property
+    def breakdown_radius(self) -> float:
+        return self.r_c
+
+
+class BreakdownCOP(CoilsetOptimisationProblem):
+    """
+    Coilset optimisation problem for the premagnetisation / breakdown phase.
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        breakdown: Breakdown,
+        breakdown_strategy: BreakdownZoneStrategy,
+        B_stray_max,
+        B_stray_con_tol,
+        n_B_stray_points,
+        max_currents: npt.ArrayLike,
+        opt_algorithm="SLSQP",
+        opt_conditions=None,
+        constraints: Optional[List[UpdateableConstraint]] = None,
+    ):
+        self.coilset = coilset
+        self.eq = breakdown
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = opt_conditions
+
+        self._args = {
+            "c_psi_mat": np.array(
+                coilset.psi_response(*breakdown_strategy.breakdown_point)
+            ),
+            "scale": self.scale,
+        }
+        x_zone, z_zone = breakdown_strategy.calculate_zone_points(n_B_stray_points)
+        stray_field_cons = FieldConstraints(
+            x_zone, z_zone, B_max=B_stray_max, tolerance=B_stray_con_tol
+        )
+
+        self._constraints = constraints
+        if self._constraints is not None:
+            self._constraints.append(stray_field_cons)
+        else:
+            self._constraints = [stray_field_cons]
+
+        max_currents = np.atleast_1d(max_currents)
+        self.bounds = (-max_currents / self.scale, max_currents / self.scale)
+
+    def optimise(self, x0=None, fixed_coils=True):
+        """
+        Solve the optimisation problem.
+        """
+        self.update_magnetic_constraints(I_not_dI=True, fixed_coils=fixed_coils)
+
+        initial_state, n_states = self.read_coilset_state(self.coilset, self.scale)
+        _, _, initial_currents = np.array_split(initial_state, n_states)
+        initial_currents = np.clip(initial_currents, *self.bounds)
+
+        objective = MaximiseFluxObjective(**self._args)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
+        opt_result = optimise(
+            f_objective=objective.f_objective,
+            df_objective=objective.df_objective,
+            x0=initial_currents,
+            algorithm=self.opt_algorithm,
+            opt_conditions=self.opt_conditions,
+            bounds=self.bounds,
+            eq_constraints=eq_constraints,
+            ineq_constraints=ineq_constraints,
+        )
+        currents = opt_result.x
+        self.coilset.get_control_coils().current = currents * self.scale
+        return CoilsetOptimiserResult.from_opt_result(self.coilset, opt_result)

--- a/bluemira/equilibria/optimisation/problem/_minimal_current.py
+++ b/bluemira/equilibria/optimisation/problem/_minimal_current.py
@@ -1,0 +1,100 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from typing import Dict, Optional
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.coils import CoilSet
+from bluemira.equilibria.equilibrium import Equilibrium
+from bluemira.equilibria.optimisation.objectives import CoilCurrentsObjective
+from bluemira.equilibria.optimisation.problem.base import (
+    CoilsetOptimisationProblem,
+    CoilsetOptimiserResult,
+)
+from bluemira.optimisation import optimise
+
+
+class MinimalCurrentCOP(CoilsetOptimisationProblem):
+    """
+    Bounded, constrained, minimal current optimisation problem.
+
+    Parameters
+    ----------
+    eq: Equilibrium
+        Equilibrium object to optimise the currents for
+    optimiser: Optimiser
+        Optimiser object to use
+    max_currents: np.ndarray
+        Current bounds vector [A]
+    constraints: Optional[List[OptimisationConstraint]]
+        List of optimisation constraints to apply to the optimisation problem
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        eq: Equilibrium,
+        max_currents: npt.ArrayLike = None,
+        opt_conditions: Optional[Dict[str, float]] = None,
+        opt_algorithm: str = "SLSQP",
+    ):
+        self.eq = eq
+        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+        self.coilset = coilset
+        self.opt_conditions = opt_conditions
+        self.opt_algorithm = opt_algorithm
+
+    def optimise(self, x0: Optional[npt.NDArray] = None, fixed_coils: bool = True):
+        """
+        Run the optimisation problem
+
+        Parameters
+        ----------
+        fixed_coils:
+            Whether or not to update to coilset response matrices
+
+        Returns
+        -------
+        coilset: CoilSet
+            Optimised CoilSet
+        """
+        self.update_magnetic_constraints(I_not_dI=True, fixed_coils=fixed_coils)
+
+        if x0 is None:
+            initial_state, n_states = self.read_coilset_state(
+                self.eq.coilset, self.scale
+            )
+            _, _, initial_currents = np.array_split(initial_state, n_states)
+            x0 = np.clip(initial_currents, *self.bounds)
+
+        objective = CoilCurrentsObjective()
+        opt_result = optimise(
+            f_objective=objective.f_objective,
+            df_objective=objective.df_objective,
+            x0=x0,
+            algorithm=self.opt_algorithm,
+            opt_conditions=self.opt_conditions,
+        )
+        currents = opt_result.x
+        self.coilset.get_control_coils().current = currents * self.scale
+        return CoilsetOptimiserResult.from_opt_result(self.coilset, opt_result)

--- a/bluemira/equilibria/optimisation/problem/_minimal_current.py
+++ b/bluemira/equilibria/optimisation/problem/_minimal_current.py
@@ -41,13 +41,13 @@ class MinimalCurrentCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    eq: Equilibrium
+    eq:
         Equilibrium object to optimise the currents for
-    optimiser: Optimiser
+    optimiser:
         Optimiser object to use
-    max_currents: np.ndarray
+    max_currents:
         Current bounds vector [A]
-    constraints: Optional[List[OptimisationConstraint]]
+    constraints:
         List of optimisation constraints to apply to the optimisation problem
     """
 

--- a/bluemira/equilibria/optimisation/problem/_nested_position.py
+++ b/bluemira/equilibria/optimisation/problem/_nested_position.py
@@ -1,0 +1,156 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+OptimisationProblems for coilset design.
+
+New optimisation schemes for the coilset can be provided by subclassing
+from CoilsetOP, which is an abstract base class for OptimisationProblems
+that use a coilset as their parameterisation object.
+
+Subclasses must provide an optimise() method that returns an optimised
+coilset according to a given optimisation objective function.
+As the exact form of the state vector that is optimised is often
+specific to each objective function, each subclass of CoilsetOP is
+generally also specific to a given objective function, since
+the method used to map the coilset object to the state vector
+(and additional required arguments) will generally differ in each case.
+
+"""
+
+from typing import Dict
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.equilibrium import Equilibrium
+from bluemira.equilibria.optimisation.constraints import MagneticConstraintSet
+from bluemira.equilibria.optimisation.problem.base import (
+    CoilsetOptimisationProblem,
+    CoilsetOptimiserResult,
+)
+from bluemira.equilibria.positioner import RegionMapper
+from bluemira.geometry.coordinates import Coordinates
+from bluemira.optimisation import optimise
+
+
+class NestedCoilsetPositionCOP(CoilsetOptimisationProblem):
+    """
+    Coilset OptimisationProblem for coil currents and positions
+    subject to maximum current bounds and positions bounded within
+    a provided region. Performs a nested optimisation for coil
+    currents within each position optimisation function call.
+
+    Parameters
+    ----------
+    sub_opt:
+        Coilset OptimisationProblem to use for the optimisation of
+        coil currents at each trial set of coil positions.
+        sub_opt.coilset must exist, and will be modified
+        during the optimisation.
+    eq:
+        Equilibrium object used to update magnetic field targets.
+    targets:
+        Set of magnetic field targets to use in objective function.
+    pfregions:
+        Dictionary of Coordinates that specify convex hull regions inside which
+        each PF control coil position is to be optimised.
+        The Coordinates must be 2d in x,z in units of [m].
+    opt_algorithm:
+        The optimisation algorithm to use (e.g. SLSQP)
+    opt_conditions:
+        The stopping conditions for the optimiser.
+
+    Notes
+    -----
+    Setting stopval and maxeval is the most reliable way to stop optimisation
+    at the desired figure of merit and number of iterations respectively.
+    Some NLOpt optimisers display unexpected behaviour when setting xtol and
+    ftol, and may not terminate as expected when those criteria are reached.
+    """
+
+    def __init__(
+        self,
+        sub_opt: CoilsetOptimisationProblem,
+        eq: Equilibrium,
+        targets: MagneticConstraintSet,
+        pfregions: Dict[str, Coordinates],
+        opt_algorithm="SBPLX",
+        opt_conditions={
+            "stop_val": 1.0,
+            "max_eval": 100,
+        },
+    ):
+        self.region_mapper = RegionMapper(pfregions)
+        self.eq = eq
+        self.targets = targets
+        _, lower_bounds, upper_bounds = self.region_mapper.get_Lmap(self.coilset)
+        self.bounds = (lower_bounds, upper_bounds)
+        self.coilset = sub_opt.coilset
+        self.sub_opt = sub_opt
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = opt_conditions
+
+        self.initial_state, self.substates = self.read_coilset_state(
+            self.coilset, self.scale
+        )
+        self.I0 = np.array_split(self.initial_state, self.substates)[2]
+
+    def optimise(self):
+        """
+        Run the optimisation.
+
+        Returns
+        -------
+        Optimised CoilSet object.
+        """
+        # Get initial currents, and trim to within current bounds.
+        initial_state, substates = self.read_coilset_state(self.coilset, self.scale)
+        _, _, initial_currents = np.array_split(initial_state, substates)
+        initial_mapped_positions, _, _ = self.region_mapper.get_Lmap(self.coilset)
+
+        # TODO: find more explicit way of passing this to objective?
+        self.I0 = initial_currents
+
+        opt_result = optimise(
+            f_objective=self.objective,
+            x0=initial_mapped_positions,
+            algorithm=self.opt_algorithm,
+            opt_conditions=self.opt_conditions,
+        )
+        self.set_coilset_state(self.coilset, opt_result.x, self.scale)
+        return CoilsetOptimiserResult.from_opt_result(self.coilset, opt_result)
+
+    def objective(self, vector: npt.NDArray) -> float:
+        """Objective function to minimise."""
+        self.region_mapper.set_Lmap(vector)
+        x_vals, z_vals = self.region_mapper.get_xz_arrays()
+        positions = np.concatenate((x_vals, z_vals))
+        coilset_state = np.concatenate((positions, self.I0))
+        self.set_coilset_state(self.coilset, coilset_state, self.scale)
+
+        # Update targets
+        self.eq._remap_greens()
+        self.targets(self.eq, I_not_dI=True, fixed_coils=False)
+
+        # Run the sub-optimisation
+        sub_opt_result = self.sub_opt.optimise()
+        return sub_opt_result.f_x

--- a/bluemira/equilibria/optimisation/problem/_nested_position.py
+++ b/bluemira/equilibria/optimisation/problem/_nested_position.py
@@ -274,7 +274,7 @@ class PulsedNestedPositionCOP(CoilsetOptimisationProblem):
         """The objective function of the parent optimisation."""
         return self.sub_opt_objective(vector, verbose=verbose)
 
-    def _get_initial_vector(self):
+    def _get_initial_vector(self) -> npt.NDArray:
         """
         Get a vector representation of the initial coilset state from the PositionMapper.
         """
@@ -284,20 +284,22 @@ class PulsedNestedPositionCOP(CoilsetOptimisationProblem):
             z.append(self.coilset[name].z)
         return self.position_mapper.to_L(x, z)
 
-    def optimise(self, x0=None, verbose=False):
+    def optimise(
+        self, x0: Optional[npt.NDArray] = None, verbose: bool = False
+    ) -> CoilsetOptimiserResult:
         """
         Run the PulsedNestedPositionCOP
 
         Parameters
         ----------
-        x0: Optional[np.ndarray]
+        x0:
             Initial solution vector (parameterised positions)
-        verbose: bool
+        verbose:
             Whether or not to print progress information
 
         Returns
         -------
-        coilset: CoilSet
+        coilset:
             Optimised CoilSet
         """
         if x0 is None:

--- a/bluemira/equilibria/optimisation/problem/_position.py
+++ b/bluemira/equilibria/optimisation/problem/_position.py
@@ -1,0 +1,186 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from typing import Dict, Optional
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.coils import CoilSet
+from bluemira.equilibria.equilibrium import Equilibrium
+from bluemira.equilibria.opt_constraints import MagneticConstraintSet
+from bluemira.equilibria.optimisation.objectives import regularised_lsq_fom
+from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
+from bluemira.equilibria.positioner import RegionMapper
+from bluemira.geometry.coordinates import Coordinates
+from bluemira.optimisation import optimise
+
+
+class CoilsetPositionCOP(CoilsetOptimisationProblem):
+    """
+    Coilset OptimisationProblem for coil currents and positions
+    subject to maximum current bounds and positions bounded within
+    a provided region.
+
+    Coil currents and positions are optimised simultaneously.
+
+    Parameters
+    ----------
+    coilset:
+        Coilset to optimise.
+    eq:
+        Equilibrium object used to update magnetic field targets.
+    targets:
+        Set of magnetic field targets to use in objective function.
+    pfregions:
+        Dictionary of Coordinates that specify convex hull regions inside which
+        each PF control coil position is to be optimised.
+        The Coordinates must be 2d in x,z in units of [m].
+    max_currents:
+        Maximum allowed current for each independent coil current in coilset [A].
+        If specified as a float, the float will set the maximum allowed current
+        for all coils.
+    gamma:
+        Tikhonov regularisation parameter in units of [A⁻¹].
+    opt_algorithm:
+        The optimisation algorithm to use (e.g. SLSQP)
+    opt_conditions:
+        The stopping conditions for the optimiser.
+
+    Notes
+    -----
+    Setting stopval and maxeval is the most reliable way to stop optimisation
+    at the desired figure of merit and number of iterations respectively.
+    Some NLOpt optimisers display unexpected behaviour when setting xtol and
+    ftol, and may not terminate as expected when those criteria are reached.
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        eq: Equilibrium,
+        targets: MagneticConstraintSet,
+        pfregions: Dict[str, Coordinates],
+        max_currents: Optional[npt.ArrayLike] = None,
+        gamma=1e-8,
+        opt_algorithm: str = "SBPLX",
+        opt_conditions: Dict[str, float] = {
+            "stop_val": 1.0,
+            "max_eval": 100,
+        },
+    ):
+        self.coilset = coilset
+        self.eq = eq
+        self.targets = targets
+        self.region_mapper = RegionMapper(pfregions)
+        self.bounds = self.get_mapped_state_bounds(self.region_mapper, max_currents)
+        self.gamma = gamma
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = opt_conditions
+
+    def optimise(self) -> CoilSet:
+        """
+        Run the optimisation.
+
+        Returns
+        -------
+        Optimised CoilSet object.
+        """
+        # Get initial state and apply region mapping to coil positions.
+        initial_state, _ = self.read_coilset_state(self.coilset, self.scale)
+        _, _, initial_currents = np.array_split(initial_state, self.substates)
+        initial_mapped_positions, _, _ = self.region_mapper.get_Lmap(self.coilset)
+        initial_mapped_state = np.concatenate(
+            (initial_mapped_positions, initial_currents)
+        )
+
+        opt_result = optimise(
+            f_objective=self.objective,
+            df_objective=None,  # numerical approximation
+            x0=initial_mapped_state,
+            opt_conditions=self.opt_conditions,
+            algorithm=self.opt_algorithm,
+        )
+        state = opt_result.x
+        self.set_coilset_state(self.coilset, state, self.scale)
+        return self.coilset
+
+    def objective(self, vector: npt.NDArray) -> float:
+        """
+        Least-squares objective with Tikhonov regularisation term.
+
+        Parameters
+        ----------
+        vector:
+            The new coilset state vector.
+
+        Returns
+        -------
+        The figure of merit being minimised.
+        """
+        # Update the coilset with the new state vector
+        mapped_x, mapped_z, currents = np.array_split(vector, 3)
+        mapped_positions = np.concatenate((mapped_x, mapped_z))
+        self.region_mapper.set_Lmap(mapped_positions)
+        x_vals, z_vals = self.region_mapper.get_xz_arrays()
+        coilset_state = np.concatenate((x_vals, z_vals, currents))
+        self.set_coilset_state(self.coilset, coilset_state, self.scale)
+
+        # Update target
+        self.eq._remap_greens()
+
+        # Scale the control matrix and constraint vector by weights.
+        self.targets(self.eq, I_not_dI=True, fixed_coils=False)
+        _, a_mat, b_vec = self.targets.get_weighted_arrays()
+
+        return regularised_lsq_fom(currents * self.scale, a_mat, b_vec, self.gamma)[0]
+
+    def get_mapped_state_bounds(
+        self, region_mapper: RegionMapper, max_currents: Optional[npt.ArrayLike] = None
+    ):
+        """
+        Get mapped bounds on the coilset state vector from the coil regions and
+        maximum coil currents.
+
+        Parameters
+        ----------
+        region_mapper:
+            RegionMapper mapping coil positions within the allowed optimisation
+            regions.
+        max_currents:
+            Maximum allowed current for each independent coil current in coilset [A].
+            If specified as a float, the float will set the maximum allowed current
+            for all coils.
+
+        Returns
+        -------
+        bounds: np.array
+            Array containing state vectors representing lower and upper bounds
+            for coilset state degrees of freedom.
+        """
+        # Get mapped position bounds from RegionMapper
+        _, lower_lmap_bounds, upper_lmap_bounds = region_mapper.get_Lmap(self.coilset)
+        current_bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+
+        lower_bounds = np.concatenate((lower_lmap_bounds, current_bounds[0]))
+        upper_bounds = np.concatenate((upper_lmap_bounds, current_bounds[1]))
+        bounds = (lower_bounds, upper_bounds)
+        return bounds

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -29,7 +29,10 @@ from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.opt_constraints import MagneticConstraintSet
 from bluemira.equilibria.optimisation.constraints import ConstraintFunction
 from bluemira.equilibria.optimisation.objectives import RegularisedLsqObjective
-from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
+from bluemira.equilibria.optimisation.problem.base import (
+    CoilsetOptimisationProblem,
+    CoilsetOptimiserResult,
+)
 from bluemira.optimisation import optimise
 
 
@@ -81,7 +84,6 @@ class TikhonovCurrentCOP(CoilsetOptimisationProblem):
         max_currents: Optional[npt.ArrayLike] = None,
         constraints: Optional[List[ConstraintFunction]] = None,
     ):
-        self.scale = 1e6  # current_scale
         self.coilset = coilset
         self.eq = eq
         self.targets = targets
@@ -92,7 +94,7 @@ class TikhonovCurrentCOP(CoilsetOptimisationProblem):
         self.opt_parameters = opt_parameters
         self._constraints = constraints
 
-    def optimise(self, x0=None, fixed_coils=True):
+    def optimise(self, x0=None, fixed_coils=True) -> CoilsetOptimiserResult:
         """
         Solve the optimisation problem
 
@@ -133,4 +135,4 @@ class TikhonovCurrentCOP(CoilsetOptimisationProblem):
         )
         currents = opt_result.x
         self.coilset.get_control_coils().current = currents * self.scale
-        return self.coilset
+        return CoilsetOptimiserResult.from_opt_result(self.coilset, opt_result)

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -101,12 +101,12 @@ class TikhonovCurrentCOP(CoilsetOptimisationProblem):
 
         Parameters
         ----------
-        fixed_coils: True
+        fixed_coils:
             Whether or not to update to coilset response matrices
 
         Returns
         -------
-        coilset: CoilSet
+        coilset:
             Optimised CoilSet
         """
         # Scale the control matrix and magnetic field targets vector by weights.

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -1,0 +1,136 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from bluemira.equilibria.coils import CoilSet
+from bluemira.equilibria.equilibrium import Equilibrium
+from bluemira.equilibria.opt_constraints import MagneticConstraintSet
+from bluemira.equilibria.optimisation.constraints import ConstraintFunction
+from bluemira.equilibria.optimisation.objectives import RegularisedLsqObjective
+from bluemira.equilibria.optimisation.problem.base import CoilsetOptimisationProblem
+from bluemira.optimisation import optimise
+
+
+class TikhonovCurrentCOP(CoilsetOptimisationProblem):
+    """
+    Coilset OptimisationProblem for coil currents subject to maximum current bounds.
+
+    Coilset currents optimised using objectives.regularised_lsq_objective as
+    objective function.
+
+    Parameters
+    ----------
+    coilset:
+        Coilset to optimise.
+    eq:
+        Equilibrium object used to update magnetic field targets.
+    targets:
+        Set of magnetic field targets to use in objective function.
+    gamma:
+        Tikhonov regularisation parameter in units of [A⁻¹].
+    max_currents:
+        Maximum allowed current for each independent coil current in coilset [A].
+        If specified as a float, the float will set the maximum allowed current
+        for all coils.
+    optimiser:
+        Optimiser object to use for constrained optimisation.
+    constraints:
+        Optional list of OptimisationConstraint objects storing
+        information about constraints that must be satisfied
+        during the coilset optimisation, to be provided to the
+        optimiser.
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        eq: Equilibrium,
+        targets: MagneticConstraintSet,
+        gamma: float,
+        opt_algorithm: str = "SLSQP",
+        opt_conditions: Dict[str, Union[float, int]] = {
+            "xtol_rel": 1e-4,
+            "xtol_abs": 1e-4,
+            "ftol_rel": 1e-4,
+            "ftol_abs": 1e-4,
+            "max_eval": 100,
+        },
+        opt_parameters: Dict[str, Any] = {"initial_step": 0.03},
+        max_currents: Optional[npt.ArrayLike] = None,
+        constraints: Optional[List[ConstraintFunction]] = None,
+    ):
+        self.scale = 1e6  # current_scale
+        self.coilset = coilset
+        self.eq = eq
+        self.targets = targets
+        self.gamma = gamma
+        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = opt_conditions
+        self.opt_parameters = opt_parameters
+        self._constraints = constraints
+
+    def optimise(self, x0=None, fixed_coils=True):
+        """
+        Solve the optimisation problem
+
+        Parameters
+        ----------
+        fixed_coils: True
+            Whether or not to update to coilset response matrices
+
+        Returns
+        -------
+        coilset: CoilSet
+            Optimised CoilSet
+        """
+        # Scale the control matrix and magnetic field targets vector by weights.
+        self.targets(self.eq, I_not_dI=True, fixed_coils=fixed_coils)
+        _, a_mat, b_vec = self.targets.get_weighted_arrays()
+        self.update_magnetic_constraints(I_not_dI=True, fixed_coils=fixed_coils)
+
+        if x0 is None:
+            initial_state, n_states = self.read_coilset_state(self.coilset, self.scale)
+            _, _, initial_currents = np.array_split(initial_state, n_states)
+            x0 = np.clip(initial_currents, *self.bounds)
+
+        objective = RegularisedLsqObjective(
+            scale=self.scale,
+            a_mat=a_mat,
+            b_vec=b_vec,
+            gamma=self.gamma,
+        )
+        opt_result = optimise(
+            f_objective=objective.f_objective,
+            df_objective=getattr(objective, "df_objective", None),
+            x0=x0,
+            bounds=self.bounds,
+            opt_conditions=self.opt_conditions,
+            algorithm=self.opt_algorithm,
+            opt_parameters=self.opt_parameters,
+        )
+        currents = opt_result.x
+        self.coilset.get_control_coils().current = currents * self.scale
+        return self.coilset

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -18,18 +18,22 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+Equilibria Optimisation base module
+"""
+
 from __future__ import annotations
 
 import abc
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 
 from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.error import EquilibriaError
-from bluemira.equilibria.optimisation.constraint_funcs import ConstraintFunction
 from bluemira.equilibria.optimisation.constraints import UpdateableConstraint
 from bluemira.optimisation._optimiser import OptimiserResult
 from bluemira.optimisation.typing import ConstraintT
@@ -37,6 +41,8 @@ from bluemira.optimisation.typing import ConstraintT
 
 @dataclass
 class CoilsetOptimiserResult:
+    """Coilset optimisation result object"""
+
     coilset: CoilSet
     """The optimised coilset."""
     f_x: float
@@ -86,6 +92,7 @@ class CoilsetOptimisationProblem(abc.ABC):
 
     @property
     def coilset(self) -> CoilSet:
+        """The optimisation problem coilset"""
         return self._coilset
 
     @coilset.setter
@@ -288,4 +295,5 @@ class CoilsetOptimisationProblem(abc.ABC):
 
     @property
     def scale(self) -> float:
+        """Problem scaling value"""
         return 1e6

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -219,3 +219,7 @@ class CoilsetOptimisationProblem(abc.ABC):
                     )
                 if "scale" in constraint._args:
                     constraint._args["scale"] = self.scale
+
+    @property
+    def scale(self) -> float:
+        return 1e6

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -18,9 +18,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import abc
-from typing import Tuple
+from dataclasses import dataclass, field
+from typing import List, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -28,6 +30,42 @@ import numpy.typing as npt
 from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.opt_constraints import UpdateableConstraint
+from bluemira.optimisation._optimiser import OptimiserResult
+
+
+@dataclass
+class CoilsetOptimiserResult:
+    coilset: CoilSet
+    """The optimised coilset."""
+    f_x: float
+    """The evaluation of the optimised parameterisation."""
+    n_evals: int
+    """The number of evaluations of the objective function in the optimisation."""
+    history: List[Tuple[np.ndarray, float]] = field(repr=False)
+    """
+    The history of the parametrisation at each iteration.
+
+    The first element of each tuple is the parameterisation (x), the
+    second is the evaluation of the objective function at x (f(x)).
+    """
+    constraints_satisfied: Union[bool, None] = None
+    """
+    Whether all constraints have been satisfied to within the required tolerance.
+
+    Is ``None`` if constraints have not been checked.
+    """
+
+    @classmethod
+    def from_opt_result(
+        cls, coilset: CoilSet, opt_result: OptimiserResult
+    ) -> CoilsetOptimiserResult:
+        return cls(
+            coilset=coilset,
+            f_x=opt_result.f_x,
+            n_evals=opt_result.n_evals,
+            history=opt_result.history,
+            constraints_satisfied=opt_result.constraints_satisfied,
+        )
 
 
 class CoilsetOptimisationProblem(abc.ABC):

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -59,6 +59,7 @@ class CoilsetOptimiserResult:
     def from_opt_result(
         cls, coilset: CoilSet, opt_result: OptimiserResult
     ) -> CoilsetOptimiserResult:
+        """Make a coilset optimisation result from a normal optimisation result."""
         return cls(
             coilset=coilset,
             f_x=opt_result.f_x,
@@ -76,6 +77,10 @@ class CoilsetOptimisationProblem(abc.ABC):
     returns an optimised coilset object, optimised according
     to a specific objective function for that subclass.
     """
+
+    @abc.abstractmethod
+    def optimise(self) -> CoilsetOptimiserResult:
+        """Run the coilset optimisation."""
 
     @property
     def coilset(self) -> CoilSet:

--- a/bluemira/equilibria/optimisation/problems.py
+++ b/bluemira/equilibria/optimisation/problems.py
@@ -1,0 +1,359 @@
+# bluemira is an integrated inter-disciplinary design tool for future fusion
+# reactors. It incorporates several modules, some of which rely on other
+# codes, to carry out a range of typical conceptual fusion reactor design
+# activities.
+#
+# Copyright (C) 2021-2023 M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh,
+#                         J. Morris, D. Short
+#
+# bluemira is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# bluemira is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
+
+"""
+OptimisationProblems for coilset design.
+
+New optimisation schemes for the coilset can be provided by subclassing
+from CoilsetOP, which is an abstract base class for OptimisationProblems
+that use a coilset as their parameterisation object.
+
+Subclasses must provide an optimise() method that returns an optimised
+coilset according to a given optimisation objective function.
+As the exact form of the state vector that is optimised is often
+specific to each objective function, each subclass of CoilsetOP is
+generally also specific to a given objective function, since
+the method used to map the coilset object to the state vector
+(and additional required arguments) will generally differ in each case.
+
+"""
+
+import abc
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import numpy.typing as npt
+
+import bluemira.equilibria.opt_objectives as objectives
+from bluemira.base.look_and_feel import bluemira_print_flush
+from bluemira.equilibria.coils import CoilSet
+from bluemira.equilibria.equilibrium import Breakdown, Equilibrium
+from bluemira.equilibria.error import EquilibriaError
+from bluemira.equilibria.opt_constraints import (
+    FieldConstraints,
+    MagneticConstraintSet,
+    UpdateableConstraint,
+)
+from bluemira.equilibria.optimisation.constraints import ConstraintFunction
+from bluemira.equilibria.optimisation.objectives import (
+    ObjectiveFunction,
+    RegularisedLsqObjective,
+)
+from bluemira.equilibria.positioner import RegionMapper
+from bluemira.optimisation import optimise
+from bluemira.utilities.opt_tools import regularised_lsq_fom, tikhonov
+from bluemira.utilities.optimiser import Optimiser, approx_derivative
+from bluemira.utilities.positioning import PositionMapper
+
+__all__ = [
+    "UnconstrainedTikhonovCurrentGradientCOP",
+    "TikhonovCurrentCOP",
+    "CoilsetPositionCOP",
+    "NestedCoilsetPositionCOP",
+]
+
+
+class CoilsetOptimisationProblem:
+    """
+    Abstract base class for OptimisationProblems for the coilset.
+    Provides helper methods and utilities for OptimisationProblems
+    using a coilset as their parameterisation object.
+
+    Subclasses should provide an optimise() method that
+    returns an optimised coilset object, optimised according
+    to a specific objective function for that subclass.
+    """
+
+    @property
+    def coilset(self):
+        return self._parameterisation
+
+    @coilset.setter
+    def coilset(self, value: CoilSet):
+        self._parameterisation = value
+
+    @staticmethod
+    def read_coilset_state(coilset, current_scale):
+        """
+        Reads the input coilset and generates the state vector as an array to represent
+        it.
+
+        Parameters
+        ----------
+        coilset: Coilset
+            Coilset to be read into the state vector.
+        current_scale: float
+            Factor to scale coilset currents down by for population of coilset_state.
+            Used to minimise round-off errors in optimisation.
+
+        Returns
+        -------
+        coilset_state: np.array
+            State vector containing substate (position and current)
+            information for each coil.
+        substates: int
+            Number of substates (blocks) in the state vector.
+        """
+        substates = 3
+        x, z = coilset.position
+        currents = coilset.current / current_scale
+
+        coilset_state = np.concatenate((x, z, currents))
+        return coilset_state, substates
+
+    @staticmethod
+    def set_coilset_state(coilset, coilset_state, current_scale):
+        """
+        Set the optimiser coilset from a provided state vector.
+
+        Parameters
+        ----------
+        coilset: Coilset
+            Coilset to set from state vector.
+        coilset_state: np.array
+            State vector representing degrees of freedom of the coilset,
+            to be used to update the coilset.
+        current_scale: float
+            Factor to scale state vector currents up by when setting
+            coilset currents.
+            Used to minimise round-off errors in optimisation.
+        """
+        x, z, currents = np.array_split(coilset_state, 3)
+
+        coilset.x = x
+        coilset.z = z
+        coilset.current = currents * current_scale
+
+    @staticmethod
+    def get_state_bounds(x_bounds, z_bounds, current_bounds):
+        """
+        Get bounds on the state vector from provided bounds on the substates.
+
+        Parameters
+        ----------
+        x_bounds: tuple
+            Tuple containing lower and upper bounds on the radial coil positions.
+        z_bounds: tuple
+            Tuple containing lower and upper bounds on the vertical coil positions.
+        current_bounds: tuple
+            Tuple containing bounds on the coil currents.
+
+        Returns
+        -------
+        bounds: np.array
+            Array containing state vectors representing lower and upper bounds
+            for coilset state degrees of freedom.
+        """
+        lower_bounds = np.concatenate((x_bounds[0], z_bounds[0], current_bounds[0]))
+        upper_bounds = np.concatenate((x_bounds[1], z_bounds[1], current_bounds[1]))
+        bounds = np.array([lower_bounds, upper_bounds])
+        return bounds
+
+    @staticmethod
+    def get_current_bounds(coilset, max_currents, current_scale):
+        """
+        Gets the scaled current vector bounds. Must be called prior to optimise.
+
+        Parameters
+        ----------
+        coilset: Coilset
+            Coilset to fetch current bounds for.
+        max_currents: float or np.ndarray
+            Maximum magnitude of currents in each coil [A] permitted during optimisation.
+            If max_current is supplied as a float, the float will be set as the
+            maximum allowed current magnitude for all coils.
+            If the coils have current density limits that are more restrictive than these
+            coil currents, the smaller current limit of the two will be used for each
+            coil.
+        current_scale: float
+            Factor to scale coilset currents down when returning scaled current limits.
+
+        Returns
+        -------
+        current_bounds: (np.narray, np.narray)
+            Tuple of arrays containing lower and upper bounds for currents
+            permitted in each control coil.
+        """
+        n_control_currents = len(coilset.current[coilset._control_ind])
+        scaled_input_current_limits = np.inf * np.ones(n_control_currents)
+
+        if max_currents is not None:
+            input_current_limits = np.asarray(max_currents)
+            input_size = np.size(np.asarray(input_current_limits))
+            if input_size == 1 or input_size == n_control_currents:
+                scaled_input_current_limits = input_current_limits / current_scale
+            else:
+                raise EquilibriaError(
+                    "Length of max_currents array provided to optimiser is not"
+                    "equal to the number of control currents present."
+                )
+
+        # Get the current limits from coil current densities
+        coilset_current_limits = np.infty * np.ones(n_control_currents)
+        coilset_current_limits[coilset._flag_sizefix] = coilset.get_max_current()[
+            coilset._flag_sizefix
+        ]
+
+        # Limit the control current magnitude by the smaller of the two limits
+        control_current_limits = np.minimum(
+            scaled_input_current_limits, coilset_current_limits
+        )
+        current_bounds = (-control_current_limits, control_current_limits)
+
+        return current_bounds
+
+    def set_current_bounds(self, max_currents: np.ndarray):
+        """
+        Set the current bounds on this instance.
+
+        Parameters
+        ----------
+        max_currents:
+            Vector of maximum currents [A]
+        """
+        n_control_currents = len(self.coilset.current[self.coilset._control_ind])
+        if len(max_currents) != n_control_currents:
+            raise ValueError(
+                "Length of maximum current vector must be equal to the number of controls."
+            )
+
+        # TODO: sort out this interface
+        upper_bounds = np.abs(max_currents) / self.scale
+        lower_bounds = -upper_bounds
+        self.bounds = (lower_bounds, upper_bounds)
+
+    def update_magnetic_constraints(
+        self, I_not_dI: bool = True, fixed_coils: bool = True
+    ):
+        """
+        Update the magnetic optimisation constraints with the state of the Equilibrium
+        """
+        if self._constraints is not None:
+            for constraint in self._constraints:
+                if isinstance(constraint, UpdateableConstraint):
+                    constraint.prepare(
+                        self.eq, I_not_dI=I_not_dI, fixed_coils=fixed_coils
+                    )
+                if "scale" in constraint._args:
+                    constraint._args["scale"] = self.scale
+
+
+class TikhonovCurrentCOP(CoilsetOptimisationProblem):
+    """
+    Coilset OptimisationProblem for coil currents subject to maximum current bounds.
+
+    Coilset currents optimised using objectives.regularised_lsq_objective as
+    objective function.
+
+    Parameters
+    ----------
+    coilset: CoilSet
+        Coilset to optimise.
+    eq: Equilibrium
+        Equilibrium object used to update magnetic field targets.
+    targets: MagneticConstraintSet
+        Set of magnetic field targets to use in objective function.
+    gamma: float (default = 1e-8)
+        Tikhonov regularisation parameter in units of [A⁻¹].
+    max_currents Union[float, np.ndarray] (default = None)
+        Maximum allowed current for each independent coil current in coilset [A].
+        If specified as a float, the float will set the maximum allowed current
+        for all coils.
+    optimiser: bluemira.utilities.optimiser.Optimiser
+        Optimiser object to use for constrained optimisation.
+    constraints: List[OptimisationConstraint] (default: None)
+        Optional list of OptimisationConstraint objects storing
+        information about constraints that must be satisfied
+        during the coilset optimisation, to be provided to the
+        optimiser.
+    """
+
+    def __init__(
+        self,
+        coilset: CoilSet,
+        eq: Equilibrium,
+        targets: MagneticConstraintSet,
+        gamma: float,
+        opt_algorithm: str = "SLSQP",
+        opt_conditions: Dict[str, Union[float, int]] = {
+            "xtol_rel": 1e-4,
+            "xtol_abs": 1e-4,
+            "ftol_rel": 1e-4,
+            "ftol_abs": 1e-4,
+            "max_eval": 100,
+        },
+        opt_parameters: Dict[str, Any] = {"initial_step": 0.03},
+        max_currents: Optional[npt.ArrayLike] = None,
+        constraints: Optional[List[ConstraintFunction]] = None,
+    ):
+        self.scale = 1e6  # current_scale
+        self.coilset = coilset
+        self.eq = eq
+        self.targets = targets
+        self.gamma = gamma
+        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = opt_conditions
+        self.opt_parameters = opt_parameters
+        self._constraints = constraints
+
+    def optimise(self, x0=None, fixed_coils=True):
+        """
+        Solve the optimisation problem
+
+        Parameters
+        ----------
+        fixed_coils: True
+            Whether or not to update to coilset response matrices
+
+        Returns
+        -------
+        coilset: CoilSet
+            Optimised CoilSet
+        """
+        # Scale the control matrix and magnetic field targets vector by weights.
+        self.targets(self.eq, I_not_dI=True, fixed_coils=fixed_coils)
+        _, a_mat, b_vec = self.targets.get_weighted_arrays()
+        self.update_magnetic_constraints(I_not_dI=True, fixed_coils=fixed_coils)
+
+        if x0 is None:
+            initial_state, n_states = self.read_coilset_state(self.coilset, self.scale)
+            _, _, initial_currents = np.array_split(initial_state, n_states)
+            x0 = np.clip(initial_currents, *self.bounds)
+
+        objective = RegularisedLsqObjective(
+            scale=self.scale,
+            a_mat=a_mat,
+            b_vec=b_vec,
+            gamma=self.gamma,
+        )
+        opt_result = optimise(
+            f_objective=objective.f_objective,
+            df_objective=getattr(objective, "df_objective", None),
+            x0=x0,
+            bounds=self.bounds,
+            opt_conditions=self.opt_conditions,
+            algorithm=self.opt_algorithm,
+            opt_parameters=self.opt_parameters,
+        )
+        currents = opt_result.x
+        self.coilset.get_control_coils().current = currents * self.scale
+        return self.coilset

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -475,7 +475,7 @@ class PicardIterator:
 
     def _optimise_coilset(self):
         try:
-            coilset = self.opt_prob.optimise(fixed_coils=self.fixed_coils)
+            coilset = self.opt_prob.optimise(fixed_coils=self.fixed_coils).coilset
             self.store.append(coilset)
         except ExternalOptError:
             coilset = self.store[-1]

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -475,7 +475,11 @@ class PicardIterator:
 
     def _optimise_coilset(self):
         try:
-            coilset = self.opt_prob.optimise(fixed_coils=self.fixed_coils).coilset
+            result = self.opt_prob.optimise(fixed_coils=self.fixed_coils)
+            try:
+                coilset = result.coilset
+            except AttributeError:
+                coilset = result
             self.store.append(coilset)
         except ExternalOptError:
             coilset = self.store[-1]

--- a/tests/equilibria/test_optimiser.py
+++ b/tests/equilibria/test_optimiser.py
@@ -22,7 +22,7 @@
 import numpy as np
 
 from bluemira.equilibria.coils import Coil, CoilSet, SymmetricCircuit
-from bluemira.equilibria.opt_problems import CoilsetPositionCOP
+from bluemira.equilibria.optimisation.problem import CoilsetPositionCOP
 from bluemira.geometry.coordinates import Coordinates
 
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Partially addresses #2383 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This needs a lot of cleaning up. I've been rushing through it a bit, trying to get things in (at least) working order. I'm expecting flake8 to tell me off.

The idea has basically been to copy across all the old classes in `equlilibria.opt_[problems|constraints|constraint_funcs|objectives]` into a new module: `equilibria.optimisation`. `CoilsetOptimisation` no longer inherits from `OptimisationProblem`, it's now just an abstract class where you need to define `optimise` which returns a `CoilsetOptimiserResult`. The approach I've taken is to make a call to `bluemira.optimisation.optimise` in the `CoilsetOptimisation.optimise` implementations.

The old coilset optimisation objectives have been re-written to match a new `ObjectiveFunction` interface. Which requires definition of `f_objective`, and optionally, `df_objective`. The coilset constraint function have been re-written to satisfy a new interface defined by `ConstraintFunction` (you must define `f_constraint` and optionally `df_constraint`). The `UpdateableConstraint` interface has been largely unchanged, but a `f_constraint` abstract method has been added, which must return a `ConstraintFunction`.

The old interface had a few inconsistencies that have been carried through here, like one of the base `CoilsetOptimisationProblem` methods assumes a `self.eq` exists, but the interface does not guarantee that, similar for `self.coilset`. We also need to clear up the constraint interface a little, so it's clear where `constraint_type` and `tolerance` should be defined.

I've been using `examples/equilibria/single_null.ex.py` and `examples/equilibria/eudemo_2017.ex.py` as test beds and get pretty much the exact same results. The `single_null` example seems to just do one extra iteration, could be the handling of the opt conditions, but I haven't had a chance to dig into that yet.

There are still some places using `equlilibria.opt_[problems|constraints|constraint_funcs|objectives]` that need to be dealt with, but it should all work similarly.

It could be worth splitting this branch into several PRs, one for each opt problem - might make things easier to review. Or just review one optimisation problem at a time - I've split them into separate files, so hopefully they're a bit more readable.

There's a real lack of tests in equilibria - could be worth fashioning one or two regression tests from the examples I mentioned above. I've run out of time a bit, I'm afraid. 

Note that the branch that contains the more ambitious refactor, with a more polished interface, is: [hsaunders1904/2383_update_coilsetoptimisationproblem_for_new_optimisation_interface](https://github.com/Fusion-Power-Plant-Framework/bluemira/tree/hsaunders1904/2383_update_coilsetoptimisationproblem_for_new_optimisation_interface). I was quickly running out of time, so abandoned this for the quicker refactor that is this PR.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
