### PR TITLE
✅ Add iefrf = 13

### DIFF
--- a/bluemira/codes/process/model_mapping.py
+++ b/bluemira/codes/process/model_mapping.py
@@ -1090,6 +1090,7 @@ class CurrentDriveEfficiencyModel(PROCESSModel):
     10 - ECRH user input gamma
     11 - ECRH "HARE" model (E. Poli, Physics of Plasmas 2019)
     12 - EBW user scaling input. Scaling (S. Freethy)
+    13 - ECRH O-mode cutoff with Zeff and Te (Physical review letters. 90. 075003)
     """
 
     @classproperty
@@ -1110,6 +1111,7 @@ class CurrentDriveEfficiencyModel(PROCESSModel):
     ECRH_UI_GAM = 10
     ECRH_HARE = 11
     EBW_UI = 12
+    ECRH_O = 13
 
 
 class PlasmaIgnitionModel(PROCESSModel):


### PR DESCRIPTION
## Linked Issues

Adds ECRH O-mode cutoff with Zeff and Te (Physical review letters. 90. 075003) current drive efficiency model, iefrf = 13, as per PROCESS 


## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
