### PR TITLE
Changed the cutting method of the divertor

### DIFF
--- a/bluemira/codes/openmc/make_csg.py
+++ b/bluemira/codes/openmc/make_csg.py
@@ -1404,12 +1404,14 @@ class BlanketCellStack:
         cls.check_cut_point_ordering(
             wall_cut_pts[:, 0],
             dirs[0],
-            location_msg=f"Occuring in cell stack {i}'s CCW wall",
+            location_msg=f"\nOccuring in cell stack {i}'s CCW wall:"
+            "\nCheck if the thickness specified can fit into the blanket?",
         )
         cls.check_cut_point_ordering(
             wall_cut_pts[:, 1],
             dirs[1],
-            location_msg=f"Occuring in cell stack {i}'s CW wall",
+            location_msg=f"\nOccuring in cell stack {i}'s CW wall:"
+            "\nCheck if the thickness specified can fit into the blanket?",
         )
         # 2. Accumulate the corners of each cell.
         vertices = [

--- a/bluemira/radiation_transport/neutronics/make_pre_cell.py
+++ b/bluemira/radiation_transport/neutronics/make_pre_cell.py
@@ -379,7 +379,10 @@ class PreCellArray:
                     f"corners; but instead we have {this_wall}!={next_wall}."
                 )
         self.cell_walls = CellWalls.from_pre_cell_array(self)
+        self.check_convexity()
 
+    def check_convexity(self):
+        """Check that the outermost points of self forms a convex hull."""
         if not is_convex(self.exterior_vertices()[:, ::2]):
             raise GeometryError(f"{self} must have convex exterior wires!")
 
@@ -690,7 +693,10 @@ class DivertorPreCellArray:
                 curr_cell.vertex.xyz[:, Vert.exterior_end],
             ):
                 raise GeometryError("Expect neighbouring cells to share corners!")
+        self.check_convexity()
 
+    def check_convexity(self):
+        """Check that the outermost points of self forms a convex hull."""
         if not is_convex(self.exterior_vertices()[:, ::2]):
             raise GeometryError(f"{self} must have convex exterior vertices!")
 

--- a/bluemira/radiation_transport/neutronics/neutronics_axisymmetric.py
+++ b/bluemira/radiation_transport/neutronics/neutronics_axisymmetric.py
@@ -76,7 +76,7 @@ class PreCellStage:
     def __init__(self, blanket: PreCellArray, divertor: DivertorPreCellArray):
         """Check convexity after initialization"""
         self.blanket = blanket.copy()
-        self.divertor = divertor.copy()
+        self.divertor = divertor
         # 1. stretch first blanket cell in PreCellArray to reach div_start_wire
         div_start_wire = self.divertor[0].cw_wall.restore_to_wire()
         # pull everything down to: div_start_wire.


### PR DESCRIPTION
## Description
Instead of cutting by bisecting tangents, we cut by ray-tracing from a common, central point above the divertor.

## Interface Changes
N/A

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
