### PR TITLE
Fixed broken conditional statements in ComponentPlotter so now chooses correct plotting option

### DIFF
--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -41,6 +41,7 @@ from bluemira.geometry.coordinates import (
     get_centroid_3d,
     rotation_matrix_v1v2,
 )
+from bluemira.utilities.tools import flatten_iterable
 
 if TYPE_CHECKING:
     from bluemira.geometry.base import BluemiraGeo
@@ -552,9 +553,15 @@ class ComponentPlotter(BasePlotter):
 
         def _populate_plotters(comp):
             if comp.is_leaf and getattr(comp, "shape", None) is not None:
-                options = (
-                    self.options if comp.plot_options is None else comp.plot_options
-                )
+                if comp.plot_options.face_options["color"] in flatten_iterable(
+                    BLUE_PALETTE.as_hex()
+                ):
+                    if self.options.face_options["color"] == "blue":
+                        options = comp.plot_options
+                    else:
+                        options = self.options
+                else:
+                    options = comp.plot_options
                 plotter = _get_plotter_class(comp.shape)(options)
                 plotter._populate_data(comp.shape)
                 self._cplotters.append(plotter)

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -559,6 +559,7 @@ class ComponentPlotter(BasePlotter):
                     if self.options.face_options["color"] == "blue":
                         options = comp.plot_options
                     else:
+                        # not possible with ComponentPlotter only plot_2d
                         options = self.options
                 else:
                     options = comp.plot_options

--- a/examples/geometry/plotting_tutorial.ex.py
+++ b/examples/geometry/plotting_tutorial.ex.py
@@ -413,6 +413,8 @@ c1 = PhysicalComponent("Comp1", face, parent=group)
 c2 = PhysicalComponent("Comp2", wface, parent=group)
 c3 = PhysicalComponent("Comp3", w1face, parent=group)
 display.plot_2d(group, **my_group_options)
+my_group_options["face_options"] = {}
+display.plot_2d(group, **my_group_options)
 
 # %% [markdown]
 # Note that, since wire_options = {}, wire color is automatically changed by matplotlib

--- a/examples/geometry/plotting_tutorial.ex.py
+++ b/examples/geometry/plotting_tutorial.ex.py
@@ -403,6 +403,9 @@ plt.show(block=True)
 #
 # Creates a `Component` and plots it in the xz plane using matplotlib defaults.
 # Here we override some defaults and make our custom set of plot options.
+# The custom setting of red loses out in priority to c3 comp being set specifically
+# to green. In latter 2 plots shows that returns to component default settings when
+# custom options are default or removed.
 
 # %%
 group = Component("Components")
@@ -412,6 +415,9 @@ my_group_options["face_options"] = {"color": "red"}
 c1 = PhysicalComponent("Comp1", face, parent=group)
 c2 = PhysicalComponent("Comp2", wface, parent=group)
 c3 = PhysicalComponent("Comp3", w1face, parent=group)
+c3.plot_options.face_options["color"] = "green"
+display.plot_2d(group, **my_group_options)
+my_group_options["face_options"] = {"color": "blue"}
 display.plot_2d(group, **my_group_options)
 my_group_options["face_options"] = {}
 display.plot_2d(group, **my_group_options)

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -15,7 +15,7 @@ import pytest
 
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.constants import EPS
-from bluemira.display import plot_3d, plotter
+from bluemira.display import plot_2d, plot_3d, plotter
 from bluemira.display.error import DisplayError
 from bluemira.geometry import face, placement, tools
 from bluemira.utilities.plot_tools import Plot3D
@@ -236,15 +236,30 @@ class TestComponentPlotter:
     def setup_method(self):
         wire1 = tools.make_polygon(SQUARE_POINTS, closed=True)
         wire2 = tools.make_polygon(SQUARE_POINTS + 2.0, closed=True)
+        wire3 = tools.make_polygon(SQUARE_POINTS + 4.0, closed=True)
+        wire4 = tools.make_polygon(SQUARE_POINTS + 6.0, closed=True)
         face1 = face.BluemiraFace(wire1)
         face2 = face.BluemiraFace(wire2)
-
+        face3 = face.BluemiraFace(wire3)
+        face4 = face.BluemiraFace(wire4)
+        # default group
         self.group = Component("Parent")
         self.child1 = PhysicalComponent("Child1", shape=face1, parent=self.group)
         self.child2 = PhysicalComponent("Child2", shape=face2, parent=self.group)
+        # make child2 have non-default colour on creation
+        self.child2.plot_options.face_options["color"] = "green"
+        # custom group
+        self.group2 = Component("Components")
+        self.group2_options = self.group2.plot_options.as_dict()
+        self.group2_options["wire_options"] = {}
+        self.group2_options["face_options"] = {"color": "red"}
+        self.child3 = PhysicalComponent("Child3", shape=face3, parent=self.group2)
+        self.child4 = PhysicalComponent("Child4", shape=face4, parent=self.group2)
+        self.child4.plot_options.face_options["color"] = "green"
 
     def test_plotting_2d(self):
         plotter.ComponentPlotter().plot_2d(self.group)
+        plot_2d(self.group2, **self.group2_options)
 
     def test_plotting_2d_no_wires(self):
         plotter.ComponentPlotter(show_wires=True).plot_2d(self.group)


### PR DESCRIPTION
## Linked Issues

Closes #2293 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Before the conditional statements relied on plotting options being None, however since default options exist this could never be true. This meant that when providing custom plotting options to a component post creation it was ignored and the default was used instead.

Wanted to change this so the following priority ordering existed:

1. component with non-default plotting options at creation
2. custom plotting options post-creation
3. default component plotting option

This was done by checking the various plotting options against their default values. Was not possible to check entire options dictionary against default but could however check the face colour, which is what was done until the full dictionary can be compared in a concise manner.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
