### PR TITLE
🐛 Enforce use of ordered edges

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -769,13 +769,13 @@ def tessellate(obj: apiShape, tolerance: float) -> tuple[np.ndarray, np.ndarray]
 
 def start_point(obj: apiShape) -> np.ndarray:
     """The start point of the object"""
-    point = obj.Edges[0].firstVertex().Point
+    point = obj.OrderedEdges[0].firstVertex().Point
     return vector_to_numpy(point)
 
 
 def end_point(obj: apiShape) -> np.ndarray:
     """The end point of the object"""
-    point = obj.Edges[-1].lastVertex().Point
+    point = obj.OrderedEdges[-1].lastVertex().Point
     return vector_to_numpy(point)
 
 

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -135,13 +135,13 @@ class TestFreecadapi:
 
     def test_make_bezier(self):
         bezier: Part.Wire = cadapi.make_bezier(self.square_points)
-        curve = bezier.Edges[0].Curve
+        curve = bezier.OrderedEdges[0].Curve
         assert type(curve) is Part.BezierCurve
 
     def test_interpolate_bspline(self):
         pntslist = self.square_points
         bspline: Part.Wire = cadapi.interpolate_bspline(pntslist)
-        curve = bspline.Edges[0].Curve
+        curve = bspline.OrderedEdges[0].Curve
         assert type(curve) is Part.BSplineCurve
         # assert that the bspline pass through the points
         # get the points parameter

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -103,7 +103,7 @@ class TestGeometry:
             major_radius=major_radius,
             minor_radius=minor_radius,
         )
-        edge = bm_ellipse.boundary[0].Edges[0]
+        edge = bm_ellipse.boundary[0].OrderedEdges[0]
 
         # ellispe eccentricity
         eccentricity = math.sqrt(1 - (minor_radius / major_radius) ** 2)

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -493,7 +493,7 @@ class TestMakeBSpline:
         # np.testing.assert_allclose(spline.length, expected_length)
         if st and et:
             assert spline.length > 1.0
-            e = spline.shape.Edges[0]
+            e = spline.shape.OrderedEdges[0]
             np.testing.assert_allclose(
                 e.tangentAt(e.FirstParameter), np.array(st) / norm(st)
             )
@@ -510,7 +510,7 @@ class TestMakeBSpline:
             points, closed=True, start_tangent=st, end_tangent=et
         )
         if st and et:
-            e = spline.shape.Edges[0]
+            e = spline.shape.OrderedEdges[0]
             np.testing.assert_allclose(
                 e.tangentAt(e.FirstParameter), np.array(st) / norm(st)
             )

--- a/tests/geometry/test_wire.py
+++ b/tests/geometry/test_wire.py
@@ -11,7 +11,7 @@ from bluemira.base.file import get_bluemira_path
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.error import GeometryError
 from bluemira.geometry.tools import (
-    deserialize_shape,
+    deserialise_shape,
     make_bezier,
     make_circle,
     make_polygon,
@@ -133,8 +133,8 @@ class TestWire:
                 "BluemiraWire": {"label": label, "boundary": [{"Wire": [cadapi_item]}]}
             }
 
-        w1 = deserialize_shape(wrap_as_BMWdict(straight_line_end))
-        w2 = deserialize_shape(wrap_as_BMWdict(arc_start))
+        w1 = deserialise_shape(wrap_as_BMWdict(straight_line_end))
+        w2 = deserialise_shape(wrap_as_BMWdict(arc_start))
         wrong_wire = BluemiraWire([
             w1,
             w2,

--- a/tests/geometry/test_wire.py
+++ b/tests/geometry/test_wire.py
@@ -3,13 +3,22 @@
 # SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
+
 import numpy as np
 import pytest
 
+from bluemira.base.file import get_bluemira_path
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.error import GeometryError
-from bluemira.geometry.tools import make_bezier, make_circle, make_polygon
+from bluemira.geometry.tools import (
+    deserialize_shape,
+    make_bezier,
+    make_circle,
+    make_polygon,
+)
 from bluemira.geometry.wire import BluemiraWire
+
+TEST_PATH = get_bluemira_path("geometry/test_data", subfolder="tests")
 
 
 class TestWire:
@@ -91,6 +100,43 @@ class TestWire:
         np.testing.assert_allclose(vertexes[:, 0], p1)
         np.testing.assert_allclose(vertexes[:, 1], p2)
         np.testing.assert_allclose(vertexes[:, 2], p3)
+
+    def test_end_points(self):
+        """Test SHOULD FAIL after change of behaviour"""
+        # Toughest case
+        rightmost_point = [10.538050403959396, 0.0, -5.974513810642086]
+        straight_line_end = {
+            "LineSegment": {
+                "StartPoint": [9.598817369491535, 0.0, -5.72284707755179],
+                "EndPoint": rightmost_point,
+            }
+        }
+        arc_start = {
+            "ArcOfCircle": {
+                "Radius": 0.8508213264708893,
+                "Center": [9.558782242701866, 0.0, -6.572725961982168],
+                "Axis": [-0.0, 1.0, -0.0],
+                "StartAngle": 180.0,
+                "EndAngle": 272.69703056741383,
+                "StartPoint": [8.707960916230977, 0.0, -6.572725961982168],
+                "EndPoint": [9.598817369491535, 0.0, -5.722847077551793],
+            }
+        }
+
+        def wrap_as_BMWdict(cadapi_item, label=""):
+            return {
+                "BluemiraWire": {"label": label, "boundary": [{"Wire": [cadapi_item]}]}
+            }
+
+        w1 = deserialize_shape(wrap_as_BMWdict(straight_line_end))
+        w2 = deserialize_shape(wrap_as_BMWdict(arc_start))
+        wrong_wire = BluemiraWire([
+            w1,
+            w2,
+        ])  # we expect this line to potentially throw an error in future versions??
+        right_wire = BluemiraWire([w2, w1])
+        np.testing.assert_allclose(wrong_wire.end_point(), Coordinates(rightmost_point))
+        np.testing.assert_allclose(right_wire.end_point(), Coordinates(rightmost_point))
 
 
 class ValueParameterBase:

--- a/tests/geometry/test_wire.py
+++ b/tests/geometry/test_wire.py
@@ -102,7 +102,12 @@ class TestWire:
         np.testing.assert_allclose(vertexes[:, 2], p3)
 
     def test_end_points(self):
-        """Test SHOULD FAIL after change of behaviour"""
+        """
+        Test to make sure that the .end_point() is actually the end point, rather than
+        somewhere in the middle of the wire.
+        Potentially needs to be removed after the next API-breaking change where wires
+        are only allowed to be joined when they're oriented correctly.
+        """
         # Toughest case
         rightmost_point = [10.538050403959396, 0.0, -5.974513810642086]
         straight_line_end = {


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3037

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
The deserialiser is not necessarily stable but in 3037 there was a second bug because `Edges` over `OrderedEdges` was used.  

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
