### PR TITLE
Clip the grid in the z-direction for SH LCFS fit metric

### DIFF
--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -684,6 +684,8 @@ def spherical_harmonic_approximation(
             eq=eq,
             vac_psi_app=coilset_approx_psi,
             nlevels=nlevels,
+            original_LCFS=original_LCFS,
+            approx_LCFS=approx_LCFS,
         )
 
     return (
@@ -703,6 +705,8 @@ def plot_psi_comparision(
     vac_psi_app: np.ndarray,
     axes: list[plt.Axes] | None = None,
     nlevels: int = 50,
+    original_LCFS: Coordinates | None = None,
+    approx_LCFS: Coordinates | None = None,
     *,
     show: bool = True,
 ) -> tuple[plt.Axes, ...]:
@@ -735,7 +739,8 @@ def plot_psi_comparision(
     tot_psi_app = eq.plasma.psi(grid.x, grid.z) + vac_psi_app
 
     cmap = PLOT_DEFAULTS["psi"]["cmap"]
-    clevels = np.linspace(np.amin(tot_psi_org), np.amax(tot_psi_org), nlevels)
+    clevels_org = np.linspace(np.amin(tot_psi_org), np.amax(tot_psi_org), nlevels)
+    clevels_app = np.linspace(np.amin(tot_psi_org), np.amax(tot_psi_app), nlevels)
     n_ax = 4
 
     if axes is not None:
@@ -753,13 +758,22 @@ def plot_psi_comparision(
         )
 
     plot1.set_title("Original, Total Psi")
-    plot1.contour(grid.x, grid.z, tot_psi_org, levels=clevels, cmap=cmap, zorder=8)
+    plot1.contour(grid.x, grid.z, tot_psi_org, levels=clevels_org, cmap=cmap, zorder=8)
     plot2.set_title("SH Approximation, Total Psi")
-    plot2.contour(grid.x, grid.z, tot_psi_app, levels=clevels, cmap=cmap, zorder=8)
+    plot2.contour(grid.x, grid.z, tot_psi_app, levels=clevels_app, cmap=cmap, zorder=8)
     plot3.set_title("Original, Vacuum Psi")
-    plot3.contour(grid.x, grid.z, vac_psi_org, levels=clevels, cmap=cmap, zorder=8)
+    plot3.contour(grid.x, grid.z, vac_psi_org, levels=clevels_org, cmap=cmap, zorder=8)
     plot4.set_title("SH Approximation, Vacuum Psi")
-    plot4.contour(grid.x, grid.z, vac_psi_app, levels=clevels, cmap=cmap, zorder=8)
+    plot4.contour(grid.x, grid.z, vac_psi_app, levels=clevels_app, cmap=cmap, zorder=8)
+
+    if original_LCFS is not None:
+        plot1.plot(original_LCFS.x, original_LCFS.z, color="r")
+        plot2.plot(original_LCFS.x, original_LCFS.z, color="r")
+        plot3.plot(original_LCFS.x, original_LCFS.z, color="r")
+        plot4.plot(original_LCFS.x, original_LCFS.z, color="r")
+    if approx_LCFS is not None:
+        plot2.plot(approx_LCFS.x, approx_LCFS.z, color="b", linestyle="--")
+        plot4.plot(approx_LCFS.x, approx_LCFS.z, color="b", linestyle="--")
 
     if show:
         plt.show()

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -617,7 +617,9 @@ def spherical_harmonic_approximation(
     # for a flux surface that wraps around the divertor coils and thereby affects
     # the result of the LCFS finding function used in the fit metric calculaton.
     clipped_eq = deepcopy(sh_eq)
-    clip = (grid.z[0, :] > np.min(sh_eq.coilset.z)) & (grid.z[0, :] < np.max(sh_eq.coilset.z))
+    clip = (grid.z[0, :] > np.min(sh_eq.coilset.z)) & (
+        grid.z[0, :] < np.max(sh_eq.coilset.z)
+    )
     clipped_eq.grid.x, clipped_eq.grid.z = grid.x[:, clip], grid.z[:, clip]
     clipped_eq.x, clipped_eq.z = grid.x[:, clip], grid.z[:, clip]
 

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -50,6 +50,7 @@ An example that shows how the Spherical Harmonic Approximation works
 # ### Imports
 
 # %%
+from copy import deepcopy
 from pathlib import Path
 
 import matplotlib.patches as patch
@@ -400,7 +401,6 @@ min_degree = 2
 acceptable = 0.05
 
 # Clip the grid in the z-direction to remove area below upper/lower-most coil
-from copy import deepcopy
 clipped_eq = deepcopy(eq)
 clip = (eq.grid.z[0, :] > np.min(eq.coilset.z)) & (
     eq.grid.z[0, :] < np.max(eq.coilset.z)

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -202,12 +202,12 @@ plt.show()
 
 # %%
 # Number of desired collocation points excluding extrema (always 4 or +4 automatically)
-n = 20
+n = 10
 
 # Create the set of collocation points for the harmonics
 collocation = collocation_points(
     original_LCFS,
-    PointType.ARC_PLUS_EXTREMA,
+    PointType.GRID_POINTS,
     n,
     seed=15,
 )
@@ -399,6 +399,15 @@ min_degree = 2
 # 0 = good, 1 = bad
 acceptable = 0.05
 
+# Clip the grid in the z-direction to remove area below upper/lower-most coil
+from copy import deepcopy
+clipped_eq = deepcopy(eq)
+clip = (eq.grid.z[0, :] > np.min(eq.coilset.z)) & (
+    eq.grid.z[0, :] < np.max(eq.coilset.z)
+)
+clipped_eq.grid.x, clipped_eq.grid.z = eq.grid.x[:, clip], eq.grid.z[:, clip]
+clipped_eq.x, clipped_eq.z = eq.grid.x[:, clip], eq.grid.z[:, clip]
+
 for degree in np.arange(min_degree, max_degree):  # + 1):
     # Construct matrix from harmonic amplitudes for coils
     currents2harmonics = coil_harmonic_amplitude_matrix(
@@ -436,14 +445,19 @@ for degree in np.arange(min_degree, max_degree):  # + 1):
     approx_total_psi = coilset_approx_psi + plasma_psi
     eq.get_OX_points(approx_total_psi, force_update=True)
 
+    # Clip the grid in the z direction to remove area below upper/lower-most coil
+    clip_psi = approx_total_psi[:, clip]
+    clipped_eq.get_OX_points(clip_psi, force_update=True)
+
     # Get LCFS for approximation
-    approx_LCFS = eq.get_LCFS(psi=approx_total_psi)
+    approx_LCFS = clipped_eq.get_LCFS(psi=clip_psi)
 
     # Compare staring equilibrium to new approximate equilibrium
     fit_metric_value = lcfs_fit_metric(original_LCFS, approx_LCFS)
 
+    print("fit metric = ", fit_metric_value, "degree required = ", degree)
+
     if fit_metric_value <= acceptable:
-        print("fit metric = ", fit_metric_value, "degree required = ", degree)
         break
     elif degree == max_degree:
         print(

--- a/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
@@ -109,7 +109,7 @@ plt.show()
 # ### Always output
 #
 # - "sh_coil_names", names of the coils that can be used with SH approximation
-# - "coil_current_harmonic_amplitudes", SH coefficients/amplitudes for required number of degrees
+# - "coil_current_harmonic_amplitudes", SH amplitudes for required number of degrees
 # - "max_degree", number of degrees required for a SH approx with the desired fit metric
 # - "fit_metric_value", fit metric achieved
 # - "approx_total_psi", the total psi obtained using the SH approximation

--- a/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
@@ -93,9 +93,9 @@ plt.show()
     sh_coilset_current,
 ) = spherical_harmonic_approximation(
     eq,
-    n_points=20,
-    point_type=PointType.ARC_PLUS_EXTREMA,
-    acceptable_fit_metric=0.05,
+    n_points=10,
+    point_type=PointType.GRID_POINTS,
+    acceptable_fit_metric=0.01,
     seed=15,
     plot=True,
 )
@@ -103,36 +103,28 @@ plt.show()
 # %% [markdown]
 # ## Outputs
 #
-# spherical_harmonic_approximation outputs a dictionary of results
+# spherical_harmonic_approximation outputs results
 # that can be used in optimisation.
 #
 # ### Always output
 #
-# - "coilset", coilset to use with SH approximation
-# - "r_t", typical length scale for spherical harmonic approximation
-# - "harmonic_amplitudes", SH coefficients/amplitudes for required number of degrees
+# - "sh_coil_names", names of the coils that can be used with SH approximation
+# - "coil_current_harmonic_amplitudes", SH coefficients/amplitudes for required number of degrees
 # - "max_degree", number of degrees required for a SH approx with the desired fit metric
+# - "fit_metric_value", fit metric achieved
+# - "approx_total_psi", the total psi obtained using the SH approximation
+# - "r_t", typical length scale for spherical harmonic approximation
+# - "sh_coilset_current", the coil currents obtained using the approximation
 
 # %%
 print(sh_coil_names)
-
-# %%
-print(r_t)
+print(sh_coilset_current)
 
 # %%
 print(coil_current_harmonic_amplitudes)
-
-# %%
 print(degree)
-
-# %% [markdown]
-# ### Output on request
-#
-# - "fit_metric_value", fit metric achieved
-# - "approx_total_psi", the total psi obtained using the SH approximation
-
-# %%
 print(fit_metric_value)
+print(r_t)
 
 # %%
 psi = approx_total_psi

--- a/tests/equilibria/test_harmonics.py
+++ b/tests/equilibria/test_harmonics.py
@@ -218,52 +218,45 @@ def test_spherical_harmonic_approximation():
         test_sh_coilset_current,
     ) = spherical_harmonic_approximation(
         eq,
-        n_points=20,
-        point_type=PointType.ARC_PLUS_EXTREMA,
-        acceptable_fit_metric=0.05,
+        n_points=10,
+        point_type=PointType.GRID_POINTS,
+        acceptable_fit_metric=0.01,
     )
 
     sh_coilset_current = np.array([
-        7.62910582e03,
-        1.43520553e05,
-        -1.39959367e05,
-        1.38307695e05,
-        -3.03734221e05,
-        -7.65433152e04,
-        -6.29515063e05,
-        -1.95322559e05,
-        2.07073399e06,
-        1.20763164e04,
-        -7.36786063e06,
-        8.49088150e06,
-        3.62769044e06,
-        -2.38451828e06,
-        2.04882463e06,
-        -2.60376386e05,
-        -7.47634692e04,
-        -3.23836517e06,
-    ])
+        7629.10582467,
+        70698.33769641,
+        67490.69283484,
+        31121.21496069,
+        74960.89700748,
+        -15405.55822637,
+        -107155.40127941,
+        -119761.54614875,
+        -22836.61530337,
+        12076.3164052,
+        74352.13320461,
+        71459.62798936,
+        33758.08895758,
+        81867.51397822,
+        -26684.21663108,
+        -107953.36722597,
+        -127015.41959899,
+        -21793.83849537,
+        ])
 
     harmonic_amps = np.array([
-        0.1165182,
-        -0.00254487,
-        -0.03455892,
-        -0.00585685,
-        -0.00397113,
-        -0.01681114,
-        0.01649549,
-        -0.02803212,
-        0.03035956,
-        -0.03828872,
-        0.04051739,
-        -0.04283815,
+        0.11582153,
+        -0.00059338,
+        -0.03868344,
+        0.0014262,
+        -0.01530302,
     ])
 
-    assert test_sh_coilset_current == pytest.approx(sh_coilset_current)
-    assert test_r_t == pytest.approx(1.3661669578370919)
-    assert test_harmonic_amps == pytest.approx(harmonic_amps)
-    assert test_degree == 13
-    assert test_fit_metric == pytest.approx(0.031, abs=0.0006)
+    assert test_sh_coilset_current == pytest.approx(sh_coilset_current, abs=0.0005)
+    assert test_r_t == pytest.approx(1.3661, abs=0.0001)
+    assert test_harmonic_amps == pytest.approx(harmonic_amps, abs=0.0005)
+    assert test_degree == 6
+    assert test_fit_metric == pytest.approx(0.0025, abs=0.0001)
 
 
 def test_SphericalHarmonicConstraintFunction():

--- a/tests/equilibria/test_harmonics.py
+++ b/tests/equilibria/test_harmonics.py
@@ -242,7 +242,7 @@ def test_spherical_harmonic_approximation():
         -107953.36722597,
         -127015.41959899,
         -21793.83849537,
-        ])
+    ])
 
     harmonic_amps = np.array([
         0.11582153,


### PR DESCRIPTION
## Description

Clip the equilibrium grid, so that the lower/upper-most coils are at the grid edges when inside the spherical harmonic approximation finding function. Prevents the use of an excessive number of required degrees in an approximation for cases where the LCFS appears to wrap around the divertor coils. 

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
