### PR TITLE
✅ Python310 accepts Union in parameterframes

### DIFF
--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -141,13 +141,13 @@ class TestParameterFrame:
         assert frame.x.value == pytest.approx(1e51)
 
     @pytest.mark.parametrize("value", ["OK", ["OK"]])
-    def test_TypeError_given_field_has_Union_Parameter_type(self, value):
+    def test_no_TypeError_given_field_has_Union_Parameter_type(self, value):
         @dataclass
         class GenericFrame(ParameterFrame):
             x: Parameter[Union[str, list]]
 
-        with pytest.raises(TypeError):
-            GenericFrame.from_dict({"x": {"value": value, "unit": "m"}})
+        gf = GenericFrame.from_dict({"x": {"value": value, "unit": "m"}})
+        assert gf.x.value == value
 
     def test_TypeError_given_field_does_not_have_Parameter_type(self):
         @dataclass


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This is one of the starts for python3.10 support.

`Parameter[str|list]` now implicitly works.

This is being merged into the python3.10 branch 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
