### PR TITLE
✅ Fix process race condition in test

### DIFF
--- a/tests/codes/process/utilities.py
+++ b/tests/codes/process/utilities.py
@@ -42,7 +42,7 @@ class FakeMFile:
     PROCESS installed.
     """
 
-    data = mfile_data()
+    data = deepcopy(mfile_data())
 
     def __init__(self, filename, name="PROCESS"):
         self.filename = filename


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Fixes a race condition in our tests that appears when running in parallel with xdist

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
