### PR TITLE
🧐 Setup default pytest temp dir for data

### DIFF
--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -48,7 +48,7 @@ from tabulate import tabulate
 
 from bluemira.base.components import PhysicalComponent
 from bluemira.base.constants import EPS, MU_0
-from bluemira.base.file import get_bluemira_path, try_get_bluemira_path
+from bluemira.base.file import try_get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
 from bluemira.codes.plasmod import plot_default_profiles
@@ -236,6 +236,7 @@ def solve_transport_fixed_boundary(
     num_levels: int = 2,
     distance: float = 1.0,
     ny_fs_min: int = 40,
+    directory: str = "",
 ):
     """
     Solve the plasma fixed boundary problem using delta95 and kappa95 as target
@@ -291,7 +292,6 @@ def solve_transport_fixed_boundary(
     kappa_95 = kappa95_t
     delta_95 = delta95_t
 
-    directory = get_bluemira_path("", subfolder="generated_data")
     mesh_name_msh = mesh_filename + ".msh"
 
     paramet_params = PlasmaFixedBoundaryParams(

--- a/conftest.py
+++ b/conftest.py
@@ -23,13 +23,15 @@
 Used by pytest for configuration like adding command line options.
 """
 
+import os
 from contextlib import suppress
+from pathlib import Path
 from unittest import mock
 
 import matplotlib as mpl
 import pytest
 
-from bluemira.base.file import try_get_bluemira_private_data_root
+from bluemira.base.file import get_bluemira_path, try_get_bluemira_private_data_root
 
 
 def pytest_addoption(parser):
@@ -95,6 +97,11 @@ def pytest_configure(config):
     logic_string = " and ".join(strings)
 
     config.option.markexpr = logic_string
+    config.option.basetemp = (
+        basetemp
+        if (basetemp := os.environ.get("PYTEST_TMPDIR", config.option.basetemp))
+        else Path(get_bluemira_path("", subfolder="generated_data"), "test_data")
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/codes/plasmod/test_equilibrium.py
+++ b/tests/codes/plasmod/test_equilibrium.py
@@ -188,7 +188,7 @@ class TestSolveTransportFixedBoundary:
             (1, "did not"),
         ],
     )
-    def test_full_run_through(self, max_iter, message, caplog):
+    def test_full_run_through(self, max_iter, message, caplog, tmp_path):
         johner_parameterisation = JohnerLCFS(
             {
                 "r_0": {"value": 8.9830e00},
@@ -212,5 +212,6 @@ class TestSolveTransportFixedBoundary:
             refine=True,
             num_levels=1,
             distance=0.1,
+            directory=tmp_path,
         )
         assert message in caplog.messages[-1]

--- a/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
+++ b/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
@@ -23,7 +23,6 @@ import numpy as np
 import pytest
 
 from bluemira.base.components import PhysicalComponent
-from bluemira.base.file import get_bluemira_path
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.fem_fixed_boundary.fem_magnetostatic_2D import (
     FemGradShafranovFixedBoundary,
@@ -32,10 +31,6 @@ from bluemira.equilibria.fem_fixed_boundary.utilities import create_mesh
 from bluemira.equilibria.profiles import DoublePowerFunc, LaoPolynomialFunc
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import make_polygon
-
-DATA_DIR = get_bluemira_path(
-    "equilibria/fem_fixed_boundary/test_generated_data", subfolder="tests"
-)
 
 
 def parameterisation_fixture_not_fully_init(
@@ -54,14 +49,15 @@ def parameterisation_fixture_not_fully_init(
 
 @pytest.mark.classplot
 class TestFemGradShafranovFixedBoundary:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup_method(self, tmp_path):  # noqa: PT004
         lcfs_shape = make_polygon({"x": [7, 10, 7], "z": [-4, 0, 4]}, closed=True)
         lcfs_face = BluemiraFace(lcfs_shape)
         plasma = PhysicalComponent("plasma", lcfs_face)
         plasma.shape.mesh_options = {"lcar": 0.3, "physical_group": "plasma_face"}
         plasma.shape.boundary[0].mesh_options = {"lcar": 0.3, "physical_group": "lcfs"}
         self.mesh = create_mesh(
-            plasma, DATA_DIR, "fixed_boundary_example", "fixed_boundary_example.msh"
+            plasma, tmp_path, "fixed_boundary_example", "fixed_boundary_example.msh"
         )
 
         self.p_prime = LaoPolynomialFunc([2, 3, 1])

--- a/tests/equilibria/fem_fixed_boundary/test_generated_data/.gitignore
+++ b/tests/equilibria/fem_fixed_boundary/test_generated_data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -659,15 +659,15 @@ class TestSavingCAD:
         self.obj = make_circle(5, axis=(1, 1, 1))
 
     @pytest.mark.xfail(reason="Unknown, passes locally")
-    def test_save_as_STP(self, tmpdir):
-        self._save_and_check(self.obj, save_as_STP, tmpdir)
+    def test_save_as_STP(self, tmp_path):
+        self._save_and_check(self.obj, save_as_STP, tmp_path)
 
-    def test_save_cad(self, tmpdir):
-        self._save_and_check(self.obj, save_cad, tmpdir)
+    def test_save_cad(self, tmp_path):
+        self._save_and_check(self.obj, save_cad, tmp_path)
 
-    def _save_and_check(self, obj, save_func, tmpdir):
+    def _save_and_check(self, obj, save_func, tmp_path):
         # Can't mock out as written by freecad not python
-        self.generated_file = tmpdir.join(self.generated_file)
+        self.generated_file = tmp_path / self.generated_file
         save_func(obj, filename=str(self.generated_file).split(".")[0])
 
         with open(self.test_file) as tf:

--- a/tests/magnetostatics/test_finite_element_2d.py
+++ b/tests/magnetostatics/test_finite_element_2d.py
@@ -35,11 +35,9 @@ from bluemira.magnetostatics.finite_element_2d import (
 from bluemira.mesh import meshing
 from bluemira.mesh.tools import import_mesh, msh_to_xdmf
 
-DATA_DIR = Path(Path(__file__).parent, "test_generated_data")
-
 
 class TestGetNormal:
-    def test_simple_thin_coil(self):
+    def test_simple_thin_coil(self, tmp_path):
         """
         Compare the magnetic field on the axis of a coil with a very small cross-section
         calculated with the fem module and the analytic solution as limit of the
@@ -86,16 +84,16 @@ class TestGetNormal:
         c_coil = PhysicalComponent(name="coil", shape=coil, parent=c_universe)
 
         meshfiles = [
-            Path(DATA_DIR, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
+            Path(tmp_path, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
         ]
         m = meshing.Mesh(meshfile=meshfiles)
         m(c_universe, dim=2)
 
-        msh_to_xdmf("Mesh.msh", dimensions=(0, 2), directory=DATA_DIR)
+        msh_to_xdmf("Mesh.msh", dimensions=(0, 2), directory=tmp_path)
 
         mesh, boundaries, subdomains, labels = import_mesh(
             "Mesh",
-            directory=DATA_DIR,
+            directory=tmp_path,
             subdomains=True,
         )
 

--- a/tests/magnetostatics/test_generated_data/.gitignore
+++ b/tests/magnetostatics/test_generated_data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/tests/mesh/test_generated_data/.gitignore
+++ b/tests/mesh/test_generated_data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/tests/mesh/test_meshing.py
+++ b/tests/mesh/test_meshing.py
@@ -25,12 +25,10 @@ from bluemira.geometry.face import BluemiraFace
 from bluemira.mesh import meshing
 from bluemira.mesh.tools import import_mesh, msh_to_xdmf
 
-DATA_DIR = Path(Path(__file__).parent, "test_generated_data")
-
 
 class TestMeshing:
     @pytest.mark.parametrize(("lcar", "nodes_num"), [(0.1, 40), (0.25, 16), (0.5, 8)])
-    def test_mesh_poly(self, lcar, nodes_num):
+    def test_mesh_poly(self, lcar, nodes_num, tmp_path):
         poly = tools.make_polygon(
             [[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]], closed=True, label="poly"
         )
@@ -41,16 +39,16 @@ class TestMeshing:
         surf.mesh_options = {"physical_group": "coil"}
 
         meshfiles = [
-            Path(DATA_DIR, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
+            Path(tmp_path, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
         ]
         m = meshing.Mesh(meshfile=meshfiles)
         m(surf)
 
-        msh_to_xdmf("Mesh.msh", dimensions=(0, 1), directory=DATA_DIR)
+        msh_to_xdmf("Mesh.msh", dimensions=(0, 1), directory=tmp_path)
 
         _, boundaries, _, labels = import_mesh(
             "Mesh",
-            directory=DATA_DIR,
+            directory=tmp_path,
             subdomains=True,
         )
 
@@ -58,7 +56,7 @@ class TestMeshing:
         assert (arr == labels["poly"]).sum() == nodes_num
 
     @pytest.mark.parametrize(("lcar", "nodes_num"), [(0.1, 40), (0.25, 16), (0.5, 8)])
-    def test_override_lcar_surf(self, lcar, nodes_num):
+    def test_override_lcar_surf(self, lcar, nodes_num, tmp_path):
         poly = tools.make_polygon(
             [[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]], closed=True, label="poly"
         )
@@ -69,16 +67,16 @@ class TestMeshing:
         surf.mesh_options = {"lcar": lcar / 2, "physical_group": "coil"}
 
         meshfiles = [
-            Path(DATA_DIR, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
+            Path(tmp_path, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]
         ]
         m = meshing.Mesh(meshfile=meshfiles)
         m(surf)
 
-        msh_to_xdmf("Mesh.msh", dimensions=(0, 1), directory=DATA_DIR)
+        msh_to_xdmf("Mesh.msh", dimensions=(0, 1), directory=tmp_path)
 
         _, boundaries, _, labels = import_mesh(
             "Mesh",
-            directory=DATA_DIR,
+            directory=tmp_path,
             subdomains=True,
         )
 

--- a/tests/utilities/test_tools.py
+++ b/tests/utilities/test_tools.py
@@ -323,9 +323,9 @@ class TestGetModule:
         with pytest.raises(ImportError):
             get_module(Path(get_bluemira_path(), "../README.md").as_posix())
 
-    def test_get_weird_ext_python_file(self, tmpdir):
-        path1 = tmpdir.join("file")
-        path2 = tmpdir.join("file.hello")
+    def test_get_weird_ext_python_file(self, tmp_path):
+        path1 = tmp_path / "file"
+        path2 = tmp_path / "file.hello"
         function = """def f():
     return True"""
         for path in [path1, path2]:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Changes the default pytest temp directory to `generated_data/test_data` in the repo root unless overridden.
Removes all `test_generated_data` folders in tests

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
