### PR TITLE
🐛 Fix ordering of PROCESS impurity data outputs

### DIFF
--- a/bluemira/codes/process/api.py
+++ b/bluemira/codes/process/api.py
@@ -162,7 +162,8 @@ class Impurities(Enum):
         """Get contents of impurity data files"""
         files = self.files()
         return tuple(
-            read_impurity_file(files[file]) for file in set(filetype).intersection(files)
+            read_impurity_file(files[file])
+            for file in sorted(set(filetype).intersection(files), key=filetype.index)
         )
 
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Sets are explicitly not ordered 🙄 so sometimes in the radiation work the data would be given to the wrong variables

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
