### PR TITLE
Fix `BluemiraWire.vertexes` for 3-vertex wire.

### DIFF
--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -247,14 +247,14 @@ class BluemiraWire(BluemiraGeo):
         """
         The ordered vertexes of the wire.
         """
-        verteces = cadapi.ordered_vertexes(self.shape)
-        if len(verteces) == 3:
+        vertexes = cadapi.ordered_vertexes(self.shape)
+        if len(vertexes) == 3:
             LOGGER.disabled = True
-            coords = Coordinates(verteces.T)
+            coords = Coordinates(vertexes.T)
             LOGGER.disabled = False
             return coords
 
-        return Coordinates(cadapi.ordered_vertexes(self.shape))
+        return Coordinates(vertexes)
 
     @property
     def edges(self) -> Tuple[BluemiraWire]:

--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -30,10 +30,8 @@ import numpy as np
 
 import bluemira.codes._freecadapi as cadapi
 from bluemira.base.constants import EPS
-from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.base.look_and_feel import LOGGER, bluemira_warn
 from bluemira.codes.error import FreeCADError
-
-# import from bluemira
 from bluemira.geometry.base import BluemiraGeo, _Orientation
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.error import (
@@ -249,6 +247,13 @@ class BluemiraWire(BluemiraGeo):
         """
         The ordered vertexes of the wire.
         """
+        verteces = cadapi.ordered_vertexes(self.shape)
+        if len(verteces) == 3:
+            LOGGER.disabled = True
+            coords = Coordinates(verteces.T)
+            LOGGER.disabled = False
+            return coords
+
         return Coordinates(cadapi.ordered_vertexes(self.shape))
 
     @property

--- a/tests/geometry/test_wire.py
+++ b/tests/geometry/test_wire.py
@@ -93,6 +93,18 @@ class TestWire:
         vertices.set_ccw([0, 0, -1])
         np.testing.assert_allclose(points.xyz[:, :-1], vertices.xyz)
 
+    def test_3_vertices_correct(self):
+        p1 = [0, 1, 2]
+        p2 = [4, 5, 6]
+        p3 = [7, 8, 9]
+        w1 = make_polygon([p1, p2])
+        w2 = make_polygon([p2, p3])
+        wire = BluemiraWire([w1, w2])
+        vertexes = wire.vertexes
+        np.testing.assert_allclose(vertexes[:, 0], p1)
+        np.testing.assert_allclose(vertexes[:, 1], p2)
+        np.testing.assert_allclose(vertexes[:, 2], p3)
+
 
 class ValueParameterBase:
     @classmethod


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2598 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Fixes above bug. Preserves the convention of discretised geometry as being [[x], [y], [z]] rather than [[p1], [p2], [p3], [p4], ...]

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
