### PR TITLE
Collate random seed setting

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -8,6 +8,7 @@
 A collection of generic physical constants, conversions, and miscellaneous constants.
 """
 
+from enum import Enum
 from typing import Callable, List, Optional, Union
 
 import numpy as np
@@ -616,3 +617,15 @@ ANSI_COLOR = {
     "lightcyan": "\x1b[96m",
     "darkred": "\x1b[38;5;124m",
 }
+
+
+class RNGSeeds(Enum):
+    """
+    Random Seeds for necessary use cases
+    """
+
+    equilibria_harmonics = 2944412338698111642
+    timeline_tools_lognorm = 6613659347120864846
+    timeline_tools_truncnorm = 9523110846560405221
+    timeline_tools_expo = 15335509124046896388
+    timeline_outages = 5876826953682921855

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy.interpolate import RectBivariateSpline
 from scipy.special import lpmv
 
-from bluemira.base.constants import MU_0
+from bluemira.base.constants import MU_0, RNGSeeds
 from bluemira.base.error import BluemiraError
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print
 from bluemira.equilibria.coils import CoilSet
@@ -192,7 +192,7 @@ def collocation_points(
     n_points: int,
     plasma_boundary: np.ndarray,
     point_type: str,
-    seed: Optional[int] = 42,
+    seed: Optional[int] = RNGSeeds.equilibria_harmonics.value,
 ) -> Collocation:
     """
     Create a set of collocation points for use wih spherical harmonic

--- a/bluemira/fuel_cycle/timeline.py
+++ b/bluemira/fuel_cycle/timeline.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Union
 import matplotlib.pyplot as plt
 import numpy as np
 
-from bluemira.base.constants import S_TO_YR, YR_TO_S
+from bluemira.base.constants import S_TO_YR, YR_TO_S, RNGSeeds
 from bluemira.fuel_cycle.timeline_tools import (
     LogNormalAvailabilityStrategy,
     OperationalAvailabilityStrategy,
@@ -175,7 +175,7 @@ class OperationPhase(Phase):
 
         dist += self.t_min_down
         self._dist = dist  # Store for plotting/debugging
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(RNGSeeds.timeline_outages.value)
         return rng.permutation(dist)
 
     def plot_dist(self):

--- a/bluemira/fuel_cycle/timeline_tools.py
+++ b/bluemira/fuel_cycle/timeline_tools.py
@@ -14,6 +14,7 @@ from typing import Iterable, Tuple
 import numpy as np
 from scipy.optimize import brentq
 
+from bluemira.base.constants import RNGSeeds
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.fuel_cycle.error import FuelCycleError
 
@@ -70,7 +71,7 @@ def generate_lognorm_distribution(n: int, integral: float, sigma: float) -> np.n
     -------
     The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(RNGSeeds.timeline_tools_lognorm.value)
 
     def f_integral(x):
         return np.sum(rng.lognormal(x, sigma, n)) - integral
@@ -100,7 +101,7 @@ def generate_truncnorm_distribution(n: int, integral: float, sigma: float) -> np
     -------
     The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(RNGSeeds.timeline_tools_truncnorm.value)
     distribution = rng.normal(0, sigma, n)
     # Truncate distribution by 0-folding
     distribution = np.abs(distribution)
@@ -129,7 +130,7 @@ def generate_exponential_distribution(
     -------
     The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(RNGSeeds.timeline_tools_expo.value)
     distribution = rng.exponential(lambdda, n)
     # Correct distribution integral
     distribution /= np.sum(distribution)


### PR DESCRIPTION
## Linked Issues

Closes #2960

## Description

Collate random seed setting: sets the random number seed so our results in some cases are reproduceable.

Added the class `RNGSeeds `in `bluemira/base/constants.py`.

It sets random seeds to be used in functions that depend on random number generations:

- `collocation_points()` in `bluemira.equilibria.harmonics`,

- `generate_lognorm_distribution()`, `generate_truncnorm_distribution()`, and `generate_exponential_distribution()` in `bluemira.fuel_cycle.timeline_tools`,

and 

- `calculate_outages()` in `bluemira.fuel_cycle.timeline`

In case you add new functionalities in Bluemira in future that would depend on random number generations, it will be suggested to put a corresponding random seed in the `RNGSeeds` class too.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
