### PR TITLE
Add `FixedPlasmaEquilibrium` for loading fixed boundary EQDSKs.

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -269,9 +269,6 @@ class FixedPlasmaEquilibrium(MHDState):
         -------
         Radial magnetic field at x, z
         """
-        if x is None and z is None:
-            return self.plasma._Bx_greens(self._bx_green)
-
         return self.plasma.Bx(x, z)
 
     def Bz(
@@ -295,9 +292,6 @@ class FixedPlasmaEquilibrium(MHDState):
         -------
         Vertical magnetic field at x, z
         """
-        if x is None and z is None:
-            return self.plasma._Bz_greens(self._bz_green)
-
         return self.plasma.Bz(x, z)
 
     def Bp(

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -390,7 +390,7 @@ class CoilSetMHDState(MHDState):
         limiter:
             Limiter instance if any limiters are in file
         """
-        e, psi, grid = super()._get_eqdsk(filename, force_symmetry)
+        e, psi, grid = super()._get_eqdsk(filename)
         coilset = CoilSet.from_group_vecs(e)
         if force_symmetry:
             coilset = symmetrise_coilset(coilset)

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -22,9 +22,18 @@
 """
 Plot utilities for equilibria
 """
+from __future__ import annotations
 
 import warnings
 from itertools import cycle
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bluemira.equilibria.equilibrium import (
+        Equilibrium,
+        FixedPlasmaEquilibrium,
+    )
+    from bluemira.equilibria.grid import Grid
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -124,7 +133,7 @@ class GridPlotter(Plotter):
     Utility class for plotting Grid objects
     """
 
-    def __init__(self, grid, ax=None, edge=False, **kwargs):
+    def __init__(self, grid: Grid, ax=None, edge: bool = False, **kwargs):
         super().__init__(ax)
         self.grid = grid
         self.plot_grid(**kwargs)
@@ -411,23 +420,93 @@ class PlasmaCoilPlotter(Plotter):
             self.ax.plot(sq_x, sq_z, linewidth=1.5, color="k")
 
 
-class FixedPlasmaEquilibriumPlotter(Plotter):
+class EquilibriumPlotterMixin:
+    """
+    DRY plotting mixin class.
+    """
+
+    def plot_Bp(self, **kwargs):
+        """
+        Plots the poloidal field onto the Axes.
+        """
+        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["field"]["nlevels"])
+        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["field"]["cmap"])
+
+        Bp = self.eq.Bp()
+        levels = np.linspace(1e-36, np.amax(Bp), nlevels)
+        c = self.ax.contourf(self.eq.x, self.eq.z, Bp, levels=levels, cmap=cmap)
+        cbar = plt.colorbar(c)
+        cbar.set_label("$B_{p}$ [T]")
+
+    def plot_psi(self, **kwargs):
+        """
+        Plot flux surfaces
+        """
+        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["psi"]["nlevels"])
+        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["psi"]["cmap"])
+
+        levels = np.linspace(np.amin(self.psi), np.amax(self.psi), nlevels)
+        self.ax.contour(
+            self.eq.x, self.eq.z, self.psi, levels=levels, cmap=cmap, zorder=8
+        )
+
+    def plot_plasma_current(self, **kwargs):
+        """
+        Plots flux surfaces inside plasma
+        """
+        if self.eq._jtor is None:
+            return
+
+        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["current"]["nlevels"])
+        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["current"]["cmap"])
+
+        levels = np.linspace(J_TOR_MIN, np.amax(self.eq._jtor), nlevels)
+        self.ax.contourf(
+            self.eq.x, self.eq.z, self.eq._jtor, levels=levels, cmap=cmap, zorder=7
+        )
+
+
+class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
     """
     Utility class for FixedPlasmaEquilibrium plotting
     """
 
-    def __init__(self, equilibrium, Bp: bool = False):
-        pass
+    def __init__(
+        self, equilibrium: FixedPlasmaEquilibrium, ax=None, field: bool = False
+    ):
+        super().__init__(ax)
+        self.eq = equilibrium
+        self.psi = self.eq.psi()
+
+        if not field:
+            self.plot_plasma_current()
+            self.plot_psi()
+        else:
+            self.plot_Bp()
+        self.plot_LCFS()
+
+    def plot_LCFS(self):
+        """
+        Plot the last closed flux surface
+        """
+        x, z = self.eq.get_LCFS().xz
+        self.ax.plot(
+            x,
+            z,
+            color=PLOT_DEFAULTS["separatrix"]["color"],
+            linewidth=PLOT_DEFAULTS["separatrix"]["linewidth"],
+            zorder=9,
+        )
 
 
-class EquilibriumPlotter(Plotter):
+class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
     """
     Utility class for Equilibrium plotting
     """
 
     def __init__(
         self,
-        equilibrium,
+        equilibrium: Equilibrium,
         ax=None,
         plasma=False,
         show_ox=True,
@@ -474,46 +553,6 @@ class EquilibriumPlotter(Plotter):
 
         if plasma:
             self.plot_plasma_coil()
-
-    def plot_Bp(self, **kwargs):
-        """
-        Plots the poloidal field onto the Axes.
-        """
-        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["field"]["nlevels"])
-        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["field"]["cmap"])
-
-        Bp = self.eq.Bp()
-        levels = np.linspace(1e-36, np.amax(Bp), nlevels)
-        c = self.ax.contourf(self.eq.x, self.eq.z, Bp, levels=levels, cmap=cmap)
-        cbar = plt.colorbar(c)
-        cbar.set_label("$B_{p}$ [T]")
-
-    def plot_psi(self, **kwargs):
-        """
-        Plot flux surfaces
-        """
-        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["psi"]["nlevels"])
-        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["psi"]["cmap"])
-
-        levels = np.linspace(np.amin(self.psi), np.amax(self.psi), nlevels)
-        self.ax.contour(
-            self.eq.x, self.eq.z, self.psi, levels=levels, cmap=cmap, zorder=8
-        )
-
-    def plot_plasma_current(self, **kwargs):
-        """
-        Plots flux surfaces inside plasma
-        """
-        if self.eq._jtor is None:
-            return
-
-        nlevels = kwargs.pop("nlevels", PLOT_DEFAULTS["current"]["nlevels"])
-        cmap = kwargs.pop("cmap", PLOT_DEFAULTS["current"]["cmap"])
-
-        levels = np.linspace(J_TOR_MIN, np.amax(self.eq._jtor), nlevels)
-        self.ax.contourf(
-            self.eq.x, self.eq.z, self.eq._jtor, levels=levels, cmap=cmap, zorder=7
-        )
 
     def plot_flux_surface(self, psi_norm, color="k"):
         """

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -476,7 +476,7 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
     ):
         super().__init__(ax)
         self.eq = equilibrium
-        self.psi = self.eq.psi()
+        self.psi = self.eq.psi(self.eq.x, self.eq.z)
 
         if not field:
             self.plot_plasma_current()

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -411,6 +411,15 @@ class PlasmaCoilPlotter(Plotter):
             self.ax.plot(sq_x, sq_z, linewidth=1.5, color="k")
 
 
+class FixedPlasmaEquilibriumPlotter(Plotter):
+    """
+    Utility class for FixedPlasmaEquilibrium plotting
+    """
+
+    def __init__(self, equilibrium, Bp: bool = False):
+        pass
+
+
 class EquilibriumPlotter(Plotter):
     """
     Utility class for Equilibrium plotting

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -39,7 +39,7 @@ from scipy.optimize import curve_fit
 from bluemira.base.constants import MU_0
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.file import EQDSKInterface
-from bluemira.equilibria.find import find_LCFS_separatrix, in_plasma
+from bluemira.equilibria.find import find_LCFS_separatrix, in_plasma, in_zone
 from bluemira.equilibria.grid import integrate_dx_dz, revolved_volume, volume_integral
 from bluemira.equilibria.plotting import ProfilePlotter
 
@@ -422,6 +422,7 @@ class Profile:
         psi: np.ndarray,
         o_points: List[Opoint],
         x_points: List[Xpoint],
+        lcfs: Optional[np.ndarray] = None,
     ) -> Tuple[float, float, np.ndarray]:
         """
         Do-not-repeat-yourself utility
@@ -449,6 +450,15 @@ class Profile:
             The numpy array of 0/1 denoting the out/in points of the plasma in
             the grid
         """
+        if lcfs:
+            # This is for fixed boundary equilibrium handling
+            if not o_points or not x_points:
+                raise EquilibriaError(
+                    "Need to specify O and X-points when providing an LCFS."
+                )
+
+            return x_points[0][2], o_points[0][2], in_zone(x, z, lcfs)
+
         if not o_points:
             f, ax = plt.subplots()
             ax.contour(x, z, psi, cmap="viridis")

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -765,6 +765,7 @@ class CustomProfile(Profile):
         psi: np.ndarray,
         o_points: List[Opoint],
         x_points: List[Xpoint],
+        lcfs: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Calculate toroidal plasma current
@@ -773,7 +774,7 @@ class CustomProfile(Profile):
         """
         self.dx = x[1, 0] - x[0, 0]
         self.dz = z[0, 1] - z[0, 0]
-        psisep, psiax, mask = self._jtor(x, z, psi, o_points, x_points)
+        psisep, psiax, mask = self._jtor(x, z, psi, o_points, x_points, lcfs=lcfs)
         self.psisep = psisep
         self.psiax = psiax
         psi_norm = np.clip((psi - psiax) / (psisep - psiax), 0, 1)

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -450,7 +450,7 @@ class Profile:
             The numpy array of 0/1 denoting the out/in points of the plasma in
             the grid
         """
-        if lcfs:
+        if lcfs is not None:
             # This is for fixed boundary equilibrium handling
             if not o_points or not x_points:
                 raise EquilibriaError(

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -418,7 +418,9 @@ class TestFixedPlasmaEquilibrium:
     @classmethod
     def setup_class(cls):
         root = try_get_bluemira_private_data_root()
-        cls.path = Path(root, "equilibria", "STEP_SPR_08", "jetto.eqdsk_out")
+        path = Path(root, "equilibria", "STEP_SPR_08", "jetto.eqdsk_out")
+        cls.eq = FixedPlasmaEquilibrium.from_eqdsk(path)
 
-    def test_init(self):
-        eq = FixedPlasmaEquilibrium.from_eqdsk(self.path)
+    def test_plotting(self):
+        self.eq.plot()
+        plt.show()

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -421,6 +421,7 @@ class TestFixedPlasmaEquilibrium:
         path = Path(root, "equilibria", "STEP_SPR_08", "jetto.eqdsk_out")
         cls.eq = FixedPlasmaEquilibrium.from_eqdsk(path)
 
-    def test_plotting(self):
-        self.eq.plot()
+    @pytest.mark.parametrize("field", [False, True])
+    def test_plotting(self, field):
+        self.eq.plot(field=field)
         plt.show()

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -425,3 +425,4 @@ class TestFixedPlasmaEquilibrium:
     def test_plotting(self, field):
         self.eq.plot(field=field)
         plt.show()
+        plt.close()

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -28,7 +28,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 from bluemira.base.file import get_bluemira_path, try_get_bluemira_private_data_root
-from bluemira.equilibria.equilibrium import Equilibrium
+from bluemira.equilibria.equilibrium import Equilibrium, FixedPlasmaEquilibrium
 from bluemira.equilibria.file import EQDSKInterface
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.opt_constraints import (
@@ -411,3 +411,14 @@ class TestQBenchmark:
 
         assert 100 * np.median(abs_rel_difference(q, self.q_ref)) < 3.5
         assert 100 * np.mean(abs_rel_difference(q, self.q_ref)) < 4.0
+
+
+@pytest.mark.private
+class TestFixedPlasmaEquilibrium:
+    @classmethod
+    def setup_class(cls):
+        root = try_get_bluemira_private_data_root()
+        cls.path = Path(root, "equilibria", "STEP_SPR_08", "jetto.eqdsk_out")
+
+    def test_init(self):
+        eq = FixedPlasmaEquilibrium.from_eqdsk(self.path)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2639

## Description

Adds `FixedPlasmaEquilibrium` to handle loading EQDSKs that come from fixed boundary solvers. I'm not sure what the convention is regarding extrapolation of poloidal magnetic flux outside of the plasma boundary.

It appears JETTO does not do this for you, so the resulting `FixedPlasmaEquilibrium` looks like this:

![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/26097289/9e1972a6-f6ec-4251-bd61-2e5ea3154dc9)
![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/26097289/06bac12e-f052-4a72-a071-d196d07a9053)

It would be easy enough to include extrapolation, but a little fiddly if other solvers actually do provide non-0 poloidal magnetic flux outside the plasma.

There is the outstanding issue of #318, which is not addressed here.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
