### PR TITLE
`CircularArcCurrentSource` API fixed to degrees, not radians

### DIFF
--- a/bluemira/magnetostatics/circular_arc.py
+++ b/bluemira/magnetostatics/circular_arc.py
@@ -623,7 +623,7 @@ class CircularArcCurrentSource(RectangularCrossSectionCurrentSource):
     radius:
         The radius of the circular arc from the origin [m]
     dtheta:
-        The azimuthal width of the arc [rad]
+        The azimuthal width of the arc [°]
     current:
         The current flowing through the source [A]
 
@@ -654,7 +654,7 @@ class CircularArcCurrentSource(RectangularCrossSectionCurrentSource):
         self._radius = radius
         self._update_r1r2()
 
-        self.dtheta = dtheta
+        self.dtheta = np.deg2rad(dtheta)
         self.rho = current / (4 * breadth * depth)
         self.dcm = np.array([ds, normal, t_vec])
         self.points = self._calculate_points()

--- a/documentation/source/magnetostatics/doc_circular.py
+++ b/documentation/source/magnetostatics/doc_circular.py
@@ -11,7 +11,7 @@ source = CircularArcCurrentSource(
     breadth=0.25,
     depth=1,
     radius=2,
-    dtheta=3 * np.pi / 2,
+    dtheta=270,
     current=1e6,
 )
 

--- a/examples/magnetostatics/helmholtz_example.ex.py
+++ b/examples/magnetostatics/helmholtz_example.ex.py
@@ -120,7 +120,7 @@ analytical_circuit2 = CircularArcCurrentSource(
     breadth=breadth,
     depth=depth,
     radius=radius,
-    dtheta=2 * np.pi,
+    dtheta=360,
     current=current,
 )
 

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -96,16 +96,16 @@ def test_mixedsourcesolver():
     )
 
     arc_1 = CircularArcCurrentSource(
-        [-1, 0, 1], [0, 0, 1], [-1, 0, 0], [0, 1, 0], dz, dx, 1, np.pi / 2, current
+        [-1, 0, 1], [0, 0, 1], [-1, 0, 0], [0, 1, 0], dz, dx, 1, 90, current
     )
     arc_2 = CircularArcCurrentSource(
-        [-1, 0, -1], [-1, 0, 0], [0, 0, -1], [0, 1, 0], dz, dx, 1, np.pi / 2, current
+        [-1, 0, -1], [-1, 0, 0], [0, 0, -1], [0, 1, 0], dz, dx, 1, 90, current
     )
     arc_3 = CircularArcCurrentSource(
-        [1, 0, -1], [0, 0, -1], [1, 0, 0], [0, 1, 0], dz, dx, 1, np.pi / 2, current
+        [1, 0, -1], [0, 0, -1], [1, 0, 0], [0, 1, 0], dz, dx, 1, 90, current
     )
     arc_4 = CircularArcCurrentSource(
-        [1, 0, 1], [1, 0, 0], [0, 0, 1], [0, 1, 0], dz, dx, 1, np.pi / 2, current
+        [1, 0, 1], [1, 0, 0], [0, 0, 1], [0, 1, 0], dz, dx, 1, 90, current
     )
 
     solver = SourceGroup([bar_1, bar_2, bar_3, bar_4, arc_1, arc_2, arc_3, arc_4])

--- a/tests/magnetostatics/test_circular_arc.py
+++ b/tests/magnetostatics/test_circular_arc.py
@@ -42,7 +42,7 @@ class TestCircularArcCurrentSource:
             cls.dx,
             cls.dz,
             cls.xc,
-            2 * np.pi,
+            360,
             cls.current,
         )
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
