### PR TITLE
🎨 Improve plotting styles for equilibria

### DIFF
--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -21,7 +21,7 @@ from typing import (
 import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d as a3
 import numpy as np
-from matplotlib.patches import PathPatch
+from matplotlib.patches import PathPatch, Polygon
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.display.error import DisplayError
@@ -490,7 +490,17 @@ class FacePlotter(BasePlotter):
 
     def _make_plot_2d(self):
         if self.options.show_faces:
-            self.ax.fill(*self._data_to_plot, **self.options.face_options)
+            face_opts = self.options.face_options
+            if "hatch" in face_opts and face_opts["hatch"] is not None:
+                self.ax.add_patch(
+                    Polygon(
+                        np.asarray(self._data_to_plot).T,
+                        fill=False,
+                        **face_opts,
+                    )
+                )
+            else:
+                self.ax.fill(*self._data_to_plot, **face_opts)
 
         for w in self._wplotters:
             w.ax = self.ax

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -509,7 +509,7 @@ class FacePlotter(BasePlotter):
     def _make_plot_2d(self):
         if self.options.show_faces:
             face_opts = self.options.face_options
-            if "hatch" in face_opts and face_opts["hatch"] is not None:
+            if face_opts.get("hatch", None) is not None:
                 self.ax.add_patch(
                     Polygon(
                         np.asarray(self._data_to_plot).T,

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -195,10 +195,10 @@ class DefaultPlotOptions:
         }
     )
     wire_options: DictOptionsDescriptor = DictOptionsDescriptor(
-        lambda: {"color": "black", "linewidth": 0.5, "zorder": Zorder.WIRE}
+        lambda: {"color": "black", "linewidth": 0.5, "zorder": Zorder.WIRE.value}
     )
     face_options: DictOptionsDescriptor = DictOptionsDescriptor(
-        lambda: {"color": "blue", "zorder": Zorder.FACE}
+        lambda: {"color": "blue", "zorder": Zorder.FACE.value}
     )
     # discretisation properties for plotting wires (and faces)
     ndiscr: int = 100

--- a/bluemira/display/plotter.py
+++ b/bluemira/display/plotter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,6 +47,23 @@ UNIT_LABEL = "[m]"
 X_LABEL = f"x {UNIT_LABEL}"
 Y_LABEL = f"y {UNIT_LABEL}"
 Z_LABEL = f"z {UNIT_LABEL}"
+
+
+class Zorder(Enum):
+    """Layer ordering of common plots"""
+
+    POSITION_1D = 1
+    POSITION_2D = 2
+    PLASMACURRENT = 7
+    PSI = 8
+    FLUXSURFACE = 9
+    SEPARATRIX = 10
+    OXPOINT = 11
+    FACE = 20
+    WIRE = 30
+    RADIATION = 40
+    CONSTRAINT = 45
+    TEXT = 100
 
 
 class ViewDescriptor:
@@ -177,10 +195,10 @@ class DefaultPlotOptions:
         }
     )
     wire_options: DictOptionsDescriptor = DictOptionsDescriptor(
-        lambda: {"color": "black", "linewidth": 0.5, "zorder": 20}
+        lambda: {"color": "black", "linewidth": 0.5, "zorder": Zorder.WIRE}
     )
     face_options: DictOptionsDescriptor = DictOptionsDescriptor(
-        lambda: {"color": "blue", "zorder": 10}
+        lambda: {"color": "blue", "zorder": Zorder.FACE}
     )
     # discretisation properties for plotting wires (and faces)
     ndiscr: int = 100

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -564,8 +564,8 @@ class FieldNullConstraint(AbsoluteMagneticConstraint):
             self.z,
             marker="x",
             color="b",
-            markersize=10,
-            markeredgewidth=3,
+            markersize=6,
+            markeredgewidth=2,
             zorder=Zorder.CONSTRAINT.value,
             linestyle="None",
         )

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from bluemira.display.plotter import Zorder
 from bluemira.equilibria.optimisation.constraint_funcs import (
     AxBConstraint,
     ConstraintFunction,
@@ -565,7 +566,7 @@ class FieldNullConstraint(AbsoluteMagneticConstraint):
             color="b",
             markersize=10,
             markeredgewidth=3,
-            zorder=45,
+            zorder=Zorder.CONSTRAINT,
             linestyle="None",
         )
 
@@ -622,6 +623,7 @@ class PsiConstraint(AbsoluteMagneticConstraint):
             markersize=8,
             color="b",
             linestyle="None",
+            zorder=Zorder.CONSTRAINT,
         )
 
 
@@ -682,7 +684,7 @@ class IsofluxConstraint(RelativeMagneticConstraint):
             "markersize": 5,
             "linestyle": "None",
             "markerfacecolor": "None",
-            "zorder": 45,
+            "zorder": Zorder.CONSTRAINT,
         }
         ax.plot(self.x, self.z, **kwargs)
         kwargs["markerfacecolor"] = "m"
@@ -736,6 +738,7 @@ class PsiBoundaryConstraint(AbsoluteMagneticConstraint):
             markersize=8,
             color="b",
             linestyle="None",
+            zorder=Zorder.CONSTRAINT,
         )
 
 

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -566,7 +566,7 @@ class FieldNullConstraint(AbsoluteMagneticConstraint):
             color="b",
             markersize=10,
             markeredgewidth=3,
-            zorder=Zorder.CONSTRAINT,
+            zorder=Zorder.CONSTRAINT.value,
             linestyle="None",
         )
 
@@ -623,7 +623,7 @@ class PsiConstraint(AbsoluteMagneticConstraint):
             markersize=8,
             color="b",
             linestyle="None",
-            zorder=Zorder.CONSTRAINT,
+            zorder=Zorder.CONSTRAINT.value,
         )
 
 
@@ -684,7 +684,7 @@ class IsofluxConstraint(RelativeMagneticConstraint):
             "markersize": 5,
             "linestyle": "None",
             "markerfacecolor": "None",
-            "zorder": Zorder.CONSTRAINT,
+            "zorder": Zorder.CONSTRAINT.value,
         }
         ax.plot(self.x, self.z, **kwargs)
         kwargs["markerfacecolor"] = "m"
@@ -738,7 +738,7 @@ class PsiBoundaryConstraint(AbsoluteMagneticConstraint):
             markersize=8,
             color="b",
             linestyle="None",
-            zorder=Zorder.CONSTRAINT,
+            zorder=Zorder.CONSTRAINT.value,
         )
 
 

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -558,14 +558,16 @@ class FieldNullConstraint(AbsoluteMagneticConstraint):
         """
         Plot the constraint onto an Axes.
         """
-        kwargs = {
-            "marker": "X",
-            "color": "b",
-            "markersize": 10,
-            "zorder": 45,
-            "linestyle": "None",
-        }
-        ax.plot(self.x, self.z, **kwargs)
+        ax.plot(
+            self.x,
+            self.z,
+            marker="x",
+            color="b",
+            markersize=10,
+            markeredgewidth=3,
+            zorder=45,
+            linestyle="None",
+        )
 
     def __len__(self) -> int:
         """
@@ -613,8 +615,14 @@ class PsiConstraint(AbsoluteMagneticConstraint):
         """
         Plot the constraint onto an Axes.
         """
-        kwargs = {"marker": "s", "markersize": 8, "color": "b", "linestyle": "None"}
-        ax.plot(self.x, self.z, **kwargs)
+        ax.plot(
+            self.x,
+            self.z,
+            marker="s",
+            markersize=8,
+            color="b",
+            linestyle="None",
+        )
 
 
 class IsofluxConstraint(RelativeMagneticConstraint):
@@ -670,15 +678,14 @@ class IsofluxConstraint(RelativeMagneticConstraint):
         """
         kwargs = {
             "marker": "o",
-            "markeredgewidth": 3,
             "markeredgecolor": "b",
-            "markersize": 10,
+            "markersize": 5,
             "linestyle": "None",
             "markerfacecolor": "None",
             "zorder": 45,
         }
         ax.plot(self.x, self.z, **kwargs)
-        kwargs["markeredgewidth"] = 5
+        kwargs["markerfacecolor"] = "m"
         ax.plot(self.ref_x, self.ref_z, **kwargs)
 
 
@@ -722,8 +729,14 @@ class PsiBoundaryConstraint(AbsoluteMagneticConstraint):
         """
         Plot the constraint onto an Axes.
         """
-        kwargs = {"marker": "o", "markersize": 8, "color": "b", "linestyle": "None"}
-        ax.plot(self.x, self.z, **kwargs)
+        ax.plot(
+            self.x,
+            self.z,
+            marker="o",
+            markersize=8,
+            color="b",
+            linestyle="None",
+        )
 
 
 class MagneticConstraintSet:

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -20,6 +20,7 @@ from scipy.special import lpmv
 from bluemira.base.constants import MU_0, RNGSeeds
 from bluemira.base.error import BluemiraError
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_print, bluemira_warn
+from bluemira.display.plotter import Zorder
 from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.error import EquilibriaError
@@ -743,13 +744,21 @@ def plot_psi_comparision(
         )
 
     plot1.set_title("Original, Total Psi")
-    plot1.contour(grid.x, grid.z, tot_psi_org, levels=clevels_org, cmap=cmap, zorder=8)
+    plot1.contour(
+        grid.x, grid.z, tot_psi_org, levels=clevels_org, cmap=cmap, zorder=Zorder.PSI
+    )
     plot2.set_title("SH Approximation, Total Psi")
-    plot2.contour(grid.x, grid.z, tot_psi_app, levels=clevels_app, cmap=cmap, zorder=8)
+    plot2.contour(
+        grid.x, grid.z, tot_psi_app, levels=clevels_app, cmap=cmap, zorder=Zorder.PSI
+    )
     plot3.set_title("Original, Vacuum Psi")
-    plot3.contour(grid.x, grid.z, vac_psi_org, levels=clevels_org, cmap=cmap, zorder=8)
+    plot3.contour(
+        grid.x, grid.z, vac_psi_org, levels=clevels_org, cmap=cmap, zorder=Zorder.PSI
+    )
     plot4.set_title("SH Approximation, Vacuum Psi")
-    plot4.contour(grid.x, grid.z, vac_psi_app, levels=clevels_app, cmap=cmap, zorder=8)
+    plot4.contour(
+        grid.x, grid.z, vac_psi_app, levels=clevels_app, cmap=cmap, zorder=Zorder.PSI
+    )
 
     if original_LCFS is not None:
         plot1.plot(original_LCFS.x, original_LCFS.z, color="r")

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -745,19 +745,39 @@ def plot_psi_comparision(
 
     plot1.set_title("Original, Total Psi")
     plot1.contour(
-        grid.x, grid.z, tot_psi_org, levels=clevels_org, cmap=cmap, zorder=Zorder.PSI
+        grid.x,
+        grid.z,
+        tot_psi_org,
+        levels=clevels_org,
+        cmap=cmap,
+        zorder=Zorder.PSI.value,
     )
     plot2.set_title("SH Approximation, Total Psi")
     plot2.contour(
-        grid.x, grid.z, tot_psi_app, levels=clevels_app, cmap=cmap, zorder=Zorder.PSI
+        grid.x,
+        grid.z,
+        tot_psi_app,
+        levels=clevels_app,
+        cmap=cmap,
+        zorder=Zorder.PSI.value,
     )
     plot3.set_title("Original, Vacuum Psi")
     plot3.contour(
-        grid.x, grid.z, vac_psi_org, levels=clevels_org, cmap=cmap, zorder=Zorder.PSI
+        grid.x,
+        grid.z,
+        vac_psi_org,
+        levels=clevels_org,
+        cmap=cmap,
+        zorder=Zorder.PSI.value,
     )
     plot4.set_title("SH Approximation, Vacuum Psi")
     plot4.contour(
-        grid.x, grid.z, vac_psi_app, levels=clevels_app, cmap=cmap, zorder=Zorder.PSI
+        grid.x,
+        grid.z,
+        vac_psi_app,
+        levels=clevels_app,
+        cmap=cmap,
+        zorder=Zorder.PSI.value,
     )
 
     if original_LCFS is not None:

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -70,7 +70,8 @@ PLOT_DEFAULTS = {
     "xpoint": {
         "marker": "x",
         "color": "k",
-        "linewidth": 2,
+        "linewidth": 1.4,
+        "size": 5,
     },
     "grid": {
         "edgewidth": 2,
@@ -621,6 +622,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                     p.x,
                     p.z,
                     marker=PLOT_DEFAULTS["xpoint"]["marker"],
+                    markersize=PLOT_DEFAULTS["xpoint"]["size"],
                     markeredgewidth=PLOT_DEFAULTS["xpoint"]["linewidth"],
                     color=PLOT_DEFAULTS["xpoint"]["color"],
                     zorder=Zorder.OXPOINT.value,

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -350,7 +350,7 @@ class CoilGroupPlotter(Plotter):
                 "linewidth": 1,
                 "edgecolor": "k",
             },
-            zorder=Zorder.TEXT,
+            zorder=Zorder.TEXT.value,
         )
 
     def _plot_coil(self, x_boundary, z_boundary, ctype, *, fill=True, **kwargs):
@@ -369,16 +369,18 @@ class CoilGroupPlotter(Plotter):
         z = np.append(z_boundary, z_boundary[0])
         if all(x_boundary == x_boundary[0]) or all(z_boundary == z_boundary[0]):
             self.ax.plot(
-                x[0], z[0], zorder=Zorder.WIRE, color="k", lw=linewidth, marker="+"
+                x[0], z[0], zorder=Zorder.WIRE.value, color="k", lw=linewidth, marker="+"
             )
         else:
-            self.ax.plot(x, z, zorder=Zorder.WIRE, color=color, linewidth=linewidth)
+            self.ax.plot(
+                x, z, zorder=Zorder.WIRE.value, color=color, linewidth=linewidth
+            )
 
         if fill:
             if mask:
-                self.ax.fill(x, z, color="w", zorder=Zorder.FACE, alpha=1)
+                self.ax.fill(x, z, color="w", zorder=Zorder.FACE.value, alpha=1)
 
-            self.ax.fill(x, z, zorder=Zorder.FACE, color=fcolor, alpha=alpha)
+            self.ax.fill(x, z, zorder=Zorder.FACE.value, color=fcolor, alpha=alpha)
 
 
 class PlasmaCoilPlotter(Plotter):
@@ -455,7 +457,7 @@ class EquilibriumPlotterMixin:
             self.psi,
             levels=levels,
             cmap=cmap,
-            zorder=Zorder.PSI,
+            zorder=Zorder.PSI.value,
             linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
         )
 
@@ -476,7 +478,7 @@ class EquilibriumPlotterMixin:
             self.eq._jtor,
             levels=levels,
             cmap=cmap,
-            zorder=Zorder.PLASMACURRENT,
+            zorder=Zorder.PLASMACURRENT.value,
         )
 
 
@@ -509,7 +511,7 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
             z,
             color=PLOT_DEFAULTS["separatrix"]["color"],
             linewidth=PLOT_DEFAULTS["separatrix"]["linewidth"],
-            zorder=Zorder.SEPARATRIX,
+            zorder=Zorder.SEPARATRIX.value,
         )
 
 
@@ -583,7 +585,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 self.psi,
                 levels=[psi],
                 colors=color,
-                zorder=Zorder.FLUXSURFACE,
+                zorder=Zorder.FLUXSURFACE.value,
                 linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
             )
 
@@ -606,7 +608,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 z,
                 color=PLOT_DEFAULTS["separatrix"]["color"],
                 linewidth=PLOT_DEFAULTS["separatrix"]["linewidth"],
-                zorder=Zorder.SEPARATRIX,
+                zorder=Zorder.SEPARATRIX.value,
             )
 
     def plot_X_points(self):  # noqa: N802
@@ -621,7 +623,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                     marker=PLOT_DEFAULTS["xpoint"]["marker"],
                     markeredgewidth=PLOT_DEFAULTS["xpoint"]["linewidth"],
                     color=PLOT_DEFAULTS["xpoint"]["color"],
-                    zorder=Zorder.OXPOINT,
+                    zorder=Zorder.OXPOINT.value,
                 )
 
     def plot_O_points(self):  # noqa: N802
@@ -634,7 +636,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 p.z,
                 marker=PLOT_DEFAULTS["opoint"]["marker"],
                 color=PLOT_DEFAULTS["opoint"]["color"],
-                zorder=Zorder.OXPOINT,
+                zorder=Zorder.OXPOINT.value,
             )
 
     def plot_plasma_coil(self):
@@ -729,7 +731,7 @@ class XZLPlotter(Plotter):
                 self.ax,
                 fill=False,
                 edgecolor="r",
-                zorder=Zorder.POSITION_1D,
+                zorder=Zorder.POSITION_1D.value,
                 linestyle="--",
             )
 
@@ -739,7 +741,7 @@ class XZLPlotter(Plotter):
                 self.ax,
                 fill=False,
                 edgecolor="k",
-                zorder=Zorder.POSITION_1D,
+                zorder=Zorder.POSITION_1D.value,
                 linestyle="--",
             )
 
@@ -759,7 +761,7 @@ class RegionPlotter(Plotter):
                 self.ax,
                 fill=True,
                 alpha=0.2,
-                zorder=Zorder.POSITION_2D,
+                zorder=Zorder.POSITION_2D.value,
                 facecolor="g",
                 edgecolor="g",
             )

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -28,7 +28,7 @@ from scipy.interpolate import RectBivariateSpline
 
 from bluemira.base.constants import CoilType, raw_uc
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.display.plotter import plot_coordinates
+from bluemira.display.plotter import Zorder, plot_coordinates
 from bluemira.equilibria.constants import J_TOR_MIN, M_PER_MN
 from bluemira.equilibria.find import Xpoint, get_contours, grid_2d_contour
 from bluemira.equilibria.physics import calc_psi
@@ -214,7 +214,7 @@ class CoilGroupPlotter(Plotter):
             alpha = kwargs["alpha"]
             if isinstance(alpha, cycle):
                 kwargs["alpha"] = next(alpha)
-            if isinstance(kwargs["alpha"], list):
+            if isinstance(alpha, list):
                 kwargs["alpha"] = alpha[0]
 
         self.plot_coil(subcoil=subcoil, label=label, force=force, **kwargs)
@@ -350,7 +350,7 @@ class CoilGroupPlotter(Plotter):
                 "linewidth": 1,
                 "edgecolor": "k",
             },
-            zorder=100,
+            zorder=Zorder.TEXT,
         )
 
     def _plot_coil(self, x_boundary, z_boundary, ctype, *, fill=True, **kwargs):
@@ -369,16 +369,16 @@ class CoilGroupPlotter(Plotter):
         z = np.append(z_boundary, z_boundary[0])
         if all(x_boundary == x_boundary[0]) or all(z_boundary == z_boundary[0]):
             self.ax.plot(
-                x[0], z[0], zorder=11, color="k", linewidth=linewidth, marker="+"
+                x[0], z[0], zorder=Zorder.WIRE, color="k", lw=linewidth, marker="+"
             )
         else:
-            self.ax.plot(x, z, zorder=11, color=color, linewidth=linewidth)
+            self.ax.plot(x, z, zorder=Zorder.WIRE, color=color, linewidth=linewidth)
 
         if fill:
             if mask:
-                self.ax.fill(x, z, color="w", zorder=10, alpha=1)
+                self.ax.fill(x, z, color="w", zorder=Zorder.FACE, alpha=1)
 
-            self.ax.fill(x, z, zorder=10, color=fcolor, alpha=alpha)
+            self.ax.fill(x, z, zorder=Zorder.FACE, color=fcolor, alpha=alpha)
 
 
 class PlasmaCoilPlotter(Plotter):
@@ -455,7 +455,7 @@ class EquilibriumPlotterMixin:
             self.psi,
             levels=levels,
             cmap=cmap,
-            zorder=8,
+            zorder=Zorder.PSI,
             linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
         )
 
@@ -471,7 +471,12 @@ class EquilibriumPlotterMixin:
 
         levels = np.linspace(J_TOR_MIN, np.amax(self.eq._jtor), nlevels)
         self.ax.contourf(
-            self.eq.x, self.eq.z, self.eq._jtor, levels=levels, cmap=cmap, zorder=7
+            self.eq.x,
+            self.eq.z,
+            self.eq._jtor,
+            levels=levels,
+            cmap=cmap,
+            zorder=Zorder.PLASMACURRENT,
         )
 
 
@@ -504,7 +509,7 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
             z,
             color=PLOT_DEFAULTS["separatrix"]["color"],
             linewidth=PLOT_DEFAULTS["separatrix"]["linewidth"],
-            zorder=9,
+            zorder=Zorder.SEPARATRIX,
         )
 
 
@@ -578,7 +583,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 self.psi,
                 levels=[psi],
                 colors=color,
-                zorder=9,
+                zorder=Zorder.FLUXSURFACE,
                 linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
             )
 
@@ -601,7 +606,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 z,
                 color=PLOT_DEFAULTS["separatrix"]["color"],
                 linewidth=PLOT_DEFAULTS["separatrix"]["linewidth"],
-                zorder=9,
+                zorder=Zorder.SEPARATRIX,
             )
 
     def plot_X_points(self):  # noqa: N802
@@ -616,7 +621,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                     marker=PLOT_DEFAULTS["xpoint"]["marker"],
                     markeredgewidth=PLOT_DEFAULTS["xpoint"]["linewidth"],
                     color=PLOT_DEFAULTS["xpoint"]["color"],
-                    zorder=10,
+                    zorder=Zorder.OXPOINT,
                 )
 
     def plot_O_points(self):  # noqa: N802
@@ -629,7 +634,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 p.z,
                 marker=PLOT_DEFAULTS["opoint"]["marker"],
                 color=PLOT_DEFAULTS["opoint"]["color"],
-                zorder=10,
+                zorder=Zorder.OXPOINT,
             )
 
     def plot_plasma_coil(self):
@@ -720,12 +725,22 @@ class XZLPlotter(Plotter):
 
         for coords in self.xzl.excl_loops:
             plot_coordinates(
-                coords, self.ax, fill=False, edgecolor="r", zorder=1, linestyle="--"
+                coords,
+                self.ax,
+                fill=False,
+                edgecolor="r",
+                zorder=Zorder.POSITION_1D,
+                linestyle="--",
             )
 
         for coords in self.xzl.incl_loops:
             plot_coordinates(
-                coords, self.ax, fill=False, edgecolor="k", zorder=1, linestyle="--"
+                coords,
+                self.ax,
+                fill=False,
+                edgecolor="k",
+                zorder=Zorder.POSITION_1D,
+                linestyle="--",
             )
 
 
@@ -744,7 +759,7 @@ class RegionPlotter(Plotter):
                 self.ax,
                 fill=True,
                 alpha=0.2,
-                zorder=1,
+                zorder=Zorder.POSITION_2D,
                 facecolor="g",
                 edgecolor="g",
             )

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -61,15 +61,16 @@ PLOT_DEFAULTS = {
     },
     "separatrix": {
         "color": "r",
-        "linewidth": 3,
+        "linewidth": 1.5,
     },
     "opoint": {
         "marker": "o",
         "color": "g",
     },
     "xpoint": {
-        "marker": "X",
+        "marker": "x",
         "color": "k",
+        "linewidth": 2,
     },
     "grid": {
         "edgewidth": 2,
@@ -88,10 +89,11 @@ PLOT_DEFAULTS = {
             "NONE": "grey",
         },
         "edgecolor": "k",
-        "linewidth": 2,
+        "linewidth": 1,
         "fontsize": 6,
         "alpha": 0.5,
     },
+    "contour": {"linewidths": 1.5},
 }
 
 
@@ -202,7 +204,9 @@ class CoilGroupPlotter(Plotter):
         super().__init__(ax)
         self._cg = coil
         self.colors = kwargs.pop("facecolor", None)
-        self.linewidth = kwargs.pop("linewidth", PLOT_DEFAULTS["coil"]["linewidth"])
+        self.linewidth = kwargs.pop(
+            "linewidth", PLOT_DEFAULTS["coil"]["linewidth"] + 0.5
+        )
         self.edgecolor = kwargs.pop("edgecolor", PLOT_DEFAULTS["coil"]["edgecolor"])
         if "alpha" in kwargs:
             # Alpha can be provided as a list or cycle to other systems, so make sure we
@@ -446,7 +450,13 @@ class EquilibriumPlotterMixin:
 
         levels = np.linspace(np.amin(self.psi), np.amax(self.psi), nlevels)
         self.ax.contour(
-            self.eq.x, self.eq.z, self.psi, levels=levels, cmap=cmap, zorder=8
+            self.eq.x,
+            self.eq.z,
+            self.psi,
+            levels=levels,
+            cmap=cmap,
+            zorder=8,
+            linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
         )
 
     def plot_plasma_current(self, **kwargs):
@@ -563,7 +573,13 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.ax.contour(
-                self.eq.x, self.eq.z, self.psi, levels=[psi], colors=color, zorder=9
+                self.eq.x,
+                self.eq.z,
+                self.psi,
+                levels=[psi],
+                colors=color,
+                zorder=9,
+                linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
             )
 
     def plot_separatrix(self):
@@ -598,6 +614,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                     p.x,
                     p.z,
                     marker=PLOT_DEFAULTS["xpoint"]["marker"],
+                    markeredgewidth=PLOT_DEFAULTS["xpoint"]["linewidth"],
                     color=PLOT_DEFAULTS["xpoint"]["color"],
                     zorder=10,
                 )
@@ -648,7 +665,14 @@ class BreakdownPlotter(Plotter):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.ax.contour(self.bd.x, self.bd.z, self.psi, levels=levels, colors="r")
+            self.ax.contour(
+                self.bd.x,
+                self.bd.z,
+                self.psi,
+                levels=levels,
+                colors="r",
+                linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
+            )
 
     def plot_Bp(self, **kwargs):
         """
@@ -673,6 +697,7 @@ class BreakdownPlotter(Plotter):
             levels=[field],
             colors=colors,
             linestyles="dashed",
+            linewidths=PLOT_DEFAULTS["contour"]["linewidths"],
         )
 
         if self.psi_bd is not None:

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -451,7 +451,7 @@ class ChargedParticleSolver:
             self.result[1],
             c=self.result[2],
             s=10,
-            zorder=Zorder.RADIATION,
+            zorder=Zorder.RADIATION.value,
             cmap="plasma",
         )
         f = ax.figure

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -18,7 +18,7 @@ from matplotlib.axes import Axes
 import bluemira.radiation_transport.flux_surfaces_maker as fsm
 from bluemira.base.constants import EPS
 from bluemira.base.look_and_feel import bluemira_warn
-from bluemira.display.plotter import plot_coordinates
+from bluemira.display.plotter import Zorder, plot_coordinates
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.plane import BluemiraPlane
 from bluemira.radiation_transport.error import AdvectionTransportError
@@ -451,7 +451,7 @@ class ChargedParticleSolver:
             self.result[1],
             c=self.result[2],
             s=10,
-            zorder=40,
+            zorder=Zorder.RADIATION,
             cmap="plasma",
         )
         f = ax.figure

--- a/bluemira/radiation_transport/radiation_profile.py
+++ b/bluemira/radiation_transport/radiation_profile.py
@@ -21,7 +21,7 @@ from scipy.interpolate import interp1d
 
 from bluemira.base import constants
 from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
-from bluemira.display.plotter import plot_coordinates
+from bluemira.display.plotter import Zorder, plot_coordinates
 from bluemira.equilibria.physics import calc_psi_norm
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.radiation_transport.flux_surfaces_maker import (
@@ -492,7 +492,7 @@ class CoreRadiation(Radiation):
                 cmap="plasma",
                 vmin=p_min,
                 vmax=p_max,
-                zorder=40,
+                zorder=Zorder.RADIATION,
             )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")
@@ -1184,7 +1184,7 @@ class ScrapeOffLayerRadiation(Radiation):
                 cmap="plasma",
                 vmin=p_min,
                 vmax=p_max,
-                zorder=40,
+                zorder=Zorder.RADIATION,
             )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")
@@ -2089,7 +2089,7 @@ class RadiationSource:
             cmap="plasma",
             vmin=min(self.rad_tot),
             vmax=max(self.rad_tot),
-            zorder=40,
+            zorder=Zorder.RADIATION,
         )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")

--- a/bluemira/radiation_transport/radiation_profile.py
+++ b/bluemira/radiation_transport/radiation_profile.py
@@ -492,7 +492,7 @@ class CoreRadiation(Radiation):
                 cmap="plasma",
                 vmin=p_min,
                 vmax=p_max,
-                zorder=Zorder.RADIATION,
+                zorder=Zorder.RADIATION.value,
             )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")
@@ -1184,7 +1184,7 @@ class ScrapeOffLayerRadiation(Radiation):
                 cmap="plasma",
                 vmin=p_min,
                 vmax=p_max,
-                zorder=Zorder.RADIATION,
+                zorder=Zorder.RADIATION.value,
             )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")
@@ -2089,7 +2089,7 @@ class RadiationSource:
             cmap="plasma",
             vmin=min(self.rad_tot),
             vmax=max(self.rad_tot),
-            zorder=Zorder.RADIATION,
+            zorder=Zorder.RADIATION.value,
         )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -156,16 +156,22 @@ plot1.set_title("Total")
 plot2.set_title("Plasma")
 plot3.set_title("Vacuum")
 
-plot1.contour(x_plot, z_plot, total_psi, levels=levels1, cmap=cmap, zorder=Zorder.PSI)
-plot2.contour(x_plot, z_plot, plasma_psi, levels=levels2, cmap=cmap, zorder=Zorder.PSI)
-plot3.contour(x_plot, z_plot, vacuum_psi, levels=levels3, cmap=cmap, zorder=Zorder.PSI)
+plot1.contour(
+    x_plot, z_plot, total_psi, levels=levels1, cmap=cmap, zorder=Zorder.PSI.value
+)
+plot2.contour(
+    x_plot, z_plot, plasma_psi, levels=levels2, cmap=cmap, zorder=Zorder.PSI.value
+)
+plot3.contour(
+    x_plot, z_plot, vacuum_psi, levels=levels3, cmap=cmap, zorder=Zorder.PSI.value
+)
 plot3.contour(
     x_plot,
     z_plot,
     non_sh_coil_cont,
     levels=levels3,
     cmap=cmap,
-    zorder=Zorder.PSI,
+    zorder=Zorder.PSI.value,
     linestyles="dashed",
 )
 
@@ -221,7 +227,9 @@ nlevels = 50
 levels = np.linspace(np.amin(total_psi), np.amax(total_psi), nlevels)
 cmap = "viridis"
 plot1 = plt.subplot2grid((3, 3), (0, 0), rowspan=2, colspan=1)
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
+plot1.contour(
+    x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI.value
+)
 plot1.scatter(collocation.x, collocation.z, color="purple")
 plot1.plot(x_bdry, z_bdry, color="red")
 plt.show()
@@ -323,7 +331,9 @@ plot2 = plt.subplot2grid((3, 3), (0, 1), rowspan=2, colspan=1)
 plot3 = plt.subplot2grid((3, 3), (0, 2), rowspan=2, colspan=1)
 plot1.set_title("Vacuum Psi")
 plot3.set_title("SH Psi")
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
+plot1.contour(
+    x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI.value
+)
 plot1.plot(x_bdry, z_bdry, color="red")
 if plot_diff:
     plot2.contour(
@@ -332,11 +342,16 @@ if plot_diff:
         vacuum_psi - approx_psi_vac_data,
         levels=levels,
         cmap=cmap,
-        zorder=Zorder.PSI,
+        zorder=Zorder.PSI.value,
     )
 else:
     plot2.contour(
-        x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
+        x_plot,
+        z_plot,
+        approx_psi_vac_data,
+        levels=levels,
+        cmap=cmap,
+        zorder=Zorder.PSI.value,
     )
     plot2.contour(
         x_plot,
@@ -344,12 +359,17 @@ else:
         vacuum_psi,
         levels=levels,
         cmap=cmap,
-        zorder=Zorder.PSI,
+        zorder=Zorder.PSI.value,
         linestyles="dashed",
     )
 plot2.plot(x_bdry, z_bdry, color="red")
 plot3.contour(
-    x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
+    x_plot,
+    z_plot,
+    approx_psi_vac_data,
+    levels=levels,
+    cmap=cmap,
+    zorder=Zorder.PSI.value,
 )
 plot3.plot(x_bdry, z_bdry, color="red")
 plt.show()
@@ -472,16 +492,28 @@ plot1.set_title("Vacuum Psi")
 plot2.set_title("SH Approx Psi")
 plot3.set_title("Coilset Approx Psi")
 
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
+plot1.contour(
+    x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI.value
+)
 plot1.plot(x_bdry, z_bdry, color="red")
 
 plot2.contour(
-    x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
+    x_plot,
+    z_plot,
+    approx_psi_vac_data,
+    levels=levels,
+    cmap=cmap,
+    zorder=Zorder.PSI.value,
 )
 plot2.plot(x_bdry, z_bdry, color="red")
 
 plot3.contour(
-    x_plot, z_plot, coilset_approx_psi_plot, levels=levels, cmap=cmap, zorder=Zorder.PSI
+    x_plot,
+    z_plot,
+    coilset_approx_psi_plot,
+    levels=levels,
+    cmap=cmap,
+    zorder=Zorder.PSI.value,
 )
 plot3.plot(x_bdry, z_bdry, color="red")
 
@@ -530,7 +562,7 @@ plot1.contour(
     vacuum_psi - approx_psi_vac_data,
     levels=levels,
     cmap=cmap,
-    zorder=Zorder.PSI,
+    zorder=Zorder.PSI.value,
 )
 plot1.plot(x_bdry, z_bdry, color="red")
 
@@ -540,7 +572,7 @@ plot2.contour(
     vacuum_psi - coilset_approx_psi_plot,
     levels=levels,
     cmap=cmap,
-    zorder=Zorder.PSI,
+    zorder=Zorder.PSI.value,
 )
 plot2.plot(x_bdry, z_bdry, color="red")
 plot2.plot(x_lcfs, z_lcfs, color="blue", linestyle="dashed")

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -59,6 +59,7 @@ from scipy.interpolate import RectBivariateSpline
 from scipy.special import lpmv
 
 from bluemira.base.file import get_bluemira_path
+from bluemira.display.plotter import Zorder
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions import (
     PointType,
@@ -155,16 +156,16 @@ plot1.set_title("Total")
 plot2.set_title("Plasma")
 plot3.set_title("Vacuum")
 
-plot1.contour(x_plot, z_plot, total_psi, levels=levels1, cmap=cmap, zorder=8)
-plot2.contour(x_plot, z_plot, plasma_psi, levels=levels2, cmap=cmap, zorder=8)
-plot3.contour(x_plot, z_plot, vacuum_psi, levels=levels3, cmap=cmap, zorder=8)
+plot1.contour(x_plot, z_plot, total_psi, levels=levels1, cmap=cmap, zorder=Zorder.PSI)
+plot2.contour(x_plot, z_plot, plasma_psi, levels=levels2, cmap=cmap, zorder=Zorder.PSI)
+plot3.contour(x_plot, z_plot, vacuum_psi, levels=levels3, cmap=cmap, zorder=Zorder.PSI)
 plot3.contour(
     x_plot,
     z_plot,
     non_sh_coil_cont,
     levels=levels3,
     cmap=cmap,
-    zorder=8,
+    zorder=Zorder.PSI,
     linestyles="dashed",
 )
 
@@ -220,7 +221,7 @@ nlevels = 50
 levels = np.linspace(np.amin(total_psi), np.amax(total_psi), nlevels)
 cmap = "viridis"
 plot1 = plt.subplot2grid((3, 3), (0, 0), rowspan=2, colspan=1)
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=8)
+plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
 plot1.scatter(collocation.x, collocation.z, color="purple")
 plot1.plot(x_bdry, z_bdry, color="red")
 plt.show()
@@ -322,7 +323,7 @@ plot2 = plt.subplot2grid((3, 3), (0, 1), rowspan=2, colspan=1)
 plot3 = plt.subplot2grid((3, 3), (0, 2), rowspan=2, colspan=1)
 plot1.set_title("Vacuum Psi")
 plot3.set_title("SH Psi")
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=8)
+plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
 plot1.plot(x_bdry, z_bdry, color="red")
 if plot_diff:
     plot2.contour(
@@ -331,11 +332,11 @@ if plot_diff:
         vacuum_psi - approx_psi_vac_data,
         levels=levels,
         cmap=cmap,
-        zorder=8,
+        zorder=Zorder.PSI,
     )
 else:
     plot2.contour(
-        x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=8
+        x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
     )
     plot2.contour(
         x_plot,
@@ -343,11 +344,13 @@ else:
         vacuum_psi,
         levels=levels,
         cmap=cmap,
-        zorder=8,
+        zorder=Zorder.PSI,
         linestyles="dashed",
     )
 plot2.plot(x_bdry, z_bdry, color="red")
-plot3.contour(x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=8)
+plot3.contour(
+    x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
+)
 plot3.plot(x_bdry, z_bdry, color="red")
 plt.show()
 
@@ -469,14 +472,16 @@ plot1.set_title("Vacuum Psi")
 plot2.set_title("SH Approx Psi")
 plot3.set_title("Coilset Approx Psi")
 
-plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=8)
+plot1.contour(x_plot, z_plot, vacuum_psi, levels=levels, cmap=cmap, zorder=Zorder.PSI)
 plot1.plot(x_bdry, z_bdry, color="red")
 
-plot2.contour(x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=8)
+plot2.contour(
+    x_plot, z_plot, approx_psi_vac_data, levels=levels, cmap=cmap, zorder=Zorder.PSI
+)
 plot2.plot(x_bdry, z_bdry, color="red")
 
 plot3.contour(
-    x_plot, z_plot, coilset_approx_psi_plot, levels=levels, cmap=cmap, zorder=8
+    x_plot, z_plot, coilset_approx_psi_plot, levels=levels, cmap=cmap, zorder=Zorder.PSI
 )
 plot3.plot(x_bdry, z_bdry, color="red")
 
@@ -520,7 +525,12 @@ plot1.set_title("Vacuum - SH Approx Psi")
 plot2.set_title("Vacuum - Coilset Approx Psi")
 
 plot1.contour(
-    x_plot, z_plot, vacuum_psi - approx_psi_vac_data, levels=levels, cmap=cmap, zorder=8
+    x_plot,
+    z_plot,
+    vacuum_psi - approx_psi_vac_data,
+    levels=levels,
+    cmap=cmap,
+    zorder=Zorder.PSI,
 )
 plot1.plot(x_bdry, z_bdry, color="red")
 
@@ -530,7 +540,7 @@ plot2.contour(
     vacuum_psi - coilset_approx_psi_plot,
     levels=levels,
     cmap=cmap,
-    zorder=8,
+    zorder=Zorder.PSI,
 )
 plot2.plot(x_bdry, z_bdry, color="red")
 plot2.plot(x_lcfs, z_lcfs, color="blue", linestyle="dashed")

--- a/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
@@ -140,5 +140,7 @@ psi = approx_total_psi
 levels = np.linspace(np.amin(psi), np.amax(psi), 50)
 plot = plt.subplot2grid((2, 2), (0, 0), rowspan=2, colspan=1)
 plot.set_title("approx_total_psi")
-plot.contour(eq.grid.x, eq.grid.z, psi, levels=levels, cmap="viridis", zorder=Zorder.PSI)
+plot.contour(
+    eq.grid.x, eq.grid.z, psi, levels=levels, cmap="viridis", zorder=Zorder.PSI.value
+)
 plt.show()

--- a/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
@@ -42,6 +42,7 @@ import numpy as np
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.display.auto_config import plot_defaults
+from bluemira.display.plotter import Zorder
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions import (
     PointType,
@@ -139,5 +140,5 @@ psi = approx_total_psi
 levels = np.linspace(np.amin(psi), np.amax(psi), 50)
 plot = plt.subplot2grid((2, 2), (0, 0), rowspan=2, colspan=1)
 plot.set_title("approx_total_psi")
-plot.contour(eq.grid.x, eq.grid.z, psi, levels=levels, cmap="viridis", zorder=8)
+plot.contour(eq.grid.x, eq.grid.z, psi, levels=levels, cmap="viridis", zorder=Zorder.PSI)
 plt.show()


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This PR changes some stylistic things about equilibria in an attempt to make them more professional looking.

|Before |After|
| ------------- | ------------- |
|<img src="https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/81617086/715e34a6-27cf-4dad-8c34-27689358ac0b" width="350"/> |<img src="https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/81617086/4f52fd58-4c8d-4a3e-89a1-0a86dc307143" width="370" height="90%"/>|

|Before |After|
| ------------- | ------------- |
|<img src="https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/81617086/441d5db1-0b31-4606-ba29-b97f94af08c4" width="350"/>|<img src="https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/81617086/2a09cfed-e05c-4736-8ed2-98177c0e40a3" width="370" height="90%"/>|

|Before |After|
| ------------- | ------------- |
![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/3520445/7304895a-6468-46c1-88e4-5dfab1b8a819)|![image](https://github.com/Fusion-Power-Plant-Framework/bluemira/assets/3520445/5f4e4815-2895-46ca-870c-ae87f812adb8)



@CoronelBuendia interested to hear your opinion on the changes

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
