### PR TITLE
FEM fixed boundary equilibrium solver - flux surface cut-off

### DIFF
--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -233,6 +233,7 @@ def solve_transport_fixed_boundary(
     refine: bool = False,
     num_levels: int = 2,
     distance: float = 1.0,
+    ny_fs_min: int = 40,
 ):
     """
     Solve the plasma fixed boundary problem using delta95 and kappa95 as target
@@ -273,9 +274,11 @@ def solve_transport_fixed_boundary(
     refine:
         Whether or not the mesh should be refined around the magnetic axis
     num_levels:
-        number of refinement levels
+        Number of refinement levels
     distance:
-        maximum distance from the magnetic axis to which the refinement will be applied
+        Maximum distance from the magnetic axis to which the refinement will be applied
+    ny_fs_min:
+        Minimum number of points in a flux surface extracted from the mesh.
 
     Returns
     -------
@@ -392,7 +395,10 @@ def solve_transport_fixed_boundary(
             )
 
             x1d, flux_surfaces = get_flux_surfaces_from_mesh(
-                mesh, gs_solver.psi_norm_2d, x_1d=x_psi_plasmod
+                mesh,
+                gs_solver.psi_norm_2d,
+                x_1d=x_psi_plasmod,
+                ny_fs_min=ny_fs_min,
             )
 
             x1d, volume, _, g2, g3 = calc_metric_coefficients(

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -290,7 +290,7 @@ def get_flux_surfaces_from_mesh(
     psi_norm_func: Callable[[float, float], float],
     x_1d: Optional[np.ndarray] = None,
     nx: Optional[int] = None,
-    ny_min: int = 40,
+    ny_fs_min: int = 40,
 ) -> Tuple[np.ndarray, List[ClosedFluxSurface]]:
     """
     Get a list of flux surfaces from a mesh and normalised psi callable.
@@ -307,8 +307,9 @@ def get_flux_surfaces_from_mesh(
     nx:
         Number of points to linearly space along [0..1]. If x_1d is
         defined, not used.
-    ny_min:
-        Minimum number of points in a flux surface retrieved from mesh.
+    ny_fs_min:
+        Minimum number of points in a flux surface retrieved from mesh. Below
+        this, flux surfaces will be discarded.
 
     Returns
     -------
@@ -350,7 +351,7 @@ def get_flux_surfaces_from_mesh(
             flux_surfaces.append(ClosedFluxSurface(fs))
         else:
             path = get_tricontours(x, z, psi_norm_data, xi)[0]
-            if path is not None and len(path.T[0]) > ny_min:
+            if path is not None and len(path.T[0]) > ny_fs_min:
                 # Only capture flux surfaces with sufficient points
                 fs = Coordinates({"x": path.T[0], "z": path.T[1]})
                 fs.close()

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -290,6 +290,7 @@ def get_flux_surfaces_from_mesh(
     psi_norm_func: Callable[[float, float], float],
     x_1d: Optional[np.ndarray] = None,
     nx: Optional[int] = None,
+    ny_min: int = 40,
 ) -> Tuple[np.ndarray, List[ClosedFluxSurface]]:
     """
     Get a list of flux surfaces from a mesh and normalised psi callable.
@@ -306,6 +307,8 @@ def get_flux_surfaces_from_mesh(
     nx:
         Number of points to linearly space along [0..1]. If x_1d is
         defined, not used.
+    ny_min:
+        Minimum number of points in a flux surface retrieved from mesh.
 
     Returns
     -------
@@ -319,6 +322,9 @@ def get_flux_surfaces_from_mesh(
     -----
     x_1d is returned, as it is not always possible to return a flux surface for
     small values of normalised psi.
+    Some flux surfaces near the axis can have few points and be relatively
+    distorted, causing convergence issues. Make sure to change the cut-off
+    when changing the mesh discretisation.
     """
     if x_1d is None:
         if nx is None:
@@ -344,7 +350,8 @@ def get_flux_surfaces_from_mesh(
             flux_surfaces.append(ClosedFluxSurface(fs))
         else:
             path = get_tricontours(x, z, psi_norm_data, xi)[0]
-            if path is not None and len(path.T[0]) > 40:
+            if path is not None and len(path.T[0]) > ny_min:
+                # Only capture flux surfaces with sufficient points
                 fs = Coordinates({"x": path.T[0], "z": path.T[1]})
                 fs.close()
                 flux_surfaces.append(ClosedFluxSurface(fs))

--- a/bluemira/equilibria/fem_fixed_boundary/utilities.py
+++ b/bluemira/equilibria/fem_fixed_boundary/utilities.py
@@ -344,7 +344,7 @@ def get_flux_surfaces_from_mesh(
             flux_surfaces.append(ClosedFluxSurface(fs))
         else:
             path = get_tricontours(x, z, psi_norm_data, xi)[0]
-            if path is not None:
+            if path is not None and len(path.T[0]) > 40:
                 fs = Coordinates({"x": path.T[0], "z": path.T[1]})
                 fs.close()
                 flux_surfaces.append(ClosedFluxSurface(fs))

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -32,7 +32,11 @@
       "p_order": 2,
       "max_iter": 30,
       "iter_err_max": 1e-4,
-      "relaxation": 0.05
+      "relaxation": 0.05,
+      "refine": true,
+      "num_levels": 2,
+      "distance": 1.0,
+      "ny_fs_min": 40
     },
     "transport_eq_settings": {
       "lcar_mesh": 0.3,

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -7,7 +7,7 @@
     "plot": false
   },
   "Fixed boundary equilibrium": {
-    "run_mode": "read",
+    "run_mode": "run",
     "file_path": "config/fixed_boundary_eqdsk.json",
     "param_class": "JohnerLCFS",
     "shape_config": {
@@ -31,19 +31,19 @@
     "fixed_equilibrium_settings": {
       "p_order": 2,
       "max_iter": 30,
-      "iter_err_max": 1e-4,
-      "relaxation": 0.05,
+      "iter_err_max": 1e-3,
+      "relaxation": 0.0
+    },
+    "transport_eq_settings": {
+      "lcar_mesh": 0.2,
+      "max_iter": 15,
+      "iter_err_max": 1e-1,
+      "relaxation": 0.0,
+      "plot": false,
       "refine": true,
       "num_levels": 2,
       "distance": 1.0,
       "ny_fs_min": 40
-    },
-    "transport_eq_settings": {
-      "lcar_mesh": 0.3,
-      "max_iter": 15,
-      "iter_err_max": 1e-1,
-      "relaxation": 0.0,
-      "plot": false
     }
   },
   "Dummy fixed boundary equilibrium": {

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -7,7 +7,7 @@
     "plot": false
   },
   "Fixed boundary equilibrium": {
-    "run_mode": "run",
+    "run_mode": "read",
     "file_path": "config/fixed_boundary_eqdsk.json",
     "param_class": "JohnerLCFS",
     "shape_config": {


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2574 

The FEM fixed boundary equilibrium solver does not do a great job converging in many cases. Right now, since #2484, the example of PLASMOD <-> fixed boundary equilibrium no longer converges.

I recently discovered that this is partly due to poor quality flux surfaces near the axis being extracted from the mesh and used to calculate profile quantities. 

Very commonly, the first one or two flux surfaces as extracted from the mesh (even with refinement) can be diamond- or square-shaped (with the number of points on a flux surface ranging from ~13-50 or so). They can oscillate between the two from one iteration to another (modifying V, g2 and g3), causing poor convergence.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

This PR puts a crude number of points cut-off below which the flux surfaces are not used.

Really, we need a mesh that is adaptive or at least with some knowledge of the problem, a la SPIDER or similar.

Alternatively one could return values of V, g2, and g3 near the axis based on reasonable geometrical extrapolations of the LCFS and the last available flux surface, similar perhaps to what is done in METIS - at least this is done from the LCFS there I believe.

I don't have time for either right now, and frankly would rather invest said time in writing a proper 1.5-D solver with a fixed boundary that can be specified from points. Regardless, this PR fixes convergence on the example, and adds a few settings into EU-DEMO for good measure (although of course it does not presently work for EU-DEMO).

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
