### PR TITLE
Reactor config addition for handling path expansion

### DIFF
--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -2,13 +2,13 @@
   "params": "$path:params.json",
   "Radial build": {
     "run_mode": "run",
-    "read_dir": "config/",
-    "run_dir": "config/",
+    "read_dir": "$path_expand:./",
+    "run_dir": "$path_expand:./",
     "plot": true
   },
   "Fixed boundary equilibrium": {
     "run_mode": "read",
-    "file_path": "config/fixed_boundary_eqdsk.json",
+    "file_path": "$path_expand:./fixed_boundary_eqdsk.json",
     "param_class": "JohnerLCFS",
     "shape_config": {
       "f_delta_l": 1.25,
@@ -63,8 +63,8 @@
     "run_mode": "run",
     "plot": true,
     "save": true,
-    "fixed_eq_file_path": "config/fixed_boundary_eqdsk.json",
-    "file_path": "config/equilibrium_eqdsk.json",
+    "fixed_eq_file_path": "$path_expand./:fixed_boundary_eqdsk.json",
+    "file_path": "$path_expand./:equilibrium_eqdsk.json",
     "settings": {
       "iter_err_max": 1e-3,
       "max_iter": 50,
@@ -91,7 +91,7 @@
         }
       },
       "run_mode": "run",
-      "file_path": "config/FirstWallDesign.json",
+      "file_path": "$path_expand:./FirstWallDesign.json",
       "problem_settings": {
         "n_koz_points": 100
       },
@@ -107,7 +107,7 @@
   },
   "TF coils": {
     "run_mode": "run",
-    "file_path": "config/TFCoilDesign.json",
+    "file_path": "$path_expand:./TFCoilDesign.json",
     "plot": true,
     "param_class": "TripleArc",
     "variables_map": {},
@@ -131,7 +131,7 @@
   },
   "PF coils": {
     "run_mode": "run",
-    "file_path": "config/PFCoilDesign.json",
+    "file_path": "$path_expand:./PFCoilDesign.json",
     "verbose": false,
     "plot": true,
     "grid_settings": {

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -63,8 +63,8 @@
     "run_mode": "run",
     "plot": true,
     "save": true,
-    "fixed_eq_file_path": "$path_expand./:fixed_boundary_eqdsk.json",
-    "file_path": "$path_expand./:equilibrium_eqdsk.json",
+    "fixed_eq_file_path": "$path_expand:./fixed_boundary_eqdsk.json",
+    "file_path": "$path_expand:./equilibrium_eqdsk.json",
     "settings": {
       "iter_err_max": 1e-3,
       "max_iter": 50,

--- a/tests/base/reactor_config/data/reactor_config.test.json
+++ b/tests/base/reactor_config/data/reactor_config.test.json
@@ -5,6 +5,8 @@
       "height": { "value": 18, "unit": "cm" },
       "name": { "value": "Comp A", "unit": "" }
     },
+    "test_expand_dir": "$path_expand:./",
+    "test_expand_file": "$path_expand:./nest_a/nest_a.config.json",
     "config_a": {
       "a_value": "overridden_value"
     },

--- a/tests/base/reactor_config/test_reactor_config.py
+++ b/tests/base/reactor_config/test_reactor_config.py
@@ -257,3 +257,15 @@ class TestReactorConfigClass:
 
         assert reactor_config.params_for("nest_a").local_params["a_param"] == "nest_a"
         assert reactor_config.params_for("nest_b").local_params["a_param"] == "nest_b"
+
+    def test_path_expansion(self):
+        reactor_config = ReactorConfig(test_config_path, TestGlobalParams)
+
+        assert (
+            reactor_config.config_for("comp A")["test_expand_dir"]
+            == test_config_path.parent.as_posix()
+        )
+        assert (
+            reactor_config.config_for("comp A")["test_expand_file"]
+            == (Path(test_config_path.parent) / "nest_a/nest_a.config.json").as_posix()
+        )


### PR DESCRIPTION
… config directory and accompanying tests

## Linked Issues

Closes #2965 

## Description

Added new directive to handle path expansion from config files, so will now be absolute file paths.

Added tests to check functionality.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
