### PR TITLE
Changes to get flux_surfaces and find_legs

### DIFF
--- a/bluemira/equilibria/find_legs.py
+++ b/bluemira/equilibria/find_legs.py
@@ -11,6 +11,7 @@ import operator
 from enum import Enum, auto
 
 import numpy as np
+import numpy.typing as npt
 
 from bluemira.base.error import BluemiraError
 from bluemira.base.look_and_feel import bluemira_print
@@ -245,7 +246,7 @@ class LegFlux:
 
 def get_legs_length_and_angle(
     eq: Equilibrium,
-    leg_dict: dict,
+    leg_dict: dict[str, npt.NDArray[np.float64] | None],
     plasma_facing_boundary: Grid | Coordinates | None = None,
 ):
     """Calculates the length of all the divertor legs in a dictionary."""

--- a/bluemira/equilibria/find_legs.py
+++ b/bluemira/equilibria/find_legs.py
@@ -253,30 +253,26 @@ def get_legs_length_and_angle(
     length_dict = {}
     angle_dict = {}
     for name, leg_list in leg_dict.items():
-        if not leg_list:
-            lengths = [0.0]
-            angles = [np.pi]
-        else:
-            lengths = []
-            angles = []
-            for leg in leg_list:
-                if leg is None:
-                    con_length = 0.0
+        lengths = []
+        angles = []
+        for leg in leg_list:
+            if leg is None:
+                con_length = 0.0
+                grazing_ang = np.pi
+            else:
+                leg_fs = PartialOpenFluxSurface(leg)
+                if plasma_facing_boundary is not None:
+                    leg_fs.clip(plasma_facing_boundary)
+                con_length = OpenFluxSurface(leg_fs.coords).connection_length(eq)
+                alpha = leg_fs.alpha
+                if alpha is None:
                     grazing_ang = np.pi
+                elif alpha <= 0.5 * np.pi:
+                    grazing_ang = alpha
                 else:
-                    leg_fs = PartialOpenFluxSurface(leg)
-                    if plasma_facing_boundary is not None:
-                        leg_fs.clip(plasma_facing_boundary)
-                    con_length = OpenFluxSurface(leg_fs.coords).connection_length(eq)
-                    alpha = leg_fs.alpha
-                    if alpha is None:
-                        grazing_ang = np.pi
-                    elif alpha <= 0.5 * np.pi:
-                        grazing_ang = alpha
-                    else:
-                        grazing_ang = np.pi - alpha
-                lengths.append(con_length)
-                angles.append(grazing_ang)
+                    grazing_ang = np.pi - alpha
+            lengths.append(con_length)
+            angles.append(grazing_ang)
         length_dict.update({name: lengths})
         angle_dict.update({name: angles})
     return length_dict, angle_dict

--- a/bluemira/equilibria/find_legs.py
+++ b/bluemira/equilibria/find_legs.py
@@ -34,23 +34,25 @@ from bluemira.geometry.coordinates import (
 class NumNull(Enum):
     """
     Class for use with LegFlux.
-    Double Null (DN)
-    Single Null (SN)
     """
 
     DN = auto()
+    # Double Null
     SN = auto()
+    # Single Null
 
 
 class SortSplit(Enum):
     """
     Class for use with LegFlux.
-    Split the flux in x-direction (X)
-    Split the flux in z-direction (Z)
+     (X)
+
     """
 
     X = auto()
+    # Split the flux in x-direction
     Z = auto()
+    # Split the flux in z-direction
 
 
 class LegFlux:
@@ -257,14 +259,14 @@ def get_legs_length_and_angle(
     for name, leg_list in leg_dict.items():
         if not leg_list:
             lengths = [0.0]
-            angles = [180.0]
+            angles = [np.pi]
         else:
             lengths = []
             angles = []
             for leg in leg_list:
                 if leg is None:
                     con_length = 0.0
-                    grazing_ang = 180.0
+                    grazing_ang = np.pi
                 else:
                     leg_fs = PartialOpenFluxSurface(leg)
                     if plasma_facing_boundary is not None:
@@ -272,11 +274,11 @@ def get_legs_length_and_angle(
                     con_length = OpenFluxSurface(leg_fs.coords).connection_length(eq)
                     alpha = leg_fs.alpha
                     if alpha is None:
-                        grazing_ang = 180.0
-                    elif alpha <= np.pi:
+                        grazing_ang = np.pi
+                    elif alpha <= 0.5 * np.pi:
                         grazing_ang = alpha
                     else:
-                        grazing_ang = 2 * np.pi - alpha
+                        grazing_ang = np.pi - alpha
                 lengths.append(con_length)
                 angles.append(grazing_ang)
         length_dict.update({name: lengths})
@@ -515,7 +517,7 @@ def calculate_connection_length(
     eq: Equilibrium,
     div_target_start_point: Coordinates | None = None,
     first_wall: Coordinates | Grid | None = None,
-    forward: bool = True,
+    forward: bool = True,  # noqa: FBT001, FBT002
     psi_n_tol: float = 1e-6,
     delta_start: float = 0.01,
     rtol: float = 1e-1,
@@ -529,7 +531,7 @@ def calculate_connection_length(
 
     Raises
     ------
-    BluemiraError:
+    BluemiraError
         If an invalid option calculation_method is selected.
     """
     calculation_method = CalcMethod[calculation_method.upper()]

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -486,8 +486,8 @@ class PartialOpenFluxSurface(OpenFluxSurface):
 
         # Relying on the fact that first wall is ccw, get the intersection angle
         self.alpha = get_angle_between_points(
-            self.coords.points[1],
-            self.coords.points[0],
+            self.coords.points[-2],
+            self.coords.points[-1],
             first_wall.points[fw_arg],
         )
 

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -369,18 +369,21 @@ class OpenFluxSurface(FluxSurface):
         super().__init__(coords)
 
     def split(
-        self, o_point: PsiPoint, plane: BluemiraPlane | None = None
+        self, psi_point: PsiPoint, plane: BluemiraPlane | None = None
     ) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface]:
         """
         Split an OpenFluxSurface into two separate PartialOpenFluxSurfaces about a
         horizontal plane.
 
+        N.B.  The magnetic centre of the plasma (O-point) is often the
+        value that is used for the PsiPoint and X-Y plane.
+
         Parameters
         ----------
-        o_point:
-            The magnetic centre of the plasma
+        psi_point:
+            Point at which to make the split.
         plane:
-            The x-y cutting plane. Will default to the O-point x-y plane
+            The x-y cutting plane. Will default to the psi_point x-y plane
 
         Returns
         -------
@@ -397,9 +400,9 @@ class OpenFluxSurface(FluxSurface):
 
         if plane is None:
             plane = BluemiraPlane.from_3_points(
-                [o_point.x, 0, o_point.z],
-                [o_point.x + 1, 0, o_point.z],
-                [o_point.x, 1, o_point.z],
+                [psi_point.x, 0, psi_point.z],
+                [psi_point.x + 1, 0, psi_point.z],
+                [psi_point.x, 1, psi_point.z],
             )
 
         ref_coords = deepcopy(self.coords)
@@ -407,15 +410,15 @@ class OpenFluxSurface(FluxSurface):
         x_inter = intersections.T[0]
 
         # Pick the first intersection, travelling from the o_point outwards
-        deltas = x_inter - o_point.x
+        deltas = x_inter - psi_point.x
         arg_inter = np.argmax(deltas >= 0)
         x_mp = x_inter[arg_inter]
-        z_mp = o_point.z
+        z_mp = psi_point.z
 
         # Split the flux surface geometry into LFS and HFS geometries
 
-        delta = 1e-1 if o_point.x < x_mp else -1e-1
-        radial_line = Coordinates({"x": [o_point.x, x_mp + delta], "z": [z_mp, z_mp]})
+        delta = 1e-1 if psi_point.x < x_mp else -1e-1
+        radial_line = Coordinates({"x": [psi_point.x, x_mp + delta], "z": [z_mp, z_mp]})
         # Add the intersection point to the Coordinates
         arg_inter = join_intersect(ref_coords, radial_line, get_arg=True)[0]
 

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -584,8 +584,6 @@ class FieldLine:
         """
         Plot the FieldLine.
 
-        #TODO this needs updating
-
         Parameters
         ----------
         ax:

--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -486,9 +486,7 @@ class PartialOpenFluxSurface(OpenFluxSurface):
 
         # Relying on the fact that first wall is ccw, get the intersection angle
         self.alpha = get_angle_between_points(
-            self.coords.points[-2],
-            self.coords.points[-1],
-            first_wall.points[fw_arg],
+            self.coords.points[-2], self.coords.points[-1], first_wall.points[fw_arg]
         )
 
     def flux_expansion(self, eq: Equilibrium) -> float:

--- a/tests/equilibria/test_find.py
+++ b/tests/equilibria/test_find.py
@@ -153,7 +153,7 @@ class TestGetLegs:
             double_null=True,
             psi_n_tol=1e-6,
         )
-        test_falsified_dn_eq = LegFlux(self.falsified_dn_eq)
+        test_falsified_dn_eq = LegFlux(self.falsified_dn_eq, rtol=1e-2)
         test_falsified_dn_eq.x_points = x_points[:2]
         test_falsified_dn_eq.separatrix = separatrix
         n_null, sort_split = test_falsified_dn_eq.which_legs()
@@ -240,7 +240,7 @@ class TestGetLegs:
             double_null=True,
             psi_n_tol=1e-6,
         )
-        legflux = LegFlux(self.falsified_dn_eq)
+        legflux = LegFlux(self.falsified_dn_eq, rtol=1e-2)
         legflux.x_points = x_points[:2]
         legflux.separatrix = separatrix
         legflux.n_null, legflux.sort_split = legflux.which_legs()
@@ -265,7 +265,7 @@ class TestGetLegs:
             double_null=True,
             psi_n_tol=1e-6,
         )
-        legflux = LegFlux(self.falsified_dn_eq)
+        legflux = LegFlux(self.falsified_dn_eq, rtol=1e-2)
         legflux.x_points = x_points[:2]
         legflux.separatrix = separatrix
         legflux.n_null, legflux.sort_split = legflux.which_legs()


### PR DESCRIPTION
## Description

find_legs.py 
- added function calculate_connection_length that takes target coordinate and can use either the flux surface geometry or field line tracer methods
- default rtol value changed in LegFlux
- converted get_legs_length to get_legs_length_and_angle

flux_surfaces.py 
- corrections (e.g. <0 set to <= 0) 
- fs input option for calculate_connection_length_fs

test_find.py 
- update for changed default tolerance. 

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
