### PR TITLE
🎨 Change base RunMode name

### DIFF
--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -31,7 +31,7 @@ from bluemira.codes.params import MappedParameterFrame
 from bluemira.codes.utilities import run_subprocess
 
 
-class RunMode(enum.Enum):
+class BaseRunMode(enum.Enum):
     """
     Base enum class for defining run modes within a solver.
 
@@ -319,7 +319,7 @@ class CodesSolver(abc.ABC):
         pass
 
     @abc.abstractproperty
-    def run_mode_cls(self) -> Type[RunMode]:
+    def run_mode_cls(self) -> Type[BaseRunMode]:
         """
         Class enumerating the run modes for this solver.
 
@@ -327,7 +327,7 @@ class CodesSolver(abc.ABC):
         """
         pass
 
-    def execute(self, run_mode: Union[str, RunMode]) -> Any:
+    def execute(self, run_mode: Union[str, BaseRunMode]) -> Any:
         """Execute the setup, run, and teardown tasks, in order."""
         if isinstance(run_mode, str):
             run_mode = self.run_mode_cls.from_string(run_mode)
@@ -375,7 +375,7 @@ class CodesSolver(abc.ABC):
                     setattr(p_map, sr_key, sr_val)
 
     def _get_execution_method(
-        self, task: CodesTask, run_mode: RunMode
+        self, task: CodesTask, run_mode: BaseRunMode
     ) -> Optional[Callable]:
         """
         Return the method on the task corresponding to this solver's run

--- a/bluemira/codes/plasmod/api/_solver.py
+++ b/bluemira/codes/plasmod/api/_solver.py
@@ -29,8 +29,7 @@ from scipy.interpolate import interp1d
 
 from bluemira.base.parameter_frame import ParameterFrame
 from bluemira.codes.error import CodesError
-from bluemira.codes.interface import CodesSolver
-from bluemira.codes.interface import RunMode as BaseRunMode
+from bluemira.codes.interface import BaseRunMode, CodesSolver
 from bluemira.codes.plasmod.api._outputs import PlasmodOutputs
 from bluemira.codes.plasmod.api._run import Run
 from bluemira.codes.plasmod.api._setup import Setup

--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -45,7 +45,7 @@ from bluemira.base.constants import MU_0
 from bluemira.base.file import get_bluemira_path, try_get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
-from bluemira.codes.interface import CodesSolver, RunMode
+from bluemira.codes.interface import BaseRunMode, CodesSolver
 from bluemira.codes.plasmod import plot_default_profiles
 from bluemira.equilibria.constants import DPI_GIF, PLT_PAUSE
 from bluemira.equilibria.fem_fixed_boundary.fem_magnetostatic_2D import (
@@ -159,7 +159,7 @@ def create_plasma_xz_cross_section(
 def _run_transport_solver(
     transport_solver: CodesSolver,
     transport_params: ParameterFrame,
-    transport_run_mode: Union[str, RunMode],
+    transport_run_mode: Union[str, BaseRunMode],
 ) -> Tuple[ParameterFrame, np.ndarray, np.ndarray, np.ndarray]:
     """Run transport solver"""
     transport_solver.params.update_from_frame(transport_params)
@@ -225,7 +225,7 @@ def solve_transport_fixed_boundary(
     max_inner_iter: int = 20,
     inner_iter_err_max: float = 1e-4,
     relaxation: float = 0.2,
-    transport_run_mode: Union[str, RunMode] = "run",
+    transport_run_mode: Union[str, BaseRunMode] = "run",
     mesh_filename: str = "FixedBoundaryEquilibriumMesh",
     plot: bool = False,
     debug: bool = False,

--- a/bluemira/codes/process/_solver.py
+++ b/bluemira/codes/process/_solver.py
@@ -29,8 +29,7 @@ import numpy as np
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.base.parameter_frame import ParameterFrame
 from bluemira.codes.error import CodesError
-from bluemira.codes.interface import CodesSolver
-from bluemira.codes.interface import RunMode as BaseRunMode
+from bluemira.codes.interface import BaseRunMode, CodesSolver
 from bluemira.codes.process._run import Run
 from bluemira.codes.process._setup import Setup
 from bluemira.codes.process._teardown import Teardown

--- a/eudemo/eudemo/power_cycle.py
+++ b/eudemo/eudemo/power_cycle.py
@@ -39,9 +39,8 @@ from bluemira.balance_of_plant.steady_state import (
     SuperheatedRankine,
 )
 from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
-from bluemira.codes.interface import CodesSolver
+from bluemira.codes.interface import BaseRunMode, CodesSolver
 from bluemira.codes.interface import CodesTask as Task
-from bluemira.codes.interface import RunMode
 
 __all__ = ["SteadyStatePowerCycleSolver"]
 
@@ -100,7 +99,7 @@ class EUDEMOReferenceParasiticLoadStrategy(ParasiticLoadStrategy):
         return p_mag, p_cryo, p_t_plant, p_other
 
 
-class SteadyStatePowerCycleRunMode(RunMode):
+class SteadyStatePowerCycleRunMode(BaseRunMode):
     """Enumeration of the run modes for the steady state power cycle solver"""
 
     RUN = enum.auto()

--- a/examples/codes/external_code.ex.py
+++ b/examples/codes/external_code.ex.py
@@ -48,8 +48,13 @@ from ext_code_script import get_filename
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
-from bluemira.codes.interface import CodesSetup, CodesSolver, CodesTask, CodesTeardown
-from bluemira.codes.interface import RunMode as BaseRunMode
+from bluemira.codes.interface import (
+    BaseRunMode,
+    CodesSetup,
+    CodesSolver,
+    CodesTask,
+    CodesTeardown,
+)
 from bluemira.codes.params import MappedParameterFrame
 from bluemira.codes.utilities import ParameterMapping
 

--- a/tests/codes/test_interface.py
+++ b/tests/codes/test_interface.py
@@ -23,11 +23,11 @@ from dataclasses import dataclass
 
 from bluemira.base.parameter_frame import Parameter
 from bluemira.codes import interface
-from bluemira.codes.interface import NoOpTask, RunMode
+from bluemira.codes.interface import BaseRunMode, NoOpTask
 from bluemira.codes.params import MappedParameterFrame, ParameterMapping
 
 
-class NoOpRunMode(RunMode):
+class NoOpRunMode(BaseRunMode):
     RUN = 0
 
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
RunMode is always imported and renamed, this just renames it to BaseRunMode anyway

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Nothing major, although RunMode no longer exists.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
