### PR TITLE
Improve robustness of FEM solver

### DIFF
--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -41,7 +41,7 @@ from scipy.interpolate import interp1d
 from tabulate import tabulate
 
 from bluemira.base.components import PhysicalComponent
-from bluemira.base.constants import EPS, MU_0
+from bluemira.base.constants import MU_0
 from bluemira.base.file import get_bluemira_path, try_get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
@@ -667,9 +667,7 @@ def calc_curr_dens_profiles(
         dum3 = np.gradient(dum2, psi_1D)
         betahat = dum3 / q3 / AA
         chat = -4 * np.pi**2 * MU_0 * pprime / AA
-        #  or np.where(y >= 0, np.sqrt(2.0 * y), -np.sqrt(2.0 * abs(y)))
-        #  or np.sqrt(2.0 * abs(y))
-        FF = np.sqrt(2.0 * np.clip(y, EPS, None))  # noqa: N806
+        FF = np.sqrt(2.0 * np.clip(y, 0, None))  # noqa: N806
 
         ff_prime = 4 * np.pi**2 * (chat - betahat * FF**2)
 

--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -41,7 +41,7 @@ from scipy.interpolate import interp1d
 from tabulate import tabulate
 
 from bluemira.base.components import PhysicalComponent
-from bluemira.base.constants import MU_0
+from bluemira.base.constants import EPS, MU_0
 from bluemira.base.file import get_bluemira_path, try_get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
@@ -667,7 +667,8 @@ def calc_curr_dens_profiles(
         dum3 = np.gradient(dum2, psi_1D)
         betahat = dum3 / q3 / AA
         chat = -4 * np.pi**2 * MU_0 * pprime / AA
-        FF = np.sqrt(2.0 * np.clip(y, 0, None))  # noqa: N806
+        # EPS clipping here otherwise DOLFIN crashes with index error in MeshEntity.cpp
+        FF = np.sqrt(2.0 * np.clip(y, EPS, None))  # noqa: N806
 
         ff_prime = 4 * np.pi**2 * (chat - betahat * FF**2)
 

--- a/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
+++ b/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
@@ -168,7 +168,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
         return self._grad_psi(point)
 
     @property
-    def psi_norm_2d(self) -> Callable[[np.ndarray], float]:
+    def psi_norm_2d(self) -> Callable[[np.ndarray], np.ndarray]:
         """Normalized flux function in 2-D"""
         return lambda x: np.sqrt(
             np.abs((self.psi(x) - self.psi_ax) / (self.psi_b - self.psi_ax))

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -352,8 +352,7 @@ def get_flux_surfaces_from_mesh(
                 index.append(i)
 
     mask = np.ones_like(x_1d, dtype=bool)
-    mask_index = index + np.arange(len(index))
-    mask[mask_index[mask_index < len(x_1d)]] = False
+    mask[index] = False
     return x_1d[mask], flux_surfaces
 
 

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -352,7 +352,8 @@ def get_flux_surfaces_from_mesh(
                 index.append(i)
 
     mask = np.ones_like(x_1d, dtype=bool)
-    mask[index] = False
+    mask_index = index + np.arange(len(index))
+    mask[mask_index[mask_index < len(x_1d)]] = False
     return x_1d[mask], flux_surfaces
 
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
While checking on the fem rework with the new optimiser I ran into the 'Jackpot' message. This is an attempt to avoid that as dividing by 0 and sqrt -ves gives Nans which will always hit the end of the loop.
Secondly there was a weird array masking deletion thing that I dont think worked as it was intended

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
