### PR TITLE
Correct type of names for ParameterFrame.get_values

### DIFF
--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -157,7 +157,7 @@ class ParameterFrame:
             except TypeError:
                 self.update_values(new_values)
 
-    def get_values(self, *names: List[str]) -> Tuple[ParameterValueType, ...]:
+    def get_values(self, *names: Tuple[str]) -> Tuple[ParameterValueType, ...]:
         """Get values of a set of Parameters"""
         try:
             return tuple(getattr(self, n).value for n in names)

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -157,7 +157,7 @@ class ParameterFrame:
             except TypeError:
                 self.update_values(new_values)
 
-    def get_values(self, *names: str) -> Tuple[ParameterValueType, ...]:
+    def get_values(self, *names: List[str]) -> Tuple[ParameterValueType, ...]:
         """Get values of a set of Parameters"""
         try:
             return tuple(getattr(self, n).value for n in names)


### PR DESCRIPTION
## Linked Issues

Very minor fix. Didn't think it needed an issue, but can create one if you like.

## Description

The type annotation for the `names` argument of `ParameterFrame.get_values` should be `List[str]` but is currently just `str`.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [ ] ~~Tests run locally and pass `pytest tests --reactor`~~
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] ~~Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`~~
