### PR TITLE
`BiotSavartFilament` plotting fixed

### DIFF
--- a/tests/magnetostatics/test_biot_savart.py
+++ b/tests/magnetostatics/test_biot_savart.py
@@ -56,6 +56,7 @@ def test_biot_savart_loop():
     circle = make_circle(radius=x_coil, center=(0, z_coil, 0), axis=(0, 0, 1))
     filament = circle.discretize(ndiscr=2000)
     bsf = BiotSavartFilament(filament, radius)
+    bsf.plot()
 
     Bx2, _, Bz2 = bsf.field(x_2d, np.zeros_like(x_2d), z_2d)
 

--- a/tests/magnetostatics/test_biot_savart.py
+++ b/tests/magnetostatics/test_biot_savart.py
@@ -57,6 +57,8 @@ def test_biot_savart_loop():
     filament = circle.discretize(ndiscr=2000)
     bsf = BiotSavartFilament(filament, radius)
     bsf.plot()
+    plt.show()
+    plt.close()
 
     Bx2, _, Bz2 = bsf.field(x_2d, np.zeros_like(x_2d), z_2d)
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2593 

## Description
At present all I have done is fix the plotting, which was not showing the last point of a single filament. 

This sounds quite innocuous, but to avoid a whole bunch of length checking and closed/open checking for each individual array, I've simplified things down, at potentially some non-negligible additional computational cost. If Biot-Savart ever shows up in profiling, I can take another look at this.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
