### PR TITLE
(Few) Complete docstrings for physics/equation based functions

### DIFF
--- a/bluemira/balance_of_plant/calculations.py
+++ b/bluemira/balance_of_plant/calculations.py
@@ -148,6 +148,19 @@ def H2O_pumping(  # noqa: N802
         The isentropic pumping power (added to the working fluid)
     P_pump_el:
         The eletrical pumping power (parasitic load)
+
+    Notes
+    -----
+    The equations used in this function are:
+
+    .. math::
+        f_{pump} = \\frac{f_{pump}}{\\eta_{isen}}
+
+    .. math::
+        P_{pump\\_is} = \\frac{f_{pump} \\cdot p_{blanket}}{1 - f_{pump}}
+
+    .. math::
+        P_{pump\\_el} = \\frac{P_{pump\\_is}}{\\eta_{el}}
     """
     # TODO: Add proper pump model
     f_pump /= eta_isen
@@ -178,6 +191,22 @@ def superheated_rankine(
     Returns
     -------
     Efficiency of a superheated Rankine cycle
+
+    Notes
+    -----
+    The equations used in this function are:
+
+    .. math::
+        t_{turb} = bb_{outlet\\_temp} - \\delta_{t\\_turbine}
+
+    .. math::
+        f_{lgh} = \\frac{div_{power}}{blanket_{power} + div_{power}}
+
+    .. math::
+        \\delta_{\\eta} = 0.339 \\cdot f_{lgh}
+
+    .. math::
+        Efficiency = 0.1802 \\cdot log(t_{turb}) - 0.7823 - \\delta_{\\eta}
     """
     t_turb = bb_outlet_temp - delta_t_turbine
     if t_turb < 657 or t_turb > 915:  # noqa: PLR2004

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -287,6 +287,13 @@ class Coil(CoilFieldsMixin):
         Returns
         -------
         The cross-sectional area of the coil [m^2]
+
+        Notes
+        -----
+
+        .. math::
+            \\text{area} = 4 \\cdot dx \\cdot dz
+
         """
         return 4 * self.dx * self.dz
 
@@ -298,6 +305,12 @@ class Coil(CoilFieldsMixin):
         Returns
         -------
         The volume of the coil [m^3]
+
+        Notes
+        -----
+
+        .. math::
+            \\text{volume} =\\text{area} \\cdot 2 \\pi x
         """
         return self.area * 2 * np.pi * self.x
 

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -893,23 +893,21 @@ def normal_vector(side_vectors: np.ndarray) -> np.ndarray:
 
     Returns
     -------
-    np.ndarray:
+    np.ndarray
         The array of 2-D normal vectors of each side of a polygon
         (shape: (2, N)).
 
     Notes
     -----
     The normal vector `a` is calculated using the formula:
+
     .. math::
-        \\mathbf{a} = -\frac{
-                \begin{bmatrix}
-                -\text{y} \\
-                \text{x}
-                \\end{bmatrix}
-            }{
-            \\sqrt{\text{x}^2 + \text{y}^2}
-            }
-    where x and y are the x and y components of the side vectors, respectively.
+
+            \\mathbf{a} = -\\frac{-[\\mathbf{v}[1],~
+            \\mathbf{v}[0]]}{\\sqrt{\\mathbf{v}[0]^2~
+            + \\mathbf{v}[1]^2}}
+
+    where :math:`\\mathbf{v}` are the side vectors.
     """
     a = -np.array([-side_vectors[1], side_vectors[0]]) / np.sqrt(
         side_vectors[0] ** 2 + side_vectors[1] ** 2
@@ -949,8 +947,10 @@ def vector_intersect(
 
     Otherwise:
         - Calculates the intersection point using vector algebra:
+
         .. math::
-            \text{point} = \frac{
+
+            \\text{point} = \\frac{
                 \\mathbf{dap} \\cdot (\\mathbf{p1} - \\mathbf{p3})
             }{
             \\mathbf{dap} \\cdot (\\mathbf{p4} - \\mathbf{p3})

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -888,13 +888,28 @@ def normal_vector(side_vectors: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    side_vectors:
+    side_vectors: np.ndarray
         The side vectors of a polygon (shape: (N, 2)).
 
     Returns
     -------
-    The array of 2-D normal vectors of each side of a polygon
-    (shape: (2, N)).
+    np.ndarray:
+        The array of 2-D normal vectors of each side of a polygon
+        (shape: (2, N)).
+
+    Notes
+    -----
+    The normal vector `a` is calculated using the formula:
+    .. math::
+        \\mathbf{a} = -\frac{
+                \begin{bmatrix}
+                -\text{y} \\
+                \text{x}
+                \\end{bmatrix}
+            }{
+            \\sqrt{\text{x}^2 + \text{y}^2}
+            }
+    where x and y are the x and y components of the side vectors, respectively.
     """
     a = -np.array([-side_vectors[1], side_vectors[0]]) / np.sqrt(
         side_vectors[0] ** 2 + side_vectors[1] ** 2
@@ -912,18 +927,34 @@ def vector_intersect(
 
     Parameters
     ----------
-    p1:
+    p1: np.ndarray
         The first point on the first vector (shape: (2,)).
-    p2:
+    p2: np.ndarray
         The second point on the first vector (shape: (2,)).
-    p3:
+    p3: np.ndarray
         The first point on the second vector (shape: (2,)).
-    p4:
+    p4: np.ndarray
         The second point on the second vector (shape: (2,)).
 
     Returns
     -------
+    point: np.ndarray
     The point of the intersection between the two vectors (shape: (2,)).
+
+    Notes
+    -----
+    If the vectors are parallel:
+        - The vectors do not intersect.
+        - The function returns p2
+
+    Otherwise:
+        - Calculates the intersection point using vector algebra:
+        .. math::
+            \text{point} = \frac{
+                \\mathbf{dap} \\cdot (\\mathbf{p1} - \\mathbf{p3})
+            }{
+            \\mathbf{dap} \\cdot (\\mathbf{p4} - \\mathbf{p3})
+            } (\\mathbf{p4} - \\mathbf{p3}) + \\mathbf{p3}
     """
     da = p2 - p1
     db = p4 - p3
@@ -951,21 +982,27 @@ def get_bisection_line(
 
     Parameters
     ----------
-    p1:
+    p1: npt.NDArray
         The first point on the first vector (shape: (2,)).
-    p2:
+    p2: npt.NDArray
         The second point on the first vector (shape: (2,)).
-    p3:
+    p3: npt.NDArray
         The first point on the second vector (shape: (2,)).
-    p4:
+    p4: npt.NDArray
         The second point on the second vector (shape: (2,)).
 
     Returns
     -------
-    origin:
+    origin: npt.NDArray
         A point on that bisection line. (shape: (2,))
-    direction:
+    direction: npt.NDArray
         A normal vector that the bisection line points in (shape: (2,))
+
+    Notes
+    -----
+    The intersection point is calculated using vector algebra, and the
+    direction is the normalized sum of the normalized vectors of da and db.
+
     """
     origin = vector_intersect(p1, p2, p3, p4)
     da = p2 - p1

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -888,14 +888,13 @@ def normal_vector(side_vectors: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    side_vectors: np.ndarray
+    side_vectors:
         The side vectors of a polygon (shape: (N, 2)).
 
     Returns
     -------
-    np.ndarray
-        The array of 2-D normal vectors of each side of a polygon
-        (shape: (2, N)).
+    The array of 2-D normal vectors of each side of a polygon
+    (shape: (2, N)).
 
     Notes
     -----
@@ -925,18 +924,17 @@ def vector_intersect(
 
     Parameters
     ----------
-    p1: np.ndarray
+    p1:
         The first point on the first vector (shape: (2,)).
-    p2: np.ndarray
+    p2:
         The second point on the first vector (shape: (2,)).
-    p3: np.ndarray
+    p3:
         The first point on the second vector (shape: (2,)).
-    p4: np.ndarray
+    p4:
         The second point on the second vector (shape: (2,)).
 
     Returns
     -------
-    point: np.ndarray
     The point of the intersection between the two vectors (shape: (2,)).
 
     Notes
@@ -982,20 +980,20 @@ def get_bisection_line(
 
     Parameters
     ----------
-    p1: npt.NDArray
+    p1:
         The first point on the first vector (shape: (2,)).
-    p2: npt.NDArray
+    p2:
         The second point on the first vector (shape: (2,)).
-    p3: npt.NDArray
+    p3:
         The first point on the second vector (shape: (2,)).
-    p4: npt.NDArray
+    p4:
         The second point on the second vector (shape: (2,)).
 
     Returns
     -------
-    origin: npt.NDArray
+    origin:
         A point on that bisection line. (shape: (2,))
-    direction: npt.NDArray
+    direction:
         A normal vector that the bisection line points in (shape: (2,))
 
     Notes

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -949,9 +949,11 @@ def vector_intersect(
         .. math::
 
             \\text{point} = \\frac{
-                \\lVert \\mathbf{p2} - \\mathbf{p1} \\rVert \\cdot (\\mathbf{p1} - \\mathbf{p3})
+                \\lVert \\mathbf{p2} - \\mathbf{p1} \\rVert~
+                \\cdot (\\mathbf{p1} - \\mathbf{p3})
             }{
-            \\mathbf{dap} \\cdot (\\mathbf{p4} - \\mathbf{p3})
+            \\lVert \\mathbf{p2} - \\mathbf{p1} \\rVert~
+            \\cdot (\\mathbf{p4} - \\mathbf{p3})
             } (\\mathbf{p4} - \\mathbf{p3}) + \\mathbf{p3}
     """
     da = p2 - p1

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -949,7 +949,7 @@ def vector_intersect(
         .. math::
 
             \\text{point} = \\frac{
-                \\mathbf{dap} \\cdot (\\mathbf{p1} - \\mathbf{p3})
+                \\lVert \\mathbf{p2} - \\mathbf{p1} \\rVert \\cdot (\\mathbf{p1} - \\mathbf{p3})
             }{
             \\mathbf{dap} \\cdot (\\mathbf{p4} - \\mathbf{p3})
             } (\\mathbf{p4} - \\mathbf{p3}) + \\mathbf{p3}

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -15,6 +15,7 @@ from scipy.special import ellipe, ellipk
 from bluemira.base.constants import MU_0, MU_0_2PI, MU_0_4PI
 
 __all__ = [
+    "circular_coil_inductance_elliptic",
     "greens_Bx",
     "greens_Bz",
     "greens_all",
@@ -104,21 +105,21 @@ def circular_coil_inductance_elliptic(radius: float, rc: float) -> float:
 
     Notes
     -----
-    The equations used in this function are:
+    The inductance is given by
 
     .. math::
-        k = \\frac{4 \\cdot radius \\cdot (radius - rc)}~
-        {(2 \\cdot radius - rc)^2}
+        L = \\mu_{0} (2 r - r_c) \\Biggl((1 - k^2 / 2)~
+        \\int_0^{\\frac{\\pi}{2}} \\frac{d\\theta}{\\sqrt{1 - k~
+        \\sin (\\theta)^2}} - \\int_0^{\\frac{\\pi}{2}}~
+        \\sqrt{1 - k \\sin (\\theta)^2} \\, d\\theta\\Biggr)
+
+    where :math:`r` is the radius, :math:`\\mu_{0}` is the vacuum
+    permeability, and
 
     .. math::
-        k = clip_{nb}(k, GREENS_{ZERO}, 1.0 - GREENS_{ZERO})
-
-    .. math::
-        Inductance = \\mu_{0} \\cdot (2 \\cdot radius - rc)~
-        \\cdot ((1 - k^2 / 2) \\cdot ellipk_{nb}(k) - ellipe_{nb}(k))
-
-    where :math:`\\mu_{0}` is the vacuum permeability
-
+        k = \\max\\left(10^{-8}, \\min~
+        \\left(\\frac{4r(r - r_c)}{(2r - r_c)^2}~
+        , 1.0 - 10^{-8}\\right)\\right)
     """
     k = 4 * radius * (radius - rc) / (2 * radius - rc) ** 2
     k = clip_nb(k, GREENS_ZERO, 1.0 - GREENS_ZERO)

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -15,7 +15,6 @@ from scipy.special import ellipe, ellipk
 from bluemira.base.constants import MU_0, MU_0_2PI, MU_0_4PI
 
 __all__ = [
-    "circular_coil_inductance_elliptic",
     "greens_Bx",
     "greens_Bz",
     "greens_all",

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -101,6 +101,24 @@ def circular_coil_inductance_elliptic(radius: float, rc: float) -> float:
     Returns
     -------
     The self-inductance of the circular coil [H]
+
+    Notes
+    -----
+    The equations used in this function are:
+
+    .. math::
+        k = \\frac{4 \\cdot radius \\cdot (radius - rc)}~
+        {(2 \\cdot radius - rc)^2}
+
+    .. math::
+        k = clip_{nb}(k, GREENS_{ZERO}, 1.0 - GREENS_{ZERO})
+
+    .. math::
+        Inductance = \\mu_{0} \\cdot (2 \\cdot radius - rc)~
+        \\cdot ((1 - k^2 / 2) \\cdot ellipk_{nb}(k) - ellipe_{nb}(k))
+
+    where :math:`\\mu_{0}` is the vacuum permeability
+
     """
     k = 4 * radius * (radius - rc) / (2 * radius - rc) ** 2
     k = clip_nb(k, GREENS_ZERO, 1.0 - GREENS_ZERO)
@@ -119,6 +137,14 @@ def circular_coil_inductance_kirchhoff(radius: float, rc: float) -> float:
     Returns
     -------
     The self-inductance of the circular coil [H]
+
+    Notes
+    -----
+
+    .. math::
+        Inductance = \\mu_{0} * radius * (log(8 * radius / rc) - 2 + 0.25)
+
+    where :math:`\\mu_{0}` is the vacuum permeability
     """
     return MU_0 * radius * (np.log(8 * radius / rc) - 2 + 0.25)
 

--- a/bluemira/magnetostatics/semianalytic_2d.py
+++ b/bluemira/magnetostatics/semianalytic_2d.py
@@ -339,8 +339,13 @@ def semianalytic_psi(
 
     Notes
     -----
-    Integrates x*Bz to resolve psi. More analytical approaches are possible and
-    will no doubt be faster.
+    The function returns
+
+    .. math::
+        2 \\times 10^{-7} {\\frac{1}{4 d_{xc} d_{zc}}} \\psi
+
+    The function integrates :math:`x B_z` to resolve psi. More analytical
+    approaches are possible and will no doubt be faster.
     """
     j_tor = 1 / (4 * d_xc * d_zc)  # Keep current out of the equation
     psi = n_integrate(_full_psi_integrand, (xc, zc, z, d_xc, d_zc), [[0, x], [0, np.pi]])

--- a/bluemira/plasma_physics/collisions.py
+++ b/bluemira/plasma_physics/collisions.py
@@ -34,6 +34,29 @@ def debye_length(temperature: float, density: float) -> float:
     Returns
     -------
     Debye length [m]
+
+    Notes
+    -----
+    Debye length is given by the formula:
+
+    .. math::
+        \\lambda_D = \\sqrt{\\frac{\\varepsilon_0 k_B T}{n e^2}}
+
+    where:
+
+    - :math:`\\varepsilon_0` is the vacuum permittivity,
+
+    - :math:`k_B` is the Boltzmann constant,
+
+    - :math:`T` is the temperature in Kelvin,
+
+    - :math:`n` is the number density of particles,
+
+    - :math:`e` is the elementary charge.
+
+    The conversion of the temperature from Kelvin to Joules
+    implicitly includes the Boltzmann constant (:math:`k_B`).
+
     """
     return np.sqrt(
         EPS_0 * raw_uc(temperature, "K", "J") / (ELEMENTARY_CHARGE**2 * density)
@@ -54,6 +77,17 @@ def reduced_mass(mass_1: float, mass_2: float) -> float:
     Returns
     -------
     Reduced mass
+
+    Notes
+    -----
+    Reduced mass of a two-particle system :
+
+    .. math::
+
+        \\mu_{AB} = \\frac{m_A m_B}{m_A + m_B}
+
+    where :math:`m_A` and :math:`m_B` are the masses
+    of the particles.
     """
     return (mass_1 * mass_2) / (mass_1 + mass_2)
 
@@ -73,8 +107,18 @@ def thermal_velocity(temperature: float, mass: float) -> float:
 
     Notes
     -----
-    The sqrt(2) term is for a 3-dimensional system and the most probable velocity in
-    the particle velocity distribution.
+    The thremal velocity is calculated as
+
+     .. math::
+
+        \\sqrt{\\frac{2 k_B T}{m}}
+
+    The conversion of the temperature from Kelvin to Joules
+    implicitly includes the Boltzmann constant (  :math:`k_B` ).
+
+    The  :math:`\\sqrt 2` term is for a 3-dimensional system and the
+    most probable velocity in the particle velocity distribution.
+
     """
     return np.sqrt(2) * np.sqrt(
         raw_uc(temperature, "K", "J")  # = Joule = kg*m^2/s^2
@@ -96,6 +140,17 @@ def de_broglie_length(velocity: float, mu_12: float) -> float:
     Returns
     -------
     De Broglie wavelength [m]
+
+    Notes
+    -----
+    The de Broglie length is given by
+
+    .. math::
+
+        \\frac{h}{2 \\cdot \\mu_{12} \\cdot velocity}
+
+    where  :math:`h` is the Planck Constant.
+
     """
     return H_PLANCK / (2 * mu_12 * velocity)
 
@@ -114,6 +169,23 @@ def impact_parameter_perp(velocity: float, mu_12: float) -> float:
     Returns
     -------
     Perpendicular impact parameter [m]
+
+    Notes
+    -----
+
+    .. math::
+
+        b_{90} = \\frac{e^2}{4 \\pi \\epsilon_0 \\mu_{12} v^2}
+
+    where:
+
+    - :math:`e` is the elementary charge (absolute charge of an electron)
+
+    - :math:`\\epsilon_0` is the vacuum permittivity,
+
+    - :math:`\\mu_{12}` is the reduced mass,
+
+    - :math:`v` is the relative velocity.
     """
     return ELEMENTARY_CHARGE**2 / (4 * np.pi * EPS_0 * mu_12 * velocity**2)
 
@@ -132,6 +204,23 @@ def coulomb_logarithm(temperature: float, density: float) -> float:
     Returns
     -------
     Coulomb logarithm value
+
+    Notes
+    -----
+    The Coulomb logarithm is calculated using the formula:
+
+    .. math::
+
+        \\ln{\\Lambda} = \\ln{\\left(1 + \\left(\\frac{\\lambda_{Debye}}
+        {b_{min}}\\right)^2\\right)^{1/2}}
+
+    where:
+
+    - :math:`\\lambda_{Debye}` is the Debye length,
+
+    - :math:`b_{min}` is the minimum impact parameter,
+    which is the maximum of the de Broglie wavelength~
+    and the perpendicular impact parameter.
     """
     lambda_debye = debye_length(temperature, density)
     mu_12 = reduced_mass(ELECTRON_MASS, PROTON_MASS)

--- a/bluemira/plasma_physics/collisions.py
+++ b/bluemira/plasma_physics/collisions.py
@@ -147,7 +147,7 @@ def de_broglie_length(velocity: float, mu_12: float) -> float:
 
     .. math::
 
-        \\frac{h}{2 \\cdot \\mu_{12} \\cdot velocity}
+        \\lambda_{th} = \\frac{h}{2 \\cdot \\mu_{12} \\cdot velocity}
 
     where  :math:`h` is the Planck Constant.
 

--- a/bluemira/plasma_physics/collisions.py
+++ b/bluemira/plasma_physics/collisions.py
@@ -216,9 +216,12 @@ def coulomb_logarithm(temperature: float, density: float) -> float:
 
     where:
 
-    - :math:`\\lambda_{Debye}` is the Debye length,
+    :math:`\\lambda_{Debye}` is the Debye length,
 
-    - :math:`b_{min}` is the minimum impact parameter
+    :math:`b_{min}` is the minimum impact parameter, which
+    is defined as the maximum value between :math:`b_{90}`
+    (the perpendicular impact parameter) and the de Broglie
+    wavelegth :math:`\\lambda_{th}`
 
     """
     lambda_debye = debye_length(temperature, density)

--- a/bluemira/plasma_physics/collisions.py
+++ b/bluemira/plasma_physics/collisions.py
@@ -218,9 +218,8 @@ def coulomb_logarithm(temperature: float, density: float) -> float:
 
     - :math:`\\lambda_{Debye}` is the Debye length,
 
-    - :math:`b_{min}` is the minimum impact parameter,
-    which is the maximum of the de Broglie wavelength~
-    and the perpendicular impact parameter.
+    - :math:`b_{min}` is the minimum impact parameter
+
     """
     lambda_debye = debye_length(temperature, density)
     mu_12 = reduced_mass(ELECTRON_MASS, PROTON_MASS)

--- a/bluemira/structural/element.py
+++ b/bluemira/structural/element.py
@@ -76,6 +76,29 @@ def _k_array(
     Returns
     -------
     The local member stiffness matrix
+
+    Notes
+    -----
+    The matrix is given by
+
+    .. math::
+        \\small{
+        \\left[
+        \\begin{array}{cccccccccccc}
+        k11 & 0 & 0 & 0 & 0 & 0 & -k11 & 0 & 0 & 0 & 0 & 0 \\\\
+        0 & k22 & 0 & 0 & 0 & k26 & 0 & -k22 & 0 & 0 & 0 & k26 \\\\
+        0 & 0 & k33 & 0 & k35 & 0 & 0 & 0 & -k33 & 0 & k35 & 0 \\\\
+        0 & 0 & 0 & k44 & 0 & 0 & 0 & 0 & 0 & -k44 & 0 & 0 \\\\
+        0 & 0 & k35 & 0 & k55 & 0 & 0 & 0 & -k35 & 0 & k511 & 0 \\\\
+        0 & k26 & 0 & 0 & 0 & k66 & 0 & -k26 & 0 & 0 & 0 & k612 \\\\
+        -k11 & 0 & 0 & 0 & 0 & 0 & k11 & 0 & 0 & 0 & 0 & 0 \\\\
+        0 & -k22 & 0 & 0 & 0 & -k26 & 0 & k22 & 0 & 0 & 0 & -k26 \\\\
+        0 & 0 & -k33 & 0 & -k35 & 0 & 0 & 0 & k33 & 0 & -k35 & 0 \\\\
+        0 & 0 & 0 & -k44 & 0 & 0 & 0 & 0 & 0 & k44 & 0 & 0 \\\\
+        0 & 0 & k35 & 0 & k511 & 0 & 0 & 0 & -k35 & 0 & k55 & 0 \\\\
+        0 & k26 & 0 & 0 & 0 & k612 & 0 & -k26 & 0 & 0 & 0 & k66 \\\\
+        \\end{array}
+        \\right]}
     """
     return np.array([
         [k11, 0, 0, 0, 0, 0, -k11, 0, 0, 0, 0, 0],
@@ -132,6 +155,32 @@ def local_k_shear(
     Returns
     -------
     The local member stiffness matrix
+
+    Notes
+    -----
+    The shear deformation parameters are calculated by
+
+    .. math::
+
+        \\phi_{y} = 24 (1 + \\nu) \\left(\\frac{A}{A_{sy}}\\right)~
+        \\left(\\frac{r_{z}}{L}\\right)^2
+
+        \\phi_{z} = 24 (1 + \\nu) \\left(\\frac{A}{A_{sz}}\\right)~
+        \\left(\\frac{r_{y}}{L}\\right)^2
+
+    The equations for different k-values are
+
+    .. math:: k_{11} = \\frac{EA}{L} \\\\
+    .. math:: k_{22} = \\frac{12 EI_{zz}}{L^3 (1 + \\phi_{y})} \\\\
+    .. math:: k_{33} = \\frac{12 EI_{yy}}{L^3 (1 + \\phi_{z})} \\\\
+    .. math:: k_{44} = \\frac{GJ}{L} \\\\
+    .. math:: k_{55} = \\frac{(4 + \\phi_{z}) EI_{yy}}{L (1 + \\phi_{z})} \\\\
+    .. math:: k_{66} = \\frac{(4 + \\phi_{y}) EI_{zz}}{L (1 + \\phi_{y})} \\\\
+    .. math:: k_{35} = \\frac{-6 EI_{yy}}{L^2 (1 + \\phi_{z})} \\\\
+    .. math:: k_{26} = \\frac{6 EI_{zz}}{L^2 (1 + \\phi_{y})} \\\\
+    .. math:: k_{511} = \\frac{(2 - \\phi_{z}) EI_{yy}}{L (1 + \\phi_{z})} \\\\
+    .. math:: k_{612} = \\frac{(2 - \\phi_{y}) EI_{zz}}{L (1 + \\phi_{y})} \\\\
+
     """
     phi_y = 24 * (1 + nu) * (A / A_sy) * (rz / L) ** 2  # y shear deformation parameter
     phi_z = 24 * (1 + nu) * (A / A_sz) * (ry / L) ** 2  # z shear deformation parameter
@@ -175,6 +224,22 @@ def local_k(
     Returns
     -------
     The local member stiffness matrix
+
+    Notes
+    -----
+    The equations for different k-values are
+
+    .. math:: k_{11} = \\frac{EA}{L} \\\\
+    .. math:: k_{22} = \\frac{12 EI_{zz}}{L^3} \\\\
+    .. math:: k_{33} = \\frac{12 EI_{yy}}{L^3} \\\\
+    .. math:: k_{44} = \\frac{GJ}{L} \\\\
+    .. math:: k_{55} = \\frac{4 EI_{yy}}{L} \\\\
+    .. math:: k_{66} = \\frac{4 EI_{zz}}{L} \\\\
+    .. math:: k_{35} = \\frac{-6 EI_{yy}}{L^2} \\\\
+    .. math:: k_{26} = \\frac{6 EI_{zz}}{L^2} \\\\
+    .. math:: k_{511} = \\frac{2 EI_{yy}}{L} \\\\
+    .. math:: k_{612} = \\frac{2 EI_{zz}}{L} \\\\
+
     """
     k11 = EA / L
     k22 = 12 * EIzz / L**3


### PR DESCRIPTION
…section_line

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Addresses #1043

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Added/amended docstrings for:

`bluemira.geometry.coordinates` :
- [x] vector_intersect()
- [x] get_bisection_line()
- [x] normal_vector()

`bluemira.plasma_physics.collisions`:
- [x] debye_length()
- [x] thermal_velocity()
- [x] reduced_mass()
- [x] de_broglie_length()
- [x] coulomb_logarithm()
- [x] impact_parameter_perp()

`bluemira.structural.element`:
- [x] _k_array()
- [x] local_k_shear()
- [x] local_k()

`bluemira.balance_of_plant.calculations`:
- [x] H2O_pumping()
- [x] superheated_rankine()

`bluemira.magnetostatics.greens`:
- [x] circular_coil_inductance_kirchhoff()
- [x] circular_coil_inductance_elliptic()

`bluemira.magnetostatics.semianalytic_2d`:
- [x] semianalytic_psi()

`bluemira.equilibria.coils._coil`:
- [x] area()
- [x] volume()


## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
