### PR TITLE
`Coil` remove control=False call

### DIFF
--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -333,7 +333,6 @@ class CoilGroup(CoilGroupFieldsMixin):
                         dx=dx,
                         dz=dz,
                         ctype="NONE",
-                        control=False,
                     )
                 )
             elif dx != dz:  # Rough and ready


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

:/ removing the control flag from Coil internals means that now when loading an EQDSK with passive coils, one has to manually assign those coils as non-controlled coils after initialisation.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
