### PR TITLE
Papercut: Deprecating separatrix into ripple_wire

### DIFF
--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -475,25 +475,18 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
         self.algorithm = algorithm
         self.opt_parameters = opt_parameters
         self.opt_conditions = opt_conditions
-        if ripple_wire is not None:
-            self.ripple_wire = ripple_wire
-            if separatrix is not None:
-                warnings.warn(
+        if separatrix is not None:
+            if ripple_wire is None:
+                ripple_wire = separatrix
+            warnings.warn(
                     "Argument 'separatrix' is deprecated, "
                     "argument 'ripple_wire' is used instead.",
                     category=DeprecationWarning,
                     stacklevel=2,
                 )
-        elif separatrix is not None:
-            warnings.warn(
-                "Argument 'separatrix' is deprecated. "
-                "Please use argument 'ripple_wire' instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            self.ripple_wire = separatrix
-        else:
+        elif ripple_wire is None:
             raise ValueError("No value for ripple_wire found!")
+        self.ripple_wire = ripple_wire      
         if keep_out_zone:
             self._keep_out_zone = [
                 KeepOutZone(

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -458,7 +458,7 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
         opt_parameters: Dict[str, float],
         params: ParameterFrame,
         wp_cross_section: BluemiraWire,
-        separatrix: BluemiraWire,
+        ripple_wire: Optional[BluemiraWire] = None,
         keep_out_zone: Optional[BluemiraWire] = None,
         rip_con_tol: float = 1e-3,
         koz_con_tol: float = 1e-3,
@@ -467,15 +467,33 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
         n_rip_points: int = 100,
         n_koz_points: int = 100,
         ripple_selector: Optional[RipplePointSelector] = None,
+        separatrix: Optional[BluemiraWire] = None,
     ):
         self.parameterisation = parameterisation
         self.params = make_parameter_frame(params, RippleConstrainedLengthGOPParams)
-        self.separatrix = separatrix
         self.wp_cross_section = wp_cross_section
         self.algorithm = algorithm
         self.opt_parameters = opt_parameters
         self.opt_conditions = opt_conditions
-
+        if ripple_wire is not None:
+            self.ripple_wire = ripple_wire
+            if separatrix is not None:
+                warnings.warn(
+                    "Argument 'separatrix' is deprecated, "
+                    "argument 'ripple_wire' is used instead.",
+                    category=DeprecationWarning,
+                    stacklevel=2,
+                )
+        elif separatrix is not None:
+            warnings.warn(
+                "Argument 'separatrix' is deprecated. "
+                "Please use argument 'ripple_wire' instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            self.ripple_wire = separatrix
+        else:
+            raise ValueError("No value for ripple_wire found!")
         if keep_out_zone:
             self._keep_out_zone = [
                 KeepOutZone(
@@ -500,7 +518,7 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
             )
             ripple_selector = EquispacedSelector(n_rip_points)
 
-        ripple_selector.set_wire(self.separatrix)
+        ripple_selector.set_wire(self.ripple_wire)
         self.ripple_values = None
 
         self.solver = ParameterisedRippleSolver(
@@ -571,7 +589,7 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
             ax = plt.gca()
 
         plot_2d(
-            self.separatrix,
+            self.ripple_wire,
             ax=ax,
             show=False,
             wire_options={"color": "red", "linewidth": "0.5"},

--- a/bluemira/builders/tf_coils.py
+++ b/bluemira/builders/tf_coils.py
@@ -479,14 +479,14 @@ class RippleConstrainedLengthGOP(GeomOptimisationProblem):
             if ripple_wire is None:
                 ripple_wire = separatrix
             warnings.warn(
-                    "Argument 'separatrix' is deprecated, "
-                    "argument 'ripple_wire' is used instead.",
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
+                "Argument 'separatrix' is deprecated, "
+                "argument 'ripple_wire' is used instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
         elif ripple_wire is None:
             raise ValueError("No value for ripple_wire found!")
-        self.ripple_wire = ripple_wire      
+        self.ripple_wire = ripple_wire
         if keep_out_zone:
             self._keep_out_zone = [
                 KeepOutZone(


### PR DESCRIPTION
## Linked Issues

Fixed RippleConstrainedLengthGOP init signature: Closes #2719

## Description

Changed the parameters, so that:
|                         |     'ripple_wire' provided     |  'ripple_wire' not provided   |
|-------------------------|--------------------------------|-------------------------------|
|'separatrix' provided    | self.ripple_wire = ripple_wire<br />throw DeprecationWarning | self.ripple_wire = separatrix<br />throw DeprecationWarning |
|'separatrix' not provided| self.ripple_wire = ripple_wire | throw ValueError              |

## Interface Changes

No API breaking change, but the keyword argument 'separatrix' is tagged onto the end of of the init method of builder.tf_coils.RippleConstrainedLengthGOP.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
