### PR TITLE
User input for psi_n_tol, PSI_NORM_TOL as default

### DIFF
--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -554,7 +554,12 @@ def analyse_plasma_core(eq: Equilibrium, n_points: int = 50) -> CoreResults:
     -------
     Results dataclass
     """
-    psi_n = np.linspace(PSI_NORM_TOL, 1 - PSI_NORM_TOL, n_points, endpoint=False)
+    if eq.psi_n_tol is None:
+        psi_n_tol = PSI_NORM_TOL
+    else:
+        psi_n_tol = eq.psi_n_tol
+
+    psi_n = np.linspace(psi_n_tol, 1 - psi_n_tol, n_points, endpoint=False)
     coords = [eq.get_flux_surface(pn) for pn in psi_n]
     coords.append(eq.get_LCFS())
     psi_n = np.append(psi_n, 1.0)

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -223,7 +223,7 @@ def calc_energy(eq: Equilibrium) -> float:
 
     \t:math:`W=\\dfrac{LI^2}{2}`
     """
-    mask = in_plasma(eq.x, eq.z, eq.psi())
+    mask = in_plasma(eq.x, eq.z, eq.psi(), eq.psi_n_tol)
     Bp = eq.Bp()
     return volume_integral(Bp**2 * mask, eq.x, eq.dx, eq.dz) / (2 * MU_0)
 
@@ -262,7 +262,7 @@ def calc_li3(eq: Equilibrium) -> float:
 
     where: Bp is the poloidal magnetic field and V is the plasma volume
     """
-    mask = in_plasma(eq.x, eq.z, eq.psi())
+    mask = in_plasma(eq.x, eq.z, eq.psi(), eq.psi_n_tol)
     Bp = eq.Bp()
     bpavg = volume_integral(Bp**2 * mask, eq.x, eq.dx, eq.dz)
     return 2 * bpavg / (eq.profiles.R_0 * (MU_0 * eq.profiles.I_p) ** 2)
@@ -280,6 +280,7 @@ def calc_li3minargs(
     mask: Optional[np.ndarray] = None,
     o_points: Optional[Iterable[Opoint]] = None,
     x_points: Optional[Iterable[Xpoint]] = None,
+    psi_n_tol: Optional[float] = None,
 ) -> float:
     """
     Calculate the normalised plasma internal inductance with arguments only.
@@ -287,7 +288,9 @@ def calc_li3minargs(
     Used in the optimisation of the plasma profiles.
     """
     if mask is None:
-        mask = in_plasma(x, z, psi, o_points=o_points, x_points=x_points)
+        mask = in_plasma(
+            x, z, psi, o_points=o_points, x_points=x_points, psi_n_tol=psi_n_tol
+        )
     bpavg = volume_integral(Bp**2 * mask, x, dx, dz)
     return 2 * bpavg / (R_0 * (MU_0 * I_p) ** 2)
 
@@ -382,7 +385,7 @@ def calc_summary(eq: Equilibrium) -> Dict[str, float]:
     Calculates interesting values in one go
     """
     R_0, I_p = eq.profiles.R_0, eq.profiles.I_p
-    mask = in_plasma(eq.x, eq.z, eq.psi())
+    mask = in_plasma(eq.x, eq.z, eq.psi(), eq.psi_n_tol)
     Bp = eq.Bp()
     bpavg = volume_integral(Bp**2 * mask, eq.x, eq.dx, eq.dz)
     energy = bpavg / (2 * MU_0)

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -427,6 +427,7 @@ class Profile:
         psi: np.ndarray,
         o_points: List[Opoint],
         x_points: List[Xpoint],
+        psi_n_tol: Optional[float] = None,
     ) -> Tuple[float, float, np.ndarray]:
         """
         Do-not-repeat-yourself utility
@@ -466,7 +467,7 @@ class Profile:
             psio = o_points[0][2]
         if x_points:
             psix = x_points[0][2]
-            mask = in_plasma(x, z, psi, o_points, x_points)
+            mask = in_plasma(x, z, psi, o_points, x_points, psi_n_tol)
         else:
             psix = psi[0, 0]
             mask = None
@@ -557,6 +558,7 @@ class BetaIpProfile(Profile):
         psi: np.ndarray,
         o_points: List[Opoint],
         x_points: List[Xpoint],
+        psi_n_tol: Optional[float] = None,
     ) -> np.ndarray:
         """
         Calculate toroidal plasma current array.
@@ -577,7 +579,7 @@ class BetaIpProfile(Profile):
         """  # noqa :W505
         self.dx = x[1, 0] - x[0, 0]
         self.dz = z[0, 1] - z[0, 0]
-        psix, psio, mask = self._jtor(x, z, psi, o_points, x_points)
+        psix, psio, mask = self._jtor(x, z, psi, o_points, x_points, psi_n_tol)
         psi_norm = (psi - psio) / (psix - psio)
         self.psisep = psix
         self.psiax = psio
@@ -597,7 +599,7 @@ class BetaIpProfile(Profile):
             # More accurate beta_p constraint calculation
             # This is the Freidberg approximation
             lcfs, _ = find_LCFS_separatrix(
-                x, z, psi, o_points=o_points, x_points=x_points
+                x, z, psi, o_points=o_points, x_points=x_points, psi_n_tol=psi_n_tol
             )
             v_plasma = revolved_volume(*lcfs.xz)
             Bp = MU_0 * self.I_p / lcfs.length
@@ -761,6 +763,7 @@ class CustomProfile(Profile):
         psi: np.ndarray,
         o_points: List[Opoint],
         x_points: List[Xpoint],
+        psi_n_tol: Optional[float] = None,
     ) -> np.ndarray:
         """
         Calculate toroidal plasma current
@@ -769,7 +772,7 @@ class CustomProfile(Profile):
         """
         self.dx = x[1, 0] - x[0, 0]
         self.dz = z[0, 1] - z[0, 0]
-        psisep, psiax, mask = self._jtor(x, z, psi, o_points, x_points)
+        psisep, psiax, mask = self._jtor(x, z, psi, o_points, x_points, psi_n_tol)
         self.psisep = psisep
         self.psiax = psiax
         psi_norm = np.clip((psi - psiax) / (psisep - psiax), 0, 1)

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -638,5 +638,5 @@ class PicardIterator:
         """
         o_points, x_points = self.eq.get_OX_points(force_update=True)
         self.eq._jtor = self.eq.profiles.jtor(
-            self.eq.x, self.eq.z, self.eq.psi(), o_points, x_points
+            self.eq.x, self.eq.z, self.eq.psi(), o_points, x_points, self.eq.psi_n_tol
         )


### PR DESCRIPTION
## Linked Issues

Related to #2165.

## Description

PSI_NORM_TOL as default if none specified by user.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x ] Code quality checks run locally and pass `flake8` and `black .`
- [x ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
