### PR TITLE
Core radiation fix

### DIFF
--- a/bluemira/radiation_transport/radiation_profile.py
+++ b/bluemira/radiation_transport/radiation_profile.py
@@ -375,32 +375,23 @@ class CoreRadiation(Radiation):
 
         exclude_species = ["Ar"]
 
-        # Construct impurity contents, excluding Argon
-        self.impurities_content = [
-            frac for key, frac in impurity_content.items() if key not in exclude_species
+        # Filtering out excluded species
+        included_species = [key for key in impurity_data if key not in exclude_species]
+
+        # Using the filtered list to build other lists
+        self.impurities_content = [impurity_content[key] for key in included_species]
+
+        self.imp_data_t_ref = [
+            constants.raw_uc(impurity_data[key]["T_ref"], "eV", "keV")
+            for key in included_species
         ]
 
-        # Extract impurity data, excluding Argon
-        self.imp_data_t_ref = [
-            [t / 1000.0 for t in data["T_ref"]]
-            for key, data in impurity_data.items()
-            if key not in exclude_species
-        ]
-        self.imp_data_l_ref = [
-            data["L_ref"]
-            for key, data in impurity_data.items()
-            if key not in exclude_species
-        ]
-        self.imp_data_z_ref = [
-            data["z_ref"]
-            for key, data in impurity_data.items()
-            if key not in exclude_species
-        ]
+        self.imp_data_l_ref = [impurity_data[key]["L_ref"] for key in included_species]
+
+        self.imp_data_z_ref = [impurity_data[key]["z_ref"] for key in included_species]
 
         # Store impurity symbols, excluding Argon
-        self.impurity_symbols = [
-            key for key in impurity_content if key not in exclude_species
-        ]
+        self.impurity_symbols = impurity_content.keys() - exclude_species
 
         # Store the midplane profiles
         self.profiles = midplane_profiles
@@ -438,7 +429,7 @@ class CoreRadiation(Radiation):
 
         Returns
         -------
-        rad : list[list[np.ndarray]]
+        rad :
             Line core radiation for each impurity species
             and for each closed flux line in the core.
         """

--- a/bluemira/radiation_transport/radiation_tools.py
+++ b/bluemira/radiation_transport/radiation_tools.py
@@ -23,6 +23,7 @@ from scipy.interpolate import (
     interp1d,
     interp2d,
 )
+from scipy.spatial import Delaunay
 
 from bluemira.base.constants import C_LIGHT, D_MOLAR_MASS, E_CHARGE, raw_uc
 from bluemira.base.look_and_feel import bluemira_error
@@ -294,12 +295,20 @@ def specific_point_temperature(
     # Distinction between lfs and hfs
     d = sep_corrector if lfs else -sep_corrector
 
+    # need to simplify this
+    if lfs and z_p < z_mp:
+        forward = True
+    elif (lfs and z_p > z_mp) or (z_p < z_mp and not lfs):
+        forward = False
+    elif z_p > z_mp and not lfs:
+        forward = True
+
     # Distance between the chosen point and the the target
     l_p = calculate_connection_length_flt(
         eq,
         x_p + (d * f_exp),
         z_p,
-        forward=lfs,
+        forward=forward,
         first_wall=firstwall_geom,
     )
     # connection length from the midplane to the target
@@ -308,7 +317,7 @@ def specific_point_temperature(
             eq,
             r_sep_mp,
             z_mp,
-            forward=lfs,
+            forward=forward,
             first_wall=firstwall_geom,
         )
         if connection_length is None
@@ -329,7 +338,6 @@ def electron_density_and_temperature_sol_decay(
     lambda_q_far: float,
     dx_mp: float,
     f_exp: float = 1,
-    near_sol_gradient: float = 0.99,
 ) -> tuple[np.ndarray, ...]:
     """
     Generic radial esponential decay to be applied from a generic starting point
@@ -365,14 +373,15 @@ def electron_density_and_temperature_sol_decay(
         radial decayed densities through the SoL. unit [1/m^3]
     """
     # temperature and density decay factors
-    t_factor = 7 / 2
-    n_factor = 1
+    if f_exp == 1:
+        t_factor = 7 / 2
+        n_factor = 1 / 3
+    else:
+        t_factor = 7
+        n_factor = 1 / 7
 
     # radial distance of flux tubes from the separatrix
     dr = dx_mp * f_exp
-
-    # temperature and density percentage decay within the far SOL
-    far_sol_gradient = 1 - near_sol_gradient
 
     # power decay length modified according to the flux expansion
     lambda_q_near *= f_exp
@@ -380,16 +389,10 @@ def electron_density_and_temperature_sol_decay(
 
     # Assuming conduction-limited regime.
     lambda_t_near = t_factor * lambda_q_near
-    lambda_t_far = t_factor * lambda_q_far
     lambda_n_near = n_factor * lambda_t_near
-    lambda_n_far = n_factor * lambda_t_far
 
-    te_sol = (near_sol_gradient * t_sep) * np.exp(-dr / lambda_t_near) + (
-        far_sol_gradient * t_sep
-    ) * np.exp(-dr / lambda_t_far)
-    ne_sol = (near_sol_gradient * n_sep) * np.exp(-dr / lambda_n_near) + (
-        far_sol_gradient * n_sep
-    ) * np.exp(-dr / lambda_n_far)
+    te_sol = (t_sep) * np.exp(-dr / lambda_t_near)
+    ne_sol = (n_sep) * np.exp(-dr / lambda_n_near)
 
     return te_sol, ne_sol
 
@@ -542,30 +545,155 @@ def ion_front_distance(
     return abs(z_strike - x_pt_z) - abs(z_ext)
 
 
-def calculate_z_species(
-    t_ref: np.ndarray, z_ref: np.ndarray, species_frac: float, te: np.ndarray
-) -> np.ndarray:
+def calculate_zeff(
+    impurities_content: np.ndarray,
+    imp_data_z_ref: np.ndarray,
+    imp_data_t_ref: np.ndarray,
+    impurity_symbols: np.ndarray,
+    te: np.ndarray,
+):
     """
-    Calculation of species ion charge, in condition of quasi-neutrality.
+    Calculate the effective charge (Z_eff) for the plasma core.
+
+    This function computes Z_eff based on the species information
+    and the temperature profile.
 
     Parameters
     ----------
-    t_ref:
-        temperature reference [keV]
-    z_ref:
-        effective charge reference [m]
-    species_frac:
-        fraction of relevant impurity
-    te:
-        electron temperature [keV]
+    impurities_content: np.array
+        Content of each impurity species in the plasma.
+    imp_data_z_ref: np.array
+        Reference effective charge values corresponding to the reference temperatures.
+    imp_data_t_ref: np.array
+        Reference temperatures (in keV) for interpolation.
+    impurity_symbols: np.array
+        All the impurity species symbols in the plasma.
+    te : np.ndarray
+        Electron temperature profile (in keV) at various positions in the plasma.
 
     Returns
     -------
-        species ion charge
+    zeff: np.ndarray
+        Effective charge profile for each plasma position.
+    avg_zeff: float
+        Average Z_eff across the plasma.
+    total_fraction: float
+        Total fraction of impurities.
+    intermediate_values: dict
+        A dictionary containing species fractions, average charge states, and symbols.
     """
-    z_interp = interp1d(t_ref, z_ref)
+    # Get the electron temperature profile (flattened) [keV]
+    te = np.concatenate(te)
 
-    return species_frac * z_interp(te) ** 2
+    # Initialize lists to hold species fractions and charge states
+    species_fractions = []
+    species_zi = []
+    symbols = []
+
+    # Include other species
+    for frac, z_r, t_r, symbol in zip(
+        impurities_content,
+        imp_data_z_ref,
+        imp_data_t_ref,
+        impurity_symbols,
+        strict=False,
+    ):
+        species_fractions.append(frac)
+        symbols.append(symbol)
+
+        # Ensure data is in correct numerical format
+        t_ref = np.array(t_r, dtype=float)
+        z_ref = np.array(z_r, dtype=float)
+        te = np.array(te, dtype=float)
+        z_interp = interp1d(t_ref, z_ref, fill_value="extrapolate", bounds_error=False)
+        z_i = z_interp(te)
+        species_zi.append(z_i)
+
+    # Convert lists to numpy arrays for vectorized operations
+    z_i_all = np.array(species_zi)
+    f_i_all = np.array(species_fractions)[:, np.newaxis]
+
+    # Compute numerator and denominator for Zeff at each position
+    numerator = np.sum(f_i_all * z_i_all**2, axis=0)
+    denominator = np.sum(f_i_all * z_i_all, axis=0)
+
+    # Calculate Zeff at each position
+    zeff = numerator / denominator
+
+    # Compute average Zeff over all positions
+    avg_zeff = np.mean(zeff)
+
+    # Calculate intermediate values to return as a dictionary
+    intermediate_values = {
+        "species_fractions": species_fractions,
+        "species_zi": [np.mean(z_i) for z_i in species_zi],
+        "symbols": symbols,
+    }
+
+    # Calculate total fraction of impurities
+    total_fraction = np.sum(species_fractions)
+
+    return zeff, avg_zeff, total_fraction, intermediate_values
+
+
+def calculate_total_radiated_power(
+    x: np.ndarray, z: np.ndarray, p_rad: np.ndarray
+) -> float:
+    """
+    Calculate the total radiated power from the radiation map.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Array of x-coordinates (in meters) of the radiation map.
+    z : np.ndarray
+        Array of z-coordinates (in meters) of the radiation map.
+    Prad : np.ndarray
+        Array of radiation power density values (in MW/m³)
+        at the corresponding x and z coordinates.
+
+    Returns
+    -------
+    P_total : float
+        Total radiated power in megawatts (MW).
+    """
+    # Stack x and z coordinates
+    points = np.column_stack((x, z))
+
+    # Delaunay triangulation
+    tri = Delaunay(points)
+
+    # Initialize total power
+    p_total = 0.0
+
+    # Loop over each triangle in the Delaunay triangulation
+    for simplex in tri.simplices:
+        indices = simplex
+        x_vertices = x[indices]
+        z_vertices = z[indices]
+        p_rad_vertices = p_rad[indices]
+
+        # Compute area of the triangle in x-z plane using determinant formula
+        area = 0.5 * abs(
+            (x_vertices[1] - x_vertices[0]) * (z_vertices[2] - z_vertices[0])
+            - (x_vertices[2] - x_vertices[0]) * (z_vertices[1] - z_vertices[0])
+        )
+        if area <= 0:  # Check if area is non-zero and positive
+            continue
+
+        # Compute centroid (average position of vertices)
+        x_centroid = np.mean(x_vertices)
+        p_rad_centroid = np.mean(p_rad_vertices)
+
+        # Compute volume element using cylindrical symmetry
+        dv = 2 * np.pi * x_centroid * area  # Volume element in m^3
+
+        # Compute differential power
+        dp = p_rad_centroid * dv  # Power in MW (MW/m^3 * m^3)
+        # Accumulate total power
+        p_total += dp
+
+    return p_total
 
 
 def radiative_loss_function_values(
@@ -578,7 +706,7 @@ def radiative_loss_function_values(
     Parameters
     ----------
     te:
-        electron temperature [eV]
+        electron temperature [keV]
     t_ref:
         temperature reference [eV]
     l_ref:
@@ -647,7 +775,7 @@ def calculate_line_radiation_loss(
     -------
         Line radiation losses [MW m^-3]
     """
-    return raw_uc((species_frac * (ne**2) * p_loss_f) / (4 * np.pi), "W", "MW")
+    return raw_uc((species_frac * (ne**2) * p_loss_f), "W", "MW")
 
 
 def linear_interpolator(
@@ -821,6 +949,7 @@ def get_impurity_data(
         impurity_data[imp] = {
             "T_ref": imp_data_getter(imp, confinement_time_ms)[0],
             "L_ref": imp_data_getter(imp, confinement_time_ms)[1],
+            "z_ref": imp_data_getter(imp, confinement_time_ms)[2],
         }
 
     return impurity_data

--- a/bluemira/radiation_transport/radiation_tools.py
+++ b/bluemira/radiation_transport/radiation_tools.py
@@ -295,13 +295,7 @@ def specific_point_temperature(
     # Distinction between lfs and hfs
     d = sep_corrector if lfs else -sep_corrector
 
-    # need to simplify this
-    if lfs and z_p < z_mp:
-        forward = True
-    elif (lfs and z_p > z_mp) or (z_p < z_mp and not lfs):
-        forward = False
-    elif z_p > z_mp and not lfs:
-        forward = True
+    forward = False if z_p == z_mp else (lfs and z_p < z_mp) or (not lfs and z_p > z_mp)
 
     # Distance between the chosen point and the the target
     l_p = calculate_connection_length_flt(
@@ -323,6 +317,7 @@ def specific_point_temperature(
         if connection_length is None
         else connection_length
     )
+
     # connection length from mp to p point
     s_p = l_tot - l_p
     if round(abs(z_p)) == 0:

--- a/bluemira/radiation_transport/radiation_tools.py
+++ b/bluemira/radiation_transport/radiation_tools.py
@@ -338,6 +338,8 @@ def electron_density_and_temperature_sol_decay(
     lambda_q_far: float,
     dx_mp: float,
     f_exp: float = 1,
+    t_factor_det: float | None = None,
+    n_factor_det: float | None = None,
 ) -> tuple[np.ndarray, ...]:
     """
     Generic radial esponential decay to be applied from a generic starting point
@@ -361,9 +363,10 @@ def electron_density_and_temperature_sol_decay(
         Gaps between flux tubes at the mp [m]
     f_exp:
         flux expansion. Default value=1 referred to the mid-plane
-    near_sol_gradient:
-        temperature and density drop within the near scrape-off layer
-        from the separatrix value
+    t_factor_det: temperature decay length scaling factor in relation
+        to the power decay length.
+    n_factor_det: density decay length scaling factor in relation
+        to the temperature decay length.
 
     Returns
     -------
@@ -371,14 +374,28 @@ def electron_density_and_temperature_sol_decay(
         radial decayed temperatures through the SoL. Unit [eV]
     ne_sol:
         radial decayed densities through the SoL. unit [1/m^3]
+
+    Notes
+    -----
+        Temperature and density radially decay different than power.
+        At the mid-plane, the decay length relationships are usually
+        assumed to be lambda_q = 0.285*lambda_t and lambda_n = 0.333*lambda_t.
+        In more radiative regions, especially in a detached regime, they may change.
+
+    References
+    ----------
+        [1] Stangeby, P. C. (2000). The Plasma Boundary of Magnetic Fusion Devices.
+            Institute of Physics Publishing.
+        [2] Loarte, A., et al. (2007). "Chapter 4: Power and particle control."
+            Nuclear Fusion, 47(6), S203.
     """
     # temperature and density decay factors
     if f_exp == 1:
         t_factor = 7 / 2
         n_factor = 1 / 3
     else:
-        t_factor = 7
-        n_factor = 1 / 7
+        t_factor = t_factor_det
+        n_factor = n_factor_det
 
     # radial distance of flux tubes from the separatrix
     dr = dx_mp * f_exp

--- a/examples/radiation_transport/radiation_calculation_solver_DEMO.py
+++ b/examples/radiation_transport/radiation_calculation_solver_DEMO.py
@@ -45,13 +45,14 @@ SINGLE_NULL = False
 if SINGLE_NULL:
     eq_name = "EU-DEMO_EOF.json"
     fw_name = "first_wall.json"
-    sep_corrector = 5e-2
+    sep_corrector_omp = 5e-2
     lfs_p_fraction = 1
     tungsten_fraction = 1e-4
 else:
     eq_name = "DN-DEMO_eqref.json"
     fw_name = "DN_fw_shape.json"
-    sep_corrector = 5e-3
+    sep_corrector_omp = 5e-3
+    sep_corrector_imp = 6e-3
     lfs_p_fraction = 0.9
     tungsten_fraction = 1e-5
 
@@ -78,12 +79,16 @@ fw_shape = Coordinates.from_json(
 
 # %%
 params = {
-    "sep_corrector": {"value": sep_corrector, "unit": "dimensionless"},
+    "sep_corrector_omp": {"value": sep_corrector_omp, "unit": "m"},
+    "sep_corrector_imp": {"value": sep_corrector_imp, "unit": "m"},
     "alpha_n": {"value": 1.15, "unit": "dimensionless"},
     "alpha_t": {"value": 1.905, "unit": "dimensionless"},
     "det_t": {"value": 0.0015, "unit": "keV"},
     "eps_cool": {"value": 25.0, "unit": "eV"},
     "f_ion_t": {"value": 0.01, "unit": "keV"},
+    "main_ext": {"value": None, "unit": "m"},
+    "rec_ext_out_leg": {"value": 2, "unit": "m"},
+    "rec_ext_in_leg": {"value": 0.2, "unit": "m"},
     "fw_lambda_q_near_omp": {"value": 0.002, "unit": "m"},
     "fw_lambda_q_far_omp": {"value": 0.1, "unit": "m"},
     "fw_lambda_q_near_imp": {"value": 0.002, "unit": "m"},
@@ -114,7 +119,8 @@ params = {
 config = {
     "f_imp_core": {"H": 1e-1, "He": 1e-2, "Xe": 1e-4, "W": tungsten_fraction},
     "f_imp_sol": {"H": 0, "He": 0, "Ar": 0.003, "Xe": 0, "W": 0},
-    "confinement": 0.1,
+    "tau_core": np.inf,
+    "tau_sol": 10,
 }
 
 
@@ -138,7 +144,8 @@ source = RadiationSource(
     midplane_profiles=profiles,
     core_impurities=config["f_imp_core"],
     sol_impurities=config["f_imp_sol"],
-    confinement_time=config["confinement"],
+    confinement_time_core=config["tau_core"],
+    confinement_time_sol=config["tau_sol"],
 )
 source.analyse(firstwall_geom=fw_shape)
 source.rad_map(fw_shape)
@@ -150,7 +157,7 @@ source.rad_map(fw_shape)
 
 
 # %%
-only_source = False
+only_source = True
 if only_source:
     source.plot()
     plt.show()

--- a/examples/radiation_transport/radiation_calculation_solver_DEMO.py
+++ b/examples/radiation_transport/radiation_calculation_solver_DEMO.py
@@ -88,6 +88,8 @@ params = {
     "fw_lambda_q_far_omp": {"value": 0.1, "unit": "m"},
     "fw_lambda_q_near_imp": {"value": 0.002, "unit": "m"},
     "fw_lambda_q_far_imp": {"value": 0.1, "unit": "m"},
+    "lambda_t_factor": {"value": 7, "unit": "dimensionless"},
+    "lambda_n_factor": {"value": 1 / 7, "unit": "dimensionless"},
     "gamma_sheath": {"value": 7.0, "unit": "dimensionless"},
     "k_0": {"value": 2000.0, "unit": "dimensionless"},
     "lfs_p_fraction": {"value": lfs_p_fraction, "unit": "dimensionless"},

--- a/tests/radiation_transport/test_radiation_profile.py
+++ b/tests/radiation_transport/test_radiation_profile.py
@@ -382,4 +382,4 @@ class TestCoreRadiation:
 
         # the solver gives slightly different powers in each run
         # so just asserting the order of total power
-        assert np.isclose(wall_loads.total_power, 2.32e8, rtol=0.05)
+        assert np.isclose(wall_loads.total_power, 2.46e8, rtol=0.05)

--- a/tests/radiation_transport/test_radiation_profile.py
+++ b/tests/radiation_transport/test_radiation_profile.py
@@ -68,14 +68,20 @@ class TestCoreRadiation:
             "T_e_sep": {"value": 0.16, "unit": "keV"},
         }
         cls.params = {
-            "sep_corrector": {"value": 5e-3, "unit": "dimensionless"},
+            "sep_corrector_omp": {"value": 5e-3, "unit": "dimensionless"},
+            "sep_corrector_imp": {"value": 5e-3, "unit": "dimensionless"},
             "det_t": {"value": 0.0015, "unit": "keV"},
             "eps_cool": {"value": 25.0, "unit": "eV"},
             "f_ion_t": {"value": 0.01, "unit": "keV"},
+            "main_ext": {"value": None, "unit": "m"},
+            "rec_ext_out_leg": {"value": 2, "unit": "m"},
+            "rec_ext_in_leg": {"value": 0.2, "unit": "m"},
             "fw_lambda_q_near_omp": {"value": 0.003, "unit": "m"},
             "fw_lambda_q_far_omp": {"value": 0.1, "unit": "m"},
             "fw_lambda_q_near_imp": {"value": 0.003, "unit": "m"},
             "fw_lambda_q_far_imp": {"value": 0.1, "unit": "m"},
+            "lambda_t_factor": {"value": 7, "unit": "dimensionless"},
+            "lambda_n_factor": {"value": 1 / 7, "unit": "dimensionless"},
             "gamma_sheath": {"value": 7.0, "unit": "dimensionless"},
             "k_0": {"value": 2000.0, "unit": "dimensionless"},
             "lfs_p_fraction": {"value": 0.9, "unit": "dimensionless"},
@@ -86,9 +92,10 @@ class TestCoreRadiation:
         }
 
         cls.config = {
-            "f_imp_core": {"H": 1e-1, "He": 1e-2, "Xe": 1e-4, "W": 1e-5},
-            "f_imp_sol": {"H": 0, "He": 0, "Ar": 0.003, "Xe": 0, "W": 0},
-            "confinement": 0.1,
+            "f_imp_core": {"H": 1e-2, "He": 1e-2, "Xe": 1e-4, "W": 1e-5},
+            "f_imp_sol": {"H": 0, "He": 0, "Ar": 1e-3, "Xe": 0, "W": 0},
+            "confinement_core": 0.1,
+            "confinement_sol": 10,
         }
 
         profiles = midplane_profiles(params=midplane_params)
@@ -100,7 +107,8 @@ class TestCoreRadiation:
             midplane_profiles=profiles,
             core_impurities=cls.config["f_imp_core"],
             sol_impurities=cls.config["f_imp_sol"],
-            confinement_time=cls.config["confinement"],
+            confinement_time_core=cls.config["confinement_core"],
+            confinement_time_sol=cls.config["confinement_sol"],
         )
         source.analyse(firstwall_geom=fw_shape)
         source.rad_map(fw_shape)
@@ -157,7 +165,7 @@ class TestCoreRadiation:
     def test_calculate_core_distribution(self):
         # calls calculate_core_distribution() internally
         self.source.core_rad.calculate_core_radiation_map()
-        assert np.sum(self.source.core_rad.rad_tot) == pytest.approx(273.5583)
+        assert np.sum(self.source.core_rad.rad_tot) == pytest.approx(1295.7477)
         assert np.sum(self.source.core_rad.x_tot) == pytest.approx(55614.0533)
         assert np.sum(self.source.core_rad.z_tot) == pytest.approx(239.84336)
 

--- a/tests/radiation_transport/test_radiation_tools.py
+++ b/tests/radiation_transport/test_radiation_tools.py
@@ -9,7 +9,6 @@ import pytest
 
 from bluemira.radiation_transport.radiation_tools import (
     calculate_line_radiation_loss,
-    calculate_z_species,
     exponential_decay,
     filtering_in_or_out,
     gaussian_decay,
@@ -34,21 +33,12 @@ def test_exponential_decay():
     assert gap_1 > gap_2 > gap_3
 
 
-def test_calculate_z_species():
-    t_ref = np.array([0, 10])
-    z_ref = np.array([10, 20])
-    frac = 0.1
-    t_test = 5
-    z = calculate_z_species(t_ref, z_ref, frac, t_test)
-    assert z == pytest.approx(22.5)
-
-
 def test_calculate_line_radiation_loss():
     ne = 1e20
     p_loss = 1e-31
     frac = 0.01
     rad = calculate_line_radiation_loss(ne, p_loss, frac)
-    assert rad == pytest.approx(0.796, abs=1e-3)
+    assert rad == pytest.approx(10, abs=1e-3)
 
 
 def test_interpolated_field_values():

--- a/tests/radiation_transport/test_radiation_tools.py
+++ b/tests/radiation_transport/test_radiation_tools.py
@@ -9,6 +9,8 @@ import pytest
 
 from bluemira.radiation_transport.radiation_tools import (
     calculate_line_radiation_loss,
+    calculate_total_radiated_power,
+    calculate_zeff,
     exponential_decay,
     filtering_in_or_out,
     gaussian_decay,
@@ -70,3 +72,58 @@ def test_filtering_in_or_out():
     )
     assert not exclude_func([2.0, 5.0])
     assert exclude_func([0.0, 0.0])
+
+
+def test_calculate_zeff():
+    """
+    Test the calculate_zeff function with known inputs and expected outputs.
+    """
+    # Inputs
+    impurities_content = np.array([0.01])
+    imp_data_z_ref = [np.array([1, 2, 3])]
+    imp_data_t_ref = [np.array([0, 5, 10])]
+    impurity_symbols = np.array(["C"])
+    te = [np.array([0, 5, 10])]
+
+    # Calling function
+    zeff, avg_zeff, total_fraction, intermediate_values = calculate_zeff(
+        impurities_content, imp_data_z_ref, imp_data_t_ref, impurity_symbols, te
+    )
+
+    # Expected outputs
+    expected_zeff = np.array([1.0, 2.0, 3.0])
+    expected_avg_zeff = 2.0
+    expected_total_fraction = 0.01
+    expected_species_fractions = [0.01]
+    expected_species_zi = [2.0]
+    expected_symbols = ["C"]
+
+    # Assertions
+    assert np.allclose(zeff, expected_zeff)
+    assert np.isclose(avg_zeff, expected_avg_zeff)
+    assert np.isclose(total_fraction, expected_total_fraction)
+    assert intermediate_values["species_fractions"] == expected_species_fractions
+    assert np.allclose(intermediate_values["species_zi"], expected_species_zi)
+    assert intermediate_values["symbols"] == expected_symbols
+
+
+def test_calculate_total_radiated_power():
+    """
+    Test the calculate_total_radiated_power function
+    """
+    # Define x and z coordinates forming a rectangle
+    x = np.array([1.0, 1.0, 2.0, 2.0])
+    z = np.array([1.0, 2.0, 1.0, 2.0])
+
+    # Define p_rad as a constant value over the rectangle
+    p_rad = np.array([1.0, 1.0, 1.0, 1.0])
+
+    # Calling the function
+    p_total = calculate_total_radiated_power(x, z, p_rad)
+
+    # Expected total radiated power
+    expected_volume = np.pi * (2.0**2 - 1.0**2) * (2.0 - 1.0)
+    expected_p_total = expected_volume * 1.0
+
+    # Assertion
+    assert p_total == pytest.approx(expected_p_total, rel=1e-6)


### PR DESCRIPTION
The core radiation was not calculated correctly because when accessing the tables from ADAS stored in PROCESS, Lz and Zeff where accessed with a reference temperature in keV instead of eV.

Besides the radiation calculation fix, a few checks related to the effective charge profiles and the average Z_eff value across the plasma were added.

Also added a scaling factor to use non-uniform electron temperature and electron density along the closed flux lines in the plasma core. 