### PR TITLE
Changes to fix J. Roff issues

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -983,7 +983,7 @@ def wire_value_at(wire: apiWire, distance: float) -> np.ndarray:
 
 
 def wire_parameter_at(
-    wire: apiWire, vertex: Iterable[float], tolerance: float = EPS
+    wire: apiWire, vertex: Iterable[float], tolerance: float = EPS * 10
 ) -> float:
     """
     Get the parameter value at a vertex along a wire.

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -940,7 +940,7 @@ def distance_to(
 
 
 def split_wire(
-    wire: BluemiraWire, vertex: Iterable[float], tolerance: float = EPS
+    wire: BluemiraWire, vertex: Iterable[float], tolerance: float = EPS * 10
 ) -> Tuple[Union[None, BluemiraWire], Union[None, BluemiraWire]]:
     """
     Split a wire at a given vertex.

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -61,6 +61,8 @@ class BluemiraWire(BluemiraGeo):
         self, boundary: List[Union[cadapi.apiWire, BluemiraWire]], label: str = ""
     ):
         boundary_classes = [self.__class__, cadapi.apiWire]
+        if isinstance(boundary, cadapi.apiWire):
+            cadapi.fix_wire(boundary)
         super().__init__(boundary, label, boundary_classes)
         self._check_orientations()
 

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -207,7 +207,9 @@ class BluemiraWire(BluemiraGeo):
 
         return cadapi.wire_value_at(self.shape, distance)
 
-    def parameter_at(self, vertex: Iterable[float], tolerance: float = EPS) -> float:
+    def parameter_at(
+        self, vertex: Iterable[float], tolerance: float = EPS * 10
+    ) -> float:
         """
         Get the parameter value at a vertex along a wire.
 

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -61,8 +61,6 @@ class BluemiraWire(BluemiraGeo):
         self, boundary: List[Union[cadapi.apiWire, BluemiraWire]], label: str = ""
     ):
         boundary_classes = [self.__class__, cadapi.apiWire]
-        if isinstance(boundary, cadapi.apiWire):
-            cadapi.fix_wire(boundary)
         super().__init__(boundary, label, boundary_classes)
         self._check_orientations()
 


### PR DESCRIPTION
## Linked Issues

None, the issues are described here.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Some issues pointed out by a user James Roff can fixed with the changes in this PR.
Below are slight adaptions to the minimal reproductions supplied by him.

**A. Vertex returned from value_at throws when used with parameter_at and split_wire**:

```python
p = PictureFrame()
p.adjust_variable("x1", 2, lower_bound=0, upper_bound=5)
p.adjust_variable("x2", 13, lower_bound=10, upper_bound=20)
p.adjust_variable("z1", 13, lower_bound=8, upper_bound=15)
p.adjust_variable("z2", -11, lower_bound=-15, upper_bound=-8)
p.adjust_variable("ri", 2)
p.adjust_variable("ro", 5)

wire = p.create_shape()

dist = (13 + 11 - 2 * 2) + 0.25 * np.pi * 2
vertex = wire.value_at(distance=dist)

wire.parameter_at(vertex) # throws
first_half, second_half = split_wire(wire, vertex) # throws
```

This is due to the split_wire works internally needing to discretize the wire and FPE's around that.

The specific distance `dist` calculated and used isn't important
One can change it to use any overly precise value, if you increase the number of decimal points it fails eventually.

This not really an issue and is easily solved my slightly increasing the EPS tolerance by a factor of 10, making it a value in the order of E-15 which will be fine for every usecase I can think of for Bluemira.

**B. Coordinates class behaviour for 3x3 matrices** -? see #2598 

**C. Small bit added to wire after split_wire on a vertex**

```python
def _split_vertex(wire: BluemiraWire) -> BluemiraWire:
    vertexes = wire.vertexes.points

    v1 = vertexes[-2]
    v2 = vertexes[-1]
    v3 = vertexes[0]
    v4 = vertexes[1]

    _, wire_mid = split_wire(wire, v4)  # This adds a 'tiny' wire to the start
    return wire_mid

# Create new PictureFrame with Tapered Inner Leg
inner_rad = 1
min_x = 4
min_z = -10

p = PictureFrame(
    inner="TAPERED_INNER",
    var_dict={
        "x1": {"value": 3, "lower_bound": 0, "upper_bound": 5},
        "x4": {"value": min_x, "lower_bound": 0, "upper_bound": 5},
        "x2": {"value": 16, "lower_bound": 10, "upper_bound": 20},
        "z1": {"value": 10},
        "z2": {"value": min_z},
        "z3": {"value": 5},
        "ri": {"value": inner_rad},
        "ro": {"value": 2},
    },
)

test_wire = p.create_shape()

inner_radius_offset = (1 - np.sqrt(2) / 2) * inner_rad
bot_left_loc = (min_x + inner_radius_offset, 0, min_z + inner_radius_offset)

new_wire = _split_vertex(test_wire)

try:
    display.plot_2d(new_wire)
except Exception as e:
    print(e)

cadapi.fix_wire(new_wire.shape)  # This fixes the issue
display.plot_2d(new_wire)
```

This one is most likely a real issue, however, it may be with FreeCAD, not Bluemira.
Splitting on `v4` specifically causes the issue, other vertices do not.

As suggested, adding the fix_wire call to the init of a BluemiraWire does fix the issue and causes no noticeable downside.
So I added the change to this PR.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `flake8` and `black .`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
