### PR TITLE
Temporary for Issue #2239 -  eqdsk without a coilset

### DIFF
--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -62,6 +62,7 @@ class CoilType(Enum, metaclass=CoilTypeEnumMeta):
 
     PF = auto()
     CS = auto()
+    DUM = auto()
     NONE = auto()
 
 
@@ -72,6 +73,7 @@ class CoilNumber:
 
     __PF_counter: int = 1
     __CS_counter: int = 1
+    __DUM_counter: int = 1
     __no_counter: int = 1
 
     @staticmethod
@@ -98,6 +100,9 @@ class CoilNumber:
         elif ctype == CoilType.PF:
             idx = CoilNumber.__PF_counter
             CoilNumber.__PF_counter += 1
+        elif ctype == CoilType.DUM:
+            idx = CoilNumber.__DUM_counter
+            CoilNumber.__DUM_counter += 1
         else:
             raise ValueError(f"Unknown coil type {ctype}")
 
@@ -240,6 +245,9 @@ class Coil(CoilFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
+        if self.ctype == CoilType.DUM:
+            # Do not plot if it is a dummy coil
+            return None
         return CoilGroupPlotter(
             self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
         )

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -62,6 +62,7 @@ class CoilType(Enum, metaclass=CoilTypeEnumMeta):
 
     PF = auto()
     CS = auto()
+    DUM = auto()
     NONE = auto()
 
 
@@ -72,6 +73,7 @@ class CoilNumber:
 
     __PF_counter: int = 1
     __CS_counter: int = 1
+    __DUM_counter: int = 1
     __no_counter: int = 1
 
     @staticmethod
@@ -98,6 +100,9 @@ class CoilNumber:
         elif ctype == CoilType.PF:
             idx = CoilNumber.__PF_counter
             CoilNumber.__PF_counter += 1
+        elif ctype == CoilType.DUM:
+            idx = CoilNumber.__DUM_counter
+            CoilNumber.__DUM_counter += 1
         else:
             raise ValueError(f"Unknown coil type {ctype}")
 
@@ -240,9 +245,13 @@ class Coil(CoilFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
-        return CoilGroupPlotter(
-            self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
-        )
+        if self.ctype == CoilType.DUM:
+            # Do not plot if it is a dummy coil
+            pass
+        else:
+            return CoilGroupPlotter(
+                self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
+            )
 
     @staticmethod
     def n_coils() -> int:

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -62,7 +62,6 @@ class CoilType(Enum, metaclass=CoilTypeEnumMeta):
 
     PF = auto()
     CS = auto()
-    DUM = auto()
     NONE = auto()
 
 
@@ -73,7 +72,6 @@ class CoilNumber:
 
     __PF_counter: int = 1
     __CS_counter: int = 1
-    __DUM_counter: int = 1
     __no_counter: int = 1
 
     @staticmethod
@@ -100,9 +98,6 @@ class CoilNumber:
         elif ctype == CoilType.PF:
             idx = CoilNumber.__PF_counter
             CoilNumber.__PF_counter += 1
-        elif ctype == CoilType.DUM:
-            idx = CoilNumber.__DUM_counter
-            CoilNumber.__DUM_counter += 1
         else:
             raise ValueError(f"Unknown coil type {ctype}")
 
@@ -245,13 +240,9 @@ class Coil(CoilFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
-        if self.ctype == CoilType.DUM:
-            # Do not plot if it is a dummy coil
-            pass
-        else:
-            return CoilGroupPlotter(
-                self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
-            )
+        return CoilGroupPlotter(
+            self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
+        )
 
     @staticmethod
     def n_coils() -> int:

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -46,7 +46,6 @@ from bluemira.equilibria.coils._tools import (
 )
 from bluemira.equilibria.constants import I_MIN
 from bluemira.equilibria.error import EquilibriaError
-from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.plotting import CoilGroupPlotter
 from bluemira.utilities.tools import flatten_iterable, yintercept
 
@@ -167,13 +166,9 @@ class CoilGroup(CoilGroupFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
-        if self.ctype == CoilType.DUM:
-            # Do not plot if it is a dummy coil
-            pass
-        else:
-            return CoilGroupPlotter(
-                self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
-            )
+        return CoilGroupPlotter(
+            self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
+        )
 
     def fix_sizes(self):
         """
@@ -291,26 +286,6 @@ class CoilGroup(CoilGroupFieldsMixin):
         pfcoils = []
         cscoils = []
         passivecoils = []
-        if eqdsk.ncoil < 1:
-            grid = Grid.from_eqdsk(eqdsk)
-            dum_xc = [np.min(grid.x), np.max(grid.x), np.max(grid.x), np.min(grid.x)]
-            dum_zc = [np.min(grid.z), np.min(grid.z), np.max(grid.z), np.max(grid.z)]
-            for i in range(4):
-                coil = Coil(
-                    dum_xc[i],
-                    dum_zc[i],
-                    current=0,
-                    dx=0,
-                    dz=0,
-                    ctype="DUM",
-                    j_max=0,
-                    b_max=0,
-                )
-                coil.fix_size()  # Oh ja
-                pfcoils.append(coil)
-            coils = pfcoils
-            bluemira_warn("EQDSK coilset empty - dummy coilset in use.")
-            return cls(*coils)
         for i in range(eqdsk.ncoil):
             dx = eqdsk.dxc[i]
             dz = eqdsk.dzc[i]

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -167,9 +167,13 @@ class CoilGroup(CoilGroupFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
-        return CoilGroupPlotter(
-            self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
-        )
+        if self.ctype == CoilType.DUM:
+            # Do not plot if it is a dummy coil
+            pass
+        else:
+            return CoilGroupPlotter(
+                self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
+            )
 
     def fix_sizes(self):
         """
@@ -298,7 +302,7 @@ class CoilGroup(CoilGroupFieldsMixin):
                     current=0,
                     dx=0,
                     dz=0,
-                    ctype="PF",
+                    ctype="DUM",
                     j_max=0,
                     b_max=0,
                 )

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -307,7 +307,6 @@ class CoilGroup(CoilGroupFieldsMixin):
                     dx=0,
                     dz=0,
                     ctype="DUM",
-                    control=False,
                     j_max=0,
                     b_max=0,
                 )
@@ -318,7 +317,7 @@ class CoilGroup(CoilGroupFieldsMixin):
                 "EQDSK coilset empty - dummy coilset in use."
                 "Please replace with an appropriate coilset."
             )
-            return cls(*coils)
+            return cls(*coils, control_names=False)
         for i in range(eqdsk.ncoil):
             dx = eqdsk.dxc[i]
             dz = eqdsk.dzc[i]

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -46,6 +46,7 @@ from bluemira.equilibria.coils._tools import (
 )
 from bluemira.equilibria.constants import I_MIN
 from bluemira.equilibria.error import EquilibriaError
+from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.plotting import CoilGroupPlotter
 from bluemira.utilities.tools import flatten_iterable, yintercept
 
@@ -166,6 +167,9 @@ class CoilGroup(CoilGroupFieldsMixin):
         kwargs:
             passed to matplotlib's Axes.plot
         """
+        if self.ctype == CoilType.DUM:
+            # Do not plot if it is a dummy coil
+            return None
         return CoilGroupPlotter(
             self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
         )
@@ -282,10 +286,37 @@ class CoilGroup(CoilGroupFieldsMixin):
         occur for eqdsks only.
         Future dict instantiation methods will likely differ, hence the
         confusing name of this method.
+
+        There should always be a coilset but...
+        if for some reason the coilset is missing, and the user has not
+        provided 'user_coils' as an input for 'from_eqdsk', then a dummy
+        coilset is used and a warning message is printed.
         """
         pfcoils = []
         cscoils = []
         passivecoils = []
+        if eqdsk.ncoil < 1:
+            grid = Grid.from_eqdsk(eqdsk)
+            dum_xc = [np.min(grid.x), np.max(grid.x), np.max(grid.x), np.min(grid.x)]
+            dum_zc = [np.min(grid.z), np.min(grid.z), np.max(grid.z), np.max(grid.z)]
+            for i in range(4):
+                coil = Coil(
+                    dum_xc[i],
+                    dum_zc[i],
+                    current=0,
+                    dx=0,
+                    dz=0,
+                    ctype="DUM",
+                    j_max=0,
+                    b_max=0,
+                )
+                coil.fix_size()
+                pfcoils.append(coil)
+            coils = pfcoils
+            bluemira_warn(
+                "EQDSK coilset empty - dummy coilset in use. Please replace with an appropriate coilset."
+            )
+            return cls(*coils)
         for i in range(eqdsk.ncoil):
             dx = eqdsk.dxc[i]
             dz = eqdsk.dzc[i]

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -46,6 +46,7 @@ from bluemira.equilibria.coils._tools import (
 )
 from bluemira.equilibria.constants import I_MIN
 from bluemira.equilibria.error import EquilibriaError
+from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.plotting import CoilGroupPlotter
 from bluemira.utilities.tools import flatten_iterable, yintercept
 
@@ -286,6 +287,24 @@ class CoilGroup(CoilGroupFieldsMixin):
         pfcoils = []
         cscoils = []
         passivecoils = []
+        if eqdsk.ncoil < 1:
+            grid = Grid.from_eqdsk(eqdsk)
+            dum_xc = [np.min(grid.x), np.max(grid.x), np.max(grid.x), np.min(grid.x)]
+            dum_zc = [np.min(grid.z), np.min(grid.z), np.max(grid.z), np.max(grid.z)]
+            for i in range(4):
+                coil = Coil(
+                    dum_xc[i],
+                    dum_zc[i],
+                    current=0,
+                    dx=0,
+                    dz=0,
+                    ctype="PF",
+                )
+                coil.fix_size()  # Oh ja
+                pfcoils.append(coil)
+            coils = pfcoils
+            bluemira_warn("EQDSK coilset empty - dummy coilset in use.")
+            return cls(*coils)
         for i in range(eqdsk.ncoil):
             dx = eqdsk.dxc[i]
             dz = eqdsk.dzc[i]

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -299,6 +299,8 @@ class CoilGroup(CoilGroupFieldsMixin):
                     dx=0,
                     dz=0,
                     ctype="PF",
+                    j_max=0,
+                    b_max=0,
                 )
                 coil.fix_size()  # Oh ja
                 pfcoils.append(coil)

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -307,6 +307,7 @@ class CoilGroup(CoilGroupFieldsMixin):
                     dx=0,
                     dz=0,
                     ctype="DUM",
+                    control=False,
                     j_max=0,
                     b_max=0,
                 )
@@ -314,7 +315,8 @@ class CoilGroup(CoilGroupFieldsMixin):
                 pfcoils.append(coil)
             coils = pfcoils
             bluemira_warn(
-                "EQDSK coilset empty - dummy coilset in use. Please replace with an appropriate coilset."
+                "EQDSK coilset empty - dummy coilset in use."
+                "Please replace with an appropriate coilset."
             )
             return cls(*coils)
         for i in range(eqdsk.ncoil):

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -528,7 +528,9 @@ class Breakdown(CoilSetMHDState):
         self.filename = filename
 
     @classmethod
-    def from_eqdsk(cls, filename: str, force_symmetry: bool):
+    def from_eqdsk(
+        cls, filename: str, force_symmetry: bool, user_coils: Optional[CoilSet] = None
+    ):
         """
         Initialises a Breakdown Object from an eqdsk file. Note that this
         will involve recalculation of the magnetic flux.
@@ -541,7 +543,7 @@ class Breakdown(CoilSetMHDState):
             Whether or not to force symmetrisation in the CoilSet
         """
         cls._eqdsk, psi, coilset, grid, limiter = super()._get_eqdsk(
-            filename, force_symmetry=force_symmetry
+            filename, force_symmetry=force_symmetry, user_coils=user_coils
         )
         return cls(coilset, grid, limiter=limiter, psi=psi, filename=filename)
 
@@ -839,7 +841,12 @@ class Equilibrium(CoilSetMHDState):
         self._kwargs = {"vcontrol": vcontrol}
 
     @classmethod
-    def from_eqdsk(cls, filename: str, force_symmetry: bool = False):
+    def from_eqdsk(
+        cls,
+        filename: str,
+        force_symmetry: bool = False,
+        user_coils: Optional[CoilSet] = None,
+    ):
         """
         Initialises an Equilibrium Object from an eqdsk file. Note that this
         will involve recalculation of the magnetic flux. Because of the nature
@@ -856,7 +863,9 @@ class Equilibrium(CoilSetMHDState):
             Whether or not to force symmetrisation in the CoilSet
         """
         e, psi, coilset, grid, limiter = super()._get_eqdsk(
-            filename, force_symmetry=force_symmetry
+            filename,
+            force_symmetry=force_symmetry,
+            user_coils=user_coils,
         )
 
         profiles = CustomProfile.from_eqdsk(filename)

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -541,6 +541,9 @@ class Breakdown(CoilSetMHDState):
             Filename
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
+        user_coils:
+            Coilset provided by the user - for eqdsk with no coilset.
+            Set current, j_max and b_max to zero in user_coils.
         """
         cls._eqdsk, psi, coilset, grid, limiter = super()._get_eqdsk(
             filename, force_symmetry=force_symmetry, user_coils=user_coils
@@ -861,6 +864,9 @@ class Equilibrium(CoilSetMHDState):
             Filename
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
+        user_coils:
+            Coilset provided by the user - for eqdsk with no coilset.
+            Set current, j_max and b_max to zero in user_coils.
         """
         e, psi, coilset, grid, limiter = super()._get_eqdsk(
             filename,

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -365,7 +365,10 @@ class CoilSetMHDState(MHDState):
 
     @classmethod
     def _get_eqdsk(
-        cls, filename: str, force_symmetry: bool = False
+        cls,
+        filename: str,
+        force_symmetry: bool = False,
+        user_coils: Optional[CoilSet] = None,
     ) -> Tuple[EQDSKInterface, np.ndarray, CoilSet, Grid, Optional[Limiter]]:
         """
         Get eqdsk data from file for read in
@@ -376,6 +379,9 @@ class CoilSetMHDState(MHDState):
             Filename
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
+        user_coils:
+            Coilset provided by the user.
+            Set current, j_max and b_max to zero in user_coils.
 
         Returns
         -------
@@ -391,7 +397,7 @@ class CoilSetMHDState(MHDState):
             Limiter instance if any limiters are in file
         """
         e, psi, grid = super()._get_eqdsk(filename)
-        coilset = CoilSet.from_group_vecs(e)
+        coilset = user_coils if user_coils is not None else CoilSet.from_group_vecs(e)
         if force_symmetry:
             coilset = symmetrise_coilset(coilset)
 
@@ -542,7 +548,7 @@ class Breakdown(CoilSetMHDState):
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
         user_coils:
-            Coilset provided by the user - for eqdsk with no coilset.
+            Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
         """
         cls._eqdsk, psi, coilset, grid, limiter = super()._get_eqdsk(
@@ -865,7 +871,7 @@ class Equilibrium(CoilSetMHDState):
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
         user_coils:
-            Coilset provided by the user - for eqdsk with no coilset.
+            Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
         """
         e, psi, coilset, grid, limiter = super()._get_eqdsk(

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -140,8 +140,8 @@ class CoilsetOptimisationProblem(abc.ABC):
         Number of substates (blocks) in the state vector.
         """
         substates = 3
-        x, z = coilset.position
-        currents = coilset.current / current_scale
+        x, z = coilset.get_control_coils().position
+        currents = coilset.get_control_coils().current / current_scale
 
         coilset_state = np.concatenate((x, z, currents))
         return coilset_state, substates
@@ -241,8 +241,10 @@ class CoilsetOptimisationProblem(abc.ABC):
 
         # Get the current limits from coil current densities
         coilset_current_limits = np.infty * np.ones(n_control_currents)
-        coilset_current_limits[coilset._flag_sizefix] = coilset.get_max_current()[
-            coilset._flag_sizefix
+        coilset_current_limits[
+            coilset.get_control_coils()._flag_sizefix
+        ] = coilset.get_control_coils().get_max_current()[
+            coilset.get_control_coils()._flag_sizefix
         ]
 
         # Limit the control current magnitude by the smaller of the two limits

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -140,8 +140,8 @@ class CoilsetOptimisationProblem(abc.ABC):
         Number of substates (blocks) in the state vector.
         """
         substates = 3
-        x, z = coilset.get_control_coils().position
-        currents = coilset.get_control_coils().current / current_scale
+        x, z = coilset.position
+        currents = coilset.current / current_scale
 
         coilset_state = np.concatenate((x, z, currents))
         return coilset_state, substates
@@ -241,10 +241,8 @@ class CoilsetOptimisationProblem(abc.ABC):
 
         # Get the current limits from coil current densities
         coilset_current_limits = np.infty * np.ones(n_control_currents)
-        coilset_current_limits[
-            coilset.get_control_coils()._flag_sizefix
-        ] = coilset.get_control_coils().get_max_current()[
-            coilset.get_control_coils()._flag_sizefix
+        coilset_current_limits[coilset._flag_sizefix] = coilset.get_max_current()[
+            coilset._flag_sizefix
         ]
 
         # Limit the control current magnitude by the smaller of the two limits

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -73,7 +73,6 @@ class TestCoil:
         # make a default coil
         cls.coil = Coil(x=4, z=4, current=10e6, ctype="PF", j_max=NBTI_J_MAX)
         cls.cs_coil = Coil(x=4, z=4, current=10e6, ctype="CS", j_max=NBTI_J_MAX)
-        cls.dum_coil = Coil(x=4, z=4, current=0.0, ctype="DUM", j_max=0.0)
         cls.no_coil = Coil(x=4, z=4, current=10e6, ctype="NONE", j_max=NBTI_J_MAX)
 
     def teardown_method(self):
@@ -83,16 +82,13 @@ class TestCoil:
     def test_name(self):
         assert self.coil.ctype == CoilType.PF
         assert self.cs_coil.ctype == CoilType.CS
-        assert self.dum_coil.ctype == CoilType.DUM
         assert self.no_coil.ctype == CoilType.NONE
         coil = Coil(x=4, z=4, current=10e6, ctype="PF", j_max=NBTI_J_MAX)
         cs_coil = Coil(x=4, z=4, current=10e6, ctype="CS", j_max=NBTI_J_MAX)
-        dum_coil = Coil(x=4, z=4, current=0.0, ctype="DUM", j_max=0.0)
         no_coil = Coil(x=4, z=4, current=10e6, ctype="NONE", j_max=NBTI_J_MAX)
 
         assert coil._number == self.coil._number + 1
         assert cs_coil._number == self.cs_coil._number + 1
-        assert dum_coil._number == self.dum_coil._number + 1
         assert no_coil._number == self.no_coil._number + 1
 
     def test_field(self):

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -80,6 +80,9 @@ class TestCoil:
         plt.show()
         plt.close("all")
 
+    def test_no_plotting_dummy(self):
+        assert self.dum_coil.plot() is None
+
     def test_name(self):
         assert self.coil.ctype == CoilType.PF
         assert self.cs_coil.ctype == CoilType.CS

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -73,6 +73,7 @@ class TestCoil:
         # make a default coil
         cls.coil = Coil(x=4, z=4, current=10e6, ctype="PF", j_max=NBTI_J_MAX)
         cls.cs_coil = Coil(x=4, z=4, current=10e6, ctype="CS", j_max=NBTI_J_MAX)
+        cls.dum_coil = Coil(x=4, z=4, current=0.0, ctype="DUM", j_max=0.0)
         cls.no_coil = Coil(x=4, z=4, current=10e6, ctype="NONE", j_max=NBTI_J_MAX)
 
     def teardown_method(self):
@@ -82,13 +83,16 @@ class TestCoil:
     def test_name(self):
         assert self.coil.ctype == CoilType.PF
         assert self.cs_coil.ctype == CoilType.CS
+        assert self.dum_coil.ctype == CoilType.DUM
         assert self.no_coil.ctype == CoilType.NONE
         coil = Coil(x=4, z=4, current=10e6, ctype="PF", j_max=NBTI_J_MAX)
         cs_coil = Coil(x=4, z=4, current=10e6, ctype="CS", j_max=NBTI_J_MAX)
+        dum_coil = Coil(x=4, z=4, current=0.0, ctype="DUM", j_max=0.0)
         no_coil = Coil(x=4, z=4, current=10e6, ctype="NONE", j_max=NBTI_J_MAX)
 
         assert coil._number == self.coil._number + 1
         assert cs_coil._number == self.cs_coil._number + 1
+        assert dum_coil._number == self.dum_coil._number + 1
         assert no_coil._number == self.no_coil._number + 1
 
     def test_field(self):

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -28,6 +28,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 from bluemira.base.file import get_bluemira_path, try_get_bluemira_private_data_root
+from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.equilibrium import Equilibrium, FixedPlasmaEquilibrium
 from bluemira.equilibria.file import EQDSKInterface
 from bluemira.equilibria.grid import Grid
@@ -372,6 +373,17 @@ class TestEquilibrium:
             assert eq_q.call_count == 1
             assert "qpsi" in res
             assert np.all(res["qpsi"] == 0)  # array is all zeros
+
+    def test_woops_no_coils(self):
+        testfile = Path(get_bluemira_path("eqdsk", subfolder="data"), "jetto.eqdsk_out")
+        e = EQDSKInterface.from_file(testfile)
+        coilset = CoilSet.from_group_vecs(e)
+        zeros = np.zeros(4)
+        assert coilset.current.any() == 0
+        assert coilset.j_max.any() == 0
+        assert coilset.b_max.any() == 0
+        assert coilset.n_coils(ctype="DUM") == 4
+        assert len(coilset.control) == 0
 
 
 class TestEqReadWrite:


### PR DESCRIPTION
## Linked Issues

#2239

Closes #{ID}

## Description

If you try to initiailse an Equilibrium object with an eqdsk that doesnt have a coilset it fails with the new Coilset.

Added a user input option for a coilset when initiailse an Equilibrium and a dummy coilset that is created if no coilset is present.  Dummy coils are placed at the corners of the grid, and have current, dx, dz, j_max and b_max set to zero. A warning is printed if the dummy coilset is used. This should allow us to initiailse an eqdsk with no coilset until we have a permanent solution. 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `flake8` and `black .`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
