### PR TITLE
Reduce warning count on python310

### DIFF
--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -43,6 +43,7 @@ from bluemira.geometry.wire import BluemiraWire
 from bluemira.optimisation import OptimisationProblem
 from bluemira.optimisation.typing import ConstraintT
 from bluemira.utilities.optimiser import Optimiser as _DeprecatedOptimiser
+from bluemira.utilities.tools import floatify
 
 
 @dataclass
@@ -266,11 +267,11 @@ class ITERGravitySupportBuilder(Builder):
         # Next, make the plates in a linear pattern, in y-z, along x
         z_block_lower = connection_block.bounding_box.z_min
         shape_list.extend(
-            self._make_plates(width, float(v1.x), float(v4.x), z_block_lower)
+            self._make_plates(width, floatify(v1.x), floatify(v4.x), z_block_lower)
         )
 
         # Finally, make the floor block
-        shape_list.append(self._make_floor_block(float(v1.x), float(v4.x)))
+        shape_list.append(self._make_floor_block(floatify(v1.x), floatify(v4.x)))
         shape = boolean_fuse(shape_list)
         component = PhysicalComponent("ITER-like gravity support", shape)
         apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -49,7 +49,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes._freecadconfig import _freecad_save_config
 from bluemira.codes.error import FreeCADError, InvalidCADInputsError
 from bluemira.geometry.constants import EPS_FREECAD, MINIMUM_LENGTH
-from bluemira.utilities.tools import ColourDescriptor
+from bluemira.utilities.tools import ColourDescriptor, floatify
 
 if TYPE_CHECKING:
     from bluemira.display.palettes import ColorPalette
@@ -948,7 +948,7 @@ def wire_value_at(wire: apiWire, distance: float) -> np.ndarray:
             break
         else:
             new_distance = distance - length
-            parameter = edge.getParameterByLength(new_distance)
+            parameter = edge.getParameterByLength(floatify(new_distance))
             point = edge.valueAt(parameter)
             break
 

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -21,7 +21,7 @@ from bluemira.equilibria.coils._tools import get_max_current
 from bluemira.equilibria.constants import COIL_DISCR, NBTI_B_MAX, NBTI_J_MAX
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.plotting import CoilGroupPlotter
-from bluemira.utilities.tools import is_num
+from bluemira.utilities.tools import floatify, is_num
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -324,13 +324,13 @@ class Coil(CoilFieldsMixin):
     @x.setter
     def x(self, value: float):
         """Set coil x position"""
-        self._x = np.maximum(float(value), 0)
+        self._x = np.maximum(floatify(value), 0)
         self._re_discretise()
 
     @z.setter
     def z(self, value: float):
         """Set coil z position"""
-        self._z = float(value)
+        self._z = floatify(value)
         self._re_discretise()
 
     @position.setter
@@ -351,7 +351,7 @@ class Coil(CoilFieldsMixin):
     @dx.setter
     def dx(self, value: float):
         """Set coil dx size"""
-        self._dx = None if value is None else float(value)
+        self._dx = None if value is None else floatify(value)
         if isinstance(self._dx, float) and self._x - self._dx < 0:
             bluemira_debug(
                 "Coil extent crossing x=0, "
@@ -365,13 +365,13 @@ class Coil(CoilFieldsMixin):
     @dz.setter
     def dz(self, value: float):
         """Set coil dz size"""
-        self._dz = None if value is None else float(value)
+        self._dz = None if value is None else floatify(value)
         self._re_discretise()
 
     @current.setter
     def current(self, value: float):
         """Set coil current"""
-        self._current = float(value)
+        self._current = floatify(value)
         if None not in {self.dx, self.dz}:
             self.resize()
 
@@ -385,12 +385,12 @@ class Coil(CoilFieldsMixin):
     @b_max.setter
     def b_max(self, value: float):
         """Set coil max field"""
-        self._b_max = float(value)
+        self._b_max = floatify(value)
 
     @discretisation.setter
     def discretisation(self, value: float):
         """Set coil discretisation"""
-        self._discretisation = np.clip(float(value), COIL_DISCR, None)
+        self._discretisation = np.clip(floatify(value), COIL_DISCR, None)
         self._discretise()
 
     def assign_material(

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -26,6 +26,7 @@ from bluemira.geometry.coordinates import (
     get_area_2d,
     in_polygon,
 )
+from bluemira.utilities.tools import floatify
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -149,7 +150,7 @@ def inv_2x2_matrix(a: float, b: float, c: float, d: float) -> npt.NDArray[np.flo
     """
     Inverse of a 2 x 2 [[a, b], [c, d]] matrix.
     """
-    return np.array([[d, -b], [-c, a]]) / (a * d - b * c)
+    return np.asarray([[d, -b], [-c, a]]) / (a * d - b * c)
 
 
 def find_local_Bp_minima_cg(
@@ -187,7 +188,7 @@ def find_local_Bp_minima_cg(
         b = -f_psi(xi, zi, dy=2)[0][0] / xi
         c = -Bz / xi + f_psi(xi, zi, dx=2) / xi
         d = f_psi(xi, zi, dx=1, dy=1)[0][0] / xi
-        inv_jac = inv_2x2_matrix(float(a), float(b), float(c), float(d))
+        inv_jac = inv_2x2_matrix(floatify(a), floatify(b), floatify(c), floatify(d))
         delta = np.dot(inv_jac, [Bx, Bz])
         xi -= delta[0]
         zi -= delta[1]

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+from bluemira.utilities.tools import floatify
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -292,7 +294,7 @@ class ClosedFluxSurface(FluxSurface):
         d_ab = np.hypot(xb - xa, zb - za)
         d_ac = np.hypot(xc - xa, zc - za)
         d_cd = np.hypot(xd - xc, zd - zc)
-        return float((d_ab - d_ac) / d_cd)
+        return floatify((d_ab - d_ac) / d_cd)
 
     @property
     @lru_cache(1)

--- a/bluemira/gen_params.py
+++ b/bluemira/gen_params.py
@@ -16,6 +16,7 @@ from abc import abstractproperty
 from copy import deepcopy
 from pathlib import Path
 from pkgutil import iter_modules
+from typing import get_type_hints
 
 from setuptools import find_packages
 
@@ -49,7 +50,7 @@ def add_to_dict(pf: ParameterFrame, json_dict: dict, params: dict):
     """
     Add each parameter to the json dict and params dict
     """
-    for param, param_type in pf.__annotations__.items():
+    for param, param_type in get_type_hints(pf).items():
         dv = deepcopy(DEFAULT_PARAM)
         dv["value"] = str(param_type).split("[")[-1][:-1]
         json_dict[param] = dv

--- a/bluemira/utilities/opt_tools.py
+++ b/bluemira/utilities/opt_tools.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 
 from bluemira.base.look_and_feel import bluemira_warn
+from bluemira.utilities.tools import floatify
 from bluemira.utilities.error import InternalOptError
 
 warnings.warn(
@@ -92,7 +93,7 @@ def regularised_lsq_fom(x, A, b, gamma):
         Residual vector (Ax - b)
     """
     residual = np.dot(A, x) - b
-    number_of_targets = float(len(residual))
+    number_of_targets = floatify(len(residual))
     fom = residual.T @ residual / number_of_targets + gamma * gamma * x.T @ x
 
     if fom <= 0:

--- a/bluemira/utilities/opt_tools.py
+++ b/bluemira/utilities/opt_tools.py
@@ -13,7 +13,6 @@ import warnings
 import numpy as np
 
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.utilities.tools import floatify
 from bluemira.utilities.error import InternalOptError
 
 warnings.warn(
@@ -93,7 +92,7 @@ def regularised_lsq_fom(x, A, b, gamma):
         Residual vector (Ax - b)
     """
     residual = np.dot(A, x) - b
-    number_of_targets = floatify(len(residual))
+    number_of_targets = len(residual)
     fom = residual.T @ residual / number_of_targets + gamma * gamma * x.T @ x
 
     if fom <= 0:

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -303,10 +303,23 @@ cross = wrap.cross
 
 def floatify(x: npt.ArrayLike) -> float:
     """
-    Avoid numpy warnings for float(x) for >0 rank scalars
+    Converts the np array or float into a float by returning
+    the first element or the element itself.
+
+    Notes
+    -----
+    This function aims to avoid numpy warnings for float(x) for >0 rank scalars
+    it emulates the functionality of float conversion
+
+    Raises
+    ------
+    ValueError
+        If array like object has more than 1 element
+    TypeError
+        If object is None
     """
     if x is None:
-        raise TypeError("argument must be a string or a real number, not 'NoneType'")
+        raise TypeError("The argument cannot be None")
     return np.asarray(x, dtype=float).item()
 
 

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -301,7 +301,7 @@ cross = wrap.cross
 # =====================================================
 
 
-def floatify(x: npt.ArrayLike):
+def floatify(x: npt.ArrayLike) -> float:
     """
     Avoid numpy warnings for float(x) for >0 rank scalars
     """

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 import nlopt
 import numpy as np
+import numpy.typing as npt
 from matplotlib import colors
 
 from bluemira.base.constants import E_I, E_IJ, E_IJK
@@ -300,6 +301,15 @@ cross = wrap.cross
 # =====================================================
 
 
+def floatify(x: npt.ArrayLike):
+    """
+    Avoid numpy warnings for float(x) for >0 rank scalars
+    """
+    if x is None:
+        raise TypeError("argument must be a string or a real number, not 'NoneType'")
+    return np.asarray(x, dtype=float).item()
+
+
 class ColourDescriptor:
     """Colour Descriptor for use with dataclasses"""
 
@@ -350,7 +360,7 @@ def is_num(thing: Any) -> bool:
     if thing is np.nan:
         return False
     try:
-        float(thing)
+        floatify(thing)
     except (ValueError, TypeError):
         return False
     else:
@@ -840,7 +850,7 @@ def array_or_num(array: Any) -> np.ndarray | float:
         If the value cannot be converted to a numpy or number.
     """
     if is_num(array):
-        return float(array)
+        return floatify(array)
     if isinstance(array, np.ndarray):
         return array
     raise TypeError

--- a/tests/equilibria/test_file.py
+++ b/tests/equilibria/test_file.py
@@ -7,6 +7,7 @@
 import copy
 import json
 from pathlib import Path
+from typing import get_type_hints
 from unittest import mock
 
 import fortranformat as ff
@@ -175,7 +176,7 @@ class TestEQDSKInterface:
         eq = EQDSKInterface.from_file(self.testfiles[0])
 
         mismatched = []
-        for key, value_type in EQDSKInterface.__annotations__.items():
+        for key, value_type in get_type_hints(EQDSKInterface).items():
             value = getattr(eq, key)
             try:
                 check_type(value, value_type)

--- a/tests/utilities/test_optimiser.py
+++ b/tests/utilities/test_optimiser.py
@@ -7,6 +7,7 @@
 import numpy as np
 
 from bluemira.utilities.optimiser import Optimiser
+from bluemira.utilities.tools import floatify
 
 
 def f_rosenbrock(x, grad):
@@ -24,7 +25,7 @@ def f_rosenbrock(x, grad):
         grad[0] = -2 * a + 4 * b * x[0] ** 3 - 4 * b * x[0] * x[1] + 2 * x[0]
         grad[1] = 2 * b * (x[1] - x[0] ** 2)
 
-    return float(value)
+    return floatify(value)
 
 
 def f_simple(x, grad):
@@ -32,7 +33,7 @@ def f_simple(x, grad):
     if grad.size > 0:
         grad[:] = np.ones(5)
 
-    return float(value)
+    return floatify(value)
 
 
 def f_ineq_constraint(constraint, x, grad):


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
numpy 1.25 deprecated float conversion for rank >0 scalars 

```python
float(np.array([5]))  # warning
float(np.array(5)) # ok
```
## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
