### PR TITLE
🐛 Fix Zenodo submission

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     - id: prettier
       types_or: [json]
       args: [--tab-width=2]
+
+-   repo: https://github.com/citation-file-format/cffconvert
+    rev: 054bda51dbe278b3e86f27c890e3f3ac877d616c
+    hooks:
+      - id: validate-cff

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,7 @@ cff-version: 1.2.0
 authors:
   - family-names: Coleman
     given-names: M.
-    affiliation: United Kingdom Atomic Energy Authority, Culham Science Centre, Abingdon, Oxfordshire OX14 3DB, United Kingdom
-    affiliation: EUROfusion Consortium, Boltzmannstr.2, Garching, 85748, Germany
+    affiliation: United Kingdom Atomic Energy Authority, Culham Science Centre, Abingdon, Oxfordshire OX14 3DB, United Kingdom; EUROfusion Consortium, Boltzmannstr.2, Garching, 85748, Germany
 
   - family-names: Cook
     given-names: J. E.
@@ -19,8 +18,7 @@ authors:
 
   - family-names: McIntosh
     given-names: S.
-    affiliation: United Kingdom Atomic Energy Authority, Culham Science Centre, Abingdon, Oxfordshire OX14 3DB, United Kingdom
-    affiliation: ITER Organization, Route de Vinon-sur-Verdon, CS 90 046, 13067 St Paul Lez Durance Cedex, France
+    affiliation: United Kingdom Atomic Energy Authority, Culham Science Centre, Abingdon, Oxfordshire OX14 3DB, United Kingdom; ITER Organization, Route de Vinon-sur-Verdon, CS 90 046, 13067 St Paul Lez Durance Cedex, France
 
   - family-names: Morris
     given-names: J.
@@ -99,7 +97,7 @@ references:
         given-names: M
       - family-names: McIntosh
         given-names: S
-    doi: https://doi.org/10.1016/j.fusengdes.2018.12.036
+    doi: 10.1016/j.fusengdes.2018.12.036
     year: 2019
     volume: 139
     journal: Fusion Engineering and Design
@@ -108,9 +106,9 @@ references:
     authors:
       - family-names: Franza
         given-names: F
-    doi: https://doi.org/10.5445/IR/1000095873
+    doi: 10.5445/IR/1000095873
     year: 2019
 title: "bluemira"
 license: LGPL-2.1+
 repository-code: "https://github.com/Fusion-Power-Plant-Framework/bluemira"
-website: "https://bluemira.readthedocs.io/en/develop"
+url: "https://bluemira.readthedocs.io/en/develop"


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Zenodo at some point in the last 3.5 months decided that our CITATION.cff was no longer valid. This 'fixes' that and adds a pre-commit validation to hopefully catch this in future.

Once cff v1.3.0 comes out we should be able to add back multiple affiliations so the milestone says:

https://github.com/citation-file-format/citation-file-format/milestone/8

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
