### PR TITLE
🐛Fix docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,6 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-  jobs:
 
 conda:
   environment: conda/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,6 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-  jobs:
-    post_build:
-      - pip install --editable .
 
 conda:
   environment: conda/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-
+  jobs:
+    pre_create_environment:
+      - git fetch origin --force --prune --depth 1 refs/heads/main:refs/remotes/origin/main
 conda:
   environment: conda/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    post_build:
+      - pip install --editable .
 
 conda:
   environment: conda/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,6 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
-    pre_create_environment:
-      - git fetch origin --force --prune --depth 1 refs/heads/main:refs/remotes/origin/main
+
 conda:
   environment: conda/environment.yml

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -38,3 +38,4 @@ dependencies:
     - -r ../requirements-develop.txt
     - -r ../requirements-conda.txt
     - -r ../requirements-examples.txt
+    - -e ../

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -35,7 +35,7 @@ author = "M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris, D
 release: str = get_version(project)
 version: str = release.split("+")[0]
 
-if version == "0.1":
+if version.startswith("0.1"):
     release = "develop"
     version = "develop"
 

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -33,7 +33,11 @@ copyright = "2021-2023, M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh
 author = "M. Coleman, J. Cook, F. Franza, I.A. Maione, S. McIntosh, J. Morris, D. Short, UKAEA & contributors"
 
 release: str = get_version(project)
-version: str = ".".join(release.split(".")[:2])
+version: str = release.split("+")[0]
+
+if version == "0.1":
+    release = "develop"
+    version = "develop"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Our develop docs has been failing for the last week or so because to versioning changes. This hacks the versinoing about so it works again.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Because of how `importlib.metadata` works and because readthedocs only clones the last 50 commits, the version string in the header will break if the last tag >50 commits ago. In that instance we now just call the version `develop`

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
