### PR TITLE
Rectangular XS current source from a `BluemiraWire`

### DIFF
--- a/bluemira/magnetostatics/baseclass.py
+++ b/bluemira/magnetostatics/baseclass.py
@@ -139,6 +139,18 @@ class CrossSectionCurrentSource(CurrentSource):
         self._points = np.array([p @ r for p in self._points], dtype=object)
         self._dcm = self._dcm @ r
 
+    def translate(self, vector):
+        """
+        Translate the CurrentSource.
+
+        Parameters
+        ----------
+        vector:
+            Translation vector
+        """
+        self._origin = self._origin + vector
+        self._points = np.array([p + vector for p in self._points], dtype=object)
+
     def _local_to_global(self, points: np.ndarray) -> np.ndarray:
         """
         Convert local x', y', z' point coordinates to global x, y, z point coordinates.

--- a/bluemira/magnetostatics/trapezoidal_prism.py
+++ b/bluemira/magnetostatics/trapezoidal_prism.py
@@ -13,7 +13,12 @@ including corrections from:
 https://onlinelibrary.wiley.com/doi/abs/10.1002/jnm.675
 """
 
-from typing import Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from matplotlib.pyplot import Axes
 
 import numba as nb
 import numpy as np
@@ -443,3 +448,21 @@ class TrapezoidalPrismCurrentSource(PrismEndCapMixin, CrossSectionCurrentSource)
         ]
 
         return np.array([self._local_to_global(p) for p in points], dtype=object)
+
+    def plot(self, ax: Optional[Axes] = None, show_coord_sys: bool = False):
+        """
+        Plot the CurrentSource.
+
+        Parameters
+        ----------
+        ax: Union[None, Axes]
+            The matplotlib axes to plot on
+        show_coord_sys: bool
+            Whether or not to plot the coordinate systems
+        """
+        super().plot(ax=ax, show_coord_sys=show_coord_sys)
+        p1 = self._origin - 0.5 * self._dcm[1]
+        p2 = self._origin + 0.5 * self._dcm[1]
+        points = np.array([p1, p2])
+        ax.plot(*points.T, color="r")
+        ax.plot([points[-1][0]], [points[-1][1]], [points[-1][2]], marker="^", color="r")

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -55,8 +55,8 @@ class TestGenerateWireSources:
         "a2": {"value": 40},
     }
 
-    p_inputs = (pd_inputs, ta_inputs, pf_inputs)[1:]
-    parameterisations = (PrincetonD, TripleArc, PictureFrame)[1:]
+    p_inputs = (pd_inputs, ta_inputs, pf_inputs)
+    parameterisations = (PrincetonD, TripleArc, PictureFrame)
 
     @pytest.mark.parametrize(  # ruff: PT006
         ("parameterisation", "inputs"), zip(parameterisations, p_inputs)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

I think something like this would do the job for highest-fidelity fastest-run-time for the picture frame coils, but the function has some severe limitations at present, and lacks in generality.

![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/26097289/cbcce219-c992-415a-aeb8-babc555d0bc0)

This is quite clearly not yet working for TripleArc, and I am not sure why... It's either something really stupid with coordinate systems, or something much more sinister.

![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/26097289/319df5da-2039-4e42-b3c0-bae2d6f5d7fe)


## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
