### PR TITLE
✨ Add plotting helper for tests

### DIFF
--- a/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
+++ b/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
@@ -328,6 +328,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
         debug: bool = False,
         gif: bool = False,
         figname: Optional[str] = None,
+        *,
         autoclose_plot: bool = True,
     ) -> FixedBoundaryEquilibrium:
         """

--- a/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
+++ b/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
@@ -328,6 +328,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
         debug: bool = False,
         gif: bool = False,
         figname: Optional[str] = None,
+        autoclose_plot: bool = True,
     ) -> FixedBoundaryEquilibrium:
         """
         Solve the G-S problem.
@@ -404,7 +405,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
             if eps < self.iter_err_max:
                 break
 
-        if plot:
+        if plot and autoclose_plot:
             plt.close(f)
         if gif:
             make_gif(folder, figname, clean=not debug)

--- a/conftest.py
+++ b/conftest.py
@@ -109,12 +109,12 @@ def _plot_show_and_close(request):
 
     cls = request.node.getparent(pytest.Class)
 
-    if not (cls and "classplot" in cls.keywords):
+    if cls and "classplot" in cls.keywords:
+        yield
+    else:
         yield
         plt.show()
         plt.close()
-    else:
-        yield
 
 
 @pytest.fixture(scope="class", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -25,8 +25,10 @@ Used by pytest for configuration like adding command line options.
 
 from contextlib import suppress
 from unittest import mock
+from inspect import ismethod
 
 import matplotlib as mpl
+import pytest
 
 from bluemira.base.file import try_get_bluemira_private_data_root
 
@@ -94,3 +96,47 @@ def pytest_configure(config):
     logic_string = " and ".join(strings)
 
     config.option.markexpr = logic_string
+
+
+@pytest.fixture(scope="session", autouse=True)
+def plot_show_and_close(request):
+    import matplotlib.pyplot as plt
+
+    def _internal_tdmc(*_):
+        return
+
+    seen = set()
+    session = request.node
+    for item in session.items:
+        cls = item.getparent(pytest.Class)
+        print(item, cls)
+        if cls not in seen and cls is not None:
+            _internal_tdc = (
+                cls.teardown_class if hasattr(cls, "teardown_class") else _internal_tdmc
+            )
+            _internal_tdm = (
+                cls.teardown_method
+                if hasattr(cls, "teardown_method")
+                else _internal_tdmc
+            )
+            if ismethod(_internal_tdc) and _internal_tdc.__self__ is cls:
+
+                @pytest.fixture(scope="class", autouse=True)
+                def tdc(cls):
+                    yield
+                    plt.show()
+                    plt.close()
+
+                cls.plot_class_teardown = tdc
+
+            else:
+
+                @pytest.fixture(autouse=True, scope="function")
+                def tdm(self):
+                    plt.show()
+                    plt.close()
+
+                cls.plot_teardown = tdm
+
+            seen.add(cls)
+    print(seen)

--- a/eudemo/eudemo_tests/blanket/panelling/test_designer.py
+++ b/eudemo/eudemo_tests/blanket/panelling/test_designer.py
@@ -114,9 +114,6 @@ def cut_polygon_vertically(shape: BluemiraWire) -> Tuple[BluemiraWire, BluemiraW
 
 
 class TestPanellingDesigner:
-    def teardown_method(self):
-        plt.close("all")
-
     @pytest.mark.parametrize("max_angle", [30, 50])
     @pytest.mark.parametrize(
         "shape",
@@ -147,7 +144,6 @@ class TestPanellingDesigner:
         _, ax = plt.subplots()
         plot_2d(shape, show=False, ax=ax)
         ax.plot(panel_edges[0], panel_edges[1], "--x", linewidth=0.5, color="r")
-        plt.show()
 
         panel_vecs = np.diff(panel_edges).T
         angles = [
@@ -187,7 +183,6 @@ class TestPanellingDesigner:
         _, ax = plt.subplots()
         plot_2d(shape, show=False, ax=ax)
         ax.plot(panel_edges[0], panel_edges[1], "--x", linewidth=0.5, color="r")
-        plt.show()
 
         lengths = np.sqrt(np.sum(np.diff(panel_edges.T, axis=0) ** 2, axis=1))
         abs_tol = 1e-3
@@ -232,7 +227,6 @@ class TestPanellingDesigner:
         _, ax = plt.subplots()
         plot_2d(shape, show=False, ax=ax)
         ax.plot(panel_edges[0], panel_edges[1], "--x", linewidth=0.5, color="r")
-        plt.show()
 
         # test that we at least get a solution that encloses the boundary
         poly_panels = coords_xz_to_polygon(panel_edges).discretize()

--- a/eudemo/eudemo_tests/test_power_cycle.py
+++ b/eudemo/eudemo_tests/test_power_cycle.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 
 from bluemira.base.parameter_frame import Parameter
 from eudemo.power_cycle import SteadyStatePowerCycleParams, SteadyStatePowerCycleSolver
@@ -58,7 +57,6 @@ class TestEUDEMOPowerCycle:
 
     def test_plotting(self):
         self.sspc_solver.model.plot()
-        plt.show()
 
     def test_values(self):
         assert self.sspc_result["P_el_net"] > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,8 @@ ignore_errors = true
 markers = [
     "longrun",
     "reactor",
-    "private"
+    "private",
+    "classplot"
 ]
 addopts = "--html=report.html --self-contained-html --strict-markers -r fEX"
 filterwarnings = ['ignore:Matplotlib is currently using agg:UserWarning']

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -26,7 +26,6 @@ A collection of general helper functions for tests.
 import contextlib
 from pathlib import Path
 from unittest import mock
-from inspect import ismethod
 
 import pytest
 
@@ -95,42 +94,3 @@ def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
         reason = f"dependencies {modules} not found"
 
     return pytest.mark.skipif(any(skip), reason=reason)
-
-
-def plot_helper(cls=None, as_classmethod=False):
-    import matplotlib.pyplot as plt
-
-    def _internal_tdmc(*_):
-        return
-
-    def wrapper(cls):
-        _internal_tdc = (
-            cls.teardown_class if hasattr(cls, "teardown_class") else _internal_tdmc
-        )
-        _internal_tdm = (
-            cls.teardown_method if hasattr(cls, "teardown_method") else _internal_tdmc
-        )
-
-        if (ismethod(_internal_tdc) and _internal_tdc.__self__ is cls) or as_classmethod:
-
-            @classmethod
-            def tdc(cls):
-                _internal_tdc()
-                plt.show()
-                plt.close()
-
-            cls.teardown_class = tdc
-
-        else:
-
-            def tdm(self):
-                _internal_tdm(self)
-                plt.show()
-                plt.close()
-
-            cls.teardown_method = tdm
-        return cls
-
-    if cls is not None:
-        return wrapper(cls)
-    return wrapper

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -26,6 +26,7 @@ A collection of general helper functions for tests.
 import contextlib
 from pathlib import Path
 from unittest import mock
+from inspect import ismethod
 
 import pytest
 
@@ -94,3 +95,42 @@ def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
         reason = f"dependencies {modules} not found"
 
     return pytest.mark.skipif(any(skip), reason=reason)
+
+
+def plot_helper(cls=None, as_classmethod=False):
+    import matplotlib.pyplot as plt
+
+    def _internal_tdmc(*_):
+        return
+
+    def wrapper(cls):
+        _internal_tdc = (
+            cls.teardown_class if hasattr(cls, "teardown_class") else _internal_tdmc
+        )
+        _internal_tdm = (
+            cls.teardown_method if hasattr(cls, "teardown_method") else _internal_tdmc
+        )
+
+        if (ismethod(_internal_tdc) and _internal_tdc.__self__ is cls) or as_classmethod:
+
+            @classmethod
+            def tdc(cls):
+                _internal_tdc()
+                plt.show()
+                plt.close()
+
+            cls.teardown_class = tdc
+
+        else:
+
+            def tdm(self):
+                _internal_tdm(self)
+                plt.show()
+                plt.close()
+
+            cls.teardown_method = tdm
+        return cls
+
+    if cls is not None:
+        return wrapper(cls)
+    return wrapper

--- a/tests/balance_of_plant/test_plotting.py
+++ b/tests/balance_of_plant/test_plotting.py
@@ -31,9 +31,6 @@ from bluemira.display.auto_config import plot_defaults
 
 
 class TestSuperSankey:
-    def teardown_method(self):
-        plt.close()
-
     def test_sankey_ring(self):
         plot_defaults(True)
 
@@ -74,11 +71,9 @@ class TestSuperSankey:
             connect=[(2, 0), (1, 1)],
         )
         sankey.finish()
-
         figure = plt.gcf()
         new_file = tempfile.NamedTemporaryFile()
         figure.savefig(new_file)
-        plt.show()
 
         path = get_bluemira_path("balance_of_plant/test_data", subfolder="tests")
         reference_file = Path(path, "sankey_test.png")

--- a/tests/base/test_reactor.py
+++ b/tests/base/test_reactor.py
@@ -35,6 +35,7 @@ from bluemira.builders.plasma import Plasma, PlasmaBuilder, PlasmaBuilderParams
 from bluemira.geometry.tools import make_polygon
 from bluemira.materials.material import Void
 
+
 REACTOR_NAME = "My Reactor"
 
 
@@ -58,8 +59,8 @@ class TestReactor:
         cls.reactor = cls._make_reactor()
 
     @classmethod
-    def teardown_method(cls):
-        plt.close("all")
+    def teardown_class(cls):
+        ...
 
     def test_time_since_init(self):
         a = self.reactor.time_since_init()

--- a/tests/base/test_reactor.py
+++ b/tests/base/test_reactor.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
-import matplotlib.pyplot as plt
 import pytest
 
 from bluemira.base.builder import ComponentManager
@@ -34,7 +33,6 @@ from bluemira.base.reactor import Reactor
 from bluemira.builders.plasma import Plasma, PlasmaBuilder, PlasmaBuilderParams
 from bluemira.geometry.tools import make_polygon
 from bluemira.materials.material import Void
-
 
 REACTOR_NAME = "My Reactor"
 
@@ -53,14 +51,11 @@ class MyReactor(Reactor):
     tf_coil: TFCoil
 
 
+@pytest.mark.classplot
 class TestReactor:
     @classmethod
     def setup_class(cls):
         cls.reactor = cls._make_reactor()
-
-    @classmethod
-    def teardown_class(cls):
-        ...
 
     def test_time_since_init(self):
         a = self.reactor.time_since_init()

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -60,11 +60,6 @@ class TestRippleConstrainedLengthGOP:
         RippleConstrainedLengthGOPParams,
     )
 
-    @classmethod
-    def teardown_method(cls):
-        plt.show()
-        plt.close("all")
-
     def test_default_setup(self):
         problem = RippleConstrainedLengthGOP(
             self.princeton,

--- a/tests/builders/test_tf_coils.py
+++ b/tests/builders/test_tf_coils.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 

--- a/tests/codes/plasmod/test_profiles.py
+++ b/tests/codes/plasmod/test_profiles.py
@@ -159,7 +159,6 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
         ax.set_ylabel("[$m^3$]")
         ax.set_xlabel("$\\rho$")
         ax.legend()
-        plt.show()
         np.testing.assert_allclose(self.results["V"][1:], self.volprof[1:], rtol=5e-2)
 
     def test_gradV(self):
@@ -176,7 +175,6 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
         ax.plot(self.rho, self.vprime, label="$V^'$ PLASMOD")
         ax.set_xlabel("$\\rho$")
         ax.legend()
-        plt.show()
         np.testing.assert_allclose(grad_vol[1:], self.vprime[1:], rtol=9e-2)
 
     def test_g2(self):
@@ -186,7 +184,6 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
         ax.set_xlabel("$g_{2}$")
         ax.set_xlabel("$\\rho$")
         ax.legend()
-        plt.show()
         np.testing.assert_allclose(self.results["g2"][1:], self.g2[1:], rtol=0.26)
 
     def test_g3(self):
@@ -196,7 +193,6 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
         ax.set_xlabel("$g_{3}$")
         ax.set_xlabel("$\\rho$")
         ax.legend()
-        plt.show()
         np.testing.assert_allclose(self.results["g3"], self.g3, rtol=0.02)
 
 
@@ -243,7 +239,6 @@ class TestPLASMODVerificationCurrentProfiles(PLASMODVerificationRawData):
             else:
                 a.set_xlabel("x")
         cls.ax[1, 0].set_ylabel("PLASMOD-bluemira")
-        plt.show()
 
     def test_plasma_current(self):
         # 15/03/23: Max relative difference: 4.71793662e-05

--- a/tests/codes/plasmod/test_profiles.py
+++ b/tests/codes/plasmod/test_profiles.py
@@ -21,6 +21,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 from matplotlib.tri import LinearTriInterpolator, Triangulation
 from scipy.interpolate import interp1d
 
@@ -94,7 +95,6 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
             ax.plot(*fs.xz)
 
         ax.set_aspect("equal")
-        plt.show()
         cls.flux_surfaces = flux_surfaces
         cls._calculate_metrics(cls)
 
@@ -196,6 +196,7 @@ class TestPLASMODVerificationMetricCoefficients(PLASMODVerificationRawData):
         np.testing.assert_allclose(self.results["g3"], self.g3, rtol=0.02)
 
 
+@pytest.mark.classplot
 class TestPLASMODVerificationCurrentProfiles(PLASMODVerificationRawData):
     """
     A verification test for which we take the raw PLASMOD profiles

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -25,7 +25,6 @@ Tests for the plotter module.
 
 from dataclasses import asdict
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -197,7 +196,7 @@ class TestPlot3d:
         assert ax_2 is ax_orig
 
     def test_plot_3d_new_axis(self):
-        ax_orig = Plot3D()
+        ax_orig = Plot3D()  # Empty axis
         ax_1 = plot_3d(tools.make_circle(), show=False)
         ax_2 = plot_3d(tools.make_circle(radius=2), show=False)
 

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -188,9 +188,6 @@ class TestPlot3d:
     Generic 3D plotting tests.
     """
 
-    def teardown_method(self):
-        plt.close("all")
-
     def test_plot_3d_same_axis(self):
         ax_orig = Plot3D()
         ax_1 = plot_3d(tools.make_circle(), show=False, ax=ax_orig)
@@ -210,9 +207,6 @@ class TestPlot3d:
 
 
 class TestPointsPlotter:
-    def teardown_method(self):
-        plt.close("all")
-
     def test_plotting_2d(self):
         plotter.PointsPlotter().plot_2d(SQUARE_POINTS)
 
@@ -221,9 +215,6 @@ class TestPointsPlotter:
 
 
 class TestWirePlotter:
-    def teardown_method(self):
-        plt.close("all")
-
     def setup_method(self):
         self.wire = tools.make_polygon(SQUARE_POINTS)
 
@@ -245,9 +236,6 @@ class TestFacePlotter:
         wire = tools.make_polygon(SQUARE_POINTS)
         wire.close()
         self.face = face.BluemiraFace(wire)
-
-    def teardown_method(self):
-        plt.close("all")
 
     def test_plotting_2d(self):
         plotter.FacePlotter().plot_2d(self.face)
@@ -272,9 +260,6 @@ class TestComponentPlotter:
         self.group = Component("Parent")
         self.child1 = PhysicalComponent("Child1", shape=face1, parent=self.group)
         self.child2 = PhysicalComponent("Child2", shape=face2, parent=self.group)
-
-    def teardown_method(self):
-        plt.close("all")
 
     def test_plotting_2d(self):
         plotter.ComponentPlotter().plot_2d(self.group)

--- a/tests/equilibria/fem_fixed_boundary/test_Solovev.py
+++ b/tests/equilibria/fem_fixed_boundary/test_Solovev.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 import numpy as np
 import scipy
 
@@ -175,7 +174,6 @@ class TestSolovevZheng:
 
         levels = 50
         cls.solovev.plot_psi(5.0, -6, 8.0, 12.0, 100, 100, levels=levels)
-        plt.show()
 
         n_points = 500
         boundary = find_flux_surface(cls.solovev.psi_norm_2d, 1, n_points=n_points)
@@ -246,7 +244,6 @@ class TestSolovevZheng:
             ax=None,
             tofill=True,
         )
-        plt.show()
 
         error = abs(psi_calc_data - psi_exact)
 
@@ -259,7 +256,6 @@ class TestSolovevZheng:
             ax=None,
             tofill=True,
         )
-        plt.show()
 
         # calculate the error norm
         diff = psi_calc_data - psi_exact

--- a/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
+++ b/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -53,6 +52,7 @@ def parameterisation_fixture_not_fully_init(
     return FemGradShafranovFixedBoundary(mesh=mesh, **solver_kwargs)
 
 
+@pytest.mark.classplot
 class TestFemGradShafranovFixedBoundary:
     def setup_method(self):
         lcfs_shape = make_polygon({"x": [7, 10, 7], "z": [-4, 0, 4]}, closed=True)
@@ -86,10 +86,6 @@ class TestFemGradShafranovFixedBoundary:
             self.p_prime, self.ff_prime, self.mesh, **self.solver_kwargs
         )
 
-    @classmethod
-    def teardown_class(cls):
-        ...
-
     @pytest.mark.parametrize("plot", [False, True])
     def test_all_optional_init_12(self, plot):
         mod_current = 20e6
@@ -97,7 +93,7 @@ class TestFemGradShafranovFixedBoundary:
             self.p_prime, self.ff_prime, I_p=mod_current
         )
         self.optional_init_solver.set_mesh(self.mesh)
-        self.optional_init_solver.solve(plot=plot)
+        self.optional_init_solver.solve(plot=plot, autoclose_plot=False)
         assert np.isclose(self.optional_init_solver._curr_target, mod_current)
 
     @pytest.mark.parametrize("plot", [False, True])
@@ -107,7 +103,7 @@ class TestFemGradShafranovFixedBoundary:
         self.optional_init_solver.set_profiles(
             self.p_prime, self.ff_prime, I_p=mod_current
         )
-        self.optional_init_solver.solve(plot=plot)
+        self.optional_init_solver.solve(plot=plot, autoclose_plot=False)
         assert np.isclose(self.optional_init_solver._curr_target, mod_current)
 
     @pytest.mark.parametrize("test_no", [1, 2, 3])

--- a/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
+++ b/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
@@ -87,8 +87,8 @@ class TestFemGradShafranovFixedBoundary:
         )
 
     @classmethod
-    def teardown_method(cls):
-        plt.close()
+    def teardown_class(cls):
+        ...
 
     @pytest.mark.parametrize("plot", [False, True])
     def test_all_optional_init_12(self, plot):

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -76,10 +76,6 @@ class TestCoil:
         cls.dum_coil = Coil(x=4, z=4, current=0.0, ctype="DUM", j_max=0.0)
         cls.no_coil = Coil(x=4, z=4, current=10e6, ctype="NONE", j_max=NBTI_J_MAX)
 
-    def teardown_method(self):
-        plt.show()
-        plt.close("all")
-
     def test_no_plotting_dummy(self):
         assert self.dum_coil.plot() is None
 
@@ -224,10 +220,6 @@ class TestSemiAnalytic:
         cls.z_boundary.append(
             np.append(cls.cg2.z_boundary, cls.cg2.z_boundary[:, 0][:, None], axis=-1)
         )
-
-    def teardown_method(self):
-        plt.show()
-        plt.close("all")
 
     def _plotter(self, gp, gp_greens, gp_analytic):
         _, ax = plt.subplots(3, 3)

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -124,7 +124,6 @@ class TestFields:
         self.callable_tester(self.eq.psi)
 
     def test_out_of_bounds(self):
-        plt.close("all")
         eq = self.eq
         f, (ax, ax2, ax3, ax4) = plt.subplots(1, 4)
         psi = eq.psi()
@@ -220,7 +219,6 @@ class TestFields:
         )
         ax4.set_aspect("equal")
         ax4.set_title("plasma_Bp")
-        plt.close("all")
 
 
 class TestSolveEquilibrium:
@@ -435,5 +433,3 @@ class TestFixedPlasmaEquilibrium:
     @pytest.mark.parametrize("field", [False, True])
     def test_plotting(self, field):
         self.eq.plot(field=field)
-        plt.show()
-        plt.close()

--- a/tests/equilibria/test_positioner.py
+++ b/tests/equilibria/test_positioner.py
@@ -68,10 +68,6 @@ class TestXZLMapper:
         )
         cls.xzl_map = XZLMapper(cls.TF, solenoid.x, -10, 10, 0.1, CS=False)
 
-    def teardown_method(self):
-        plt.show()
-        plt.close("all")
-
     def test_xzl(self):
         pfcoils = self.coilset.get_coiltype("PF")
 
@@ -200,10 +196,6 @@ class TestZLMapper:
             0.1,
             CS=True,
         )
-
-    def teardown_method(self):
-        plt.show()
-        plt.close("all")
 
     @pytest.mark.parametrize(
         "up",

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -77,7 +77,6 @@ class TestCunningham:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Cunningham parameterisations")
-        plt.close(cls.f)
 
 
 class TestHirschman:
@@ -129,8 +128,6 @@ class TestHirschman:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Hirschman parameterisations")
-        plt.show()
-        plt.close(cls.f)
 
 
 class TestManickam:
@@ -171,8 +168,6 @@ class TestManickam:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Manickam parameterisations")
-        plt.show()
-        plt.close(cls.f)
 
 
 class TestKuiroukidis:
@@ -247,8 +242,6 @@ class TestKuiroukidis:
     def teardown_class(cls):
         cls.f.suptitle("Kuiroukidis parameterisations")
         plt.subplots_adjust(hspace=0.4)
-        plt.show()
-        plt.close(cls.f)
 
 
 johner_names = [
@@ -307,8 +300,6 @@ class TestJohner:
     @classmethod
     def teardown_class(cls):
         cls.f.suptitle("Johner parameterisations")
-        plt.show()
-        plt.close(cls.f)
 
 
 class TestJohnerCAD:

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -40,6 +40,7 @@ from bluemira.equilibria.shapes import (
 )
 
 
+@pytest.mark.classplot
 class TestCunningham:
     @classmethod
     def setup_class(cls):
@@ -79,6 +80,7 @@ class TestCunningham:
         cls.f.suptitle("Cunningham parameterisations")
 
 
+@pytest.mark.classplot
 class TestHirschman:
     @classmethod
     def setup_class(cls):
@@ -130,6 +132,7 @@ class TestHirschman:
         cls.f.suptitle("Hirschman parameterisations")
 
 
+@pytest.mark.classplot
 class TestManickam:
     @classmethod
     def setup_class(cls):
@@ -170,6 +173,7 @@ class TestManickam:
         cls.f.suptitle("Manickam parameterisations")
 
 
+@pytest.mark.classplot
 class TestKuiroukidis:
     fixture = (
         pytest.param(6.2, 3.1, 1.55, 2.0, -0.5, -0.5, [0, 0]),
@@ -283,6 +287,7 @@ johner_params = [
 ]
 
 
+@pytest.mark.classplot
 class TestJohner:
     @classmethod
     def setup_class(cls):

--- a/tests/fuel_cycle/test_blocks.py
+++ b/tests/fuel_cycle/test_blocks.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 from scipy.interpolate import interp1d
 
 from bluemira.base.file import get_bluemira_path
@@ -36,14 +37,11 @@ from bluemira.fuel_cycle.tools import (
 )
 
 
+@pytest.mark.classplot
 class TestFuelCycleComponent:
     @classmethod
     def setup_class(cls):
         cls.f, cls.ax = plt.subplots()
-
-    @classmethod
-    def teardown_class(cls):
-        ...
 
     def test_bathtub(self):
         t = np.linspace(0, 30, 1900)

--- a/tests/fuel_cycle/test_blocks.py
+++ b/tests/fuel_cycle/test_blocks.py
@@ -100,7 +100,7 @@ class TestSqrtFittedSinks:
         # Now build an example TCycleComponent for the HCPB upper
         # with a constant mass flux equivalent to that modelled
 
-        f, ax = plt.subplots()
+        _, ax = plt.subplots()
 
         r_2_values = []
 

--- a/tests/fuel_cycle/test_blocks.py
+++ b/tests/fuel_cycle/test_blocks.py
@@ -42,8 +42,8 @@ class TestFuelCycleComponent:
         cls.f, cls.ax = plt.subplots()
 
     @classmethod
-    def teardown_cls(cls):
-        plt.close(cls.f)
+    def teardown_class(cls):
+        ...
 
     def test_bathtub(self):
         t = np.linspace(0, 30, 1900)
@@ -69,7 +69,6 @@ class TestFuelCycleComponent:
 
         self.ax.plot(t, component.inventory, label="sqrt")
         self.ax.legend()
-        plt.show()
 
 
 class TestSqrtFittedSinks:
@@ -158,7 +157,5 @@ class TestSqrtFittedSinks:
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width * 0.6, box.height])
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        plt.show()
-        plt.close(f)
 
         assert np.all(np.array(r_2_values) > 0.9995)

--- a/tests/fuel_cycle/test_tools.py
+++ b/tests/fuel_cycle/test_tools.py
@@ -54,7 +54,7 @@ class TestSinkTools:
 
     @classmethod
     def teardown_class(cls):
-        plt.close("all")
+        ...
 
     def test_timestep(self):
         """
@@ -96,7 +96,6 @@ class TestSinkTools:
         ax.plot([0, time_y], [cross, cross])
 
         ax.plot(dt15, cross, color="r", marker="*", ms=15)
-        plt.show()
 
         # high n required to converge..
         assert np.isclose(iend2, i[-1], rtol=0.01), f"{iend2} != {i[-1]}"

--- a/tests/fuel_cycle/test_tools.py
+++ b/tests/fuel_cycle/test_tools.py
@@ -47,14 +47,11 @@ def test_distributions(n, integral, parameter):
         assert np.isclose(np.sum(d), integral)
 
 
+@pytest.mark.classplot
 class TestSinkTools:
     def setup_method(self):
         self.I_min, self.I_max = 3.0, 5.0
         self.t_in, self.t_out = 5.0, 6.0
-
-    @classmethod
-    def teardown_class(cls):
-        ...
 
     def test_timestep(self):
         """

--- a/tests/geometry/test_coordinates.py
+++ b/tests/geometry/test_coordinates.py
@@ -490,6 +490,7 @@ class TestOnPolygon:
             assert on_polygon(*fail, coords.xz.T) is False
 
 
+@pytest.mark.classplot
 class TestInPolygon:
     def test_simple(self):
         coords = Coordinates({"x": [-2, 2, 2, -2, -2, -2], "z": [-2, -2, 2, 2, 1.5, -2]})
@@ -641,6 +642,7 @@ class TestIntersections:
         assert np.allclose(np.sort(intz), np.sort(tf.z[args])), f"{intz} != {tf.z[args]}"
 
 
+@pytest.mark.classplot
 class TestCoordinatesPlaneIntersect:
     def test_simple(self):
         coords = Coordinates({"x": [0, 1, 2, 2, 0, 0], "z": [-1, -1, -1, 1, 1, -1]})

--- a/tests/geometry/test_coordinates.py
+++ b/tests/geometry/test_coordinates.py
@@ -491,10 +491,6 @@ class TestOnPolygon:
 
 
 class TestInPolygon:
-    @classmethod
-    def teardown_class(cls):
-        plt.close("all")
-
     def test_simple(self):
         coords = Coordinates({"x": [-2, 2, 2, -2, -2, -2], "z": [-2, -2, 2, 2, 1.5, -2]})
         in_points = [
@@ -545,7 +541,6 @@ class TestInPolygon:
             check = in_polygon(*point, coords.xz.T)
             c = "b" if check else "r"
             ax.plot(*point, marker="*", color=c)
-        plt.show()
 
         # Test single and arrays
         for p in in_points:
@@ -587,17 +582,12 @@ class TestInPolygon:
         _, ax = plt.subplots()
         plot_coordinates(lcfs, ax=ax, fill=False, edgecolor="k")
         ax.contourf(x, z, mask, levels=[0, 0.5, 1])
-        plt.show()
 
         hits = np.count_nonzero(mask)
         assert hits == 1171, hits
 
 
 class TestIntersections:
-    def teardown_method(self):
-        plt.show()
-        plt.close("all")
-
     @pytest.mark.parametrize(("c1", "c2"), [("x", "z"), ("x", "y"), ("y", "z")])
     def test_get_intersect(self, c1, c2):
         loop1 = Coordinates({c1: [0, 0.5, 1, 2, 3, 4, 0], c2: [1, 1, 1, 1, 2, 5, 5]})
@@ -652,10 +642,6 @@ class TestIntersections:
 
 
 class TestCoordinatesPlaneIntersect:
-    @classmethod
-    def teardown_class(cls):
-        plt.close("all")
-
     def test_simple(self):
         coords = Coordinates({"x": [0, 1, 2, 2, 0, 0], "z": [-1, -1, -1, 1, 1, -1]})
         plane = BluemiraPlane.from_3_points([0, 0, 0], [1, 0, 0], [0, 1, 0])  # x-y
@@ -722,7 +708,6 @@ class TestCoordinatesPlaneIntersect:
         plot_coordinates(coords, ax=ax)
         for i in intersect:
             ax.plot(i[0], i[2], marker="o", color="r")
-        plt.show()
 
         plane = BluemiraPlane.from_3_points([0, 10, 0], [1, 10, 0], [0, 10, 1])  # x-y
         intersect = coords_plane_intersect(coords, plane)

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -75,7 +75,7 @@ class TestInscribedRectangle:
         points[0] += np.min(shape[0])
         points[2] += np.min(shape[2])
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
 
         shape_face = BluemiraFace(make_polygon(shape, closed=True))
         plot_2d(

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -134,8 +134,6 @@ class TestInscribedRectangle:
 
                         if not np.allclose(dx / dz, k):
                             self.assertion_error_creator("Aspect", [dx, dz, dx / dz, k])
-        plt.show()
-        plt.close(fig)
 
         if self.r is not False:
             raise AssertionError(self.r)

--- a/tests/geometry/test_private_tools.py
+++ b/tests/geometry/test_private_tools.py
@@ -68,44 +68,16 @@ class TestArea:
 
 
 class TestOffset:
+    # fmt: off
     open_complex = (
         [-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2],
         [0, -2, -4, -3, -4, -2, 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 4, 3, 2, 1, 2, 2, 1],
     )
     closed_complex = (
-        [
-            -4,
-            -3,
-            -2,
-            -1,
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            7,
-            6,
-            5,
-            4,
-            3,
-            2,
-            1,
-            0,
-            -1,
-            -2,
-            -3,
-            -4,
-        ],
+        [-4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4],
         [0, -2, -4, -3, -4, -2, 0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 4, 3, 2, 1, 2, 2, 1, 1, 0],
     )
-
-    @classmethod
-    def teardown_class(cls):
-        plt.close("all")
+    # fmt: on
 
     def test_rectangle(self):
         # Rectangle - positive offset
@@ -117,7 +89,6 @@ class TestOffset:
         ax.plot(x, y, "k")
         ax.plot(*o, "r", marker="o")
         ax.set_aspect("equal")
-        plt.show()
         assert sum(o[0] - np.array([0.75, 3.25, 3.25, 0.75, 0.75])) == 0
         assert sum(o[1] - np.array([0.75, 0.75, 3.25, 3.25, 0.75])) == 0
 
@@ -129,7 +100,6 @@ class TestOffset:
         ax.plot(x, y, "k")
         ax.plot(*t, "r", marker="o")
         ax.set_aspect("equal")
-        plt.show()
         assert (
             abs(sum(t[0] - np.array([1.29511511, 1.70488489, 1.5, 1.29511511])) - 0)
             < 1e-3
@@ -149,7 +119,6 @@ class TestOffset:
         ax.plot(x, y, "k")
         ax.plot(xo, yo, "r", marker="o")
         ax.set_aspect("equal")
-        plt.show()
 
         assert np.isclose(
             np.sign(offset_value)

--- a/tests/geometry/test_pyclipper_offset.py
+++ b/tests/geometry/test_pyclipper_offset.py
@@ -57,7 +57,7 @@ class TestClipperOffset:
         coordinates = Coordinates({"x": x, "y": y, "z": rng.random()})
         c = offset_clipper(coordinates, delta, method=method)
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
         ax.plot(x, y, "k")
         ax.plot(c.x, c.y, "r", marker="o")
         ax.set_aspect("equal")
@@ -84,7 +84,7 @@ class TestClipperOffset:
             # distance = self._calculate_offset(coordinates, offset_coordinates)
             # np.testing.assert_almost_equal(distance, 1.5)
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
         ax.plot(coordinates.x, coordinates.z, color="k")
         colors = ["r", "g", "y"]
         for offset_coordinates, c in zip(offsets, colors):

--- a/tests/geometry/test_pyclipper_offset.py
+++ b/tests/geometry/test_pyclipper_offset.py
@@ -61,8 +61,6 @@ class TestClipperOffset:
         ax.plot(x, y, "k")
         ax.plot(c.x, c.y, "r", marker="o")
         ax.set_aspect("equal")
-        plt.show()
-        plt.close(fig)  # make sure we don't have lots of plots open
 
         distance = self._calculate_offset(coordinates, c)
         np.testing.assert_almost_equal(distance, abs(delta))
@@ -92,8 +90,6 @@ class TestClipperOffset:
         for offset_coordinates, c in zip(offsets, colors):
             ax.plot(offset_coordinates.x, offset_coordinates.z, color=c)
         ax.set_aspect("equal")
-        plt.show()
-        plt.close(fig)
 
     def test_wrong_method(self):
         coordinates = Coordinates({"x": [0, 1, 2, 0], "y": [0, 1, -1, 0]})

--- a/tests/magnetostatics/setup_methods.py
+++ b/tests/magnetostatics/setup_methods.py
@@ -72,6 +72,3 @@ def _plot_verification_test(
         axis.set_xlabel("$x$ [m]")
         axis.set_ylabel("$z$ [m]")
         axis.set_aspect("equal")
-
-    plt.show()
-    plt.close(f)

--- a/tests/magnetostatics/test_biot_savart.py
+++ b/tests/magnetostatics/test_biot_savart.py
@@ -58,8 +58,6 @@ def test_biot_savart_loop():
     filament = circle.discretize(ndiscr=2000)
     bsf = BiotSavartFilament(filament, radius)
     bsf.plot()
-    plt.show()
-    plt.close()
 
     Bx2, _, Bz2 = bsf.field(x_2d, np.zeros_like(x_2d), z_2d)
 
@@ -153,8 +151,6 @@ def plot_errors(x, z, Bx, Bz, Bp, Bx2, Bz2, Bp2):
     ax[2, 1].set_aspect("equal")
     ax[2, 2].set_aspect("equal")
     ax[2, 3].set_aspect(20)
-    plt.show()
-    plt.close(f)
 
 
 class TestSelfInductance:
@@ -194,8 +190,6 @@ class TestSelfInductance:
         cb = f.colorbar(cm)
         cb.set_label("%")
         plt.subplots_adjust(wspace=0.5)
-        plt.show()
-        plt.close(f)
         res = np.sum((ind2 - ind3) ** 2)
         tot = np.sum((ind2 - np.average(ind2)) ** 2)
         r2 = 1 - res / tot

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -135,7 +135,7 @@ def test_mixedsourcesolver():
     assert np.allclose(bt_bl, bt_tl)
 
     solver.plot()
-    fig, ax = plt.subplots()
+    _, ax = plt.subplots()
     ax.contourf(xx, zz, Bt)
     ax.set_aspect("equal")
 
@@ -295,7 +295,7 @@ class TestCariddiBenchmark:
     def test_cariddi(self):
         ripple = self.cage.ripple(self.x_rip[1:19], np.zeros(18), self.z_rip[1:19])
 
-        fig, (ax2, ax) = plt.subplots(1, 2)
+        _, (ax2, ax) = plt.subplots(1, 2)
         ax.scatter(list(range(1, 19)), self.cariddi_ripple, marker="o", label="CARIDDI")
         ax.scatter(list(range(1, 19)), ripple, marker="x", label="bluemira", zorder=20)
         ax.legend(loc="upper left")

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -310,7 +310,5 @@ class TestCariddiBenchmark:
 
         ax2.plot(self.coil_loop.x, self.coil_loop.z, color="b")
         ax2.plot(self.x_rip[1:19], self.z_rip[1:19], marker=".", color="r")
-        plt.show()
-        plt.close(fig)
 
         assert np.max(np.abs(ripple - self.cariddi_ripple)) < 0.04

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -138,8 +138,6 @@ def test_mixedsourcesolver():
     fig, ax = plt.subplots()
     ax.contourf(xx, zz, Bt)
     ax.set_aspect("equal")
-    plt.show()
-    plt.close(fig)
 
 
 class TestArbitraryPlanarXSCircuit:

--- a/tests/magnetostatics/test_finite_element_2d.py
+++ b/tests/magnetostatics/test_finite_element_2d.py
@@ -22,7 +22,6 @@
 from pathlib import Path
 
 import dolfin
-import matplotlib.pyplot as plt
 import numpy as np
 
 from bluemira.base.components import Component, PhysicalComponent
@@ -101,7 +100,6 @@ class TestGetNormal:
         )
 
         dolfin.plot(mesh)
-        plt.show()
 
         em_solver = FemMagnetostatic2d(3)
         em_solver.set_mesh(mesh, boundaries)

--- a/tests/magnetostatics/test_semianalytic_2d.py
+++ b/tests/magnetostatics/test_semianalytic_2d.py
@@ -117,7 +117,7 @@ class TestSemiAnalyticBxBz:
         assert np.all(bx_array == bx_results)
         assert np.all(bz_array == bz_results)
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
         ax.plot(bp_fe, marker="s", label="FE", ms=20)
         ax.plot(bp_paper, marker="^", label="Paper", ms=20)
         ax.plot(bp, marker="X", label="New", ms=20)

--- a/tests/magnetostatics/test_semianalytic_2d.py
+++ b/tests/magnetostatics/test_semianalytic_2d.py
@@ -124,8 +124,6 @@ class TestSemiAnalyticBxBz:
         ax.legend()
         ax.set_xlabel("Point number")
         ax.set_ylabel("$B_{p}$ [T]")
-        plt.show()
-        plt.close(fig)
 
     def test_tough_Bz_integration_does_not_raise_error(self):
         """
@@ -180,7 +178,7 @@ class TestPoloidalFieldBenchmark:
     def test_field_inside_coil_z_z(self):
         x, z, B = self.load_data(Path(self.path, "new_B_along_z-z.json"))
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
 
         x_values = np.unique(x)
         for x_value in x_values:
@@ -206,12 +204,11 @@ class TestPoloidalFieldBenchmark:
         ax.set_xlim([40, 80])
         ax.set_xlabel("z")
         ax.set_ylabel("$B_{p}$")
-        plt.close(fig)
 
     def test_field_inside_coil_x_x(self):
         x, z, B = self.load_data(Path(self.path, "new_B_along_x-x.json"))
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
 
         z_values = np.unique(z)[:5]  # Mirrored about coil zc-axis
         for z_value in z_values:
@@ -236,4 +233,3 @@ class TestPoloidalFieldBenchmark:
         ax.set_xlim([0, 8])
         ax.set_xlabel("x")
         ax.set_ylabel("$B_{p}$")
-        plt.close(fig)

--- a/tests/materials/test_material.py
+++ b/tests/materials/test_material.py
@@ -33,7 +33,6 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=UserWarning)
     from neutronics_material_maker.utils import make_serpent_material
 
-import matplotlib.pyplot as plt
 
 from bluemira.base.constants import EPS, kgm3_to_gcm3, to_kelvin
 from bluemira.utilities.tools import is_num

--- a/tests/materials/test_material.py
+++ b/tests/materials/test_material.py
@@ -112,8 +112,6 @@ class TestMaterials:
         self.nb_3_sn.plot(b_min, b_max, t_min, t_max, eps)
         self.nb_3_sn_2.plot(b_min, b_max, t_min, t_max, eps)
         self.nbti.plot(b_min, b_max, t_min, t_max)
-        plt.show()
-        plt.close()
 
 
 class TestLiquids:

--- a/tests/structural/test_crosssection.py
+++ b/tests/structural/test_crosssection.py
@@ -22,7 +22,6 @@
 
 import numpy as np
 import pytest
-from matplotlib import pyplot as plt
 
 from bluemira.base.constants import EPS
 from bluemira.display import plot_2d

--- a/tests/structural/test_crosssection.py
+++ b/tests/structural/test_crosssection.py
@@ -48,7 +48,6 @@ class TestIbeam:
     def test_plot(self):
         i_beam = IBeam(1, 1, 0.25, 0.5)
         plot_2d(i_beam.geometry, show_points=True)
-        plt.close()
 
     def test_errors(self):
         props = [

--- a/tests/structural/test_geometry.py
+++ b/tests/structural/test_geometry.py
@@ -44,7 +44,7 @@ class TestKMatrix:
 
         k_matrix = geometry.k_matrix()
 
-        fig, ax = plt.subplots()
+        _, ax = plt.subplots()
         ax.matshow(k_matrix)
 
         assert np.allclose(k_matrix, k_matrix.T)

--- a/tests/structural/test_geometry.py
+++ b/tests/structural/test_geometry.py
@@ -46,8 +46,6 @@ class TestKMatrix:
 
         fig, ax = plt.subplots()
         ax.matshow(k_matrix)
-        plt.show()
-        plt.close(fig)
 
         assert np.allclose(k_matrix, k_matrix.T)
 

--- a/tests/structural/test_model.py
+++ b/tests/structural/test_model.py
@@ -558,7 +558,6 @@ class TestCompoundDeflection:
 
         result = model.solve(load_case)
         result.plot()
-        plt.show()
 
 
 @pytest.mark.longrun
@@ -581,7 +580,6 @@ class TestGravityLoads:
 
         result = model.solve()
         result.plot()
-        plt.show()
 
         # Check that tip displacements in the x and y directions are equal
         assert np.isclose(result.deflections[6 * n], result.deflections[6 * n + 1])
@@ -610,7 +608,6 @@ class TestFixedFixedStress:
         result = model.solve()
 
         result.plot()
-        plt.show()
 
 
 @pytest.mark.longrun
@@ -696,7 +693,6 @@ class TestMiniEiffelTower:
         model.add_element(20, 21, cs5, SS316)
 
         model.plot()
-        plt.show()
 
         cls.model = model
 
@@ -705,7 +701,6 @@ class TestMiniEiffelTower:
         result = self.model.solve()
         result.plot(stress=True)
         self.model.clear_loads()
-        plt.show()
 
 
 @pytest.mark.longrun
@@ -740,4 +735,3 @@ class TestInterpolation:
         result = model.solve()
 
         result.plot(stress=True)
-        plt.show()

--- a/tests/structural/test_model.py
+++ b/tests/structural/test_model.py
@@ -23,7 +23,6 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-from matplotlib import pyplot as plt
 
 from bluemira.base.constants import ANSI_COLOR
 from bluemira.structural.crosssection import IBeam, RectangularBeam

--- a/tests/structural/test_plotting.py
+++ b/tests/structural/test_plotting.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
-import matplotlib.pyplot as plt
 
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.structural.crosssection import RectangularBeam
@@ -84,4 +83,3 @@ class TestPlotting:
         fem.apply_load_case(load_case)
 
         GeometryPlotter(geometry)
-        plt.show()

--- a/tests/structural/test_symmetry.py
+++ b/tests/structural/test_symmetry.py
@@ -22,7 +22,6 @@
 from copy import deepcopy
 
 import numpy as np
-from matplotlib import pyplot as plt
 
 from bluemira.geometry.tools import make_circle
 from bluemira.structural.crosssection import IBeam
@@ -77,7 +76,6 @@ class TestCyclicSymmetry:
 
         result.plot(100, stress=True, pattern=True)
         fullresult.plot(100, stress=True)
-        plt.show()
 
         left = model.cycle_sym.left_nodes
         right = model.cycle_sym.right_nodes

--- a/tests/structural/test_transformation.py
+++ b/tests/structural/test_transformation.py
@@ -72,8 +72,6 @@ class TestLambdaTransformationMatrices:
         ax.set_xlim([-2, 2])
         ax.set_ylim([-2, 2])
         ax.set_zlim([-2, 2])
-        plt.show()
-        plt.close(fig)
 
     def assert_works_good(self, dcm, local, msg=""):  # noqa: ARG002
         global_check = dcm @ local


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #1320 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This creates two fixtures one for showing and closing figures after every test and one for after all tests in the class are run (essentially `teardown_method` vs `teardown_class`). To only show and close after all tests in a class have run decorate a class like so:

```python
@pytest.mark.classplot
class TestMyStuff:
   ...
```

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
No longer need to close figures manually

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
