### PR TITLE
🐛 Fix missing cocos from examples

### DIFF
--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -89,7 +89,7 @@ file_path = Path(
     get_bluemira_path("equilibria", subfolder="examples"), "SH_test_file.json"
 )
 
-eq = Equilibrium.from_eqdsk(file_path)
+eq = Equilibrium.from_eqdsk(file_path, from_cocos=3, qpsi_sign=-1)
 
 # Get the necessary boundary locations and length scale
 # for use in spherical harmonic approximations.

--- a/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_function_check.ex.py
@@ -67,7 +67,7 @@ plot_defaults()
 file_path = Path(
     get_bluemira_path("equilibria", subfolder="examples"), "SH_test_file.json"
 )
-eq = Equilibrium.from_eqdsk(file_path.as_posix())
+eq = Equilibrium.from_eqdsk(file_path.as_posix(), from_cocos=3, qpsi_sign=-1)
 # Plot
 f, ax = plt.subplots()
 eq.plot(ax=ax)

--- a/examples/radiation_transport/heat_flux_calculation.ex.py
+++ b/examples/radiation_transport/heat_flux_calculation.ex.py
@@ -45,7 +45,7 @@ DOUBLE_NULL = False
 read_path = get_bluemira_path("equilibria", subfolder="data")
 eq_name = "DN-DEMO_eqref.json" if DOUBLE_NULL else "EU-DEMO_EOF.json"
 eq_name = Path(read_path, eq_name)
-eq = Equilibrium.from_eqdsk(eq_name)
+eq = Equilibrium.from_eqdsk(eq_name, from_cocos=3, qpsi_sign=-1)
 
 # %% [markdown]
 #


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Somehow managed to missing adding COCOS into the examples

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
