### PR TITLE
Add an alternative polyhedral VIM formulation

### DIFF
--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -681,9 +681,18 @@ def _surface_integral_bottura(face_normal, face_points, point):
 
 @nb.jit(nopython=True, cache=True)
 def _line_integral_bottura(x: float, y: float, z: float) -> float:
+    """
+
+    Notes
+    -----
+    \t:math:`\\int \\dfrac{1}{r+\\lvert z \\rvert}dx \\equiv I_{i}(x, y, z) = \textrm{ln}(x+r)+\\dfrac{\\lvert z \\rvert}{y}\\bigg(\\textrm{arctan}(\\dfrac{x\\lvert z \\rvert}{yr}) - \\textrm{arctan}(\\dfrac{x}{y})\\bigg)`
+
+    with:
+    \t:math:`r \\equiv \\sqrt(x^2+y^2+z^2)`
+    """  # noqa: W505 E501
     abs_z = abs(z)
     r = np.sqrt(x**2 + y**2 + z**2)
-    if y == 0:
+    if y == 0 or r == 0:
         # This may not be the right solution
         return np.log(x + r)
     a1 = np.arctan2(x * abs_z, (y * r))

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -52,8 +52,6 @@ from bluemira.magnetostatics.baseclass import (
 )
 from bluemira.magnetostatics.tools import process_xyz_array
 
-__all__ = ["PolyhedralPrismCurrentSource"]
-
 ZERO_DIV_GUARD_EPS = 1e-14
 
 
@@ -652,7 +650,7 @@ def _surface_integral_bottura(face_normal, face_points, point):
 
     Notes
     -----
-    \t:math:`W_f(\\mathbf{r}) = \\sum_{j} \\y_{P}^{''}\\bigg[I_{1}(x_{Q2}^{''}-x_{P}^{''}, y_{P}^{''}, z_{P}^{''}) - I_{1}(x_{Q1}^{''}-x_{P}^{''}, y_{P}^{''}, z_{P}^{''})\\bigg]
+    \t:math:`W_f(\\mathbf{r}) = \\sum_{j} y_{P}^{''}\\bigg[I_{1}(x_{Q2}^{''}-x_{P}^{''}, y_{P}^{''}, z_{P}^{''}) - I_{1}(x_{Q1}^{''}-x_{P}^{''}, y_{P}^{''}, z_{P}^{''})\\bigg]`
     """  # noqa: W505 E501
     integral = 0.0
 
@@ -682,13 +680,27 @@ def _surface_integral_bottura(face_normal, face_points, point):
 @nb.jit(nopython=True, cache=True)
 def _line_integral_bottura(x: float, y: float, z: float) -> float:
     """
+    Line integral I_1(x, y, z)
+
+    Parameters
+    ----------
+    x:
+        x coordinate
+    y:
+        y coordinate
+    z:
+        z coordinate
+
+    Returns
+    -------
+    Value of the line integral I_1(x, y, z)
 
     Notes
     -----
-    \t:math:`\\int \\dfrac{1}{r+\\lvert z \\rvert}dx \\equiv I_{i}(x, y, z) = \textrm{ln}(x+r)+\\dfrac{\\lvert z \\rvert}{y}\\bigg(\\textrm{arctan}(\\dfrac{x\\lvert z \\rvert}{yr}) - \\textrm{arctan}(\\dfrac{x}{y})\\bigg)`
+    \t:math:`\\int \\dfrac{1}{r+\\lvert z \\rvert}dx \\equiv I_{1}(x, y, z) = \\textrm{ln}(x+r)+\\dfrac{\\lvert z \\rvert}{y}\\bigg(\\textrm{arctan}\\bigg(\\dfrac{x\\lvert z \\rvert}{yr}\\bigg) - \\textrm{arctan}\\bigg(\\dfrac{x}{y}\\bigg)\\bigg)`
 
     with:
-    \t:math:`r \\equiv \\sqrt(x^2+y^2+z^2)`
+    \t:math:`r \\equiv \\sqrt{x^2+y^2+z^2}`
     """  # noqa: W505 E501
     abs_z = abs(z)
     r = np.sqrt(x**2 + y**2 + z**2)

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -598,7 +598,7 @@ def _field_bottura(
     current_direction: np.ndarray,
     face_points: np.ndarray,
     face_normals: np.ndarray,
-    mid_points: np.ndarray,
+    mid_points: np.ndarray,  # noqa: ARG001
     point: np.ndarray,
 ) -> np.ndarray:
     """
@@ -667,7 +667,8 @@ def _surface_integral_bottura(face_normal, face_points, point):
         dcm[1, :] = ypp_axis
         dcm[2, :] = face_normal
 
-        # NOTE: zpp should be constant for each surface, and ypp for each line, but i am lazy
+        # NOTE: zpp should be constant for each surface, and ypp for each line,
+        # but i am lazy
         xppq1, ypp, zpp = np.dot(dcm, corner_1 - point)
         xppq2 = np.dot(dcm, corner_2 - point)[0]
 

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with bluemira; if not, see <https://www.gnu.org/licenses/>.
 
+from copy import deepcopy
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -26,27 +28,10 @@ import pytest
 from bluemira.base.constants import EPS, raw_uc
 from bluemira.geometry.tools import Coordinates
 from bluemira.magnetostatics.polyhedral_prism import (
-    BotturaPolyhedralPrismCurrentSource,
+    Bottura,
     PolyhedralPrismCurrentSource,
 )
 from bluemira.magnetostatics.trapezoidal_prism import TrapezoidalPrismCurrentSource
-
-
-class TestMe:
-    def test_bottura_coords(self):
-        source = BotturaPolyhedralPrismCurrentSource(
-            [10, 0, 0],
-            [1, 0, 0],
-            [0, 1, 0],
-            [0, 0, 1],
-            make_xs_from_bd(0.5, 0.5),
-            20,
-            40,
-            current=1,
-        )
-        source.plot()
-        source.field(10, 1, 1)
-        plt.show()
 
 
 def make_xs_from_bd(b, d):
@@ -92,7 +77,7 @@ class TestPolyhedralMaths:
             40,
             current=1,
         ),
-        BotturaPolyhedralPrismCurrentSource(
+        PolyhedralPrismCurrentSource(
             [10, 0, 0],
             [1, 0, 0],
             [0, 1, 0],
@@ -118,7 +103,7 @@ class TestPolyhedralMaths:
             40,
             current=1,
         ),
-        BotturaPolyhedralPrismCurrentSource(
+        PolyhedralPrismCurrentSource(
             [10, 0, 0],
             [1, 0, 0],
             [0, 1, 0],
@@ -136,7 +121,7 @@ class TestPolyhedralMaths:
         self,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: BotturaPolyhedralPrismCurrentSource,
+        poly2: PolyhedralPrismCurrentSource,
     ):
         poly.plot()
         ax = plt.gca()
@@ -160,7 +145,7 @@ class TestPolyhedralMaths:
         self,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: BotturaPolyhedralPrismCurrentSource,
+        poly2: PolyhedralPrismCurrentSource,
     ):
         f = plt.figure()
         ax = f.add_subplot(1, 3, 1, projection="3d")
@@ -200,7 +185,7 @@ class TestPolyhedralMaths:
         self,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: BotturaPolyhedralPrismCurrentSource,
+        poly2: PolyhedralPrismCurrentSource,
     ):
         n = 50
         x = np.linspace(8, 12, n)
@@ -241,7 +226,7 @@ class TestPolyhedralMaths:
         self,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: BotturaPolyhedralPrismCurrentSource,
+        poly2: PolyhedralPrismCurrentSource,
     ):
         n = 50
         y = np.linspace(-2, 2, n)
@@ -281,40 +266,42 @@ class TestPolyhedralMaths:
 
 
 class TestPolyhedralPrismBabicAykel:
-    @classmethod
-    def setup_class(cls):
-        """
-        Verification test.
+    """
+    Verification test.
 
-        Babic and Aykel example
+    Babic and Aykel example
 
-        https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594
-        """
-        # Babic and Aykel example (single trapezoidal prism)
-        cls.trap = TrapezoidalPrismCurrentSource(
-            np.array([0, 0, 0]),
-            np.array([2 * 2.154700538379251, 0, 0]),  # This gives b=1
-            np.array([0, 1, 0]),
-            np.array([0, 0, 1]),
-            1,
-            1,
-            60.0,
-            30.0,
-            4e5,
-        )
-        cls.poly = PolyhedralPrismCurrentSource(
-            np.array([0, 0, 0]),
-            np.array([2 * 2.154700538379251, 0, 0]),  # This gives b=1
-            np.array([0, 1, 0]),
-            np.array([0, 0, 1]),
-            make_xs_from_bd(1, 1),
-            60.0,
-            30.0,
-            4e5,
-        )
+    https://onlinelibrary.wiley.com/doi/epdf/10.1002/jnm.594
+    """
 
+    # Babic and Aykel example (single trapezoidal prism)
+    trap = TrapezoidalPrismCurrentSource(
+        np.array([0, 0, 0]),
+        np.array([2 * 2.154700538379251, 0, 0]),  # This gives b=1
+        np.array([0, 1, 0]),
+        np.array([0, 0, 1]),
+        1,
+        1,
+        60.0,
+        30.0,
+        4e5,
+    )
+    poly = PolyhedralPrismCurrentSource(
+        np.array([0, 0, 0]),
+        np.array([2 * 2.154700538379251, 0, 0]),  # This gives b=1
+        np.array([0, 1, 0]),
+        np.array([0, 0, 1]),
+        make_xs_from_bd(1, 1),
+        60.0,
+        30.0,
+        4e5,
+    )
+    poly2 = deepcopy(poly)
+    poly2._kernel = Bottura()
+
+    @pytest.mark.parametrize("poly", [poly, poly2])
     @pytest.mark.parametrize("plane", ["x", "y", "z"])
-    def test_plot(self, plane):
+    def test_plot(self, poly, plane):
         xx, yy, zz, i, j, k = plane_setup(plane)
 
         f = plt.figure()
@@ -330,8 +317,8 @@ class TestPolyhedralPrismBabicAykel:
 
         ax = f.add_subplot(1, 3, 2, projection="3d")
         ax.set_title("PolyhedralPrism")
-        self.poly.plot(ax)
-        Bx, By, Bz = self.poly.field(xx, yy, zz)
+        poly.plot(ax)
+        Bx, By, Bz = poly.field(xx, yy, zz)
         B_new = np.sqrt(Bx**2 + By**2 + Bz**2)
         args_new = [xx, yy, zz, B_new]
         cm = ax.contourf(args_new[i], args_new[j], args_new[k], zdir=plane, offset=0)
@@ -340,26 +327,28 @@ class TestPolyhedralPrismBabicAykel:
         ax = f.add_subplot(1, 3, 3, projection="3d")
         ax.set_title("difference [%]")
         args_diff = [xx, yy, zz, 100 * (B - B_new) / B]
-        self.poly.plot(ax)
+        poly.plot(ax)
         cm = ax.contourf(args_diff[i], args_diff[j], args_diff[k], zdir=plane, offset=0)
         f.colorbar(cm)
         plt.show()
         np.testing.assert_allclose(B_new, B)
 
+    @pytest.mark.parametrize("poly", [poly, poly2])
     @pytest.mark.parametrize(
         ("point", "value", "precision"),
         [((2, 2, 2), 15.5533805, 7), ((1, 1, 1), 53.581000397, 9)],
     )
-    def test_paper_singularity_values(self, point, value, precision):
-        field = self.poly.field(*point)
+    def test_paper_singularity_values(self, poly, point, value, precision):
+        field = poly.field(*point)
         abs_field = raw_uc(np.sqrt(sum(field**2)), "T", "mT")  # Field in mT
         # As per Babic and Aykel paper
         # Assume truncated last digit and not rounded...
         field_ndecimals = np.trunc(abs_field * 10**precision) / 10**precision
         assert field_ndecimals == pytest.approx(value, rel=0, abs=EPS)
 
-    def test_paper_inside_conductor(self):
-        field = self.poly.field(0.5, 0.5, 0.5)
+    @pytest.mark.parametrize("poly", [poly, poly2])
+    def test_paper_inside_conductor(self, poly):
+        field = poly.field(0.5, 0.5, 0.5)
         abs_field = raw_uc(np.sqrt(sum(field**2)), "T", "mT")  # Field in mT
         # As per Babic and Aykel paper
         # Assume truncated last digit and not rounded...

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -121,7 +121,7 @@ class TestPolyhedralMaths:
         self,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: PolyhedralPrismCurrentSource,
+        *_,
     ):
         poly.plot()
         ax = plt.gca()

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -29,6 +29,7 @@ from bluemira.base.constants import EPS, raw_uc
 from bluemira.geometry.tools import Coordinates
 from bluemira.magnetostatics.polyhedral_prism import (
     Bottura,
+    Fabbri,
     PolyhedralPrismCurrentSource,
 )
 from bluemira.magnetostatics.trapezoidal_prism import TrapezoidalPrismCurrentSource
@@ -77,16 +78,6 @@ class TestPolyhedralMaths:
             40,
             current=1,
         ),
-        PolyhedralPrismCurrentSource(
-            [10, 0, 0],
-            [1, 0, 0],
-            [0, 1, 0],
-            [0, 0, 1],
-            make_xs_from_bd(0.5, 0.5),
-            40,
-            40,
-            current=1,
-        ),
     )
 
     diff_angle = (
@@ -103,26 +94,18 @@ class TestPolyhedralMaths:
             40,
             current=1,
         ),
-        PolyhedralPrismCurrentSource(
-            [10, 0, 0],
-            [1, 0, 0],
-            [0, 1, 0],
-            [0, 0, 1],
-            make_xs_from_bd(0.5, 0.5),
-            20,
-            40,
-            current=1,
-        ),
     )
     test_cases = (same_angle, diff_angle)
 
-    @pytest.mark.parametrize(("trap", "poly", "poly2"), test_cases)
+    @pytest.mark.parametrize("kernel", ["Fabbri", "Bottura"])
+    @pytest.mark.parametrize(("trap", "poly"), test_cases)
     def test_geometry(
         self,
+        kernel: str,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        *_,
     ):
+        poly._kernel = Fabbri() if kernel == "Fabbri" else Bottura()
         poly.plot()
         ax = plt.gca()
         trap.plot(ax)
@@ -140,15 +123,17 @@ class TestPolyhedralMaths:
         for i in range(len(trap._points)):
             np.testing.assert_allclose(trap._points[i], poly._points[i])
 
-    @pytest.mark.parametrize(("trap", "poly", "poly2"), test_cases)
+    @pytest.mark.parametrize("kernel", ["Fabbri", "Bottura"])
+    @pytest.mark.parametrize(("trap", "poly"), test_cases)
     def test_xz_field(
         self,
+        kernel: str,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: PolyhedralPrismCurrentSource,
     ):
+        poly._kernel = Fabbri() if kernel == "Fabbri" else Bottura()
         f = plt.figure()
-        ax = f.add_subplot(1, 3, 1, projection="3d")
+        ax = f.add_subplot(1, 2, 1, projection="3d")
         ax.set_title("TrapezoidalPrism")
         n = 50
         x = np.linspace(8, 12, n)
@@ -162,31 +147,26 @@ class TestPolyhedralMaths:
         cm = ax.contourf(xx, B, zz, zdir="y", offset=0)
         f.colorbar(cm)
 
-        ax = f.add_subplot(1, 3, 2, projection="3d")
-        ax.set_title("PolyhedralPrism")
+        ax = f.add_subplot(1, 2, 2, projection="3d")
+        ax.set_title(f"PolyhedralPrism {kernel}")
         poly.plot(ax)
         Bx, By, Bz = poly.field(xx, yy, zz)
         B_new = np.sqrt(Bx**2 + By**2 + Bz**2)
         cm = ax.contourf(xx, B_new, zz, zdir="y", offset=0)
         f.colorbar(cm)
-
-        ax = f.add_subplot(1, 3, 3, projection="3d")
-        ax.set_title("BotturaPolyhedralPrism")
-        poly2.plot(ax)
-        Bx, By, Bz = poly2.field(xx, yy, zz)
-        B_new2 = np.sqrt(Bx**2 + By**2 + Bz**2)
-        cm = ax.contourf(xx, B_new, zz, zdir="y", offset=0)
-        f.colorbar(cm)
         plt.show()
+
         np.testing.assert_allclose(B_new, B)
 
-    @pytest.mark.parametrize(("trap", "poly", "poly2"), test_cases)
+    @pytest.mark.parametrize("kernel", ["Fabbri", "Bottura"])
+    @pytest.mark.parametrize(("trap", "poly"), test_cases)
     def test_xy_field(
         self,
+        kernel: str,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: PolyhedralPrismCurrentSource,
     ):
+        poly._kernel = Fabbri() if kernel == "Fabbri" else Bottura()
         n = 50
         x = np.linspace(8, 12, n)
         y = np.linspace(-2, 2, n)
@@ -194,7 +174,7 @@ class TestPolyhedralMaths:
         zz = np.zeros_like(xx)
 
         f = plt.figure()
-        ax = f.add_subplot(1, 3, 1, projection="3d")
+        ax = f.add_subplot(1, 2, 1, projection="3d")
         ax.set_title("TrapezoidalPrism")
         trap.plot(ax)
 
@@ -203,31 +183,26 @@ class TestPolyhedralMaths:
         cm = ax.contourf(xx, yy, B, zdir="z", offset=0)
         f.colorbar(cm)
 
-        ax = f.add_subplot(1, 3, 2, projection="3d")
-        ax.set_title("PolyhedralPrism")
+        ax = f.add_subplot(1, 2, 2, projection="3d")
+        ax.set_title(f"PolyhedralPrism {kernel}")
         poly.plot(ax)
         Bx, By, Bz = poly.field(xx, yy, zz)
         B_new = np.sqrt(Bx**2 + By**2 + Bz**2)
         cm = ax.contourf(xx, yy, B_new, zdir="z", offset=0)
         f.colorbar(cm)
-
-        ax = f.add_subplot(1, 3, 3, projection="3d")
-        ax.set_title("BotturaPolyhedralPrism")
-        poly2.plot(ax)
-        Bx, By, Bz = poly2.field(xx, yy, zz)
-        B_new2 = np.sqrt(Bx**2 + By**2 + Bz**2)
-        cm = ax.contourf(xx, yy, B_new, zdir="z", offset=0)
-        f.colorbar(cm)
         plt.show()
+
         np.testing.assert_allclose(B_new, B)
 
-    @pytest.mark.parametrize(("trap", "poly", "poly2"), test_cases)
+    @pytest.mark.parametrize("kernel", ["Fabbri", "Bottura"])
+    @pytest.mark.parametrize(("trap", "poly"), test_cases)
     def test_yz_field(
         self,
+        kernel: str,
         trap: TrapezoidalPrismCurrentSource,
         poly: PolyhedralPrismCurrentSource,
-        poly2: PolyhedralPrismCurrentSource,
     ):
+        poly._kernel = Fabbri() if kernel == "Fabbri" else Bottura()
         n = 50
         y = np.linspace(-2, 2, n)
         z = np.linspace(-2, 2, n)
@@ -235,7 +210,7 @@ class TestPolyhedralMaths:
         xx = 10 * np.ones_like(yy)
 
         f = plt.figure()
-        ax = f.add_subplot(1, 3, 1, projection="3d")
+        ax = f.add_subplot(1, 2, 1, projection="3d")
         ax.set_title("TrapezoidalPrism")
         trap.plot(ax)
         Bx, By, Bz = trap.field(xx, yy, zz)
@@ -243,22 +218,15 @@ class TestPolyhedralMaths:
         cm = ax.contourf(B, yy, zz, zdir="x", offset=10)
         f.colorbar(cm)
 
-        ax = f.add_subplot(1, 3, 2, projection="3d")
-        ax.set_title("PolyhedralPrism")
+        ax = f.add_subplot(1, 2, 2, projection="3d")
+        ax.set_title(f"PolyhedralPrism {kernel}")
         poly.plot(ax)
         Bx, By, Bz = poly.field(xx, yy, zz)
         B_new = np.sqrt(Bx**2 + By**2 + Bz**2)
         cm = ax.contourf(B_new, yy, zz, zdir="x", offset=10)
         f.colorbar(cm)
-
-        ax = f.add_subplot(1, 3, 3, projection="3d")
-        ax.set_title("BotturaPolyhedralPrism")
-        poly2.plot(ax)
-        Bx, By, Bz = poly2.field(xx, yy, zz)
-        B_new2 = np.sqrt(Bx**2 + By**2 + Bz**2)
-        cm = ax.contourf(B_new, yy, zz, zdir="x", offset=10)
-        f.colorbar(cm)
         plt.show()
+
         np.testing.assert_allclose(B_new, B)
 
     def teardown_method(self):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

So, I wrote another one just to check if there was something wrong with the first one I wrote (either in terms of implementation or theory). The results are identical to the first one (aside from some singularity I have yet to fully resolve). The geometry they use is the same though, so there's still potential for both to be wrong. I do cross-check with the TrapezoidalPrism geometry (in terms of points), but that isn't really directly used in the trapezoidal prism.

I think it is useful to have two kernels for this, because it means we can cross-benchmark some edge cases and singularities etc. I don't think it should be user-facing, and we should pick whichever one is more robust and faster (in that order). Still need a benchmark with a FE code to proceed.

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
