### PR TITLE
⬆️ Update Myst-nb

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -241,30 +241,3 @@ def html_visit_inheritance_diagram(self, node):
 
 
 inheritance_diagram.html_visit_inheritance_diagram = html_visit_inheritance_diagram
-
-
-# myst-nb link hack
-import myst_nb.sphinx_ as myst_sphinx  # noqa: E402
-
-
-def new_parse_wrapper(parse):
-    """Wrap `myst_nb.sphinx_.Parser.parse`"""
-
-    def wrapper(self, inputstring, document):
-        """
-        Hacks links to other example notebooks written in py:percent format
-
-        The linking to other py:percent formatted examples only gets converted to an
-        html link if the extension is 'ipynb'. We replace '.ex.py' with '.ipynb' for
-        all text in the original file.
-
-        This could be made more robust but it is unlikely that '.ex.py' is used anywhere
-        else.
-        """
-        inputstring = inputstring.replace(".ex.py", ".ipynb")
-        return parse(self, inputstring, document)
-
-    return wrapper
-
-
-myst_sphinx.Parser.parse = new_parse_wrapper(myst_sphinx.Parser.parse)

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -37,7 +37,7 @@ requests==2.31.0
 ruff==0.1.4
 snowballstemmer==2.2.0
 Sphinx==7.1.2
-sphinx-autoapi==2.1.1
+sphinx-autoapi==3.0.0
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme==1.3.0
 sphinxcontrib-applehelp==1.0.4

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -19,7 +19,7 @@ jupyter-cache==0.6.1
 jupytext==1.15.2
 MarkupSafe==2.1.3
 mypy-extensions==1.0.0
-myst-nb==0.17.2
+myst-nb==1.0.0rc0
 myst-parser==0.18.1
 nbclient==0.7.4
 nodeenv==1.8.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.13
-astroid==2.15.7
+astroid==3.0.1
 attrs==23.1.0
 certifi==2023.7.22
 cfgv==3.4.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -20,7 +20,7 @@ jupytext==1.15.2
 MarkupSafe==2.1.3
 mypy-extensions==1.0.0
 myst-nb==1.0.0rc0
-myst-parser==0.18.1
+myst-parser==2.0.0
 nbclient==0.7.4
 nodeenv==1.8.0
 platformdirs==3.11.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -36,7 +36,7 @@ PyYAML==6.0.1
 requests==2.31.0
 ruff==0.1.4
 snowballstemmer==2.2.0
-Sphinx==5.3.0
+Sphinx==7.1.2
 sphinx-autoapi==2.1.1
 sphinx-copybutton==0.5.2
 sphinx-rtd-theme==1.3.0


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Allows for sphinx upgrades, bumping to rc0 because python3.8 support dropped on the full release. 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
