### PR TITLE
PROCESS - BM obsolete parameter names

### DIFF
--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -7,7 +7,7 @@
 
 import abc
 import enum
-from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from bluemira.base.constants import raw_uc
 from bluemira.base.look_and_feel import bluemira_warn
@@ -267,11 +267,14 @@ class CodesTeardown(CodesTask):
             return None
 
         # updated, but split into multiple parameters
-        if isinstance(updated_parameter_name, Iterable):
-            raise CodesError(
-                f"{parameter_name} has become obsolete and been split "
-                f"into {updated_parameter_name}. This must be handled manually."
-            ) from None
+        if isinstance(updated_parameter_name, list):
+            if len(updated_parameter_name) == 1:
+                updated_parameter_name = updated_parameter_name[0]
+            else:
+                raise CodesError(
+                    f"{parameter_name} has become obsolete and been split "
+                    f"into {updated_parameter_name}. This must be handled manually."
+                ) from None
 
         output_value = external_outputs.get(updated_parameter_name)
         if output_value is None:

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -13,7 +13,6 @@ from bluemira.base.constants import raw_uc
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes.error import CodesError
 from bluemira.codes.params import MappedParameterFrame
-from bluemira.codes.process.api import update_obsolete_vars
 from bluemira.codes.utilities import run_subprocess
 
 
@@ -242,53 +241,11 @@ class CodesTeardown(CodesTask):
         self, external_outputs: Dict[str, Any], parameter_name: str
     ):
         output_value = external_outputs.get(parameter_name)
-
-        if output_value is not None:
-            return output_value
-
-        # The parameter may have become obsolete,
-        # try to update the name and check again
-        updated_parameter_name = update_obsolete_vars(parameter_name)
-
-        # no update, not obsolete, just no value found
-        if updated_parameter_name == parameter_name:
+        if output_value is None:
             bluemira_warn(
                 f"No value for output parameter '{parameter_name}' from code "
                 f"'{self._name}', setting value to None."
             )
-            return None
-
-        # updated, but remove
-        if updated_parameter_name is None:
-            bluemira_warn(
-                f"{parameter_name} has become obsolete and been removed, "
-                "setting the value to None."
-            )
-            return None
-
-        # updated, but split into multiple parameters
-        if isinstance(updated_parameter_name, list):
-            if len(updated_parameter_name) == 1:
-                updated_parameter_name = updated_parameter_name[0]
-            else:
-                raise CodesError(
-                    f"{parameter_name} has become obsolete and been split "
-                    f"into {updated_parameter_name}. This must be handled manually."
-                ) from None
-
-        output_value = external_outputs.get(updated_parameter_name)
-        if output_value is None:
-            bluemira_warn(
-                f"{parameter_name} has become obsolete and set to "
-                f"{updated_parameter_name}, however no value was found, "
-                "setting the value to None."
-            )
-            return None
-
-        bluemira_warn(
-            f"{parameter_name} has become obsolete and set to "
-            f"{updated_parameter_name}."
-        )
         return output_value
 
 

--- a/bluemira/codes/process/_setup.py
+++ b/bluemira/codes/process/_setup.py
@@ -7,10 +7,11 @@
 Defines the setup task for running PROCESS.
 """
 
-from pathlib import Path
-from typing import ClassVar, Dict, Optional, Union
+from __future__ import annotations
 
-from bluemira.base.parameter_frame import ParameterFrame
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, Dict, Optional, Union
+
 from bluemira.codes.error import CodesError
 from bluemira.codes.interface import CodesSetup
 from bluemira.codes.process._inputs import ProcessInputs
@@ -20,7 +21,10 @@ from bluemira.codes.process._model_mapping import (
 )
 from bluemira.codes.process.api import ENABLED, InDat, _INVariable, update_obsolete_vars
 from bluemira.codes.process.constants import NAME as PROCESS_NAME
-from bluemira.codes.process.params import ProcessSolverParams
+
+if TYPE_CHECKING:
+    from bluemira.base.parameter_frame import ParameterFrame
+    from bluemira.codes.process.params import ProcessSolverParams
 
 
 class Setup(CodesSetup):

--- a/bluemira/codes/process/_setup.py
+++ b/bluemira/codes/process/_setup.py
@@ -20,6 +20,7 @@ from bluemira.codes.process._model_mapping import (
 )
 from bluemira.codes.process.api import ENABLED, InDat, _INVariable, update_obsolete_vars
 from bluemira.codes.process.constants import NAME as PROCESS_NAME
+from bluemira.codes.process.params import ProcessSolverParams
 
 
 class Setup(CodesSetup):
@@ -40,6 +41,8 @@ class Setup(CodesSetup):
         "iefrf": CurrentDriveEfficiencyModel,
         "i_tf_sup": TFCoilConductorTechnology,
     }
+
+    params: ProcessSolverParams
 
     def __init__(
         self,

--- a/bluemira/codes/process/_teardown.py
+++ b/bluemira/codes/process/_teardown.py
@@ -71,7 +71,7 @@ class Teardown(CodesTeardown):
         """
         Teardown the PROCESS solver.
 
-        This loads the MFile in the run directory and maps its outputs
+        This loads the MFile in the read directory and maps its outputs
         to bluemira parameters.
         """
         self._load_mfile(Path(self.read_directory, "MFILE.DAT"), recv_all=False)
@@ -80,7 +80,7 @@ class Teardown(CodesTeardown):
         """
         Teardown the PROCESS solver.
 
-        This loads the MFile in the run directory and maps its outputs
+        This loads the MFile in the read directory and maps its outputs
         to bluemira parameters.
         """
         self._load_mfile(Path(self.read_directory, "MFILE.DAT"), recv_all=True)

--- a/bluemira/codes/process/_teardown.py
+++ b/bluemira/codes/process/_teardown.py
@@ -8,7 +8,7 @@ PROCESS teardown functions
 """
 
 from pathlib import Path
-from typing import Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Union
 
 import numpy as np
 
@@ -157,6 +157,59 @@ class Teardown(CodesTeardown):
         self._mfile_wrapper = _MFileWrapper(path, self._name)
         self._mfile_wrapper.read()
         return self._mfile_wrapper
+
+    def _get_output_or_raise(
+        self, external_outputs: Dict[str, Any], parameter_name: str
+    ):
+        output_value = external_outputs.get(parameter_name)
+
+        if output_value is not None:
+            return output_value
+
+        # The parameter may have become obsolete,
+        # try to update the name and check again
+        updated_parameter_name = update_obsolete_vars(parameter_name)
+
+        # no update, not obsolete, just no value found
+        if updated_parameter_name == parameter_name:
+            bluemira_warn(
+                f"No value for output parameter '{parameter_name}' from code "
+                f"'{self._name}', setting value to None."
+            )
+            return None
+
+        # updated, but remove
+        if updated_parameter_name is None:
+            bluemira_warn(
+                f"{parameter_name} has become obsolete and been removed, "
+                "setting the value to None."
+            )
+            return None
+
+        # updated, but split into multiple parameters
+        if isinstance(updated_parameter_name, list):
+            if len(updated_parameter_name) == 1:
+                updated_parameter_name = updated_parameter_name[0]
+            else:
+                raise CodesError(
+                    f"{parameter_name} has become obsolete and been split "
+                    f"into {updated_parameter_name}. This must be handled manually."
+                ) from None
+
+        output_value = external_outputs.get(updated_parameter_name)
+        if output_value is None:
+            bluemira_warn(
+                f"{parameter_name} has become obsolete and set to "
+                f"{updated_parameter_name}, however no value was found, "
+                "setting the value to None."
+            )
+            return None
+
+        bluemira_warn(
+            f"{parameter_name} has become obsolete and set to "
+            f"{updated_parameter_name}."
+        )
+        return output_value
 
 
 class _MFileWrapper:


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #2012

## Description

Adds a fix to the output params mapping (from process outputs to Bluemira params), when an output parameter name becomes obsolete.

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
