### PR TITLE
Fix to incorrect PolyhedralPrismCurrentSource behaviour when inputted XS is in global not local coordinates

### DIFF
--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -29,7 +29,7 @@ import numpy as np
 import numpy.typing as npt
 
 from bluemira.base.constants import EPS, MU_0_4PI
-from bluemira.geometry.coordinates import Coordinates, get_area_2d
+from bluemira.geometry.coordinates import Coordinates, get_area_2d, get_centroid_3d
 from bluemira.magnetostatics.baseclass import (
     PolyhedralCrossSectionCurrentSource,
     PrismEndCapMixin,
@@ -471,7 +471,11 @@ class PolyhedralPrismCurrentSource(
         xs_coordinates = deepcopy(xs_coordinates)
         xs_coordinates.close()
         self._area = get_area_2d(*xs_coordinates.xz)
+        origin = [0.0, 0.0, 0.0]
         self._xs = xs_coordinates
+        if not np.allclose(origin, get_centroid_3d(*xs_coordinates.xyz)):
+            dx, dy, dz = get_centroid_3d(*xs_coordinates.xyz)
+            self._xs.translate((-dx, -dy, -dz))
         self._xs.set_ccw([0, 1, 0])
 
     @process_xyz_array

--- a/bluemira/magnetostatics/polyhedral_prism.py
+++ b/bluemira/magnetostatics/polyhedral_prism.py
@@ -29,7 +29,7 @@ import numpy as np
 import numpy.typing as npt
 
 from bluemira.base.constants import EPS, MU_0_4PI
-from bluemira.geometry.coordinates import Coordinates, get_area_2d, get_centroid_3d
+from bluemira.geometry.coordinates import Coordinates, get_area_2d, get_centroid_2d
 from bluemira.magnetostatics.baseclass import (
     PolyhedralCrossSectionCurrentSource,
     PrismEndCapMixin,
@@ -473,8 +473,10 @@ class PolyhedralPrismCurrentSource(
         self._area = get_area_2d(*xs_coordinates.xz)
         origin = [0.0, 0.0, 0.0]
         self._xs = xs_coordinates
-        if not np.allclose(origin, get_centroid_3d(*xs_coordinates.xyz)):
-            dx, dy, dz = get_centroid_3d(*xs_coordinates.xyz)
+        cx, cz = get_centroid_2d(self._xs[0, :], self._xs[2, :])
+        centroid = [cx, 0, cz]
+        if not np.allclose(origin, centroid):
+            dx, dy, dz = centroid
             self._xs.translate((-dx, -dy, -dz))
         self._xs.set_ccw([0, 1, 0])
 

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -289,9 +289,11 @@ class TestCombinedShapes:
             current,
         )
         coords = Coordinates({"x": [-1, -1, 1], "z": [1, -1, -1]})
+        offset_yz = 1 / 3
+        offset_x = offset_yz * np.tan(10 * np.pi / 180)
         cls.triangle1 = PolyhedralPrismCurrentSource(
-            [0, -1 / 3, -1 / 3],
-            [10, 0, 0],
+            [0, -offset_yz, -offset_yz],
+            [10 - 2 * offset_x, 0, 0],
             [0, 1, 0],
             [0, 0, 1],
             coords,
@@ -301,8 +303,8 @@ class TestCombinedShapes:
         )
         coords = Coordinates({"x": [-1, 1, 1], "z": [1, -1, 1]})
         cls.triangle2 = PolyhedralPrismCurrentSource(
-            [0, 1 / 3, 1 / 3],
-            [10, 0, 0],
+            [0, offset_yz, offset_yz],
+            [10 + 2 * offset_x, 0, 0],
             [0, 1, 0],
             [0, 0, 1],
             coords,

--- a/tests/magnetostatics/test_polyhedral_prism.py
+++ b/tests/magnetostatics/test_polyhedral_prism.py
@@ -290,7 +290,7 @@ class TestCombinedShapes:
         )
         coords = Coordinates({"x": [-1, -1, 1], "z": [1, -1, -1]})
         cls.triangle1 = PolyhedralPrismCurrentSource(
-            [0, 0, 0],
+            [0, -1 / 3, -1 / 3],
             [10, 0, 0],
             [0, 1, 0],
             [0, 0, 1],
@@ -301,7 +301,7 @@ class TestCombinedShapes:
         )
         coords = Coordinates({"x": [-1, 1, 1], "z": [1, -1, 1]})
         cls.triangle2 = PolyhedralPrismCurrentSource(
-            [0, 0, 0],
+            [0, 1 / 3, 1 / 3],
             [10, 0, 0],
             [0, 1, 0],
             [0, 0, 1],
@@ -343,3 +343,37 @@ class TestCombinedShapes:
         cm = ax.contourf(args_diff[i], args_diff[j], args_diff[k], zdir=plane, offset=0)
         f.colorbar(cm)
         np.testing.assert_allclose(B_new, B)
+
+
+class TestXSCoordinateInputting:
+    @classmethod
+    def setup_class(cls):
+        current = 1e6
+        xs = Coordinates({"x": [-1, -1, 1, 1], "z": [1, -1, -1, 1]})
+        xs2 = Coordinates({"x": [1, 1, 3, 3], "z": [3, 1, 1, 3]})
+        cls.source1 = PolyhedralPrismCurrentSource(
+            [0, 2, 2],
+            [10, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            xs,
+            10,
+            10,
+            current,
+        )
+        cls.source2 = PolyhedralPrismCurrentSource(
+            [0, 2, 2],
+            [10, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            xs2,
+            10,
+            10,
+            current,
+        )
+
+    def test_coords(self):
+        for face_source1, face_source2 in zip(
+            self.source1._points, self.source2._points, strict=False
+        ):
+            np.testing.assert_allclose(face_source1, face_source2)


### PR DESCRIPTION
## Linked Issues

Closes #3187 

## Description

When XS coords were given that were not local ie centered around (0, 0, 0) the _calculate_points function tried to transform it to global resulting in incorrect geometry.

## Fix

Made a change to behaviour such that XS centroid is calculated and if it doesn't match up with origin the XS is translated so it is. This means that the length of the shape is now measured from centroid rather than the midpoint. Additionally means it isn't possible to create a prism or circuit that is displaced from the origin, so if that is desired the origin has to be displaced instead.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
