### PR TITLE
🐛 Fix use of ClassVar in MappedParameterFrames

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -28,6 +28,7 @@ from operator import itemgetter
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     Generator,
     Iterable,
@@ -223,6 +224,8 @@ class ParameterFrame:
             try:
                 param_data = data.pop(member)
             except KeyError as e:
+                if cls.__dataclass_fields__[member].type == ClassVar:
+                    continue
                 raise ValueError(f"Data for parameter '{member}' not found.") from e
 
             kwargs[member] = cls._member_data_to_parameter(
@@ -326,6 +329,8 @@ class ParameterFrame:
         """Serialize this ParameterFrame to a dictionary."""
         out = {}
         for param_name in self.__dataclass_fields__:
+            if self.__dataclass_fields__[param_name].type == ClassVar:
+                continue
             param_data = getattr(self, param_name).to_dict()
             # We already have the name of the param, and use it as a
             # key. No need to repeat the name in the data, so pop it.

--- a/bluemira/codes/plasmod/params.py
+++ b/bluemira/codes/plasmod/params.py
@@ -25,7 +25,7 @@ Parameter definitions for Plasmod.
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Dict, Union
+from typing import ClassVar, Dict, Union
 
 from bluemira.base.parameter_frame import Parameter
 from bluemira.codes.params import MappedParameterFrame
@@ -126,7 +126,7 @@ class PlasmodSolverParams(MappedParameterFrame):
     v_burn: Parameter[float]
     """Target loop voltage (if lower than -1e-3, ignored)-> plasma loop voltage [V]."""
 
-    _mappings = deepcopy(mappings)
+    _mappings: ClassVar = deepcopy(mappings)
     _defaults = PlasmodInputs()
 
     @property

--- a/bluemira/codes/process/params.py
+++ b/bluemira/codes/process/params.py
@@ -25,7 +25,7 @@ PROCESS's parameter definitions.
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import ClassVar, Dict, List, Union
 
 from bluemira.base.parameter_frame import Parameter
 from bluemira.codes.params import MappedParameterFrame, ParameterMapping
@@ -330,7 +330,7 @@ class ProcessSolverParams(MappedParameterFrame):
     Z_eff: Parameter[float]
     """Effective particle radiation atomic mass [unified_atomic_mass_unit]."""
 
-    _mappings = deepcopy(mappings)
+    _mappings: ClassVar = deepcopy(mappings)
     _defaults = ProcessInputs()
 
     @property

--- a/tests/codes/test_interface.py
+++ b/tests/codes/test_interface.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 from bluemira.base.parameter_frame import Parameter
 from bluemira.codes import interface
@@ -44,7 +45,7 @@ class Params(MappedParameterFrame):
     param1: Parameter[float]
     param2: Parameter[int]
 
-    _mappings = {  # noqa: RUF012
+    _mappings: ClassVar = {
         "param1": ParameterMapping("ext1", send=True, recv=True, unit="MW"),
         "param2": ParameterMapping("ext2", send=False, recv=False),
     }

--- a/tests/codes/test_param.py
+++ b/tests/codes/test_param.py
@@ -20,6 +20,7 @@
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
 from dataclasses import asdict, dataclass
+from typing import ClassVar
 
 import pytest
 
@@ -84,7 +85,7 @@ class MyPF(MappedParameterFrame):
     E: Parameter[str]
     F: Parameter[bool]
 
-    _mappings = mappings
+    _mappings: ClassVar = mappings
     _defaults = MyDC()
 
     @property


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Our examples CI broke because it is now included in `__dataclass_fields__` there may be a better fix than this.
https://github.com/Fusion-Power-Plant-Framework/bluemira/actions/runs/6294962951

This will have broken any external code runs I think...

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
