### PR TITLE
Fixed docstring by breaking the too-long :math: lines.

### DIFF
--- a/bluemira/fuel_cycle/tools.py
+++ b/bluemira/fuel_cycle/tools.py
@@ -401,35 +401,52 @@ def legal_limit(
     TBR: float,
     mb: Optional[float] = None,
     p_fus: Optional[float] = None,
-):
+) -> float:
     r"""
     Calculates the release rate of T from the model TFV cycle in g/yr.
 
     .. math::
 
-        A_{max}\Bigg[&\Big[\dot{m_{b}}\Big((\frac{1}{f_{b}}-1)+
-        (1-{\eta}_{f_{pump}})(1-{\eta}_{f})\frac{1}{f_{b}{\eta}_{f}}\Big)+
+        \text{Legal limit} = A_{max} \Bigg[&\Big[\dot{m_{b}}\Big((\frac{1}{f_b}-1)+
+        (1-\eta_{f_{pump}})(1-\eta_f)\frac{1}{f_b \eta_f}\Big)+
         \dot{m_{gas}}\Big]
 
         &\times\Big[(1-f_{DIR})(1-f_{tfv})(1-f_{detrit})\Big]
-        +\dot{m_{b}} \Lambda f_{TERSCWPS}\Bigg]
+        +\dot{m_{b}} \Lambda (1-f_{TERSCWPS})\Bigg]
 
-        &\times365\times24\times3600
+        \times&365\times24\times3600
 
-    Where:
+    Where either :math:`\dot{m_{b}}` or :math:`P_{fus}` has to be provided,
+    as they are related by the equation:
 
     :math:`\dot{m_{b}} = \frac{P_{fus}}{E_{DT}}`
 
     Parameters
     ----------
+    mb:
+        :math:`\dot{m_{b}}` tritium inventory gross burn rate [kg/s]
+    p_fus:
+        :math:`P_{fus}` fusion power [W]
+    max_load_factor:
+        :math:`A_{max}` [dimensionless]
     m_gas:
         mass of gas flow [kg/s]
-    mb:
-        tritium inventory gross burn rate [kg/s]
-    p_fus:
-        fusion power [W]
-
-    All other parameters are dimensionless
+    eta_fuel_pump:
+        :math:`\eta_{f_{pump}}` [dimensionless]
+    eta_f:
+        :math:`\eta_f` [dimensionless]
+    fb:
+        :math:`f_b` [dimensionless]
+    f_dir:
+        :math:`f_{DIR}` [dimensionless]
+    f_detrit_split:
+        :math:`f_{detrit}` [dimensionless]
+    f_terscwps:
+        :math:`f_{TERSCWPS}` [dimensionless]
+    f_exh_split:
+        :math:`f_{tfv}` [dimensionless]
+    TBR:
+        :math:`\Lambda` [dimensionless]
 
     Returns
     -------

--- a/bluemira/fuel_cycle/tools.py
+++ b/bluemira/fuel_cycle/tools.py
@@ -409,9 +409,9 @@ def legal_limit(
 
         A_{max}\Bigg[&\Big[\dot{m_{b}}\Big((\frac{1}{f_{b}}-1)+
         (1-{\eta}_{f_{pump}})(1-{\eta}_{f})\frac{1}{f_{b}{\eta}_{f}}\Big)+
-        \dot{m_{gas}}\Big]\times
+        \dot{m_{gas}}\Big]
 
-        &\Big[(1-f_{DIR})(1-f_{tfv})(1-f_{detrit})\Big]
+        &\times\Big[(1-f_{DIR})(1-f_{tfv})(1-f_{detrit})\Big]
         +\dot{m_{b}} \Lambda f_{TERSCWPS}\Bigg]
 
         &\times365\times24\times3600
@@ -419,7 +419,7 @@ def legal_limit(
     Where:
 
     :math:`\dot{m_{b}} = \frac{P_{fus}[MW]M_{T}[g/mol]}
-        {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
+    {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
     """
     if p_fus is None and mb is None:
         raise FuelCycleError("You must specify either fusion power or burn rate.")

--- a/bluemira/fuel_cycle/tools.py
+++ b/bluemira/fuel_cycle/tools.py
@@ -402,16 +402,24 @@ def legal_limit(
     mb: Optional[float] = None,
     p_fus: Optional[float] = None,
 ):
-    """
+    r"""
     Calculates the release rate of T from the model TFV cycle in g/yr.
 
-    :math:`A_{max}\\Bigg[\\Big[\\dot{m_{b}}\\Big((\\frac{1}{f_{b}}-1)+\
-    (1-{\\eta}_{f_{pump}})(1-{\\eta}_{f})\\frac{1}{f_{b}{\\eta}_{f}}\\Big)+\
-        \\dot{m_{gas}}\\Big](1-f_{DIR})(1-f_{tfv})(1-f_{detrit})+\\dot{m_{b}}\
-        \\Lambda f_{TERSCWPS}\\Bigg]\\times365\\times24\\times3600`\n \n
-    Where:\n
-    :math:`\\dot{m_{b}} = \\frac{P_{fus}[MW]M_{T}[g/mol]}
-    {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
+    .. math::
+
+        A_{max}\Bigg[&\Big[\dot{m_{b}}\Big((\frac{1}{f_{b}}-1)+
+        (1-{\eta}_{f_{pump}})(1-{\eta}_{f})\frac{1}{f_{b}{\eta}_{f}}\Big)+
+        \dot{m_{gas}}\Big]\times
+
+        &\Big[(1-f_{DIR})(1-f_{tfv})(1-f_{detrit})\Big]
+        +\dot{m_{b}} \Lambda f_{TERSCWPS}\Bigg]
+
+        &\times365\times24\times3600
+
+    Where:
+
+    :math:`\dot{m_{b}} = \frac{P_{fus}[MW]M_{T}[g/mol]}
+        {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
     """
     if p_fus is None and mb is None:
         raise FuelCycleError("You must specify either fusion power or burn rate.")

--- a/bluemira/fuel_cycle/tools.py
+++ b/bluemira/fuel_cycle/tools.py
@@ -418,8 +418,7 @@ def legal_limit(
 
     Where:
 
-    :math:`\dot{m_{b}} = \frac{P_{fus}[MW]M_{T}[g/mol]}
-    {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
+    :math:`\dot{m_{b}} = \frac{P_{fus}}{E_{DT}}`
     """
     if p_fus is None and mb is None:
         raise FuelCycleError("You must specify either fusion power or burn rate.")

--- a/bluemira/plasma_physics/reactions.py
+++ b/bluemira/plasma_physics/reactions.py
@@ -53,17 +53,21 @@ def E_DT_fusion() -> float:
 
     Notes
     -----
+    The energy gained is equal to the mass lost:
+        :math:`\\Delta E = \\Delta m c^2`
+
+    where the change of mass is the difference between the products' and reactants'
+    mass in the equation below.
     .. math::
         {^{2}_{1}H}+{^{3}_{1}H}~\\rightarrow~{^{4}_{2}He}~
         (3.5~\\text{MeV})+\\text{n}^{0} (14.1 ~\\text{MeV})\n
-        \\Delta E = \\Delta m c^2
     """
     delta_m = (D_MOLAR_MASS + T_MOLAR_MASS) - (HE_MOLAR_MASS + NEUTRON_MOLAR_MASS)
     return delta_m * C_LIGHT**2 * AMU_TO_KG * J_TO_EV
 
 
 def E_DD_fusion() -> float:
-    """
+    r"""
     Calculates the total energy released from the D-D fusion reaction
 
     Returns
@@ -72,11 +76,18 @@ def E_DD_fusion() -> float:
 
     Notes
     -----
+    THe D-D reaction consists of 2 types of reactions, with a temperature dependent
+    branching ratio; this ratio hovers around 50:50 for fusion relevant energies.
+
     .. math::
-        {^{2}_{1}H}+{^{2}_{1}H}~\\rightarrow~{^{3}_{1}H}
-        (1.01 ~\\text{MeV})+\\text{p} (3.02~\\text{MeV})~~[50 \\textrm{\\%}]
-        ~~~~~~~~~~\\rightarrow~{^{3}_{2}He} (0.82~\\text{MeV})+\\text{n}^{0} (2.45~\\text{MeV})~~[50 \\text{\\%}]\n
-        \\Delta E = \\Delta m c^2
+
+        {^{2}_{1}H}+{^{2}_{1}H}~&\rightarrow~{^{3}_{1}H}
+        (1.01 ~\text{MeV})+\text{p} (3.02~\text{MeV})~~[50 \text{%}]
+
+        &\rightarrow~{^{3}_{2}He} (0.82~\text{MeV})+\text{n}^{0} (2.45~\text{MeV})~~[50 \text{%}]\n
+
+    The energy gained is equal to the mass lost from the reaction above.
+        :math:`\Delta E = \Delta m c^2`
     """  # noqa: W505, E501
     # NOTE: Electron mass must be included with proton mass
     delta_m = np.array(

--- a/bluemira/plasma_physics/reactions.py
+++ b/bluemira/plasma_physics/reactions.py
@@ -58,7 +58,9 @@ def E_DT_fusion() -> float:
 
     where the change of mass is the difference between the products' and reactants'
     mass in the equation below.
+
     .. math::
+
         {^{2}_{1}H}+{^{3}_{1}H}~\\rightarrow~{^{4}_{2}He}~
         (3.5~\\text{MeV})+\\text{n}^{0} (14.1 ~\\text{MeV})\n
     """
@@ -84,7 +86,7 @@ def E_DD_fusion() -> float:
         {^{2}_{1}H}+{^{2}_{1}H}~&\rightarrow~{^{3}_{1}H}
         (1.01 ~\text{MeV})+\text{p} (3.02~\text{MeV})~~[50 \text{%}]
 
-        &\rightarrow~{^{3}_{2}He} (0.82~\text{MeV})+\text{n}^{0} (2.45~\text{MeV})~~[50 \text{%}]\n
+        &\rightarrow~{^{3}_{2}He} (0.82~\text{MeV})+\text{n}^{0} (2.45~\text{MeV})~~[50 \text{%}]
 
     The energy gained is equal to the mass lost from the reaction above.
         :math:`\Delta E = \Delta m c^2`
@@ -176,6 +178,7 @@ def r_D_burn_DT(p_fus: float) -> float:
     Notes
     -----
     .. math::
+
         \\dot{m_{b}} = \\frac{P_{fus}[MW]M_{D}[g/mol]}
         {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]
     """

--- a/bluemira/plasma_physics/reactions.py
+++ b/bluemira/plasma_physics/reactions.py
@@ -109,7 +109,7 @@ def n_DT_reactions(p_fus: float) -> float:
     Calculates the number of D-T fusion reactions per s for a given D-T fusion
     power
 
-    :math:`n_{reactions} = \\frac{P_{fus}[MW]}{17.58 [MeV]eV[J]} [1/s]`
+    :math:`n_{reactions} = \\frac{P_{fus}}{E_{DT}}`
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ def n_DD_reactions(p_fus: float) -> float:
     Calculates the number of D-D fusion reactions per s for a given D-D fusion
     power
 
-    :math:`n_{reactions} = \\frac{P_{fus}[MW]}{E_{DD} [MeV] eV[J]} [1/s]`
+    :math:`n_{reactions} = \\frac{P_{fus}}{E_{DD}}`
 
     Parameters
     ----------
@@ -148,7 +148,7 @@ def r_T_burn(p_fus: float) -> float:  # noqa: N802
     """
     Calculates the tritium burn rate for a given fusion power
 
-    :math:`\\dot{m_{b}} = \\frac{P_{fus}[MW]M_{T}[g/mol]}{17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]`
+    :math:`\\dot{m_{b}} = \\frac{P_{fus}}{E_{DT}}`
 
     Parameters
     ----------
@@ -158,7 +158,7 @@ def r_T_burn(p_fus: float) -> float:  # noqa: N802
     Returns
     -------
     T burn rate in the plasma [g/s]
-    """  # noqa: W505, E501
+    """
     return n_DT_reactions(p_fus) * T_MOLAR_MASS / N_AVOGADRO
 
 
@@ -179,8 +179,8 @@ def r_D_burn_DT(p_fus: float) -> float:
     -----
     .. math::
 
-        \\dot{m_{b}} = \\frac{P_{fus}[MW]M_{D}[g/mol]}
-        {17.58 [MeV]eV[J]N_{A}[1/mol]} [g/s]
+        \\dot{m_{b}} = \\frac{P_{fus}}{E_{DT}}
+
     """
     return n_DT_reactions(p_fus) * D_MOLAR_MASS / N_AVOGADRO
 

--- a/bluemira/plasma_physics/reactions.py
+++ b/bluemira/plasma_physics/reactions.py
@@ -151,7 +151,7 @@ def r_T_burn(p_fus: float) -> float:  # noqa: N802
     Returns
     -------
     T burn rate in the plasma [kg/s]
-    """  # noqa: W505, E501
+    """
     return n_DT_reactions(p_fus) * raw_uc(T_MOLAR_MASS, "amu", "kg")
 
 
@@ -171,7 +171,7 @@ def r_D_burn_DT(p_fus: float) -> float:
     Notes
     -----
     .. math::
-        
+
         \\dot{m_{b}} = \\frac{P_{fus}}{E_{DT}}
     """
     return n_DT_reactions(p_fus) * raw_uc(D_MOLAR_MASS, "amu", "kg")
@@ -203,6 +203,8 @@ def reactivity(
     """
     Calculate the thermal reactivity of a fusion reaction in Maxwellian plasmas,
     \\t:math:`<\\sigma v>`
+
+    temp
 
     Parameters
     ----------

--- a/bluemira/plasma_physics/reactions.py
+++ b/bluemira/plasma_physics/reactions.py
@@ -204,8 +204,6 @@ def reactivity(
     Calculate the thermal reactivity of a fusion reaction in Maxwellian plasmas,
     \\t:math:`<\\sigma v>`
 
-    temp
-
     Parameters
     ----------
     temp_k:


### PR DESCRIPTION
## Linked Issues

Closes #2855 

## Description

Broke .. math:: or :math: lines that are too long. 

Some of the equations written with `quantity[unit]` inside the expression are simplified by removing the `[unit]`. This removes visual clutter while keeping the equation comprehensible. See the comments on #2855 for more details.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
