### PR TITLE
`PulsedCoilsetDesign` Passing in max_currents has no effect

### DIFF
--- a/bluemira/equilibria/run.py
+++ b/bluemira/equilibria/run.py
@@ -308,7 +308,7 @@ class PulsedCoilsetDesign(ABC):
                 opt_conditions=self.bd_settings.opt_conditions,
                 constraints=constraints,
             )
-            result = problem.optimise(x0=max_currents, fixed_coils=False)
+            result = problem.optimise(fixed_coils=False)
             breakdown.set_breakdown_point(*strategy.breakdown_point)
             psi_premag = breakdown.breakdown_psi
 


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

Creating this PR to highlight the fact that passing in max_currents has no effect as the `BreakdownCOP` ignores x0.

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
