### PR TITLE
fix to write_csv typing and removed extra indent for adding col_names

### DIFF
--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -115,7 +115,7 @@ def write_csv(
     data: np.ndarray,
     base_name: str,
     col_names: list[str],
-    metadata: str | None = "",
+    metadata: str = "",
     ext: str = ".csv",
     comment_char: str = "#",
 ):
@@ -163,7 +163,7 @@ def write_csv(
         )
 
         # Add column headings
-        metadata += ",".join(col_names)
+    metadata += ",".join(col_names)
 
     np.savetxt(
         filename,


### PR DESCRIPTION
## Linked Issues

Closes #3533 

## Description

Removed extra indent and fixed typing in write_csv


## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
