### PR TITLE
🐛 Fix freecad shape linking for saving

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1178,13 +1178,13 @@ def _setup_document(
 
     elif len(labels) != len(parts):
         raise ValueError(
-            f"Number of labels ({len(labels)}) != number of objects ({len(parts)}"
+            f"Number of labels ({len(labels)}) != number of objects ({len(parts)})"
         )
 
     for part, label in zip(parts, labels):
         new_part = part.copy()
         new_part.rotate((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), -90.0)
-        obj = doc.addObject("Part::Feature", label)
+        obj = doc.addObject("Part::FeaturePython", label)
         obj.Shape = new_part
         doc.recompute()
         yield obj
@@ -1271,7 +1271,7 @@ class CADFileType(enum.Enum):
         obj._value_ = args[0]
         return obj
 
-    def __init__(self, _, module):
+    def __init__(self, _, module: str = ""):
         self.module = module
 
     @classmethod
@@ -1327,11 +1327,10 @@ def meshed_exporter(
     """Meshing and then exporting CAD in certain formats."""
 
     @wraps(export_func)
-    def wrapper(objs: Part.Feature, filename: str, **kwargs):
+    def wrapper(objs: Part.Feature, filename: str, *, tessellate: float = 0.5, **kwargs):
         """
         Tessellation should happen on a copied object
         """
-        tessellate = kwargs.pop("tessellate", 0.5)
         if cad_format in CADFileType.unitless_formats():
             for no, obj in enumerate(objs):
                 objs[no].Shape = obj.Shape.copy()

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -292,7 +292,7 @@ class TestCADFiletype:
     @classmethod
     def setup_class(cls):
         doc = newDocument()
-        cls.shape = doc.addObject("Part::Feature")
+        cls.shape = doc.addObject("Part::FeaturePython")
         cls.shape.Shape = cadapi.extrude_shape(cadapi.make_circle(), (0, 0, 1))
         doc.recompute()
 

--- a/tests/geometry/test_data/test_circ.stp
+++ b/tests/geometry/test_data/test_circ.stp
@@ -1,7 +1,7 @@
 ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION(('FreeCAD Model'),'2;1');
-FILE_NAME('Open CASCADE Shape Model','2023-05-24T10:31:51',('Bluemira'),
+FILE_NAME('Open CASCADE Shape Model','2023-09-04T10:11:59',('Bluemira'),
   ('Bluemira'),'Open CASCADE STEP processor 7.6','FreeCAD','Unknown');
 FILE_SCHEMA((
 'AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF. {1 0 10303 442 1 1 4 
@@ -15,7 +15,7 @@ DATA;
 #4 = PRODUCT_DEFINITION_SHAPE('','',#5);
 #5 = PRODUCT_DEFINITION('design','',#6,#9);
 #6 = PRODUCT_DEFINITION_FORMATION('','',#7);
-#7 = PRODUCT('Part__Feature','Part__Feature','',(#8));
+#7 = PRODUCT('Part__FeaturePython','Part__FeaturePython','',(#8));
 #8 = PRODUCT_CONTEXT('',#2,'mechanical');
 #9 = PRODUCT_DEFINITION_CONTEXT('part definition',#2,'design');
 #10 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('',(#11,#15),


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Part::Feature does not link shapes properly in a freecad file so use Part::FeaturePython

see: https://wiki.freecad.org/Scripted_objects#Available_object_types

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
