### PR TITLE
🧪 Add closed equilibria shape CAD tests

### DIFF
--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -800,10 +800,10 @@ class _InOut(Enum):
 
 
 def _johner_quadrant(
-    delta: float, kappa: float, psi: float, n_pts: int, ul: _UpLow, io: _InOut
+    delta: float, kappa: float, phi: float, n_pts: int, ul: _UpLow, io: _InOut
 ) -> Tuple[float, float]:
     calc_t = calc_t_neg if io is _InOut.INNER else calc_t_pos
-    t = calc_t(delta, kappa, psi)
+    t = calc_t(delta, kappa, phi)
     conditional_point = 0.5
     if t < conditional_point:
         calc_angles = (
@@ -864,10 +864,10 @@ def flux_surface_johner_quadrants(
     kappa_l: float,
     delta_u: float,
     delta_l: float,
-    psi_u_neg: float,
-    psi_u_pos: float,
-    psi_l_neg: float,
-    psi_l_pos: float,
+    phi_u_neg: float,
+    phi_u_pos: float,
+    phi_l_neg: float,
+    phi_l_pos: float,
     n: int = 100,
 ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
     """
@@ -919,26 +919,26 @@ def flux_surface_johner_quadrants(
         negative = True
     else:
         negative = False
-    psi_u_neg, psi_u_pos, psi_l_neg, psi_l_pos = (
-        np.deg2rad(i) for i in [psi_u_neg, psi_u_pos, psi_l_neg, psi_l_pos]
+    phi_u_neg, phi_u_pos, phi_l_neg, phi_l_pos = (
+        np.deg2rad(i) for i in [phi_u_neg, phi_u_pos, phi_l_neg, phi_l_pos]
     )
 
     n_pts = int(n / 4)
     # inner upper
     x_ui, z_ui = _johner_quadrant(
-        delta_u, kappa_u, psi_u_neg, n_pts, ul=_UpLow.UPPER, io=_InOut.INNER
+        delta_u, kappa_u, phi_u_neg, n_pts, ul=_UpLow.UPPER, io=_InOut.INNER
     )
     # inner lower
     x_li, z_li = _johner_quadrant(
-        delta_l, kappa_l, psi_l_neg, n_pts, ul=_UpLow.LOWER, io=_InOut.INNER
+        delta_l, kappa_l, phi_l_neg, n_pts, ul=_UpLow.LOWER, io=_InOut.INNER
     )
     # outer upper
     x_uo, z_uo = _johner_quadrant(
-        delta_u, kappa_u, psi_u_pos, n_pts, ul=_UpLow.UPPER, io=_InOut.OUTER
+        delta_u, kappa_u, phi_u_pos, n_pts, ul=_UpLow.UPPER, io=_InOut.OUTER
     )
     # outer lower
     x_lo, z_lo = _johner_quadrant(
-        delta_l, kappa_l, psi_l_pos, n_pts, ul=_UpLow.LOWER, io=_InOut.OUTER
+        delta_l, kappa_l, phi_l_pos, n_pts, ul=_UpLow.LOWER, io=_InOut.OUTER
     )
 
     x_quadrants = [x_ui, x_uo[::-1], x_lo[::-1], x_li]
@@ -960,10 +960,10 @@ def flux_surface_johner(
     kappa_l: float,
     delta_u: float,
     delta_l: float,
-    psi_u_neg: float,
-    psi_u_pos: float,
-    psi_l_neg: float,
-    psi_l_pos: float,
+    phi_u_neg: float,
+    phi_u_pos: float,
+    phi_l_neg: float,
+    phi_l_pos: float,
     n: int = 100,
 ) -> Coordinates:
     """
@@ -990,13 +990,13 @@ def flux_surface_johner(
         Upper triangularity at the plasma edge (psi_n=1)
     delta_l:
         Lower triangularity at the plasma edge (psi_n=1)
-    psi_u_neg:
+    phi_u_neg:
         Upper inner angle [°]
-    psi_u_pos:
+    phi_u_pos:
         Upper outer angle [°]
-    psi_l_neg:
+    phi_l_neg:
         Lower inner angle [°]
-    psi_l_pos:
+    phi_l_pos:
         Lower outer angle [°]
     n:
         Number of point to generate on the flux surface
@@ -1013,10 +1013,10 @@ def flux_surface_johner(
         kappa_l,
         delta_u,
         delta_l,
-        psi_u_neg,
-        psi_u_pos,
-        psi_l_neg,
-        psi_l_pos,
+        phi_u_neg,
+        phi_u_pos,
+        phi_l_neg,
+        phi_l_pos,
         n=n,
     )
 

--- a/examples/design/simple_reactor.ex.py
+++ b/examples/design/simple_reactor.ex.py
@@ -190,14 +190,10 @@ class PlasmaDesigner(Designer[GeometryParameterisation]):
                 "kappa_l": {"value": params.kappa_l.value},
                 "delta_u": {"value": params.delta_u.value},
                 "delta_l": {"value": params.delta_l.value},
-                "phi_u_pos": {"value": params.phi_pos_u.value, "lower_bound": 0.0},
-                "phi_u_neg": {"value": params.phi_neg_u.value, "lower_bound": 0.0},
-                "phi_l_pos": {"value": params.phi_pos_l.value, "lower_bound": 0.0},
-                "phi_l_neg": {
-                    "value": params.phi_neg_l.value,
-                    "lower_bound": 0.0,
-                    "upper_bound": 90,
-                },
+                "phi_u_pos": {"value": params.phi_pos_u.value},
+                "phi_u_neg": {"value": params.phi_neg_u.value},
+                "phi_l_pos": {"value": params.phi_pos_l.value, "lower_bound": 0},
+                "phi_l_neg": {"value": params.phi_neg_l.value, "upper_bound": 45},
             }
         )
 

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -256,10 +256,10 @@ johner_names = [
     "kappa_l",
     "delta_u",
     "delta_l",
-    "psi_u_neg",
-    "psi_u_pos",
-    "psi_l_neg",
-    "psi_l_pos",
+    "phi_u_neg",
+    "phi_u_pos",
+    "phi_l_neg",
+    "phi_l_pos",
     "ax",
     "label",
 ]
@@ -329,6 +329,18 @@ class TestJohnerCAD:
         wire_neg = p_neg.create_shape()
 
         assert np.isclose(wire_pos.length, wire_neg.length)
+
+    @pytest.mark.parametrize("kwargs", johner_params)
+    def test_cad(self, kwargs):
+        kwargs.pop("ax")
+        kwargs.pop("label")
+        var_dict = {k: {"value": v} for k, v in kwargs.items()}
+        var_dict["r_0"] = {"value": 9}
+        var_dict["z_0"] = {"value": 0}
+        var_dict["a"] = {"value": 9 / 3}
+        param = JohnerLCFS(var_dict=var_dict)
+        shape = param.create_shape()
+        assert shape.is_closed()
 
 
 class TestKuiroukidisCAD:

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+from copy import deepcopy
+
 import numpy as np
 import pytest
 from matplotlib import pyplot as plt
@@ -295,7 +297,7 @@ class TestJohner:
     def setup_class(cls):
         cls.f, cls.ax = plt.subplots(4, 2)
 
-    @pytest.mark.parametrize("kwargs", johner_params)
+    @pytest.mark.parametrize("kwargs", deepcopy(johner_params))
     def test_johner(self, kwargs):
         ax0, ax1 = kwargs.pop("ax")
         label = kwargs.pop("label")
@@ -330,8 +332,8 @@ class TestJohnerCAD:
 
         assert np.isclose(wire_pos.length, wire_neg.length)
 
-    @pytest.mark.parametrize("kwargs", johner_params)
-    def test_cad(self, kwargs):
+    @pytest.mark.parametrize("kwargs", deepcopy(johner_params))
+    def test_cad_closed(self, kwargs):
         kwargs.pop("ax")
         kwargs.pop("label")
         var_dict = {k: {"value": v} for k, v in kwargs.items()}
@@ -361,6 +363,24 @@ class TestKuiroukidisCAD:
         wire_neg = p_neg.create_shape()
 
         assert np.isclose(wire_pos.length, wire_neg.length)
+
+    @pytest.mark.parametrize(
+        ("r_0", "a", "kappa_u", "kappa_l", "delta_u", "delta_l", "ax"),
+        TestKuiroukidis.fixture,
+    )
+    def test_cad_closed(
+        self, r_0, a, kappa_u, kappa_l, delta_u, delta_l, ax  # noqa: ARG002
+    ):
+        kwargs = dict(
+            zip(
+                ("r_0", "a", "kappa_u", "kappa_l", "delta_u", "delta_l"),
+                (r_0, a, kappa_u, kappa_l, delta_u, delta_l),
+            )
+        )
+        var_dict = {k: {"value": v} for k, v in kwargs.items()}
+        param = KuiroukidisLCFS(var_dict=var_dict)
+        shape = param.create_shape()
+        assert shape.is_closed()
 
 
 class TestManickamCunninghamZakahrovCAD:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
We aren't consistent in our Johner variable naming (psi or phi), I've picked phi because it seemed to be the original.

Our Johner CAD parameterisations are not closed (from the earlier tests). It seems to be that this has been the case for a while? 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
