### PR TITLE
`TrapezoidalPrismCurrentSource` bugfixes and API changed to degrees, not radians

### DIFF
--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -141,7 +141,7 @@ class ArbitraryPlanarRectangularXSCircuit(SourceGroup):
             beta = alpha
             betas.append(beta)
 
-        return betas, alphas
+        return np.rad2deg(betas), np.rad2deg(alphas)
 
     def _transform_to_xz(self, shape):
         normal_vector = shape.normal_vector

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -379,13 +379,13 @@ class TrapezoidalPrismCurrentSource(RectangularCrossSectionCurrentSource):
             )
         if not (0 <= abs(alpha) < 0.5 * np.pi):
             raise MagnetostaticsError(
-                f"{self.__class__.__name__} instantiation error: {alpha=} is outside "
-                "bounds of [0, pi/2)"
+                f"{self.__class__.__name__} instantiation error: {alpha=:.3f} is outside "
+                "bounds of [0, pi/2)."
             )
         if not (0 <= abs(beta) < 0.5 * np.pi):
             raise MagnetostaticsError(
-                f"{self.__class__.__name__} instantiation error: {beta=} is outside "
-                "bounds of [0, pi/2)"
+                f"{self.__class__.__name__} instantiation error: {beta=:.3f} is outside "
+                "bounds of [0, pi/2)."
             )
 
     def _check_raise_self_intersection(

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -329,11 +329,15 @@ class TrapezoidalPrismCurrentSource(RectangularCrossSectionCurrentSource):
     depth:
         The depth of the current source (half-height) [m]
     alpha:
-        The first angle of the trapezoidal prism [rad]
+        The first angle of the trapezoidal prism [degree] [0, 180)
     beta:
-        The second angle of the trapezoidal prism [rad]
+        The second angle of the trapezoidal prism [degree] [0, 180)
     current:
         The current flowing through the source [A]
+
+    Notes
+    -----
+    Negative angles are allowed, but both angles must be either 0 or negative.
     """
 
     def __init__(
@@ -348,6 +352,7 @@ class TrapezoidalPrismCurrentSource(RectangularCrossSectionCurrentSource):
         beta: float,
         current: float,
     ):
+        alpha, beta = np.deg2rad(alpha), np.deg2rad(beta)
         self.origin = origin
 
         length = np.linalg.norm(ds)

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -23,7 +23,7 @@
 Analytical expressions for the field inside an arbitrarily shaped winding pack
 of rectangular cross-section, following equations as described in:
 
-https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594?saml_referrer=
+https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594
 including corrections from:
 https://onlinelibrary.wiley.com/doi/abs/10.1002/jnm.675
 """

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -329,9 +329,9 @@ class TrapezoidalPrismCurrentSource(RectangularCrossSectionCurrentSource):
     depth:
         The depth of the current source (half-height) [m]
     alpha:
-        The first angle of the trapezoidal prism [degree] [0, 180)
+        The first angle of the trapezoidal prism [°] [0, 180)
     beta:
-        The second angle of the trapezoidal prism [degree] [0, 180)
+        The second angle of the trapezoidal prism [°] [0, 180)
     current:
         The current flowing through the source [A]
 
@@ -385,12 +385,12 @@ class TrapezoidalPrismCurrentSource(RectangularCrossSectionCurrentSource):
         if not (0 <= abs(alpha) < 0.5 * np.pi):
             raise MagnetostaticsError(
                 f"{self.__class__.__name__} instantiation error: {alpha=:.3f} is outside "
-                "bounds of [0, pi/2)."
+                "bounds of [0, 180°)."
             )
         if not (0 <= abs(beta) < 0.5 * np.pi):
             raise MagnetostaticsError(
                 f"{self.__class__.__name__} instantiation error: {beta=:.3f} is outside "
-                "bounds of [0, pi/2)."
+                "bounds of [0, 180°)."
             )
 
     def _check_raise_self_intersection(

--- a/documentation/source/magnetostatics/doc_trapezoidal.py
+++ b/documentation/source/magnetostatics/doc_trapezoidal.py
@@ -10,8 +10,8 @@ source = TrapezoidalPrismCurrentSource(
     t_vec=[1, 0, 0],
     breadth=0.5,  # in t_vec direction
     depth=0.25,  # in normal direction
-    alpha=np.pi / 4,  # angle at the tip of the current source
-    beta=np.pi / 8,  # angle at the tail of the current source
+    alpha=45.0,  # angle at the tip of the current source
+    beta=22.5,  # angle at the tail of the current source
     current=1e6,
 )
 

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -278,12 +278,6 @@ class TestCariddiBenchmark:
         coil_loop = Coordinates({"x": x[10:-10], "y": 0, "z": z[10:-10]})
         coil_loop.close()
         cls.coil_loop = coil_loop
-        from bluemira.display import plot_2d
-
-        plot_2d(coil_loop)
-        import matplotlib.pyplot as plt
-
-        plt.show()
 
         circuit = ArbitraryPlanarRectangularXSCircuit(
             coil_loop, width / 2, depth / 2, current=1.0

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -271,13 +271,19 @@ class TestCariddiBenchmark:
 
         # Smooth out graphically determined TF centreline...
         length_norm = vector_lengthnorm(x, z)
-        l_interp = np.linspace(0, 1, 150)
+        l_interp = np.linspace(0, 1, 100)
         x = UnivariateSpline(length_norm, x, s=0.02)(l_interp)
         z = UnivariateSpline(length_norm, z, s=0.02)(l_interp)
 
-        coil_loop = Coordinates({"x": x[:-10], "y": 0, "z": z[:-10]})
+        coil_loop = Coordinates({"x": x[10:-10], "y": 0, "z": z[10:-10]})
         coil_loop.close()
         cls.coil_loop = coil_loop
+        from bluemira.display import plot_2d
+
+        plot_2d(coil_loop)
+        import matplotlib.pyplot as plt
+
+        plt.show()
 
         circuit = ArbitraryPlanarRectangularXSCircuit(
             coil_loop, width / 2, depth / 2, current=1.0

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -65,7 +65,8 @@ def test_paper_example():
 
 
 class TestTrapezoidalPrismCurrentSource:
-    def test_error_on_self_intersect(self):
+    @pytest.mark.parametrize("angle", [np.pi * 0.3, 0.7853981633974485])
+    def test_error_on_self_intersect(self, angle):
         with pytest.raises(MagnetostaticsError):
             source = TrapezoidalPrismCurrentSource(
                 np.array([0, 0, 0]),
@@ -74,7 +75,20 @@ class TestTrapezoidalPrismCurrentSource:
                 np.array([0, 1, 0]),
                 0.5,
                 0.1,
-                np.pi * 0.3,
-                np.pi * 0.3,
+                angle,
+                angle,
                 current=1.0,
             )
+
+    def test_no_error_on_triangle(self):
+        source = TrapezoidalPrismCurrentSource(
+            np.array([0, 0, 0]),
+            np.array([0, 0, 1]),
+            np.array([1, 0, 0]),
+            np.array([0, 1, 0]),
+            0.5,
+            0.1,
+            0.7853981633974483,
+            0.7853981633974483,
+            current=1.0,
+        )

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -123,7 +123,9 @@ class TestTrapezoidalPrismCurrentSource:
                 current=1.0,
             )
 
-    @pytest.mark.parametrize("angle1,angle2", [[0.1, 0.1], [0.2, 0.3]])
+    @pytest.mark.parametrize(
+        "angle1,angle2", [[0.1, 0.1], [0.2, 0.3], [0, 0.2], [-0.2, 0]]
+    )
     def test_no_error_on_double_sign_angles(self, angle1, angle2):
         TrapezoidalPrismCurrentSource(
             np.array([0, 0, 0]),

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -33,7 +33,7 @@ def test_paper_example():
 
     Babic and Aykel example
 
-    https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594?saml_referrer=
+    https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594
     """
     # Babic and Aykel example (single trapezoidal prism)
     source = TrapezoidalPrismCurrentSource(

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -20,8 +20,10 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
 from bluemira.base.constants import raw_uc
+from bluemira.magnetostatics.error import MagnetostaticsError
 from bluemira.magnetostatics.trapezoidal_prism import TrapezoidalPrismCurrentSource
 
 
@@ -60,3 +62,19 @@ def test_paper_example():
     field_9decimals = np.trunc(abs_field * 10**9) / 10**9
     field_9true = 53.581000397
     assert field_9decimals == field_9true
+
+
+class TestTrapezoidalPrismCurrentSource:
+    def test_error_on_self_intersect(self):
+        with pytest.raises(MagnetostaticsError):
+            source = TrapezoidalPrismCurrentSource(
+                np.array([0, 0, 0]),
+                np.array([0, 0, 1]),
+                np.array([1, 0, 0]),
+                np.array([0, 1, 0]),
+                0.5,
+                0.1,
+                np.pi / 2,
+                np.pi / 2,
+                current=1.0,
+            )

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -74,7 +74,7 @@ class TestTrapezoidalPrismCurrentSource:
                 np.array([0, 1, 0]),
                 0.5,
                 0.1,
-                np.pi / 2,
-                np.pi / 2,
+                np.pi * 0.3,
+                np.pi * 0.3,
                 current=1.0,
             )

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -68,7 +68,7 @@ class TestTrapezoidalPrismCurrentSource:
     @pytest.mark.parametrize("angle", [np.pi * 0.3, 0.7853981633974485])
     def test_error_on_self_intersect(self, angle):
         with pytest.raises(MagnetostaticsError):
-            source = TrapezoidalPrismCurrentSource(
+            TrapezoidalPrismCurrentSource(
                 np.array([0, 0, 0]),
                 np.array([0, 0, 1]),
                 np.array([1, 0, 0]),
@@ -81,7 +81,7 @@ class TestTrapezoidalPrismCurrentSource:
             )
 
     def test_no_error_on_triangle(self):
-        source = TrapezoidalPrismCurrentSource(
+        TrapezoidalPrismCurrentSource(
             np.array([0, 0, 0]),
             np.array([0, 0, 1]),
             np.array([1, 0, 0]),

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -43,8 +43,8 @@ def test_paper_example():
         np.array([0, 0, 1]),
         1,
         1,
-        np.pi / 3,
-        np.pi / 6,
+        60.0,
+        30.0,
         4e5,
     )
     field = source.field(2, 2, 2)
@@ -65,7 +65,7 @@ def test_paper_example():
 
 
 class TestTrapezoidalPrismCurrentSource:
-    @pytest.mark.parametrize("angle", [np.pi * 0.3, 0.7853981633974485])
+    @pytest.mark.parametrize("angle", [54, 45.0001])
     def test_error_on_self_intersect(self, angle):
         with pytest.raises(MagnetostaticsError):
             TrapezoidalPrismCurrentSource(
@@ -88,12 +88,12 @@ class TestTrapezoidalPrismCurrentSource:
             np.array([0, 1, 0]),
             0.5,
             0.1,
-            0.7853981633974483,
-            0.7853981633974483,
+            45,
+            45,
             current=1.0,
         )
 
-    @pytest.mark.parametrize("angle", [np.pi / 2, np.pi, 3 * np.pi / 2])
+    @pytest.mark.parametrize("angle", [90, 180, 270, 360])
     def test_error_on_angle_limits(self, angle):
         with pytest.raises(MagnetostaticsError):
             TrapezoidalPrismCurrentSource(
@@ -108,7 +108,7 @@ class TestTrapezoidalPrismCurrentSource:
                 current=1.0,
             )
 
-    @pytest.mark.parametrize("angle1,angle2", [[0.1, -0.1], [-0.2, 0.3]])
+    @pytest.mark.parametrize("angle1,angle2", [[10, -10], [-20, 30]])
     def test_error_on_mixed_sign_angles(self, angle1, angle2):
         with pytest.raises(MagnetostaticsError):
             TrapezoidalPrismCurrentSource(
@@ -123,9 +123,7 @@ class TestTrapezoidalPrismCurrentSource:
                 current=1.0,
             )
 
-    @pytest.mark.parametrize(
-        "angle1,angle2", [[0.1, 0.1], [0.2, 0.3], [0, 0.2], [-0.2, 0]]
-    )
+    @pytest.mark.parametrize("angle1,angle2", [[1, 1], [2, 3], [0, 2], [-2, 0]])
     def test_no_error_on_double_sign_angles(self, angle1, angle2):
         TrapezoidalPrismCurrentSource(
             np.array([0, 0, 0]),

--- a/tests/magnetostatics/test_trapezoidal_prism.py
+++ b/tests/magnetostatics/test_trapezoidal_prism.py
@@ -92,3 +92,47 @@ class TestTrapezoidalPrismCurrentSource:
             0.7853981633974483,
             current=1.0,
         )
+
+    @pytest.mark.parametrize("angle", [np.pi / 2, np.pi, 3 * np.pi / 2])
+    def test_error_on_angle_limits(self, angle):
+        with pytest.raises(MagnetostaticsError):
+            TrapezoidalPrismCurrentSource(
+                np.array([0, 0, 0]),
+                np.array([0, 0, 1]),
+                np.array([1, 0, 0]),
+                np.array([0, 1, 0]),
+                0.5,
+                0.1,
+                angle,
+                0.25 * np.pi,
+                current=1.0,
+            )
+
+    @pytest.mark.parametrize("angle1,angle2", [[0.1, -0.1], [-0.2, 0.3]])
+    def test_error_on_mixed_sign_angles(self, angle1, angle2):
+        with pytest.raises(MagnetostaticsError):
+            TrapezoidalPrismCurrentSource(
+                np.array([0, 0, 0]),
+                np.array([0, 0, 1]),
+                np.array([1, 0, 0]),
+                np.array([0, 1, 0]),
+                0.5,
+                0.1,
+                angle1,
+                angle2,
+                current=1.0,
+            )
+
+    @pytest.mark.parametrize("angle1,angle2", [[0.1, 0.1], [0.2, 0.3]])
+    def test_no_error_on_double_sign_angles(self, angle1, angle2):
+        TrapezoidalPrismCurrentSource(
+            np.array([0, 0, 0]),
+            np.array([0, 0, 1]),
+            np.array([1, 0, 0]),
+            np.array([0, 1, 0]),
+            0.5,
+            0.1,
+            angle1,
+            angle2,
+            current=1.0,
+        )


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2592 

## Description
Fixes the issues in the aforementioned issue, but also:
* Moves the API of `TrapezoidalPrismCurrentSource` to use degrees and not radians
* Caps the inputs of valid angles to the necessary [0, 180)
* Deals with negative angles (allowed) and protects against mixed angles (not allowed)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
