### PR TITLE
Papercut: Fix for showing/saving empty reactor 

### DIFF
--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -200,7 +200,7 @@ class BaseManager(abc.ABC):
 
         Notes
         -----
-        A copy of the component tree must be made
+        A copy of the component tree is made
         as filtering would mutate the ComponentMangers' underlying component trees
         """
         comp_copy = comp.copy()
@@ -503,6 +503,14 @@ class Reactor(BaseManager):
         with_components: Optional[List[ComponentManager]] = None,
     ) -> Component:
         """Build the component tree from this class's annotations."""
+        if not hasattr(self, "__annotations__"):
+            raise ComponentError(
+                "This reactor is ill-defined. "
+                "Have you sub-classed Reactor and "
+                "correctly defined the component managers for it? "
+                "Please look at the examples for how to do this."
+            )
+
         component = Component(self.name)
         comp_type: Type
         for comp_name, comp_type in self.__annotations__.items():
@@ -563,6 +571,11 @@ class Reactor(BaseManager):
         comp_copy = self._filter_tree(
             self.component(with_components), dims_to_show, component_filter
         )
+        if not comp_copy.children:
+            raise ComponentError(
+                "The react has no components defined for the given "
+                "dimension(s) and/or filter."
+            )
         # if "xyz" is requested, construct the 3d cad
         # from each xyz component in the tree,
         # as it's assumed that the cad is only built for 1 sector


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2278 

## Description

This PR adds two raises that are thrown when a reactor has no component managers defined for it or the result of filtering the reactor results in no components being returned.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
