### PR TITLE
SH changes

### DIFF
--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -19,7 +19,7 @@ from scipy.special import lpmv
 
 from bluemira.base.constants import MU_0, RNGSeeds
 from bluemira.base.error import BluemiraError
-from bluemira.base.look_and_feel import bluemira_debug, bluemira_print
+from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
 from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.error import EquilibriaError
@@ -490,7 +490,7 @@ def spherical_harmonic_approximation(
     eq: Equilibrium,
     n_points: int = 8,
     point_type: PointType = PointType.ARC_PLUS_EXTREMA,
-    grid_num: str | None = None,
+    grid_num: tuple[int, int] | None = None,
     acceptable_fit_metric: float = 0.01,
     nlevels: int = 50,
     seed: int | None = None,
@@ -568,6 +568,9 @@ def spherical_harmonic_approximation(
     # Starting LCFS
     original_LCFS = eq.get_LCFS()
 
+    if eq.grid is None or eq.plasma is None:
+        raise BluemiraError("eq not setup for SH approximation.")
+
     # Grid keep the same as input equilibrium
     grid = eq.grid
 
@@ -604,10 +607,11 @@ def spherical_harmonic_approximation(
 
     # Set min to save some time
     min_degree = 2
+    # Can't have more degrees then sampled psi
     max_degree = len(collocation.x) - 1
 
     sh_eq = deepcopy(eq)
-    for degree in np.arange(min_degree, max_degree):
+    for degree in range(min_degree, max_degree + 1):
         # Construct matrix from harmonic amplitudes for coils
         currents2harmonics = coil_harmonic_amplitude_matrix(
             eq.coilset, degree, r_t, sh_coil_names
@@ -646,15 +650,14 @@ def spherical_harmonic_approximation(
         # Compare staring equilibrium to new approximate equilibrium
         fit_metric_value = lcfs_fit_metric(original_LCFS, approx_LCFS)
 
+        bluemira_print(
+            f"Fit metric value = {fit_metric_value} using" f" {degree} degrees."
+        )
         if fit_metric_value <= acceptable_fit_metric:
-            bluemira_print(
-                f"The fit metric value acheived is {fit_metric_value} using"
-                f" {degree} degrees."
-            )
             break
         if degree == max_degree:
-            raise BluemiraError(
-                "Uh oh, you may need to use more degrees for a fit metric of"
+            bluemira_warn(
+                "You may need to use more degrees for a fit metric of"
                 f" {acceptable_fit_metric}! Use a greater number of collocation points"
                 " please."
             )

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_constraint_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_constraint_functions.py
@@ -11,7 +11,6 @@ Harmonics constraint classes
 import numpy as np
 import numpy.typing as npt
 
-from bluemira.base.look_and_feel import bluemira_print
 from bluemira.equilibria.optimisation.constraints import ConstraintFunction
 
 
@@ -32,30 +31,25 @@ class SphericalHarmonicConstraintFunction(ConstraintFunction):
         Current scale with which to calculate the constraints
     """
 
-    def __init__(self, a_mat: np.ndarray, b_vec: np.ndarray, value: float, scale: float):
+    def __init__(
+        self,
+        a_mat: np.ndarray,
+        b_vec: np.ndarray,
+        value: float,
+        scale: float,
+    ) -> None:
         self.a_mat = a_mat
         self.b_vec = b_vec
         self.value = value
         self.scale = scale
-        self.debug = False
 
-    def f_constraint(self, vector: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    def f_constraint(self, vector: npt.NDArray) -> npt.NDArray:
         """Constraint function"""
         currents = self.scale * vector
-        result = self.a_mat[1:,] @ currents
-        residual = result - self.b_vec - self.value
-        if self.debug:
-            bluemira_print(
-                f"""
-            refs: {self.b_vec}
-            currents: {currents}
-            currents_sum: {np.sum(currents)}
-            result {result}
-            residual: {residual}
-            """
-            )
-        return residual
 
-    def df_constraint(self, vector: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:  # noqa: ARG002
+        result = self.a_mat[1:,] @ currents
+        return result - self.b_vec - self.value
+
+    def df_constraint(self, _vector: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
         """Constraint derivative"""
         return self.scale * self.a_mat[1:,]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

Small changes to the SH constraint.

It adds the abiliaty to create an inverse version of the constraint, useful for turning it into two inequality constraints (instead of 1 equality).

Equality constraints are notriasly unstable/unusable in the NLOP optimisers.

They are also limited in number to the size of the state vector, which simpled that we were limited in the qaulity of our approximation.

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
