### PR TITLE
🎨 Improve dictionary options for PlotOptions

### DIFF
--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -75,7 +75,7 @@ class ViewDescriptor:
 
         return getattr(obj, self._name, self._default)
 
-    def __set__(self, obj: Any, value: Union[str, _placement.BluemiraPlacement]):
+    def __set__(self, obj: Any, value: Union[str, tuple, _placement.BluemiraPlacement]):
         """Set the view"""
         if isinstance(value, str):
             if value.startswith("xy"):
@@ -86,6 +86,9 @@ class ViewDescriptor:
                 value = _placement.YZX
             else:
                 raise DisplayError(f"{value} is not a valid view")
+
+        if isinstance(value, tuple):
+            value = _placement.BluemiraPlacement(*value)
 
         setattr(
             obj,

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -109,7 +109,9 @@ class DictOptionsDescriptor:
 
       po = PlotOptions()
       po.wire_options["linewidth"] = 0.1  # overrides default
-      po.wire_options = {'zorder': 1}  # default linewidth reset
+      po.wire_options["zorder"] = 2  # adds new zorder option
+      # setting a new dictionary resets the defaults with zorder overridden
+      po.wire_options = {'zorder': 1}
       del po.wire_options["linewidth"]  # linewidth unset
 
     No checks are done on the contents of the dictionary.
@@ -138,7 +140,8 @@ class DictOptionsDescriptor:
         """Set the options dictionary"""
         if callable(value):
             value = value()
-        setattr(obj, self._name, {**getattr(obj, self._name, self.default), **value})
+        default = getattr(obj, self._name, self.default)
+        setattr(obj, self._name, {**default, **value})
 
 
 @dataclass

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -117,7 +117,7 @@ class DictOptionsDescriptor:
     """
 
     def __init__(self, default_factory: Optional[Callable[[], Dict[str, Any]]] = None):
-        self.default_factory = {} if default_factory is None else default_factory()
+        self.default = {} if default_factory is None else default_factory()
 
     def __set_name__(self, _, name: str):
         """Set the attribute name from a dataclass"""
@@ -128,9 +128,9 @@ class DictOptionsDescriptor:
     ) -> Union[Callable[[], Dict[str, Any]], Dict[str, Any]]:
         """Get the options dictionary"""
         if obj is None:
-            return lambda: self.default_factory
+            return lambda: self.default
 
-        return getattr(obj, self._name, self.default_factory)
+        return getattr(obj, self._name, self.default)
 
     def __set__(
         self, obj: Any, value: Union[Callable[[], Dict[str, Any]], Dict[str, Any]]
@@ -138,10 +138,7 @@ class DictOptionsDescriptor:
         """Set the options dictionary"""
         if callable(value):
             value = value()
-        default = getattr(obj, self._name, self.default_factory)
-        if callable(default):
-            default = default()
-        setattr(obj, self._name, {**default, **value})
+        setattr(obj, self._name, {**getattr(obj, self._name, self.default), **value})
 
 
 @dataclass

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -27,12 +27,14 @@ from dataclasses import asdict
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 import bluemira.geometry.face as face
 import bluemira.geometry.placement as placement
 import bluemira.geometry.tools as tools
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.display import plot_3d, plotter
+from bluemira.display.error import DisplayError
 from bluemira.utilities.plot_tools import Plot3D
 
 SQUARE_POINTS = np.array(
@@ -121,6 +123,25 @@ class TestPlotOptions:
             else:
                 assert val == getattr(self.default, key)
 
+    def test_dictionary_options_allow_modification(self):
+        the_options = plotter.PlotOptions()
+        the_options.wire_options["color"] = "blue"
+        assert the_options.wire_options["color"] == "blue"
+
+        dupe = plotter.PlotOptions()
+        assert dupe.wire_options["color"] == "black"
+
+    def test_dictionary_options_reset_defaults(self):
+        the_options = plotter.PlotOptions()
+        the_options.wire_options = {"color": "blue"}
+        assert the_options.wire_options["color"] == "blue"
+        assert the_options.wire_options["linewidth"] == 0.5
+
+    def test_wrong_view_str_raises_DisplayError(self):
+        the_options = plotter.PlotOptions()
+        with pytest.raises(DisplayError):
+            the_options.view = "string"
+
     def test_properties(self):
         """
         Check the display option properties can be accessed
@@ -155,6 +176,8 @@ class TestPlotOptions:
                         assert val[no] == d
                     except ValueError:
                         assert all(val[no] == d)
+            elif key.endswith("options"):
+                assert getattr(the_options, key) == val
             else:
                 assert getattr(the_options, key) != val
 

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -79,7 +79,8 @@ class TestInscribedRectangle:
             shape_face,
             self.po,
             ax=ax,
-            wire_options=dict(linewidth=0.1, zorder=-10),
+            face_options={"zorder": -10},
+            wire_options={"linewidth": 0.1},
             show=False,
         )
         for i in range(x):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This removes the defualt dictionaries from the PlotOptions dataclass it will enforce defaults unless explicitly removed or overridden.

It probably requires some thought about whether this is the direction we want to go

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
wire_options etc now are not cleared by default but use our defaults unless explicitly overridden.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
