### PR TITLE
🧱 Missed pinning of c-blosc2

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - fenics-dolfinx=0.7.3
   - freecad=0.21.2
   - h5py
+  - c-blosc2=2.14.3
   - graphviz
   - pip
   - pip:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Our CI was failing because c-blosc2 wasnt pinned in the conda env. The resultant environment crashes hard, it feels like a conda h5py interplay problem.
Until this is merged the CI will fail

We should possibly consider uv or similar for transient dependency management as it might help prevent situations like this

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
