### PR TITLE
Minor improvements to revolving and bspline use 

### DIFF
--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -558,7 +558,7 @@ def force_wire_to_spline(
     original_n_edges = len(wire.edges)
     if original_n_edges < n_edges_max:
         bluemira_debug(
-            f"Wire already has {original_n_edges} < {n_edges_max=}. No point forcing to"
+            f"Wire already has {original_n_edges=} < {n_edges_max=}. No point forcing to"
             " a spline."
         )
         return wire

--- a/eudemo/eudemo/ivc/divertor_silhouette.py
+++ b/eudemo/eudemo/ivc/divertor_silhouette.py
@@ -23,6 +23,7 @@ from bluemira.builders.divertor import DivertorBuilder
 from bluemira.equilibria.find import find_flux_surface_through_point
 from bluemira.equilibria.find_legs import LegFlux
 from bluemira.geometry.tools import (
+    interpolate_bspline,
     make_circle,
     make_polygon,
 )
@@ -231,7 +232,7 @@ class DivertorSilhouetteDesigner(Designer[tuple[BluemiraWire, ...]]):
         dome[(0, 2), 1:-1] = dome_contour
         dome[(0, 2), -1] = end_coord.T
 
-        return make_polygon(dome, label=label)
+        return interpolate_bspline(dome, label=label)
 
     @staticmethod
     def _make_baffle(

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -344,14 +344,14 @@ class TestSolidFacePlaneIntersect:
             f"{sl.length}, {length}" for sl in _slice
         ]
 
-    def test_solid_nested_donut(self):
+    @pytest.mark.parametrize("degree", [360, 359, 180, 150, 90])
+    def test_solid_nested_donut(self, degree):
         circ = make_circle(self.small, [0, 0, self.centre], axis=[0, 1, 0])
         circ2 = make_circle(self.big, [0, 0, self.centre], axis=[0, 1, 0])
 
         face = BluemiraFace([circ2, circ])
 
-        # cant join a face to itself atm 20/12/21
-        donut = revolve_shape(face, direction=[1, 0, 0], degree=359)
+        donut = revolve_shape(face, direction=[1, 0, 0], degree=degree)
 
         _slice = slice_shape(donut, self.xz_plane)
 
@@ -364,8 +364,8 @@ class TestSolidFacePlaneIntersect:
             except AssertionError:  # noqa: PERF203
                 assert np.isclose(sl.length / self.twopi, self.small)
                 no_small += 1
-        assert no_big == 2
-        assert no_small == 2
+        assert no_big == len(_slice) // 2
+        assert no_small == len(_slice) // 2
 
     def test_primitive_cut(self):
         path = PrincetonD({"x2": {"value": self.big}}).create_shape()


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Improves some things around revolving open wires and smooths out demo divertor

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
