### PR TITLE
Fix path to reactor script in eudemo README

### DIFF
--- a/eudemo/README.md
+++ b/eudemo/README.md
@@ -14,7 +14,7 @@ To run the reactor build,
 
 ```bash
 cd <path/to/bluemira>/eudemo
-python eudemo/eudemo/reactor.py
+python eudemo/reactor.py
 ```
 
 The `cd` is required, as the paths in the build config are


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Was just running the reactor example for some CAD pictures and noticed this path was wrong.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
