### PR TITLE
Add lower port tests

### DIFF
--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -17,6 +17,7 @@ from typing import Dict, Generator, Optional, TextIO, TypedDict, Union
 
 import numpy as np
 from tabulate import tabulate
+from typing_extensions import NotRequired
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.utilities.error import OptVariablesError
@@ -27,9 +28,9 @@ class OptVarVarDictValueT(TypedDict, total=False):
     """Typed dictionary for a the values of an OptVariable from a var_dict."""
 
     value: float
-    lower_bound: float
-    upper_bound: float
-    fixed: bool
+    lower_bound: NotRequired[float]
+    upper_bound: NotRequired[float]
+    fixed: NotRequired[bool]
 
 
 VarDictT = Dict[str, OptVarVarDictValueT]

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -115,7 +115,9 @@ class LowerPortKOZDesigner(Designer):
         )
 
         duct_straight_inner_extrude_boundary = self._straight_duct_inner_yz_boundary(
-            straight_top_inner_pt, straight_bot_inner_pt
+            straight_top_inner_pt,
+            straight_bot_inner_pt,
+            duct_angled_inner_extrude_boundary.bounding_box.y_max,
         )
 
         return (
@@ -176,6 +178,7 @@ class LowerPortKOZDesigner(Designer):
         self,
         straight_top_inner_pt: Tuple,
         straight_bot_inner_pt: Tuple,
+        angled_duct_ymax: float,
     ) -> BluemiraWire:
         """
         Make the inner yz boundary of the straight duct.
@@ -184,7 +187,13 @@ class LowerPortKOZDesigner(Designer):
         inboard points and uses the port width to make the boundary.
         """
         x_point = straight_top_inner_pt[0]
-        y_size = self.port_width / 2
+
+        # TODO this breaks things
+        # options:
+        #  max(0.5*port_width, angled port width)
+        # restrict port size of angled duct to port_width
+        y_size = max(angled_duct_ymax, self.port_width / 2)
+        # y_size = self.port_width / 2
 
         return make_polygon(
             [
@@ -214,6 +223,11 @@ class LowerPortKOZDesigner(Designer):
                 )
 
             return x_len * np.tan(self._half_beta)
+
+        # TODO alternative limit
+        # y_max = self.port_width / 2
+        # ib_inner_y = min(y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
+        # ob_inner_y = min(y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
 
         ib_inner_y = _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk
         ob_inner_y = _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -117,7 +117,6 @@ class LowerPortKOZDesigner(Designer):
         duct_straight_inner_extrude_boundary = self._straight_duct_inner_yz_boundary(
             straight_top_inner_pt,
             straight_bot_inner_pt,
-            # duct_angled_inner_extrude_boundary.bounding_box.y_max,
         )
 
         return (
@@ -178,7 +177,6 @@ class LowerPortKOZDesigner(Designer):
         self,
         straight_top_inner_pt: Tuple,
         straight_bot_inner_pt: Tuple,
-        # angled_duct_ymax: float,
     ) -> BluemiraWire:
         """
         Make the inner yz boundary of the straight duct.
@@ -189,7 +187,6 @@ class LowerPortKOZDesigner(Designer):
         x_point = straight_top_inner_pt[0]
 
         # restrict port size of angled duct to port_width
-        # y_size = max(angled_duct_ymax, self.port_width / 2)
         y_size = self.port_width / 2
 
         return make_polygon(
@@ -227,8 +224,6 @@ class LowerPortKOZDesigner(Designer):
         flat_y_max = self.port_width / 2
         ib_inner_y = min(flat_y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
         ob_inner_y = min(flat_y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
-        # ib_inner_y = _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk
-        # ob_inner_y = _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk
 
         # check if the space between the y-points is large enough for the
         # divertor to fit through:

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -188,9 +188,6 @@ class LowerPortKOZDesigner(Designer):
         """
         x_point = straight_top_inner_pt[0]
 
-        # TODO this breaks things
-        # options:
-        #  max(0.5*port_width, angled port width)
         # restrict port size of angled duct to port_width
         # y_size = max(angled_duct_ymax, self.port_width / 2)
         y_size = self.port_width / 2

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -135,7 +135,7 @@ class LowerPortKOZDesigner(Designer):
     def _half_beta(self) -> float:
         return np.pi / self.params.n_TF.value
 
-    def _get_div_pts_at_angle(self) -> Tuple[Tuple, Tuple]:
+    def _get_div_pts_at_angle(self) -> Tuple[Tuple[float, ...], ...]:
         div_z_top = self.divertor_face.bounding_box.z_max
         div_z_bot = self.divertor_face.bounding_box.z_min
 
@@ -210,6 +210,8 @@ class LowerPortKOZDesigner(Designer):
         self, ib_div_pt_padded: Tuple, ob_div_pt_padded: Tuple
     ):
         def _calc_y_point(x_point):
+            # TODO(je-cook) This functions assumes the TF coil is circular
+            # this is not a great approximation, in future could look at otho projection.
             x_meet = self.tf_coil_thickness / np.sin(self._half_beta)
             x_len = x_point - x_meet
 
@@ -222,10 +224,9 @@ class LowerPortKOZDesigner(Designer):
             return x_len * np.tan(self._half_beta)
 
         # TODO alternative limit
-        y_max = self.port_width / 2
-        ib_inner_y = min(y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
-        ob_inner_y = min(y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
-
+        flat_y_max = self.port_width / 2
+        ib_inner_y = min(flat_y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
+        ob_inner_y = min(flat_y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
         # ib_inner_y = _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk
         # ob_inner_y = _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk
 

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -117,7 +117,7 @@ class LowerPortKOZDesigner(Designer):
         duct_straight_inner_extrude_boundary = self._straight_duct_inner_yz_boundary(
             straight_top_inner_pt,
             straight_bot_inner_pt,
-            duct_angled_inner_extrude_boundary.bounding_box.y_max,
+            # duct_angled_inner_extrude_boundary.bounding_box.y_max,
         )
 
         return (
@@ -178,7 +178,7 @@ class LowerPortKOZDesigner(Designer):
         self,
         straight_top_inner_pt: Tuple,
         straight_bot_inner_pt: Tuple,
-        angled_duct_ymax: float,
+        # angled_duct_ymax: float,
     ) -> BluemiraWire:
         """
         Make the inner yz boundary of the straight duct.
@@ -192,8 +192,8 @@ class LowerPortKOZDesigner(Designer):
         # options:
         #  max(0.5*port_width, angled port width)
         # restrict port size of angled duct to port_width
-        y_size = max(angled_duct_ymax, self.port_width / 2)
-        # y_size = self.port_width / 2
+        # y_size = max(angled_duct_ymax, self.port_width / 2)
+        y_size = self.port_width / 2
 
         return make_polygon(
             [
@@ -225,12 +225,12 @@ class LowerPortKOZDesigner(Designer):
             return x_len * np.tan(self._half_beta)
 
         # TODO alternative limit
-        # y_max = self.port_width / 2
-        # ib_inner_y = min(y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
-        # ob_inner_y = min(y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
+        y_max = self.port_width / 2
+        ib_inner_y = min(y_max, _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk)
+        ob_inner_y = min(y_max, _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk)
 
-        ib_inner_y = _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk
-        ob_inner_y = _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk
+        # ib_inner_y = _calc_y_point(ib_div_pt_padded[0]) - self.wall_tk
+        # ob_inner_y = _calc_y_point(ob_div_pt_padded[0]) - self.wall_tk
 
         # check if the space between the y-points is large enough for the
         # divertor to fit through:

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -348,16 +348,25 @@ class LowerPortKOZDesigner(Designer):
             )
 
         # find the top and bottom itc points
-        itc_top_pt = max(itc_pts, key=lambda p: p[2])
-        itc_bot_pt = min(itc_pts, key=lambda p: p[2])
+        itc_top_ob_pt = max(itc_pts, key=lambda p: p[2])
+        itc_bot_ib_pt = min(itc_pts, key=lambda p: p[2])
+
         # remap to 2D point
-        itc_top_pt = (itc_top_pt[0], itc_top_pt[2])
-        itc_bot_pt = (itc_bot_pt[0], itc_bot_pt[2])
+        itc_top_ob_pt = (itc_top_ob_pt[0], itc_top_ob_pt[2])
+        itc_bot_ib_pt = (itc_bot_ib_pt[0], itc_bot_ib_pt[2])
+
+        if (
+            self.params.lower_port_angle.value < -45  # noqa: PLR2004
+            and itc_top_ob_pt[0] < itc_bot_ib_pt[0]
+        ):
+            # This is a weird edge case where the 'top' x point is more
+            # inboard than the 'bottom' x point
+            itc_top_ob_pt, itc_bot_ib_pt = itc_bot_ib_pt, itc_top_ob_pt
 
         # choose corner point
-        topleft_corner_pt = itc_bot_pt
+        topleft_corner_pt = itc_bot_ib_pt
         if self.params.lower_port_angle.value > -45:  # noqa: PLR2004
-            topleft_corner_pt = itc_top_pt
+            topleft_corner_pt = itc_top_ob_pt
 
         topright_corner_pt = (
             x_duct_extent,
@@ -376,7 +385,7 @@ class LowerPortKOZDesigner(Designer):
 
         # check if the left edge goes below the angled duct when
         # the corner point is the top itc point (i.e. angle > -45)
-        if topleft_corner_pt == itc_top_pt:
+        if topleft_corner_pt == itc_top_ob_pt:
             left_e = self._make_xz_wire_from_points(topleft_corner_pt, botleft_corner_pt)
             l_e_itc_pts = self._intersection_points(left_e, angled_duct_boundary)
             if len(l_e_itc_pts) == 1:

--- a/eudemo/eudemo_tests/maintenance/test_eq_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_eq_port.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Tests for EU-DEMO Maintenance
+"""
+
+import numpy as np
+import pytest
+
+from bluemira.geometry.tools import make_polygon
+from bluemira.geometry.wire import BluemiraWire
+from eudemo.maintenance.equatorial_port import (
+    EquatorialPortDuctBuilder,
+    EquatorialPortKOZDesigner,
+)
+
+
+class TestEquatorialPortKOZDesigner:
+    """Tests the Equatorial Port KOZ Designer"""
+
+    def setup_method(self) -> None:
+        """Set-up Equatorial Port Designer"""
+
+    @pytest.mark.parametrize(
+        ("xi", "xo", "zh"), zip([9.0, 9.0, 6.0], [16.0, 15.0, 9.0], [5.0, 4.0, 2.0])
+    )
+    def test_ep_designer(self, xi, xo, zh):
+        """Test Equatorial Port KOZ Designer"""
+        R_0 = xi
+        self.params = {
+            "R_0": {"value": R_0, "unit": "m"},
+            "ep_height": {"value": zh, "unit": "m"},
+            "ep_z_position": {"value": 0.0, "unit": "m"},
+            "g_vv_ts": {"value": 0.0, "unit": "m"},
+            "tk_ts": {"value": 0.0, "unit": "m"},
+            "g_ts_tf": {"value": 0.0, "unit": "m"},
+            "pf_s_g": {"value": 0.0, "unit": "m"},
+            "pf_s_tk_plate": {"value": 0.0, "unit": "m"},
+            "tk_vv_single_wall": {"value": 0.0, "unit": "m"},
+        }
+        x_len = xo - R_0
+        self.designer = EquatorialPortKOZDesigner(self.params, None, xo)
+        output = self.designer.execute()
+
+        assert np.isclose(output.length, 2 * (x_len + zh))
+        assert np.isclose(output.area, x_len * zh)
+
+
+class TestEquatorialPortDuctBuilder:
+    """Tests the Equatorial Port Duct Builder"""
+
+    def setup_method(self) -> None:
+        """Set-up to Equatorial Port Duct Builder"""
+
+    @pytest.mark.parametrize(
+        ("xi", "xo", "z", "y", "th"),
+        zip(
+            [9.0, 9.0, 6.0],  # x_inboard
+            [16.0, 15.0, 9.0],  # x_outboard
+            [5.0, 4.0, 2.0],  # z_height
+            [3.0, 2.0, 1.0],  # y_widths
+            [0.5, 0.5, 0.25],  # thickness
+            # expected volumes: [63, 42, 5.25]
+        ),
+    )
+    def test_ep_builder(self, xi, xo, z, y, th):
+        """Test Equatorial Port Duct Builder"""
+        self.params = {
+            "ep_height": {"value": z, "unit": "m"},
+            "cst_r_corner": {"value": 0, "unit": "m"},
+        }
+        y_tup = (y / 2.0, -y / 2.0, -y / 2.0, y / 2.0)
+        z_tup = (-z / 2.0, -z / 2.0, z / 2.0, z / 2.0)
+        yz_profile = BluemiraWire(
+            make_polygon({"x": xi, "y": y_tup, "z": z_tup}, closed=True)
+        )
+        length = xo - xi
+
+        self.builder = EquatorialPortDuctBuilder(self.params, {}, yz_profile, length, th)
+        output = self.builder.build()
+        out_port = output.get_component("xyz").get_component("Equatorial Port Duct 1")
+        if out_port is None:
+            out_port = output.get_component("xyz").get_component("Equatorial Port Duct")
+        expectation = length * (2 * (th * (y + z - (2 * th))))
+
+        assert np.isclose(out_port.shape.volume, expectation)

--- a/eudemo/eudemo_tests/maintenance/test_lower_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_lower_port.py
@@ -188,6 +188,19 @@ class TestLowerPort:
         assert angle_bb.y_max <= straight_bb.y_max
         assert angle_bb.y_min >= straight_bb.y_min
 
+    def test_too_thick_tf_raises_GeometryError(self):
+        self.duct_des_params.lower_port_angle.value = -60
+        self.duct_des_params.tf_wp_depth.value = 0.75
+
+        with pytest.raises(GeometryError, match="duct wall thickness is too large"):
+            LowerPortKOZDesigner(
+                self.duct_des_params,
+                {},
+                self.divertor_xz_silhouette,
+                (3.5, 0),  # connection point between divertor and blanket
+                self.tf_coils_outer_boundary,
+            ).execute()
+
     def _get_tf_y_max(self):
         return (
             (0.5 * self.duct_des_params.tf_wp_depth.value)

--- a/eudemo/eudemo_tests/maintenance/test_lower_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_lower_port.py
@@ -126,54 +126,13 @@ class TestLowerPort:
 
         np.testing.assert_allclose(angled_face.normal_at(), pl.normal_at(), atol=1e-8)
 
-
-class TestLowerPortKOZDesigner:
-    @classmethod
-    def setup_class(cls):
-        cls.divertor_xz_silhouette = BluemiraWire([
-            make_polygon([
-                [4, 6],
-                [0, 0],
-                [0, 0],
-            ]),
-            make_circle(
-                1, center=(5, 0, 0), start_angle=-180, end_angle=0, axis=(0, -1, 0)
-            ),
-        ])
-        cls.tf_coils_outer_boundary = BluemiraWire([
-            make_polygon([
-                [3, 3],
-                [0, 0],
-                [8, -8],
-            ]),
-            make_circle(
-                8, center=(3, 0, 0), start_angle=-90, end_angle=90, axis=(0, -1, 0)
-            ),
-        ])
-
-    def setup_method(self):
-        self.duct_des_params = make_parameter_frame(
-            {
-                "n_TF": {"value": 10, "unit": "dimensionless"},
-                "n_div_cassettes": {"value": 3, "unit": "dimensionless"},
-                "lower_port_angle": {"value": -30, "unit": "degrees"},
-                "g_ts_tf": {"value": 0.05, "unit": "m"},
-                "tk_ts": {"value": 0.05, "unit": "m"},
-                "g_vv_ts": {"value": 0.05, "unit": "m"},
-                "tk_vv_single_wall": {"value": 0.06, "unit": "m"},
-                "tf_wp_depth": {"value": 0.5, "unit": "m"},
-                "lp_duct_div_pad_ob": {"value": 0.3, "unit": "m"},
-                "lp_duct_div_pad_ib": {"value": 0.1, "unit": "m"},
-                "lp_height": {"value": 4.5, "unit": "m"},
-                "lp_width": {"value": 3, "unit": "m"},
-            },
-            LowerPortKOZDesignerParams,
-        )
-
     @pytest.mark.parametrize("duct_angle", [0, -30, -45, -60, -90])
     @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 1, 5))
-    def test_straight_duct_boundingbox_is_larger_than_angled_duct(self, duct_angle):
+    def test_straight_duct_boundingbox_is_larger_than_angled_duct(
+        self, duct_angle, tf_wp_depth
+    ):
         self.duct_des_params.lower_port_angle.value = duct_angle
+        self.duct_des_params.tf_wp_depth.value = tf_wp_depth
 
         (
             _,

--- a/eudemo/eudemo_tests/maintenance/test_lower_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_lower_port.py
@@ -68,8 +68,10 @@ class TestLowerPort:
         )
 
     @pytest.mark.parametrize("duct_angle", [0, -30, -45, -60, -90])
-    def test_duct_angle(self, duct_angle):
+    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 1, 5))
+    def test_duct_angle(self, duct_angle, tf_wp_depth):
         self.duct_des_params.lower_port_angle.value = duct_angle
+        self.duct_des_params.tf_wp_depth.value = tf_wp_depth
 
         (
             lp_duct_xz_void_space,
@@ -123,3 +125,70 @@ class TestLowerPort:
         angled_face = duct_xyz_cad.faces[0]  # this was an angled face when I tested it
 
         np.testing.assert_allclose(angled_face.normal_at(), pl.normal_at(), atol=1e-8)
+
+
+class TestLowerPortKOZDesigner:
+    @classmethod
+    def setup_class(cls):
+        cls.divertor_xz_silhouette = BluemiraWire([
+            make_polygon([
+                [4, 6],
+                [0, 0],
+                [0, 0],
+            ]),
+            make_circle(
+                1, center=(5, 0, 0), start_angle=-180, end_angle=0, axis=(0, -1, 0)
+            ),
+        ])
+        cls.tf_coils_outer_boundary = BluemiraWire([
+            make_polygon([
+                [3, 3],
+                [0, 0],
+                [8, -8],
+            ]),
+            make_circle(
+                8, center=(3, 0, 0), start_angle=-90, end_angle=90, axis=(0, -1, 0)
+            ),
+        ])
+
+    def setup_method(self):
+        self.duct_des_params = make_parameter_frame(
+            {
+                "n_TF": {"value": 10, "unit": "dimensionless"},
+                "n_div_cassettes": {"value": 3, "unit": "dimensionless"},
+                "lower_port_angle": {"value": -30, "unit": "degrees"},
+                "g_ts_tf": {"value": 0.05, "unit": "m"},
+                "tk_ts": {"value": 0.05, "unit": "m"},
+                "g_vv_ts": {"value": 0.05, "unit": "m"},
+                "tk_vv_single_wall": {"value": 0.06, "unit": "m"},
+                "tf_wp_depth": {"value": 0.5, "unit": "m"},
+                "lp_duct_div_pad_ob": {"value": 0.3, "unit": "m"},
+                "lp_duct_div_pad_ib": {"value": 0.1, "unit": "m"},
+                "lp_height": {"value": 4.5, "unit": "m"},
+                "lp_width": {"value": 3, "unit": "m"},
+            },
+            LowerPortKOZDesignerParams,
+        )
+
+    @pytest.mark.parametrize("duct_angle", [0, -30, -45, -60, -90])
+    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 1, 5))
+    def test_straight_duct_boundingbox_is_larger_than_angled_duct(self, duct_angle):
+        self.duct_des_params.lower_port_angle.value = duct_angle
+
+        (
+            _,
+            _,
+            lp_duct_angled_nowall_extrude_boundary,
+            lp_duct_straight_nowall_extrude_boundary,
+        ) = LowerPortKOZDesigner(
+            self.duct_des_params,
+            {},
+            self.divertor_xz_silhouette,
+            (5.5, 0),
+            self.tf_coils_outer_boundary,
+        ).execute()
+
+        angle_bb = lp_duct_angled_nowall_extrude_boundary.bounding_box
+        straight_bb = lp_duct_straight_nowall_extrude_boundary.bounding_box
+        assert angle_bb.y_max <= straight_bb.y_max
+        assert angle_bb.y_min >= straight_bb.y_min

--- a/eudemo/eudemo_tests/maintenance/test_lower_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_lower_port.py
@@ -84,7 +84,7 @@ class TestLowerPort:
         )
 
     @pytest.mark.parametrize("duct_angle", [0, -30, -45, -60, -90])
-    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 1, 5))
+    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 0.5, 3))
     def test_duct_angle(self, duct_angle, tf_wp_depth):
         self.duct_des_params.lower_port_angle.value = duct_angle
         self.duct_des_params.tf_wp_depth.value = tf_wp_depth
@@ -149,10 +149,7 @@ class TestLowerPort:
 
         with pytest.raises(
             GeometryError,
-            match=(
-                ".*[<Solid.*[\n]*.*Solid.*[\n]*.*Solid.*[\n]*.*>] "
-                "gives more than one solid."
-            ),
+            match=r".*\[(<Solid[\n ]*object at [0-9a-z]{14}>[, ]*){3}\]",
         ):
             boolean_fuse([tf, tf2, duct_xyz_cad])
         # import ipdb
@@ -166,7 +163,7 @@ class TestLowerPort:
         show_cad([tf, tf2, duct_xyz_cad, self.divertor_xz_silhouette, lp_duct_xz_koz])
 
     @pytest.mark.parametrize("duct_angle", [0, -30, -45, -60, -90])
-    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 1, 5))
+    @pytest.mark.parametrize("tf_wp_depth", np.linspace(0, 0.5, 3))
     def test_straight_duct_boundingbox_is_larger_than_angled_duct(
         self, duct_angle, tf_wp_depth
     ):

--- a/eudemo/eudemo_tests/maintenance/test_upper_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_upper_port.py
@@ -27,10 +27,6 @@ from eudemo.maintenance.duct_connection import (
     VVUpperPortDuctBuilder,
     VVUpperPortDuctBuilderParams,
 )
-from eudemo.maintenance.equatorial_port import (
-    EquatorialPortDuctBuilder,
-    EquatorialPortKOZDesigner,
-)
 from eudemo.maintenance.upper_port import UpperPortKOZDesigner
 
 
@@ -195,74 +191,3 @@ class TestDuctConnection:
 
         with pytest.raises(BuilderError):
             builder.build()
-
-
-class TestEquatorialPortKOZDesigner:
-    """Tests the Equatorial Port KOZ Designer"""
-
-    def setup_method(self) -> None:
-        """Set-up Equatorial Port Designer"""
-
-    @pytest.mark.parametrize(
-        ("xi", "xo", "zh"), zip([9.0, 9.0, 6.0], [16.0, 15.0, 9.0], [5.0, 4.0, 2.0])
-    )
-    def test_ep_designer(self, xi, xo, zh):
-        """Test Equatorial Port KOZ Designer"""
-        R_0 = xi
-        self.params = {
-            "R_0": {"value": R_0, "unit": "m"},
-            "ep_height": {"value": zh, "unit": "m"},
-            "ep_z_position": {"value": 0.0, "unit": "m"},
-            "g_vv_ts": {"value": 0.0, "unit": "m"},
-            "tk_ts": {"value": 0.0, "unit": "m"},
-            "g_ts_tf": {"value": 0.0, "unit": "m"},
-            "pf_s_g": {"value": 0.0, "unit": "m"},
-            "pf_s_tk_plate": {"value": 0.0, "unit": "m"},
-            "tk_vv_single_wall": {"value": 0.0, "unit": "m"},
-        }
-        x_len = xo - R_0
-        self.designer = EquatorialPortKOZDesigner(self.params, None, xo)
-        output = self.designer.execute()
-
-        assert np.isclose(output.length, 2 * (x_len + zh))
-        assert np.isclose(output.area, x_len * zh)
-
-
-class TestEquatorialPortDuctBuilder:
-    """Tests the Equatorial Port Duct Builder"""
-
-    def setup_method(self) -> None:
-        """Set-up to Equatorial Port Duct Builder"""
-
-    @pytest.mark.parametrize(
-        ("xi", "xo", "z", "y", "th"),
-        zip(
-            [9.0, 9.0, 6.0],  # x_inboard
-            [16.0, 15.0, 9.0],  # x_outboard
-            [5.0, 4.0, 2.0],  # z_height
-            [3.0, 2.0, 1.0],  # y_widths
-            [0.5, 0.5, 0.25],  # thickness
-            # expected volumes: [63, 42, 5.25]
-        ),
-    )
-    def test_ep_builder(self, xi, xo, z, y, th):
-        """Test Equatorial Port Duct Builder"""
-        self.params = {
-            "ep_height": {"value": z, "unit": "m"},
-            "cst_r_corner": {"value": 0, "unit": "m"},
-        }
-        y_tup = (y / 2.0, -y / 2.0, -y / 2.0, y / 2.0)
-        z_tup = (-z / 2.0, -z / 2.0, z / 2.0, z / 2.0)
-        yz_profile = BluemiraWire(
-            make_polygon({"x": xi, "y": y_tup, "z": z_tup}, closed=True)
-        )
-        length = xo - xi
-
-        self.builder = EquatorialPortDuctBuilder(self.params, {}, yz_profile, length, th)
-        output = self.builder.build()
-        out_port = output.get_component("xyz").get_component("Equatorial Port Duct 1")
-        if out_port is None:
-            out_port = output.get_component("xyz").get_component("Equatorial Port Duct")
-        expectation = length * (2 * (th * (y + z - (2 * th))))
-
-        assert np.isclose(out_port.shape.volume, expectation)


### PR DESCRIPTION
## Linked Issues

Closes #2253 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Adds some lower port tests and does some small rearrangement.

There is a choice here which limit should be imposed on the straight section size.

1) scale to the maximum size but the minimum size is the user input (alternative 1)
2) limit to the user input (alternative 2)  **taken forward**

I've currently got 2) set up but up to the reviewer. I can't decide which is best.

The approximation of the TF coil being semi circular also leads to some failures in y point selection. For now I have just added a TODO (and will open an issue if agreed). This only affects extremes of input.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
