### PR TITLE
🩹 Improve PROCESS not installed catching

### DIFF
--- a/bluemira/codes/process/_solver.py
+++ b/bluemira/codes/process/_solver.py
@@ -23,7 +23,7 @@ from bluemira.codes.process._inputs import ProcessInputs
 from bluemira.codes.process._run import Run
 from bluemira.codes.process._setup import Setup, create_template_from_path
 from bluemira.codes.process._teardown import Teardown
-from bluemira.codes.process.api import Impurities
+from bluemira.codes.process.api import ENABLED, Impurities
 from bluemira.codes.process.constants import BINARY as PROCESS_BINARY
 from bluemira.codes.process.constants import NAME as PROCESS_NAME
 from bluemira.codes.process.params import ProcessSolverParams
@@ -162,6 +162,12 @@ class Solver(CodesSolver):
         """
         if isinstance(run_mode, str):
             run_mode = self.run_mode_cls.from_string(run_mode)
+        if not ENABLED and run_mode not in {
+            self.run_mode_cls.MOCK,
+            self.run_mode_cls.NONE,
+        }:
+            raise CodesError(f"{self.name} installation not found")
+
         self._setup = self.setup_cls(
             self.params,
             self.in_dat_path,


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Currently you get a pretty opaque error if you run without PROCESS installed. There is a warning above the error but that is sometimes missed.

This PR errors on execute if you are in a run mode that requires process installed.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
