### PR TITLE
Coilset label z ordering

### DIFF
--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -22,6 +22,7 @@
 """
 Plot utilities for equilibria
 """
+
 from __future__ import annotations
 
 import warnings
@@ -353,6 +354,7 @@ class CoilGroupPlotter(Plotter):
                 "linewidth": 1,
                 "edgecolor": "k",
             },
+            zorder=100,
         )
 
     def _plot_coil(self, x_boundary, z_boundary, ctype, fill=True, **kwargs):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

Sets the coilset's label z ordering to 100 to above all other plots in a figure.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
