### PR TITLE
Select fs for sh fit metric

### DIFF
--- a/bluemira/equilibria/optimisation/harmonics/__init__.py
+++ b/bluemira/equilibria/optimisation/harmonics/__init__.py
@@ -8,11 +8,11 @@
 from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions import (
     PointType,
     coil_harmonic_amplitude_matrix,
-    coils_outside_lcfs_sphere,
+    coils_outside_fs_sphere,
     collocation_points,
+    fs_fit_metric,
     get_psi_harmonic_amplitudes,
     harmonic_amplitude_marix,
-    lcfs_fit_metric,
     plot_psi_comparision,
     spherical_harmonic_approximation,
 )
@@ -28,11 +28,11 @@ __all__ = [
     "SphericalHarmonicConstraint",
     "SphericalHarmonicConstraintFunction",
     "coil_harmonic_amplitude_matrix",
-    "coils_outside_lcfs_sphere",
+    "coils_outside_fs_sphere",
     "collocation_points",
+    "fs_fit_metric",
     "get_psi_harmonic_amplitudes",
     "harmonic_amplitude_marix",
-    "lcfs_fit_metric",
     "plot_psi_comparision",
     "spherical_harmonic_approximation",
 ]

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -563,7 +563,7 @@ def spherical_harmonic_approximation(
         available for collocation point distribution:
         - 'arc' = equispaced points on an arc of fixed radius,
         - 'arc_plus_extrema' = 'arc' plus the min and max points of either
-            the LCFS or a flux surface with a chosen normalised flux value.
+        the LCFS or a flux surface with a chosen normalised flux value.
         in the x- and z-directions (4 points total),
         - 'random',
         - 'random_plus_extrema'.

--- a/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
+++ b/bluemira/equilibria/optimisation/harmonics/harmonics_approx_functions.py
@@ -24,7 +24,6 @@ from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.find import in_zone
-from bluemira.equilibria.flux_surfaces import ClosedFluxSurface
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.plotting import PLOT_DEFAULTS
 from bluemira.geometry.coordinates import (
@@ -447,10 +446,7 @@ def coils_outside_fs_sphere(
         None value will default to LCFS.
 
     """
-    if psi_norm is None:
-        bndry = eq.get_LCFS()
-    else:
-        bndry = ClosedFluxSurface(eq.get_flux_surface(psi_norm)).coords
+    bndry = eq.get_LCFS() if psi_norm is None else eq.get_flux_surface(psi_norm)
     c_names = np.array(eq.coilset.control)
     bdry_r = np.max(np.linalg.norm([bndry.x, bndry.z], axis=0))
     coil_r = np.linalg.norm(
@@ -630,10 +626,7 @@ def spherical_harmonic_approximation(
     # Get the necessary boundary locations and length scale
     # for use in spherical harmonic approximations.
     # Starting FS
-    if psi_norm is None:
-        original_fs = eq.get_LCFS()
-    else:
-        original_fs = ClosedFluxSurface(eq.get_flux_surface(psi_norm)).coords
+    original_fs = eq.get_LCFS() if psi_norm is None else eq.get_flux_surface(psi_norm)
 
     if eq.grid is None or eq.plasma is None:
         raise EquilibriaError("eq not setup for SH approximation.")
@@ -715,7 +708,7 @@ def spherical_harmonic_approximation(
             if psi_norm is None:
                 approx_fs = sh_eq.get_LCFS(psi=approx_total_psi, delta_start=0.015)
             else:
-                approx_fs = ClosedFluxSurface(sh_eq.get_flux_surface(psi_norm)).coords
+                approx_fs = sh_eq.get_flux_surface(psi_norm)
         except EquilibriaError:
             bluemira_print(
                 "Could not find closed FS (at chosen normalised psi)"

--- a/documentation/source/examples.rst
+++ b/documentation/source/examples.rst
@@ -23,7 +23,7 @@ Equilibria Examples
     examples/equilibria/eudemo_2017
     examples/equilibria/fixed_boundary
     examples/equilibria/Spherical_Approximation_how_it_works
-    examples/equilibria/spherical_harmonic_approximation_basic_function_check
+    examples/equilibria/spherical_harmonic_approximation_basic_use
     examples/equilibria/coilset_opt_problem_tutorial
 
 Geometry Examples

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -65,10 +65,10 @@ from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions import (
     PointType,
     coil_harmonic_amplitude_matrix,
-    coils_outside_lcfs_sphere,
+    coils_outside_fs_sphere,
     collocation_points,
+    fs_fit_metric,
     harmonic_amplitude_marix,
-    lcfs_fit_metric,
 )
 
 # %pdb
@@ -76,12 +76,16 @@ from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions impor
 # %% [markdown]
 # ### Equilibria and Coilset Data from File
 #
-# Note: We cannot use coils that are within the sphere containing the LCFS
+# N.B.: We cannot use coils that are within the sphere containing the core plasma
 # for our approximation. The maximum radial distance of the LCFS is used
 # as a limit (orange shaded area in plot below).
 # If you have coils in this region then we need to specify a list of the
 # coil names that are outside of the radial limit
 # (this is done automatically in the spherical_harmonic_approximation class).
+# N.N.B.: We use the LCFS thoughout this example, however,
+# in the spherical_harmonic_approximation class 'psi_norm' can be used to
+# select a different closed flux surface that contrains the core plasma,
+# see spherical_harmonic_approximation_basic_use.ex.py.
 
 # %%
 # Data from EQDSK file
@@ -98,7 +102,7 @@ eq = Equilibrium.from_eqdsk(file_path, from_cocos=3, qpsi_sign=-1)
 original_LCFS = eq.get_LCFS()
 
 # Names of coils located outside of the sphere containing the LCFS
-sh_coil_names, bdry_r = coils_outside_lcfs_sphere(eq)
+sh_coil_names, bdry_r = coils_outside_fs_sphere(eq)
 
 # Typical length scale
 r_t = bdry_r
@@ -486,7 +490,7 @@ for degree in np.arange(min_degree, max_degree):  # + 1):
     approx_LCFS = clipped_eq.get_LCFS(psi=clip_psi)
 
     # Compare staring equilibrium to new approximate equilibrium
-    fit_metric_value = lcfs_fit_metric(original_LCFS, approx_LCFS)
+    fit_metric_value = fs_fit_metric(original_LCFS, approx_LCFS)
 
     print("fit metric = ", fit_metric_value, "number of degrees required = ", degree)
 

--- a/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
@@ -85,10 +85,14 @@ plt.show()
 #
 # - n_points: Number of desired collocation points
 # - point_type: How the collocation points are distributed
+# - grid_num: The number of points in x-direction and z-direction,
+#   to use with grid point distribution
 # - acceptable_fit_metric: how 'good' we require the approximation to be
-# - r_t: typical length scale for spherical harmonic approximation
-# - extra_info: set this to true if you wish to return additional
-#               information and plot the results.
+# - psi_norm: 'None' will default to LCFS, otherwise choose the desired
+#   normalised psi value of a closed flux surface that containe the core plasma
+# - seed: Seed value to use with random point distribution
+# - sig_figures: Number of significant figures for rounding during SH approximation
+# - plot: Whether or not to plot the results
 
 # %%
 # Information needed for SH Approximation
@@ -105,6 +109,7 @@ plt.show()
     n_points=10,
     point_type=PointType.GRID_POINTS,
     acceptable_fit_metric=0.02,
+    psi_norm=0.98,
     seed=15,
     plot=True,
 )
@@ -112,17 +117,17 @@ plt.show()
 # %% [markdown]
 # ## Outputs
 #
-# spherical_harmonic_approximation outputs results
-# that can be used in optimisation.
-#
-# ### Always output
+# ### Results for use in optimisation
 #
 # - "sh_coil_names", names of the coils that can be used with SH approximation
 # - "coil_current_harmonic_amplitudes", SH amplitudes for required number of degrees
+# - "r_t", length scale for the approximation
+#
+# ### Informative outputs
+#
 # - "max_degree", number of degrees required for a SH approx with the desired fit metric
 # - "fit_metric_value", fit metric achieved
 # - "approx_total_psi", the total psi obtained using the SH approximation
-# - "r_t", typical length scale for spherical harmonic approximation
 # - "sh_coilset_current", the coil currents obtained using the approximation
 
 # %%

--- a/tests/equilibria/test_harmonics.py
+++ b/tests/equilibria/test_harmonics.py
@@ -18,11 +18,11 @@ from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.optimisation.harmonics.harmonics_approx_functions import (
     PointType,
     coil_harmonic_amplitude_matrix,
-    coils_outside_lcfs_sphere,
+    coils_outside_fs_sphere,
     collocation_points,
+    fs_fit_metric,
     get_psi_harmonic_amplitudes,
     harmonic_amplitude_marix,
-    lcfs_fit_metric,
     spherical_harmonic_approximation,
 )
 from bluemira.equilibria.optimisation.harmonics.harmonics_constraint_functions import (
@@ -36,7 +36,7 @@ from bluemira.geometry.coordinates import Coordinates, in_polygon
 TEST_PATH = get_bluemira_path("equilibria/test_data", subfolder="tests")
 
 
-def test_lcfs_fit_metric():
+def test_fs_fit_metric():
     xa = [1, 2, 2, 1, 1]
     xb = [3, 4, 4, 3, 3]
     xc = [1.5, 2.5, 2.5, 1.5, 1.5]
@@ -48,10 +48,10 @@ def test_lcfs_fit_metric():
     poly3 = Coordinates({"x": xc, "z": zc})
     poly4 = Coordinates({"x": xc, "z": za})
 
-    assert lcfs_fit_metric(poly1, poly1) == 0
-    assert lcfs_fit_metric(poly1, poly2) == 1
-    assert lcfs_fit_metric(poly1, poly3) == pytest.approx(0.75, rel=0, abs=EPS)
-    assert lcfs_fit_metric(poly1, poly4) == pytest.approx(0.5, rel=0, abs=EPS)
+    assert fs_fit_metric(poly1, poly1) == 0
+    assert fs_fit_metric(poly1, poly2) == 1
+    assert fs_fit_metric(poly1, poly3) == pytest.approx(0.75, rel=0, abs=EPS)
+    assert fs_fit_metric(poly1, poly4) == pytest.approx(0.5, rel=0, abs=EPS)
 
 
 def test_harmonic_amplitude_marix():
@@ -205,7 +205,7 @@ class TestRegressionSH:
             from_cocos=3,
             qpsi_sign=Sign.NEGATIVE,
         )
-        cls.sh_coil_names, cls.bdry_r = coils_outside_lcfs_sphere(cls.eq)
+        cls.sh_coil_names, cls.bdry_r = coils_outside_fs_sphere(cls.eq)
         cls.test_colocation = collocation_points(
             plasma_boundary=cls.eq.get_LCFS(),
             point_type=PointType.GRID_POINTS,


### PR DESCRIPTION
## Description

Added an option to choose a flux surface with a given normalised flux, rather than the LCFS, for the spherical harmonic constraints. LCFS is still default. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
