### PR TITLE
Added check for dataclass anontation for ParamFrame & OptVarFrame

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -77,7 +77,7 @@ class ParameterFrame:
         self._types = self._get_types()
 
         for field, field_name, value_type in zip(
-            self, self.__dataclass_fields__, self._types.values()
+            self, self.__dataclass_fields__, self._types.values()  # type: ignore
         ):
             if not isinstance(field, Parameter):
                 raise TypeError(
@@ -190,7 +190,7 @@ class ParameterFrame:
         """Initialize an instance from a dictionary."""
         data = copy.deepcopy(data)
         kwargs: Dict[str, Parameter] = {}
-        for member in cls.__dataclass_fields__:
+        for member in cls.__dataclass_fields__:  # type: ignore
             try:
                 param_data = data.pop(member)
             except KeyError as e:
@@ -209,7 +209,7 @@ class ParameterFrame:
     def from_frame(cls: Type[_PfT], frame: ParameterFrame) -> _PfT:
         """Initialise an instance from another ParameterFrame."""
         kwargs = {}
-        for field in cls.__dataclass_fields__:
+        for field in cls.__dataclass_fields__:  # type: ignore
             try:
                 kwargs[field] = getattr(frame, field)
             except AttributeError:
@@ -252,7 +252,7 @@ class ParameterFrame:
         kwargs = {}
 
         lp = config_params.local_params
-        for member in cls.__dataclass_fields__:
+        for member in cls.__dataclass_fields__:  # type: ignore
             if member not in lp:
                 continue
             kwargs[member] = cls._member_data_to_parameter(
@@ -261,14 +261,14 @@ class ParameterFrame:
             )
 
         gp = config_params.global_params
-        for member in cls.__dataclass_fields__:
-            if member not in gp.__dataclass_fields__:
+        for member in cls.__dataclass_fields__:  # type: ignore
+            if member not in gp.__dataclass_fields__:  # type: ignore
                 continue
             kwargs[member] = getattr(gp, member)
 
         # now validate all dataclass_fields are in kwargs
         # (which could be super set)
-        for member in cls.__dataclass_fields__:
+        for member in cls.__dataclass_fields__:  # type: ignore
             try:
                 kwargs[member]
             except KeyError as e:
@@ -296,7 +296,7 @@ class ParameterFrame:
     def to_dict(self) -> Dict[str, Dict[str, Any]]:
         """Serialize this ParameterFrame to a dictionary."""
         out = {}
-        for param_name in self.__dataclass_fields__:
+        for param_name in self.__dataclass_fields__:  # type: ignore
             param_data = getattr(self, param_name).to_dict()
             # We already have the name of the param, and use it as a
             # key. No need to repeat the name in the data, so pop it.
@@ -401,7 +401,7 @@ def _validate_units(param_data: Dict, value_type: Iterable[Type]):
     param_data["unit"] = f"{unit:~P}"
 
 
-def _remake_units(dimensionality: Union[Dict, pint.unit.UnitsContainer]) -> pint.Unit:
+def _remake_units(dimensionality: Union[Dict, pint.util.UnitsContainer]) -> pint.Unit:
     """Reconstruct unit from its dimensionality"""
     dim_list = list(map(base_unit_defaults.get, dimensionality.keys()))
     dim_pow = list(dimensionality.values())

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 _PfT = TypeVar("_PfT", bound="ParameterFrame")
 
 
-@dataclass
 class ParameterFrame:
     """
     A data class to hold a collection of `Parameter` objects.
@@ -68,6 +67,8 @@ class ParameterFrame:
             raise TypeError(
                 "Cannot instantiate a ParameterFrame directly. It must be subclassed."
             )
+        if not hasattr(cls, "__dataclass_fields__"):
+            raise TypeError(f"{cls} must be annotated with '@dataclass'")
 
         return super().__new__(cls)
 

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -90,7 +90,7 @@ class ParameterFrame:
             vt = _validate_parameter_field(field, value_type)
 
             val_unit = {
-                "value": Parameter._type_check(field.value, vt),
+                "value": Parameter._type_check(field.name, field.value, vt),
                 "unit": field.unit,
             }
             _validate_units(val_unit, vt)

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -4,6 +4,7 @@ import copy
 from dataclasses import dataclass
 from typing import Dict, Generic, List, Optional, Tuple, Type, TypedDict, TypeVar, Union
 
+import numpy as np
 import pint
 from typeguard import config, typechecked
 
@@ -96,7 +97,11 @@ class Parameter(Generic[ParameterValueType]):
         if value_types and value is not None:
             if float in value_types and isinstance(value, int):
                 value = float(value)
-            elif int in value_types and isinstance(value, float):
+            elif (
+                int in value_types
+                and isinstance(value, float)
+                and np.isclose(value, int(value), rtol=0)
+            ):
                 value = int(value)
             elif not isinstance(value, value_types):
                 raise TypeError(

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -78,7 +78,7 @@ class Parameter(Generic[ParameterValueType]):
         long_name: str = "",
         _value_types: Optional[Tuple[Type, ...]] = None,
     ):
-        value = self._type_check(value, _value_types)
+        value = self._type_check(name, value, _value_types)
         self._name = name
         self._value = value
         self._unit = pint.Unit(unit)
@@ -91,15 +91,17 @@ class Parameter(Generic[ParameterValueType]):
 
     @staticmethod
     def _type_check(
-        value: ParameterValueType, value_types: Optional[Tuple[Type, ...]]
+        name: str, value: ParameterValueType, value_types: Optional[Tuple[Type, ...]]
     ) -> ParameterValueType:
         if value_types and value is not None:
             if float in value_types and isinstance(value, int):
                 value = float(value)
+            elif int in value_types and isinstance(value, float):
+                value = int(value)
             elif not isinstance(value, value_types):
                 raise TypeError(
-                    f'type of argument "value" must be one of {value_types}; '
-                    f"got {type(value)} instead."
+                    f'{name}: type of "value" must be one of {value_types}; '
+                    f"got {type(value)} (value: {value}) instead"
                 )
         return value
 

--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -25,7 +25,7 @@ Optimisation variable class.
 from __future__ import annotations
 
 import json
-from dataclasses import MISSING, Field, dataclass, field
+from dataclasses import MISSING, Field, field
 from typing import Dict, Generator, Optional, TextIO, TypedDict, Union
 
 import matplotlib.pyplot as plt

--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -342,8 +342,8 @@ class OptVariablesFrame:
             )
         if not hasattr(cls, "__dataclass_fields__"):
             raise TypeError(f"{cls} must be annotated with '@dataclass'")
-        for field_name in cls.__dataclass_fields__:
-            dcf: Field = cls.__dataclass_fields__[field_name]
+        for field_name in cls.__dataclass_fields__:  # type: ignore
+            dcf: Field = cls.__dataclass_fields__[field_name]  # type: ignore
             fact_inst = dcf.default_factory() if dcf.default_factory != MISSING else None
             if fact_inst is None:
                 raise TypeError(
@@ -367,7 +367,7 @@ class OptVariablesFrame:
         The order is based on the order in which the parameters were
         declared.
         """
-        for field_name in self.__dataclass_fields__:
+        for field_name in self.__dataclass_fields__:  # type: ignore
             yield getattr(self, field_name)
 
     def __getitem__(self, name: str) -> OptVariable:

--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -327,7 +327,6 @@ def ov(
     )
 
 
-@dataclass
 class OptVariablesFrame:
     """
     Class to model the variables for an optimisation
@@ -341,7 +340,7 @@ class OptVariablesFrame:
             raise TypeError(
                 "Cannot instantiate an OptVariablesFrame directly. It must be subclassed."
             )
-        if not cls.__dataclass_fields__:
+        if not hasattr(cls, "__dataclass_fields__"):
             raise TypeError(f"{cls} must be annotated with '@dataclass'")
         for field_name in cls.__dataclass_fields__:
             dcf: Field = cls.__dataclass_fields__[field_name]

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -22,6 +22,11 @@ class BasicFrame(ParameterFrame):
     age: Parameter[int]
 
 
+class NoDataclassFrame(ParameterFrame):
+    height: Parameter[float]
+    age: Parameter[int]
+
+
 @dataclass
 class BrokenFrame(ParameterFrame):
     height: float
@@ -30,6 +35,10 @@ class BrokenFrame(ParameterFrame):
 class TestParameterFrame:
     def setup_method(self):
         self.frame = BasicFrame.from_dict(deepcopy(FRAME_DATA))
+
+    def test_frame_defined_with_dataclass_annotation(self):
+        with pytest.raises(AttributeError):
+            NoDataclassFrame.from_dict(FRAME_DATA)
 
     def test_init_from_dict_sets_valid_entries(self):
         assert self.frame.height.value == 1.805

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -36,9 +36,10 @@ class TestParameterFrame:
     def setup_method(self):
         self.frame = BasicFrame.from_dict(deepcopy(FRAME_DATA))
 
-    def test_frame_defined_with_dataclass_annotation(self):
-        with pytest.raises(AttributeError):
-            NoDataclassFrame.from_dict(FRAME_DATA)
+    def test_frame_defined_with_dataclass_annotation(self, caplog):
+        NoDataclassFrame()
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
 
     def test_init_from_dict_sets_valid_entries(self):
         assert self.frame.height.value == 1.805
@@ -53,7 +54,12 @@ class TestParameterFrame:
 
     @pytest.mark.parametrize(
         "name, value",
-        [("name", 100), ("value", "wrong type"), ("value", 30.5), ("unit", 0.5)],
+        [
+            ("name", 100),
+            ("value", "wrong type"),
+            ("value", 30.532423),
+            ("unit", 0.5),
+        ],
     )
     def test_from_dict_TypeError_given_invalid_type(self, name, value):
         data = {


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Runtime error thrown if a subclass of a Parameterframe isn't annotated with @dataclass.

Supports empty pframe and optvarsframe.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
