### PR TITLE
Add functionality for uneven endcaps polyhedral current source

### DIFF
--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -58,6 +58,7 @@ class PlanarCircuit(SourceGroup):
         self.d_l = np.diff(self.shape, axis=0)
         self.midpoints = self.shape[:-1, :] + 0.5 * self.d_l
         sources = []
+        warning_called = False
         for midpoint, d_l, beta, alpha in zip(
             self.midpoints, self.d_l, betas, alphas, strict=False
         ):
@@ -76,6 +77,10 @@ class PlanarCircuit(SourceGroup):
                     bypass_error=True,
                     angle_warning=False,
                 )
+
+                if source.warning is str and (warning_called is False):
+                    bluemira_warn(source.warning)
+                    warning_called = True
             else:
                 source = source_class(
                     midpoint,

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -74,8 +74,8 @@ class PlanarCircuit(SourceGroup):
                     alpha=alpha,
                     beta=beta,
                     current=current,
-                    bypass_error=True,
-                    angle_warning=False,
+                    bypass_endcap_error=True,
+                    endcap_warning=False,
                 )
 
                 if source.warning is str and (warning_called is False):

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -58,7 +58,7 @@ class PlanarCircuit(SourceGroup):
         self.d_l = np.diff(self.shape, axis=0)
         self.midpoints = self.shape[:-1, :] + 0.5 * self.d_l
         sources = []
-        warning_called = False
+        # warning_called = False
         for midpoint, d_l, beta, alpha in zip(
             self.midpoints, self.d_l, betas, alphas, strict=False
         ):
@@ -78,12 +78,12 @@ class PlanarCircuit(SourceGroup):
                     endcap_warning=False,
                 )
 
-                if warning_called is False:
+                """ if warning_called is False:
                     try:
                         bluemira_warn(source.warning)
                         warning_called = True
                     except AttributeError:
-                        continue
+                        continue """
             else:
                 source = source_class(
                     midpoint,

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -78,9 +78,12 @@ class PlanarCircuit(SourceGroup):
                     endcap_warning=False,
                 )
 
-                if source.warning is str and (warning_called is False):
-                    bluemira_warn(source.warning)
-                    warning_called = True
+                if warning_called is False:
+                    try:
+                        bluemira_warn(source.warning)
+                        warning_called = True
+                    except AttributeError:
+                        continue
             else:
                 source = source_class(
                     midpoint,

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -58,7 +58,7 @@ class PlanarCircuit(SourceGroup):
         self.d_l = np.diff(self.shape, axis=0)
         self.midpoints = self.shape[:-1, :] + 0.5 * self.d_l
         sources = []
-        # warning_called = False
+        warning_called = False
         for midpoint, d_l, beta, alpha in zip(
             self.midpoints, self.d_l, betas, alphas, strict=False
         ):
@@ -78,12 +78,13 @@ class PlanarCircuit(SourceGroup):
                     endcap_warning=False,
                 )
 
-                """ if warning_called is False:
-                    try:
-                        bluemira_warn(source.warning)
-                        warning_called = True
-                    except AttributeError:
-                        continue """
+                if warning_called is False and source._warning is True:
+                    bluemira_warn(
+                        "Unequal end cap angles will result in result not"
+                        " being precise. This inaccuracy will increase as the"
+                        " end cap angle discrepency increases."
+                    )
+                    warning_called = True
             else:
                 source = source_class(
                     midpoint,

--- a/bluemira/magnetostatics/circuits.py
+++ b/bluemira/magnetostatics/circuits.py
@@ -63,17 +63,30 @@ class PlanarCircuit(SourceGroup):
         ):
             d_l_norm = d_l / np.linalg.norm(d_l)
             t_vec = np.cross(d_l_norm, normal)
-
-            source = source_class(
-                midpoint,
-                d_l,
-                normal,
-                t_vec,
-                *xs_args,
-                alpha=alpha,
-                beta=beta,
-                current=current,
-            )
+            if source_class is PolyhedralPrismCurrentSource:
+                source = source_class(
+                    midpoint,
+                    d_l,
+                    normal,
+                    t_vec,
+                    *xs_args,
+                    alpha=alpha,
+                    beta=beta,
+                    current=current,
+                    bypass_error=True,
+                    angle_warning=False,
+                )
+            else:
+                source = source_class(
+                    midpoint,
+                    d_l,
+                    normal,
+                    t_vec,
+                    *xs_args,
+                    alpha=alpha,
+                    beta=beta,
+                    current=current,
+                )
             sources.append(source)
         return sources
 

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -420,13 +420,13 @@ class PolyhedralPrismCurrentSource(
         alpha: float,
         beta: float,
         current: float,
+        *,
         bypass_endcap_error: bool | None = False,
         endcap_warning: bool | None = True,
     ):
         alpha, beta = np.deg2rad(alpha), np.deg2rad(beta)
         self._origin = origin
-        if endcap_warning is False:
-            self._warning = False
+        self._warning = False
         length = np.linalg.norm(ds)
         self._halflength = 0.5 * length
         self._check_angle_values(alpha, beta, bypass_endcap_error, endcap_warning)
@@ -461,14 +461,6 @@ class PolyhedralPrismCurrentSource(
         Check that end-cap angles are acceptable.
         """
         if bypass_endcap_error is True:
-            if (endcap_warning is True) and (not np.isclose(alpha, beta)):
-                bluemira_warn(
-                    "Unequal end cap angles will result in result not being precise."
-                    " This inaccuracy will increase as the end cap angle"
-                    " discrepency increases."
-                )
-            elif (endcap_warning is False) and (not np.isclose(alpha, beta)):
-                self._warning = True
             if not (0 <= abs(alpha) < 0.5 * np.pi):
                 raise MagnetostaticsError(
                     f"{self.__class__.__name__} instantiation error: {alpha=:.3f}"
@@ -479,6 +471,14 @@ class PolyhedralPrismCurrentSource(
                     f"{self.__class__.__name__} instantiation error: {beta=:.3f}"
                     " is outside bounds of [0, 180°)."
                 )
+            if (endcap_warning is True) and (not np.isclose(alpha, beta)):
+                bluemira_warn(
+                    "Unequal end cap angles will result in result not being precise."
+                    " This inaccuracy will increase as the end cap angle"
+                    " discrepency increases."
+                )
+            elif (endcap_warning is False) and (not np.isclose(alpha, beta)):
+                self._warning = True
         else:
             if not np.isclose(alpha, beta):
                 raise MagnetostaticsError(

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -466,6 +466,12 @@ class PolyhedralPrismCurrentSource(
                     "This inaccuracy will increase as the end cap angle"
                     " discrepency increases."
                 )
+            elif (endcap_warning is False) and (not np.isclose(alpha, beta)):
+                self.warning = str(
+                    "Unequal end cap angles will result in result not being"
+                    "precise. This inaccuracy will increase as the end cap angle"
+                    " discrepency increases."
+                )
             if not (0 <= abs(alpha) < 0.5 * np.pi):
                 raise MagnetostaticsError(
                     f"{self.__class__.__name__} instantiation error: {alpha=:.3f}"

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -420,8 +420,8 @@ class PolyhedralPrismCurrentSource(
         alpha: float,
         beta: float,
         current: float,
-        bypass_endcap_error: bool = False,
-        endcap_warning: bool = True,
+        bypass_endcap_error: bool | None = False,
+        endcap_warning: bool | None = True,
     ):
         alpha, beta = np.deg2rad(alpha), np.deg2rad(beta)
         self._origin = origin

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -29,6 +29,7 @@ import numpy as np
 import numpy.typing as npt
 
 from bluemira.base.constants import EPS, MU_0_4PI
+from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.geometry.coordinates import Coordinates, get_area_2d, get_centroid_2d
 from bluemira.magnetostatics.baseclass import (
     PolyhedralCrossSectionCurrentSource,
@@ -419,13 +420,15 @@ class PolyhedralPrismCurrentSource(
         alpha: float,
         beta: float,
         current: float,
+        bypass_endcap_error: bool = False,
+        endcap_warning: bool = True,
     ):
         alpha, beta = np.deg2rad(alpha), np.deg2rad(beta)
         self._origin = origin
 
         length = np.linalg.norm(ds)
         self._halflength = 0.5 * length
-        self._check_angle_values(alpha, beta)
+        self._check_angle_values(alpha, beta, bypass_endcap_error, endcap_warning)
         m_breadth = np.max(np.abs(xs_coordinates.x))
         self._check_raise_self_intersection(length, m_breadth, alpha, beta)
 
@@ -452,20 +455,38 @@ class PolyhedralPrismCurrentSource(
     def _kernel(self, value: PolyhedralKernel):
         self.__kernel = value
 
-    def _check_angle_values(self, alpha: float, beta: float):
+    def _check_angle_values(self, alpha, beta, bypass_endcap_error, endcap_warning):
         """
         Check that end-cap angles are acceptable.
         """
-        if not np.isclose(alpha, beta):
-            raise MagnetostaticsError(
-                f"{self.__class__.__name__} instantiation error: {alpha=:.3f} "
-                f"!= {beta=:.3f}"
-            )
-        if not (0 <= abs(alpha) < 0.5 * np.pi):
-            raise MagnetostaticsError(
-                f"{self.__class__.__name__} instantiation error: {alpha=:.3f} is outside"
-                " bounds of [0, 180°)."
-            )
+        if bypass_endcap_error is True:
+            if (endcap_warning is True) and (not np.isclose(alpha, beta)):
+                bluemira_warn(
+                    "Unequal end cap angles will result in result not being precise."
+                    "This inaccuracy will increase as the end cap angle"
+                    " discrepency increases."
+                )
+            if not (0 <= abs(alpha) < 0.5 * np.pi):
+                raise MagnetostaticsError(
+                    f"{self.__class__.__name__} instantiation error: {alpha=:.3f}"
+                    " is outside bounds of [0, 180°)."
+                )
+            if not (0 <= abs(beta) < 0.5 * np.pi):
+                raise MagnetostaticsError(
+                    f"{self.__class__.__name__} instantiation error: {beta=:.3f}"
+                    " is outside bounds of [0, 180°)."
+                )
+        else:
+            if not np.isclose(alpha, beta):
+                raise MagnetostaticsError(
+                    f"{self.__class__.__name__} instantiation error: {alpha=:.3f} "
+                    f"!= {beta=:.3f}"
+                )
+            if not (0 <= abs(alpha) < 0.5 * np.pi):
+                raise MagnetostaticsError(
+                    f"{self.__class__.__name__} instantiation error: {alpha=:.3f}"
+                    " is outside bounds of [0, 180°)."
+                )
 
     def _set_cross_section(self, xs_coordinates: Coordinates):
         xs_coordinates = deepcopy(xs_coordinates)

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -425,7 +425,8 @@ class PolyhedralPrismCurrentSource(
     ):
         alpha, beta = np.deg2rad(alpha), np.deg2rad(beta)
         self._origin = origin
-
+        if endcap_warning is False:
+            self._warning = False
         length = np.linalg.norm(ds)
         self._halflength = 0.5 * length
         self._check_angle_values(alpha, beta, bypass_endcap_error, endcap_warning)
@@ -463,15 +464,11 @@ class PolyhedralPrismCurrentSource(
             if (endcap_warning is True) and (not np.isclose(alpha, beta)):
                 bluemira_warn(
                     "Unequal end cap angles will result in result not being precise."
-                    "This inaccuracy will increase as the end cap angle"
+                    " This inaccuracy will increase as the end cap angle"
                     " discrepency increases."
                 )
             elif (endcap_warning is False) and (not np.isclose(alpha, beta)):
-                self.warning = str(
-                    "Unequal end cap angles will result in result not being"
-                    "precise. This inaccuracy will increase as the end cap angle"
-                    " discrepency increases."
-                )
+                self._warning = True
             if not (0 <= abs(alpha) < 0.5 * np.pi):
                 raise MagnetostaticsError(
                     f"{self.__class__.__name__} instantiation error: {alpha=:.3f}"

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -441,6 +441,14 @@ class TestPolyhedral2DRing:
         np.testing.assert_allclose(Bz, Bz_coil, rtol=1e-3)
 
 
+class TestPolyhedralSourceGeneration:
+    def test_polyhedralprism_endcapwarning(self, caplog):
+        shape = PrincetonD().create_shape()
+        xs = Coordinates({"x": [-1, 1, 1, -1], "z": [-1, -1, 1, 1]})
+        circuit = ArbitraryPlanarPolyhedralXSCircuit(shape.discretize(30), xs, current=1)
+        assert len(caplog.records) == 1
+
+
 class TestArbitraryPlanarPolyhedralPFCoil:
     coordinates = make_circle(10).discretise(31)
     xs = Coordinates({"x": [-1, 1, 1, -1], "z": [-1, -1, 1, 1]})

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -445,7 +445,7 @@ class TestPolyhedralSourceGeneration:
     def test_polyhedralprism_endcapwarning(self, caplog):
         shape = PrincetonD().create_shape()
         xs = Coordinates({"x": [-1, 1, 1, -1], "z": [-1, -1, 1, 1]})
-        circuit = ArbitraryPlanarPolyhedralXSCircuit(shape.discretize(30), xs, current=1)
+        circuit = ArbitraryPlanarPolyhedralXSCircuit(shape.discretise(30), xs, current=1)
         assert len(caplog.records) == 1
 
 

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -33,6 +33,49 @@ class TestPolyhedralInstantiation:
                 current=1,
             )
 
+    def test_diff_angle_warning(self, caplog):
+        PolyhedralPrismCurrentSource(
+            [10, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            make_xs_from_bd(0.5, 0.5),
+            40,
+            35,
+            current=1,
+            bypass_endcap_error=True,
+        )
+        assert len(caplog.records) == 1
+
+    @pytest.mark.parametrize("angle", [54, 45.0001])
+    def test_angle_bounds(self, angle):
+        with pytest.raises(MagnetostaticsError):
+            PolyhedralPrismCurrentSource(
+                [10, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                make_xs_from_bd(0.5, 0.5),
+                angle,
+                angle,
+                current=1,
+            )
+
+    @pytest.mark.parametrize(("angle1", "angle2"), [(10, 100), (100, 20)])
+    def test_angle_bounds_bypass(self, angle1, angle2):
+        with pytest.raises(MagnetostaticsError):
+            PolyhedralPrismCurrentSource(
+                [10, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                make_xs_from_bd(0.5, 0.5),
+                angle1,
+                angle2,
+                current=1,
+                bypass_endcap_error=True,
+            )
+
 
 class TestPolyhedralMaths:
     same_angle_1 = (


### PR DESCRIPTION
## Description

Adding functionality to allow for ArbitraryPlanarPolyhedralXSCircuit to work when PolyhedralPrismCurrentSource has non equal end cap angles. Ideally a way to do it such that it is obvious when done and has to be intentional. Likely add a warning when used for this effect and to point out that there is reduction in accuracy of result when doing this. For use in STEP bluemira so can have TF coils with non-rectangular cross sections.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
