### PR TITLE
🐛 Fix getting component manager type if annotations imported

### DIFF
--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -20,6 +20,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    get_type_hints,
 )
 from warnings import warn
 
@@ -498,7 +499,7 @@ class Reactor(BaseManager):
 
         component = Component(self.name)
         comp_type: Type
-        for comp_name, comp_type in self.__annotations__.items():
+        for comp_name, comp_type in get_type_hints(type(self)).items():
             if not issubclass(comp_type, ComponentManager):
                 continue
             try:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Reactor will fail on some operations if where the reactor is defined imports annotations because they could be strings.
This gets the types based on those string or the class directly.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
