### PR TITLE
Adding materials to DEMO

### DIFF
--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -307,7 +307,9 @@ class ITERGravitySupportBuilder(Builder):
         component = PhysicalComponent(
             "ITER-like gravity support",
             shape,
-            material=get_cached_material(self.build_config.get("material").get("GS")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("GS")
+            ),
         )
         apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
         return component
@@ -376,7 +378,7 @@ class PFCoilSupportBuilder(Builder):
             self.name,
             face,
             material=get_cached_material(
-                self.build_config.get("material").get("PF ICS")
+                self.build_config.get("material", {}).get("PF ICS")
             ),
         )
         apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
@@ -923,7 +925,7 @@ class OISBuilder(Builder):
                 f"{self.OIS_XZ} {i}",
                 face,
                 material=get_cached_material(
-                    self.build_config.get("material").get(self.OIS_XZ)
+                    self.build_config.get("material", {}).get(self.OIS_XZ)
                 ),
             )
             apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])

--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -42,6 +42,7 @@ from bluemira.geometry.tools import (
     sweep_shape,
 )
 from bluemira.geometry.wire import BluemiraWire
+from bluemira.materials.cache import get_cached_material
 from bluemira.optimisation import OptimisationProblem
 from bluemira.utilities.tools import floatify
 
@@ -303,7 +304,11 @@ class ITERGravitySupportBuilder(Builder):
         # Finally, make the floor block
         shape_list.append(self._make_floor_block(floatify(v1.x), floatify(v4.x)))
         shape = boolean_fuse(shape_list)
-        component = PhysicalComponent("ITER-like gravity support", shape)
+        component = PhysicalComponent(
+            "ITER-like gravity support",
+            shape,
+            material=get_cached_material(self.build_config.get("material").get("GS")),
+        )
         apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
         return component
 
@@ -367,7 +372,13 @@ class PFCoilSupportBuilder(Builder):
         result = slice_shape(xyz.shape, BluemiraPlane(axis=(0, 1, 0)))
         result.sort(key=lambda wire: -wire.length)
         face = BluemiraFace(result)
-        component = PhysicalComponent(self.name, face)
+        component = PhysicalComponent(
+            self.name,
+            face,
+            material=get_cached_material(
+                self.build_config.get("material").get("PF ICS")
+            ),
+        )
         apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
         return component
 
@@ -908,7 +919,13 @@ class OISBuilder(Builder):
         components = []
         for i, ois_profile in enumerate(self.ois_xz_profiles):
             face = BluemiraFace(ois_profile)
-            component = PhysicalComponent(f"{self.OIS_XZ} {i}", face)
+            component = PhysicalComponent(
+                f"{self.OIS_XZ} {i}",
+                face,
+                material=get_cached_material(
+                    self.build_config.get("material").get(self.OIS_XZ)
+                ),
+            )
             apply_component_display_options(component, color=BLUE_PALETTE["TF"][2])
             components.append(component)
         return components

--- a/bluemira/builders/cryostat.py
+++ b/bluemira/builders/cryostat.py
@@ -27,6 +27,7 @@ from bluemira.builders.tools import (
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import make_polygon
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.parameter_frame.typed import ParameterFrameLike
@@ -216,4 +217,7 @@ class CryostatBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE["CR"][0],
             degree,
+            material=get_cached_material(
+                self.build_config.get("material").get("Body"),
+            ),
         )

--- a/bluemira/builders/cryostat.py
+++ b/bluemira/builders/cryostat.py
@@ -27,7 +27,6 @@ from bluemira.builders.tools import (
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import make_polygon
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.parameter_frame.typed import ParameterFrameLike
@@ -107,9 +106,11 @@ class CryostatBuilder(Builder):
     Builder for the cryostat
     """
 
-    CRYO = "Cryostat VV"
     params: CryostatBuilderParams
     param_cls: type[CryostatBuilderParams] = CryostatBuilderParams
+
+    CRYO = "Cryostat VV"
+    BODY = "Body"
 
     def __init__(
         self,
@@ -217,7 +218,5 @@ class CryostatBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE["CR"][0],
             degree,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("Body"),
-            ),
+            material=self.get_material(self.BODY),
         )

--- a/bluemira/builders/cryostat.py
+++ b/bluemira/builders/cryostat.py
@@ -218,6 +218,6 @@ class CryostatBuilder(Builder):
             BLUE_PALETTE["CR"][0],
             degree,
             material=get_cached_material(
-                self.build_config.get("material").get("Body"),
+                self.build_config.get("material", {}).get("Body"),
             ),
         )

--- a/bluemira/builders/divertor.py
+++ b/bluemira/builders/divertor.py
@@ -99,7 +99,7 @@ class DivertorBuilder(Builder):
             segment = PhysicalComponent(
                 f"{self.SEGMENT_PREFIX}_{no}",
                 shape,
-                material=get_cached_material(self.build_config["material"]),
+                material=get_cached_material(self.build_config.get("material")),
             )
             apply_component_display_options(segment, BLUE_PALETTE[self.DIV][no])
             segments.append(segment)

--- a/bluemira/builders/divertor.py
+++ b/bluemira/builders/divertor.py
@@ -23,6 +23,7 @@ from bluemira.builders.tools import (
     pattern_revolved_silhouette,
 )
 from bluemira.display.palettes import BLUE_PALETTE
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -95,7 +96,11 @@ class DivertorBuilder(Builder):
 
         segments = []
         for no, shape in enumerate(shapes):
-            segment = PhysicalComponent(f"{self.SEGMENT_PREFIX}_{no}", shape)
+            segment = PhysicalComponent(
+                f"{self.SEGMENT_PREFIX}_{no}",
+                shape,
+                material=get_cached_material(self.build_config["material"]),
+            )
             apply_component_display_options(segment, BLUE_PALETTE[self.DIV][no])
             segments.append(segment)
 

--- a/bluemira/builders/divertor.py
+++ b/bluemira/builders/divertor.py
@@ -23,7 +23,6 @@ from bluemira.builders.tools import (
     pattern_revolved_silhouette,
 )
 from bluemira.display.palettes import BLUE_PALETTE
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -99,7 +98,7 @@ class DivertorBuilder(Builder):
             segment = PhysicalComponent(
                 f"{self.SEGMENT_PREFIX}_{no}",
                 shape,
-                material=get_cached_material(self.build_config.get("material", {})),
+                material=self.get_material(),
             )
             apply_component_display_options(segment, BLUE_PALETTE[self.DIV][no])
             segments.append(segment)

--- a/bluemira/builders/divertor.py
+++ b/bluemira/builders/divertor.py
@@ -99,7 +99,7 @@ class DivertorBuilder(Builder):
             segment = PhysicalComponent(
                 f"{self.SEGMENT_PREFIX}_{no}",
                 shape,
-                material=get_cached_material(self.build_config.get("material")),
+                material=get_cached_material(self.build_config.get("material", {})),
             )
             apply_component_display_options(segment, BLUE_PALETTE[self.DIV][no])
             segments.append(segment)

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -135,7 +135,7 @@ class PFCoilBuilder(Builder):
             self.WINDING_PACK,
             BluemiraFace(shape),
             material=get_cached_material(
-                self.build_config["material"][self.WINDING_PACK]
+                self.build_config.get("material").get(self.WINDING_PACK)
             ),
         )
         idx = CoilType(self.params.ctype.value).value - 1
@@ -146,7 +146,7 @@ class PFCoilBuilder(Builder):
             self.GROUND_INSULATION,
             BluemiraFace([ins_shape, shape]),
             material=get_cached_material(
-                self.build_config["material"][self.GROUND_INSULATION]
+                self.build_config.get("material").get(self.GROUND_INSULATION)
             ),
         )
         apply_component_display_options(ins, color=BLUE_PALETTE["PF"][3])
@@ -155,7 +155,9 @@ class PFCoilBuilder(Builder):
         casing = PhysicalComponent(
             self.CASING,
             BluemiraFace([cas_shape, ins_shape]),
-            material=get_cached_material(self.build_config["material"][self.CASING]),
+            material=get_cached_material(
+                self.build_config.get("material").get(self.CASING)
+            ),
         )
         apply_component_display_options(casing, color=BLUE_PALETTE["PF"][2])
         return [wp, ins, casing]

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -23,6 +23,7 @@ from bluemira.equilibria.coils import Coil, CoilType
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import PictureFrame
 from bluemira.geometry.tools import make_circle, offset_wire, revolve_shape
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -130,16 +131,32 @@ class PFCoilBuilder(Builder):
         :
             the winding pack, insulation and casing
         """
-        wp = PhysicalComponent(self.WINDING_PACK, BluemiraFace(shape))
+        wp = PhysicalComponent(
+            self.WINDING_PACK,
+            BluemiraFace(shape),
+            material=get_cached_material(
+                self.build_config["material"][self.WINDING_PACK]
+            ),
+        )
         idx = CoilType(self.params.ctype.value).value - 1
         apply_component_display_options(wp, color=BLUE_PALETTE["PF"][idx])
 
         ins_shape = offset_wire(shape, self.params.tk_insulation.value)
-        ins = PhysicalComponent(self.GROUND_INSULATION, BluemiraFace([ins_shape, shape]))
+        ins = PhysicalComponent(
+            self.GROUND_INSULATION,
+            BluemiraFace([ins_shape, shape]),
+            material=get_cached_material(
+                self.build_config["material"][self.GROUND_INSULATION]
+            ),
+        )
         apply_component_display_options(ins, color=BLUE_PALETTE["PF"][3])
 
         cas_shape = offset_wire(ins_shape, self.params.tk_casing.value)
-        casing = PhysicalComponent(self.CASING, BluemiraFace([cas_shape, ins_shape]))
+        casing = PhysicalComponent(
+            self.CASING,
+            BluemiraFace([cas_shape, ins_shape]),
+            material=get_cached_material(self.build_config["material"][self.CASING]),
+        )
         apply_component_display_options(casing, color=BLUE_PALETTE["PF"][2])
         return [wp, ins, casing]
 
@@ -170,7 +187,7 @@ class PFCoilBuilder(Builder):
         components = []
         for c in xz_components:
             shape = revolve_shape(c.shape, degree=sector_degree * n_sectors)
-            c_xyz = PhysicalComponent(c.name, shape)
+            c_xyz = PhysicalComponent(c.name, shape, material=c.material)
             apply_component_display_options(
                 c_xyz, color=c.plot_options.face_options["color"]
             )

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -135,7 +135,7 @@ class PFCoilBuilder(Builder):
             self.WINDING_PACK,
             BluemiraFace(shape),
             material=get_cached_material(
-                self.build_config.get("material").get(self.WINDING_PACK)
+                self.build_config.get("material", {}).get(self.WINDING_PACK)
             ),
         )
         idx = CoilType(self.params.ctype.value).value - 1
@@ -146,7 +146,7 @@ class PFCoilBuilder(Builder):
             self.GROUND_INSULATION,
             BluemiraFace([ins_shape, shape]),
             material=get_cached_material(
-                self.build_config.get("material").get(self.GROUND_INSULATION)
+                self.build_config.get("material", {}).get(self.GROUND_INSULATION)
             ),
         )
         apply_component_display_options(ins, color=BLUE_PALETTE["PF"][3])
@@ -156,7 +156,7 @@ class PFCoilBuilder(Builder):
             self.CASING,
             BluemiraFace([cas_shape, ins_shape]),
             material=get_cached_material(
-                self.build_config.get("material").get(self.CASING)
+                self.build_config.get("material", {}).get(self.CASING)
             ),
         )
         apply_component_display_options(casing, color=BLUE_PALETTE["PF"][2])

--- a/bluemira/builders/pf_coil.py
+++ b/bluemira/builders/pf_coil.py
@@ -23,7 +23,6 @@ from bluemira.equilibria.coils import Coil, CoilType
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import PictureFrame
 from bluemira.geometry.tools import make_circle, offset_wire, revolve_shape
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -134,9 +133,7 @@ class PFCoilBuilder(Builder):
         wp = PhysicalComponent(
             self.WINDING_PACK,
             BluemiraFace(shape),
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.WINDING_PACK)
-            ),
+            material=self.get_material(self.WINDING_PACK),
         )
         idx = CoilType(self.params.ctype.value).value - 1
         apply_component_display_options(wp, color=BLUE_PALETTE["PF"][idx])
@@ -145,9 +142,7 @@ class PFCoilBuilder(Builder):
         ins = PhysicalComponent(
             self.GROUND_INSULATION,
             BluemiraFace([ins_shape, shape]),
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.GROUND_INSULATION)
-            ),
+            material=self.get_material(self.GROUND_INSULATION),
         )
         apply_component_display_options(ins, color=BLUE_PALETTE["PF"][3])
 
@@ -155,9 +150,7 @@ class PFCoilBuilder(Builder):
         casing = PhysicalComponent(
             self.CASING,
             BluemiraFace([cas_shape, ins_shape]),
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.CASING)
-            ),
+            material=self.get_material(self.CASING),
         )
         apply_component_display_options(casing, color=BLUE_PALETTE["PF"][2])
         return [wp, ins, casing]

--- a/bluemira/builders/radiation_shield.py
+++ b/bluemira/builders/radiation_shield.py
@@ -26,7 +26,6 @@ from bluemira.builders.tools import (
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import boolean_cut, boolean_fuse, make_polygon, offset_wire
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -131,5 +130,5 @@ class RadiationShieldBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE[self.RS][0],
             degree,
-            material=get_cached_material(self.build_config.get("material", {})),
+            material=self.get_material(),
         )

--- a/bluemira/builders/radiation_shield.py
+++ b/bluemira/builders/radiation_shield.py
@@ -131,5 +131,5 @@ class RadiationShieldBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE[self.RS][0],
             degree,
-            material=get_cached_material(self.build_config.get("material")),
+            material=get_cached_material(self.build_config.get("material", {})),
         )

--- a/bluemira/builders/radiation_shield.py
+++ b/bluemira/builders/radiation_shield.py
@@ -131,5 +131,5 @@ class RadiationShieldBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE[self.RS][0],
             degree,
-            material=get_cached_material(self.build_config["material"]),
+            material=get_cached_material(self.build_config.get("material")),
         )

--- a/bluemira/builders/radiation_shield.py
+++ b/bluemira/builders/radiation_shield.py
@@ -26,6 +26,7 @@ from bluemira.builders.tools import (
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import boolean_cut, boolean_fuse, make_polygon, offset_wire
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -130,4 +131,5 @@ class RadiationShieldBuilder(Builder):
             self.params.n_TF.value,
             BLUE_PALETTE[self.RS][0],
             degree,
+            material=get_cached_material(self.build_config["material"]),
         )

--- a/bluemira/builders/thermal_shield.py
+++ b/bluemira/builders/thermal_shield.py
@@ -330,7 +330,7 @@ class CryostatTSBuilder(Builder):
             degree,
             enable_sectioning=True,
             material=[
-                get_cached_material(self.build_config["material"][self.CRYO_TS]),
+                get_cached_material(self.build_config.get("material").get(self.CRYO_TS)),
                 Void("vacuum"),
             ],
         )

--- a/bluemira/builders/thermal_shield.py
+++ b/bluemira/builders/thermal_shield.py
@@ -167,7 +167,9 @@ class VVTSBuilder(Builder):
             [BLUE_PALETTE["TS"][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material(self.build_config["material"][self.VVTS]),
+                get_cached_material(
+                    self.build_config.get("material", {}).get(self.VVTS)
+                ),
                 Void("vacuum"),
             ],
         )
@@ -330,7 +332,9 @@ class CryostatTSBuilder(Builder):
             degree,
             enable_sectioning=True,
             material=[
-                get_cached_material(self.build_config.get("material").get(self.CRYO_TS)),
+                get_cached_material(
+                    self.build_config.get("material", {}).get(self.CRYO_TS)
+                ),
                 Void("vacuum"),
             ],
         )

--- a/bluemira/builders/thermal_shield.py
+++ b/bluemira/builders/thermal_shield.py
@@ -38,7 +38,7 @@ from bluemira.geometry.tools import (
     make_polygon,
     offset_wire,
 )
-from bluemira.materials.cache import Void, get_cached_material
+from bluemira.materials.cache import Void
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -167,9 +167,7 @@ class VVTSBuilder(Builder):
             [BLUE_PALETTE["TS"][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material(
-                    self.build_config.get("material", {}).get(self.VVTS)
-                ),
+                self.get_material(self.VVTS),
                 Void("vacuum"),
             ],
         )
@@ -332,9 +330,7 @@ class CryostatTSBuilder(Builder):
             degree,
             enable_sectioning=True,
             material=[
-                get_cached_material(
-                    self.build_config.get("material", {}).get(self.CRYO_TS)
-                ),
+                self.get_material(self.CRYO_TS),
                 Void("vacuum"),
             ],
         )

--- a/bluemira/builders/thermal_shield.py
+++ b/bluemira/builders/thermal_shield.py
@@ -38,7 +38,7 @@ from bluemira.geometry.tools import (
     make_polygon,
     offset_wire,
 )
-from bluemira.materials.cache import Void
+from bluemira.materials.cache import Void, get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.builder import BuildConfig
@@ -166,7 +166,10 @@ class VVTSBuilder(Builder):
             self.params.n_TF.value,
             [BLUE_PALETTE["TS"][0], (0, 0, 0)],
             degree,
-            material=[None, Void("vacuum")],
+            material=[
+                get_cached_material(self.build_config["material"][self.VVTS]),
+                Void("vacuum"),
+            ],
         )
 
 
@@ -326,5 +329,8 @@ class CryostatTSBuilder(Builder):
             [BLUE_PALETTE["TS"][0], (0, 0, 0)],
             degree,
             enable_sectioning=True,
-            material=[None, Void("vacuum")],
+            material=[
+                get_cached_material(self.build_config["material"][self.CRYO_TS]),
+                Void("vacuum"),
+            ],
         )

--- a/bluemira/builders/tools.py
+++ b/bluemira/builders/tools.py
@@ -178,6 +178,7 @@ def circular_pattern_component(
                         f"with search index: {search_index_i}"
                     )
                 phy_comp.shape = shape
+                phy_comp.material = comp.material
 
     return sectors
 

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -229,7 +229,7 @@ def establish_material_cache(materials_json_paths: list[Path | str]):
 
 
 def get_cached_material(
-    material_name: str | None, cache: MaterialCache | None = None
+    material_name: str, cache: MaterialCache | None = None
 ) -> Material | None:
     """
     Get the named material from the MaterialCache.
@@ -245,13 +245,51 @@ def get_cached_material(
 
     Returns
     -------
-    The requested material.
+    :
+        The requested material.
+
+    Raises
+    ------
+    MaterialsError
+        If the material name is not a string.
     """
-    # mateiral name can also be an empty dict
-    # sometimes because of the dict default value used
-    # when calling .get
     if not (material_name and isinstance(material_name, str)):
-        return None
+        raise MaterialsError("Material name must be a non-empty string.")
     if cache is None:
         cache = MaterialCache.get_instance()
     return cache.get_material(material_name)
+
+
+def get_cached_material_for_component(
+    build_config: dict, component_name: str | None
+) -> Material | None:
+    """
+    Get the material for a component from the build config.
+
+    Parameters
+    ----------
+    build_config:
+        The build config dictionary.
+    component_name:
+        The name of the component.
+
+    Returns
+    -------
+    :
+        The material for the component.
+
+    Raises
+    ------
+    MaterialsError
+        If the material build config is not a string when no component name is given.
+    """
+    mats = build_config.get("material")
+    if not mats:
+        return None
+    if not component_name:
+        if isinstance(mats, str):
+            return get_cached_material(mats)
+        raise MaterialsError(
+            "Material build config must be a string if no component name is given."
+        )
+    return get_cached_material(mats.get(component_name))

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -258,38 +258,3 @@ def get_cached_material(
     if cache is None:
         cache = MaterialCache.get_instance()
     return cache.get_material(material_name)
-
-
-def get_cached_material_for_component(
-    build_config: dict, component_name: str | None
-) -> Material | None:
-    """
-    Get the material for a component from the build config.
-
-    Parameters
-    ----------
-    build_config:
-        The build config dictionary.
-    component_name:
-        The name of the component.
-
-    Returns
-    -------
-    :
-        The material for the component.
-
-    Raises
-    ------
-    MaterialsError
-        If the material build config is not a string when no component name is given.
-    """
-    mats = build_config.get("material")
-    if not mats:
-        return None
-    if not component_name:
-        if isinstance(mats, str):
-            return get_cached_material(mats)
-        raise MaterialsError(
-            "Material build config must be a string if no component name is given."
-        )
-    return get_cached_material(mats.get(component_name))

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -18,6 +18,7 @@ from bluemira.materials.material import (
     BePebbleBed,
     Liquid,
     MassFractionMaterial,
+    Material,
     MaterialsError,
     NbSnSuperconductor,
     NbTiSuperconductor,
@@ -227,7 +228,9 @@ def establish_material_cache(materials_json_paths: list[Path | str]):
     return cache
 
 
-def get_cached_material(material_name: str, cache: MaterialCache | None = None):
+def get_cached_material(
+    material_name: str | None, cache: MaterialCache | None = None
+) -> Material | None:
     """
     Get the named material from the MaterialCache.
 
@@ -244,6 +247,8 @@ def get_cached_material(material_name: str, cache: MaterialCache | None = None):
     -------
     The requested material.
     """
+    if material_name is None:
+        return None
     if cache is None:
         cache = MaterialCache.get_instance()
     return cache.get_material(material_name)

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from bluemira.materials.material import (
     BePebbleBed,
@@ -26,6 +26,9 @@ from bluemira.materials.material import (
     Void,
 )
 from bluemira.materials.mixtures import HomogenisedMixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class MaterialCache:
@@ -56,6 +59,22 @@ class MaterialCache:
             mat_class.__name__: mat_class for mat_class in self.default_classes
         }
 
+    _instance: MaterialCache | None = None
+
+    @classmethod
+    def get_instance(cls) -> MaterialCache:
+        """
+        Get the singleton instance of the MaterialCache.
+
+        Returns
+        -------
+        MaterialCache
+            The singleton instance of the MaterialCache.
+        """
+        if cls._instance is None:
+            cls._instance = MaterialCache()
+        return cls._instance
+
     def __getattr__(self, value: str):
         """Allow attribute access to cached materials
 
@@ -84,14 +103,11 @@ class MaterialCache:
         ----------
         path:
             The path to the file from which to load the materials.
-
-        Returns
-        -------
-        The dictionary containing the loaded materials.
         """
         with open(path) as fh:
             mats_dict = json.load(fh)
-        return {name: self.load_from_dict(name, mats_dict) for name in mats_dict}
+        for name in mats_dict:
+            self.load_from_dict(name, mats_dict)
 
     def load_from_dict(
         self, mat_name: str, mats_dict: dict[str, Any], *, overwrite: bool = True
@@ -186,3 +202,48 @@ class MaterialCache:
                 "exists in the cache."
             )
         self._material_dict[mat_name] = mat
+
+
+def establish_material_cache(materials_json_paths: list[Path | str]):
+    """
+    Load the material data from the provided json files into the global material cache
+    instance.
+
+    This instance can be accessed using the `MaterialCache.get_instance()`
+    function.
+
+    Parameters
+    ----------
+    materials_json_paths:
+        A list of paths to the data files to load into the material cache.
+
+    Returns
+    -------
+    The material cache.
+    """
+    cache = MaterialCache.get_instance()
+    for path in materials_json_paths:
+        cache.load_from_file(path)
+    return cache
+
+
+def get_cached_material(material_name: str, cache: MaterialCache | None = None):
+    """
+    Get the named material from the MaterialCache.
+
+    If cache is None, the global cache instance is used.
+
+    Parameters
+    ----------
+    material_name:
+        The name of the material to retrieve from the dictionary
+    cache:
+        The material cache to retrieve the material from. By default the global cache.
+
+    Returns
+    -------
+    The requested material.
+    """
+    if cache is None:
+        cache = MaterialCache.get_instance()
+    return cache.get_material(material_name)

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -247,7 +247,10 @@ def get_cached_material(
     -------
     The requested material.
     """
-    if material_name is None:
+    # mateiral name can also be an empty dict
+    # sometimes because of the dict default value used
+    # when calling .get
+    if not (material_name and isinstance(material_name, str)):
         return None
     if cache is None:
         cache = MaterialCache.get_instance()

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -112,15 +112,15 @@
   },
   "Blanket": {
     "material": {
-      "IBS": "Homogenised_HCPB_2015_v3_BZ",
-      "OBS": "Homogenised_HCPB_2015_v3_BZ"
+      "IBS": "Homogenised_HCPB_2015_v3_IB",
+      "OBS": "Homogenised_HCPB_2015_v3_OB"
     }
   },
   "Vacuum vessel": {
     "material": "SS316-LN"
   },
   "Divertor": {
-    "material": "SS316-LN"
+    "material": "Homogenised_Divertor_2015"
   },
   "Neutronics": {
     "cross_section_xml": "$path_expand:./cross_section_data/cross_sections.xml",

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -1,7 +1,7 @@
 {
   "params": "$path:params.json",
   "Radial build": {
-    "run_mode": "run",
+    "run_mode": "read",
     "read_dir": "$path_expand:./",
     "run_dir": "$path_expand:./",
     "plot": true
@@ -60,7 +60,7 @@
     }
   },
   "Free boundary equilibrium": {
-    "run_mode": "run",
+    "run_mode": "read",
     "plot": true,
     "save": true,
     "fixed_eq_file_path": "$path_expand:./fixed_boundary_eqdsk.json",
@@ -106,6 +106,20 @@
     },
     "Divertor silhouette": {}
   },
+  "Blanket": {
+    "material": {
+      "IBS": "Homogenised_HCPB_2015_v3_BZ",
+      "OBS": "Homogenised_HCPB_2015_v3_BZ"
+    }
+  },
+  "Vacuum vessel": {
+    "material": {
+      "Body": "SS316-LN"
+    }
+  },
+  "Divertor": {
+    "material": "SS316-LN"
+  },
   "Neutronics": {
     "cross_section_xml": "$path_expand:./cross_section_data/cross_sections.xml",
     "particles": 16800,
@@ -122,9 +136,14 @@
     "show_data": false
   },
   "TF coils": {
-    "run_mode": "run",
+    "run_mode": "read",
     "file_path": "$path_expand:./TFCoilDesign.json",
     "plot": true,
+    "material": {
+      "Winding Pack": "Toroidal_Field_Coil_2015",
+      "Casing": "Toroidal_Field_Coil_2015",
+      "Insulation": "Toroidal_Field_Coil_2015"
+    },
     "param_class": "TripleArc",
     "variables_map": {},
     "problem_class": "bluemira.builders.tf_coils::RippleConstrainedLengthGOP",
@@ -146,8 +165,13 @@
     }
   },
   "PF coils": {
-    "run_mode": "run",
+    "run_mode": "read",
     "file_path": "$path_expand:./PFCoilDesign.json",
+    "material": {
+      "Ground Insulation": "Poloidal_Field_Coil",
+      "Winding Pack": "Poloidal_Field_Coil",
+      "Casing": "Poloidal_Field_Coil"
+    },
     "verbose": false,
     "plot": true,
     "grid_settings": {
@@ -194,7 +218,12 @@
       }
     }
   },
-  "Upper Port": {},
+  "Upper Port": {
+    "material": {
+      "TS": "SS316-LN",
+      "VV": "SS316-LN"
+    }
+  },
   "Equatorial Port": {
     "params": {
       "ep_width": {
@@ -215,6 +244,10 @@
         "source": "Input",
         "long_name": "Equatorial port central axis z coordinate"
       }
+    },
+    "material": {
+      "TS": "SS316-LN",
+      "VV": "SS316-LN"
     }
   },
   "Lower Port": {
@@ -243,6 +276,10 @@
         "source": "Input",
         "long_name": "Width of the lower port"
       }
+    },
+    "material": {
+      "TS": "SS316-LN",
+      "VV": "SS316-LN"
     }
   },
   "Cryostat": {
@@ -265,6 +302,16 @@
         "source": "Input",
         "long_name": "Castellation offset value."
       }
+    },
+    "material": {
+      "Body": "SS316-LN",
+      "Port Plug": "SS316-LN"
+    }
+  },
+  "Thermal shield": {
+    "material": {
+      "VVTS": "SS316-LN",
+      "Cryostat TS": "SS316-LN"
     }
   },
   "RadiationShield": {
@@ -287,6 +334,14 @@
         "source": "Input",
         "long_name": "Castellation offset value."
       }
+    },
+    "material": "SS316-LN"
+  },
+  "Coil structures": {
+    "material": {
+      "PF ICS": "SS316-LN",
+      "TF OIS": "SS316-LN",
+      "GS": "SS316-LN"
     }
   }
 }

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -5,7 +5,7 @@
     "mixtures": "$path_expand:./materials_data/mixtures.json"
   },
   "Radial build": {
-    "run_mode": "read",
+    "run_mode": "run",
     "read_dir": "$path_expand:./",
     "run_dir": "$path_expand:./",
     "plot": true
@@ -64,7 +64,7 @@
     }
   },
   "Free boundary equilibrium": {
-    "run_mode": "read",
+    "run_mode": "run",
     "plot": true,
     "save": true,
     "fixed_eq_file_path": "$path_expand:./fixed_boundary_eqdsk.json",
@@ -138,7 +138,7 @@
     "show_data": false
   },
   "TF coils": {
-    "run_mode": "read",
+    "run_mode": "run",
     "file_path": "$path_expand:./TFCoilDesign.json",
     "plot": true,
     "material": {
@@ -167,7 +167,7 @@
     }
   },
   "PF coils": {
-    "run_mode": "read",
+    "run_mode": "run",
     "file_path": "$path_expand:./PFCoilDesign.json",
     "material": {
       "Ground Insulation": "Poloidal_Field_Coil",

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -1,5 +1,9 @@
 {
   "params": "$path:params.json",
+  "materials_path": {
+    "materials": "$path_expand:./materials_data/materials.json",
+    "mixtures": "$path_expand:./materials_data/mixtures.json"
+  },
   "Radial build": {
     "run_mode": "read",
     "read_dir": "$path_expand:./",

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -117,9 +117,7 @@
     }
   },
   "Vacuum vessel": {
-    "material": {
-      "Body": "SS316-LN"
-    }
+    "material": "SS316-LN"
   },
   "Divertor": {
     "material": "SS316-LN"

--- a/eudemo/eudemo/blanket/builder.py
+++ b/eudemo/eudemo/blanket/builder.py
@@ -22,6 +22,7 @@ from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.placement import BluemiraPlacement
 from bluemira.geometry.tools import slice_shape
+from bluemira.materials.cache import get_cached_material
 
 
 @dataclass
@@ -168,7 +169,11 @@ class BlanketBuilder(Builder):
             [self.OBS, self.params.n_bb_inboard.value + 1, obs_shapes],
         ]:
             for no, shape in enumerate(bs_shape):
-                segment = PhysicalComponent(f"{name}_{no}", shape)
+                segment = PhysicalComponent(
+                    f"{name}_{no}",
+                    shape,
+                    material=get_cached_material(self.build_config["material"][name]),
+                )
                 apply_component_display_options(
                     segment, color=BLUE_PALETTE[self.BB][base_no + no]
                 )

--- a/eudemo/eudemo/blanket/builder.py
+++ b/eudemo/eudemo/blanket/builder.py
@@ -172,7 +172,9 @@ class BlanketBuilder(Builder):
                 segment = PhysicalComponent(
                     f"{name}_{no}",
                     shape,
-                    material=get_cached_material(self.build_config["material"][name]),
+                    material=get_cached_material(
+                        self.build_config.get("material").get(name)
+                    ),
                 )
                 apply_component_display_options(
                     segment, color=BLUE_PALETTE[self.BB][base_no + no]

--- a/eudemo/eudemo/blanket/builder.py
+++ b/eudemo/eudemo/blanket/builder.py
@@ -22,7 +22,6 @@ from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.placement import BluemiraPlacement
 from bluemira.geometry.tools import slice_shape
-from bluemira.materials.cache import get_cached_material
 
 
 @dataclass
@@ -172,9 +171,7 @@ class BlanketBuilder(Builder):
                 segment = PhysicalComponent(
                     f"{name}_{no}",
                     shape,
-                    material=get_cached_material(
-                        self.build_config.get("material", {}).get(name)
-                    ),
+                    material=self.get_material(name),
                 )
                 apply_component_display_options(
                     segment, color=BLUE_PALETTE[self.BB][base_no + no]

--- a/eudemo/eudemo/blanket/builder.py
+++ b/eudemo/eudemo/blanket/builder.py
@@ -173,7 +173,7 @@ class BlanketBuilder(Builder):
                     f"{name}_{no}",
                     shape,
                     material=get_cached_material(
-                        self.build_config.get("material").get(name)
+                        self.build_config.get("material", {}).get(name)
                     ),
                 )
                 apply_component_display_options(

--- a/eudemo/eudemo/comp_managers.py
+++ b/eudemo/eudemo/comp_managers.py
@@ -135,15 +135,13 @@ class PlugManagerMixin(OrphanerMixin):
                 plugs.append(child)
 
         component = self.component()
-        xyz_shape = (
-            component.get_component("xyz")
-            .get_component("Sector 1")
-            .get_component(name)
-            .shape
+        comp_pc = (
+            component.get_component("xyz").get_component("Sector 1").get_component(name)
         )
+        xyz_shape = comp_pc.shape
 
         xyz_shape = boolean_cut(xyz_shape, void_shapes)[0]
-        xyz_comp = PhysicalComponent(name, xyz_shape)
+        xyz_comp = PhysicalComponent(name, xyz_shape, material=comp_pc.material)
         apply_component_display_options(xyz_comp, color=color_list[0])
         self._orphan_old_components(component)
 

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -31,7 +31,6 @@ from bluemira.geometry.tools import (
     point_inside_shape,
 )
 from bluemira.materials import Void
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.reactor_config import ConfigParams
@@ -55,6 +54,8 @@ class TSUpperPortDuctBuilder(Builder):
 
     params: TSUpperPortDuctBuilderParams
     param_cls: type[TSUpperPortDuctBuilderParams] = TSUpperPortDuctBuilderParams
+
+    TS = "TS"
 
     def __init__(
         self,
@@ -112,11 +113,9 @@ class TSUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("TS")
-            ),
+            material=self.get_material(self.TS),
         )
-        apply_component_display_options(comp, BLUE_PALETTE["TS"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.TS][0])
         void = PhysicalComponent(
             self.name + " voidspace",
             extrude_shape(xy_voidface, (0, 0, self.z_max)),
@@ -135,7 +134,7 @@ class TSUpperPortDuctBuilder(Builder):
             The xy component
         """
         comp = PhysicalComponent(self.name, face)
-        apply_component_display_options(comp, BLUE_PALETTE["TS"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.TS][0])
         return comp
 
 
@@ -161,6 +160,8 @@ class TSEquatorialPortDuctBuilder(Builder):
 
     params: TSEquatorialPortDuctBuilderParams
     param_cls = TSEquatorialPortDuctBuilderParams
+
+    TS = "TS"
 
     def __init__(
         self,
@@ -218,16 +219,14 @@ class TSEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("TS")
-            ),
+            self.get_material(self.TS),
         )
 
         void = extrude_shape(yz_voidface, vec)
         void.rotate(degree=degree)
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
 
-        apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.TS][0])
         apply_component_display_options(void, color=(0, 0, 0))
         return [comp, void]
 
@@ -251,6 +250,8 @@ class VVUpperPortDuctBuilder(Builder):
 
     params: VVUpperPortDuctBuilderParams
     param_cls = VVUpperPortDuctBuilderParams
+
+    VV = "VV"
 
     def __init__(
         self,
@@ -321,11 +322,9 @@ class VVUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("VV")
-            ),
+            material=self.get_material(self.VV),
         )
-        apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.VV][0])
         void = PhysicalComponent(
             self.name + " voidspace",
             extrude_shape(xy_voidface, (0, 0, self.z_max)),
@@ -345,7 +344,7 @@ class VVUpperPortDuctBuilder(Builder):
         """
         xy_voidface = BluemiraFace(xy_face.boundary[1])
         comp = PhysicalComponent(self.name, xy_face)
-        apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.VV][0])
         void = PhysicalComponent(
             self.name + " voidspace", xy_voidface, material=Void("vacuum")
         )
@@ -371,6 +370,8 @@ class VVEquatorialPortDuctBuilder(Builder):
 
     params: VVEquatorialPortDuctBuilderParams
     param_cls = VVEquatorialPortDuctBuilderParams
+
+    VV = "VV"
 
     def __init__(
         self,
@@ -427,16 +428,14 @@ class VVEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("VV")
-            ),
+            material=self.get_material(self.VV),
         )
 
         void = extrude_shape(yz_voidface, vec)
         void.rotate(degree=degree)
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
 
-        apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
+        apply_component_display_options(comp, BLUE_PALETTE[self.VV][0])
         apply_component_display_options(void, color=(0, 0, 0))
         return [comp, void]
 

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -31,6 +31,7 @@ from bluemira.geometry.tools import (
     point_inside_shape,
 )
 from bluemira.materials import Void
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from bluemira.base.reactor_config import ConfigParams
@@ -58,10 +59,11 @@ class TSUpperPortDuctBuilder(Builder):
     def __init__(
         self,
         params: dict | ParameterFrame | ConfigParams | None,
+        build_config: dict,
         port_koz: BluemiraFace,
         cryostat_ts_xz: BluemiraWire,
     ):
-        super().__init__(params, None)
+        super().__init__(params, build_config)
         self.x_min = port_koz.bounding_box.x_min
         self.x_max = port_koz.bounding_box.x_max
         self.z_max = cryostat_ts_xz.bounding_box.z_max + 0.5 * self.params.g_cr_ts.value
@@ -107,7 +109,11 @@ class TSUpperPortDuctBuilder(Builder):
         # Add start-cap for future boolean fragmentation help
         cap = extrude_shape(xy_outface, vec=(0, 0, 0.1))
         port = boolean_fuse([port, cap])
-        comp = PhysicalComponent(self.name, port)
+        comp = PhysicalComponent(
+            self.name,
+            port,
+            material=get_cached_material(self.build_config["material"]["TS"]),
+        )
         apply_component_display_options(comp, BLUE_PALETTE["TS"][0])
         void = PhysicalComponent(
             self.name + " voidspace",
@@ -157,9 +163,10 @@ class TSEquatorialPortDuctBuilder(Builder):
     def __init__(
         self,
         params: dict | ParameterFrame | ConfigParams | None,
+        build_config: dict,
         cryostat_xz: BluemiraWire,
     ):
-        super().__init__(params, None)
+        super().__init__(params, build_config)
         # Put the end of the equatorial port half-way between cryostat ts and
         # cryostat
         self.x_max = cryostat_xz.bounding_box.x_max + 0.5 * self.params.g_cr_ts.value
@@ -206,7 +213,11 @@ class TSEquatorialPortDuctBuilder(Builder):
         vec = (self.params.R_0.value - self.x_max, 0, 0)
         port = extrude_shape(yz_face, vec)
         port.rotate(degree=degree)
-        comp = PhysicalComponent(self.name, port)
+        comp = PhysicalComponent(
+            self.name,
+            port,
+            material=get_cached_material(self.build_config["material"]["TS"]),
+        )
 
         void = extrude_shape(yz_voidface, vec)
         void.rotate(degree=degree)
@@ -240,10 +251,11 @@ class VVUpperPortDuctBuilder(Builder):
     def __init__(
         self,
         params: dict | ParameterFrame | ConfigParams | None,
+        build_config: dict,
         port_koz: BluemiraFace,
         cryostat_ts_xz: BluemiraWire,
     ):
-        super().__init__(params, None)
+        super().__init__(params, build_config)
         koz_offset = self.params.tk_ts.value + self.params.g_vv_ts.value
         self.x_min = port_koz.bounding_box.x_min + koz_offset
         self.x_max = port_koz.bounding_box.x_max - koz_offset
@@ -302,7 +314,11 @@ class VVUpperPortDuctBuilder(Builder):
         cap = extrude_shape(xy_outface, vec=(0, 0, 0.1))
         port = boolean_fuse([port, cap])
 
-        comp = PhysicalComponent(self.name, port)
+        comp = PhysicalComponent(
+            self.name,
+            port,
+            material=get_cached_material(self.build_config["material"]["VV"]),
+        )
         apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
         void = PhysicalComponent(
             self.name + " voidspace",
@@ -353,9 +369,10 @@ class VVEquatorialPortDuctBuilder(Builder):
     def __init__(
         self,
         params: dict | ParameterFrame | ConfigParams | None,
+        build_config: dict,
         cryostat_xz: BluemiraWire,
     ):
-        super().__init__(params, None)
+        super().__init__(params, build_config)
         # Put the end of the equatorial port half-way between cryostat ts and
         # cryostat
         self.x_max = cryostat_xz.bounding_box.x_max + 0.5 * self.params.g_cr_ts.value
@@ -401,7 +418,11 @@ class VVEquatorialPortDuctBuilder(Builder):
         vec = (self.params.R_0.value - self.x_max, 0, 0)
         port = extrude_shape(yz_face, vec)
         port.rotate(degree=degree)
-        comp = PhysicalComponent(self.name, port)
+        comp = PhysicalComponent(
+            self.name,
+            port,
+            material=get_cached_material(self.build_config["material"]["VV"]),
+        )
 
         void = extrude_shape(yz_voidface, vec)
         void.rotate(degree=degree)

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -112,7 +112,7 @@ class TSUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config["material"]["TS"]),
+            material=get_cached_material(self.build_config.get("material").get("TS")),
         )
         apply_component_display_options(comp, BLUE_PALETTE["TS"][0])
         void = PhysicalComponent(
@@ -216,7 +216,7 @@ class TSEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config["material"]["TS"]),
+            material=get_cached_material(self.build_config.get("material").get("TS")),
         )
 
         void = extrude_shape(yz_voidface, vec)
@@ -317,7 +317,7 @@ class VVUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config["material"]["VV"]),
+            material=get_cached_material(self.build_config.get("material").get("VV")),
         )
         apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
         void = PhysicalComponent(
@@ -421,7 +421,7 @@ class VVEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config["material"]["VV"]),
+            material=get_cached_material(self.build_config.get("material").get("VV")),
         )
 
         void = extrude_shape(yz_voidface, vec)

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -112,7 +112,9 @@ class TSUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config.get("material").get("TS")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("TS")
+            ),
         )
         apply_component_display_options(comp, BLUE_PALETTE["TS"][0])
         void = PhysicalComponent(
@@ -216,7 +218,9 @@ class TSEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config.get("material").get("TS")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("TS")
+            ),
         )
 
         void = extrude_shape(yz_voidface, vec)
@@ -317,7 +321,9 @@ class VVUpperPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config.get("material").get("VV")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("VV")
+            ),
         )
         apply_component_display_options(comp, BLUE_PALETTE["VV"][0])
         void = PhysicalComponent(
@@ -421,7 +427,9 @@ class VVEquatorialPortDuctBuilder(Builder):
         comp = PhysicalComponent(
             self.name,
             port,
-            material=get_cached_material(self.build_config.get("material").get("VV")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("VV")
+            ),
         )
 
         void = extrude_shape(yz_voidface, vec)

--- a/eudemo/eudemo/maintenance/lower_port/builder.py
+++ b/eudemo/eudemo/maintenance/lower_port/builder.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from bluemira.materials.cache import get_cached_material
-
 if TYPE_CHECKING:
     from bluemira.geometry.solid import BluemiraSolid
     from bluemira.geometry.wire import BluemiraWire
@@ -47,6 +45,8 @@ class TSLowerPortDuctBuilder(Builder):
     """
 
     param_cls: type[TSLowerPortDuctBuilderParams] = TSLowerPortDuctBuilderParams
+
+    TS = "TS"
 
     def __init__(
         self,
@@ -97,12 +97,10 @@ class TSLowerPortDuctBuilder(Builder):
         pc = PhysicalComponent(
             self.name,
             duct,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("TS")
-            ),
+            material=self.get_material(self.TS),
         )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
-        apply_component_display_options(pc, color=BLUE_PALETTE["TS"][0])
+        apply_component_display_options(pc, color=BLUE_PALETTE[self.TS][0])
         apply_component_display_options(void, color=(0, 0, 0))
 
         return [pc, void]
@@ -125,6 +123,8 @@ class VVLowerPortDuctBuilder(Builder):
     """
 
     param_cls: type[VVLowerPortDuctBuilderParams] = VVLowerPortDuctBuilderParams
+
+    VV = "VV"
 
     def __init__(
         self,
@@ -181,12 +181,10 @@ class VVLowerPortDuctBuilder(Builder):
         pc = PhysicalComponent(
             self.name,
             duct,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get("VV")
-            ),
+            material=self.get_material(self.VV),
         )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
-        apply_component_display_options(pc, color=BLUE_PALETTE["VV"][0])
+        apply_component_display_options(pc, color=BLUE_PALETTE[self.VV][0])
         apply_component_display_options(void, color=(0, 0, 0))
 
         return [pc, void]

--- a/eudemo/eudemo/maintenance/lower_port/builder.py
+++ b/eudemo/eudemo/maintenance/lower_port/builder.py
@@ -97,7 +97,9 @@ class TSLowerPortDuctBuilder(Builder):
         pc = PhysicalComponent(
             self.name,
             duct,
-            material=get_cached_material(self.build_config["material"]["TS"]),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("TS")
+            ),
         )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
         apply_component_display_options(pc, color=BLUE_PALETTE["TS"][0])
@@ -179,7 +181,9 @@ class VVLowerPortDuctBuilder(Builder):
         pc = PhysicalComponent(
             self.name,
             duct,
-            material=get_cached_material(self.build_config.get("material").get("VV")),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get("VV")
+            ),
         )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
         apply_component_display_options(pc, color=BLUE_PALETTE["VV"][0])

--- a/eudemo/eudemo/maintenance/lower_port/builder.py
+++ b/eudemo/eudemo/maintenance/lower_port/builder.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from bluemira.materials.cache import get_cached_material
+
 if TYPE_CHECKING:
     from bluemira.geometry.solid import BluemiraSolid
     from bluemira.geometry.wire import BluemiraWire
@@ -92,7 +94,11 @@ class TSLowerPortDuctBuilder(Builder):
             self.x_straight_end,
         )
 
-        pc = PhysicalComponent(self.name, duct)
+        pc = PhysicalComponent(
+            self.name,
+            duct,
+            material=get_cached_material(self.build_config["material"]["TS"]),
+        )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
         apply_component_display_options(pc, color=BLUE_PALETTE["TS"][0])
         apply_component_display_options(void, color=(0, 0, 0))
@@ -170,7 +176,11 @@ class VVLowerPortDuctBuilder(Builder):
             self.x_straight_end,
         )
 
-        pc = PhysicalComponent(self.name, duct)
+        pc = PhysicalComponent(
+            self.name,
+            duct,
+            material=get_cached_material(self.build_config["material"]["VV"]),
+        )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
         apply_component_display_options(pc, color=BLUE_PALETTE["VV"][0])
         apply_component_display_options(void, color=(0, 0, 0))

--- a/eudemo/eudemo/maintenance/lower_port/builder.py
+++ b/eudemo/eudemo/maintenance/lower_port/builder.py
@@ -179,7 +179,7 @@ class VVLowerPortDuctBuilder(Builder):
         pc = PhysicalComponent(
             self.name,
             duct,
-            material=get_cached_material(self.build_config["material"]["VV"]),
+            material=get_cached_material(self.build_config.get("material").get("VV")),
         )
         void = PhysicalComponent(self.name + " voidspace", void, material=Void("vacuum"))
         apply_component_display_options(pc, color=BLUE_PALETTE["VV"][0])

--- a/eudemo/eudemo/maintenance/port_plug.py
+++ b/eudemo/eudemo/maintenance/port_plug.py
@@ -24,6 +24,7 @@ from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import boolean_fuse, extrude_shape, offset_wire
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.materials import Void
+from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -258,7 +259,11 @@ class CryostatPortPlugBuilder(Builder):
 
         plug_comps, void_comps = [], []
         for i, (plug, void) in enumerate(zip(plugs, voids, strict=False)):
-            plug = PhysicalComponent(f"{self.name} {i}", plug)  # noqa: PLW2901
+            plug = PhysicalComponent(  # noqa: PLW2901
+                f"{self.name} {i}",
+                plug,
+                material=get_cached_material(self.build_config["material"]["Port Plug"]),
+            )
             void = PhysicalComponent(  # noqa: PLW2901
                 f"{self.name} {i} voidspace", void, material=Void("air")
             )

--- a/eudemo/eudemo/maintenance/port_plug.py
+++ b/eudemo/eudemo/maintenance/port_plug.py
@@ -262,7 +262,9 @@ class CryostatPortPlugBuilder(Builder):
             plug = PhysicalComponent(  # noqa: PLW2901
                 f"{self.name} {i}",
                 plug,
-                material=get_cached_material(self.build_config["material"]["Port Plug"]),
+                material=get_cached_material(
+                    self.build_config.get("material").get("Port Plug")
+                ),
             )
             void = PhysicalComponent(  # noqa: PLW2901
                 f"{self.name} {i} voidspace", void, material=Void("air")

--- a/eudemo/eudemo/maintenance/port_plug.py
+++ b/eudemo/eudemo/maintenance/port_plug.py
@@ -24,7 +24,6 @@ from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import boolean_fuse, extrude_shape, offset_wire
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.materials import Void
-from bluemira.materials.cache import get_cached_material
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -211,6 +210,8 @@ class CryostatPortPlugBuilder(Builder):
 
     param_cls: type[CryostatPortPlugBuilderParams] = CryostatPortPlugBuilderParams
 
+    PORT_PLUG = "Port Plug"
+
     def __init__(
         self,
         params: dict | ParameterFrame | CryostatPortPlugBuilderParams,
@@ -262,9 +263,7 @@ class CryostatPortPlugBuilder(Builder):
             plug = PhysicalComponent(  # noqa: PLW2901
                 f"{self.name} {i}",
                 plug,
-                material=get_cached_material(
-                    self.build_config.get("material", {}).get("Port Plug")
-                ),
+                material=self.get_material(self.PORT_PLUG),
             )
             void = PhysicalComponent(  # noqa: PLW2901
                 f"{self.name} {i} voidspace", void, material=Void("air")

--- a/eudemo/eudemo/maintenance/port_plug.py
+++ b/eudemo/eudemo/maintenance/port_plug.py
@@ -263,7 +263,7 @@ class CryostatPortPlugBuilder(Builder):
                 f"{self.name} {i}",
                 plug,
                 material=get_cached_material(
-                    self.build_config.get("material").get("Port Plug")
+                    self.build_config.get("material", {}).get("Port Plug")
                 ),
             )
             void = PhysicalComponent(  # noqa: PLW2901

--- a/eudemo/eudemo/reactor.py
+++ b/eudemo/eudemo/reactor.py
@@ -44,6 +44,7 @@ from bluemira.equilibria.run import Snapshot
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import distance_to, interpolate_bspline, offset_wire
+from bluemira.materials.cache import establish_material_cache
 from eudemo.blanket import Blanket, BlanketBuilder, BlanketDesigner
 from eudemo.coil_structure import build_coil_structures_component
 from eudemo.comp_managers import (
@@ -357,9 +358,13 @@ def build_upper_port(
     :
         Upper port components
     """
-    ts_builder = TSUpperPortDuctBuilder(params, upper_port_koz, cryostat_ts_xz_boundary)
+    ts_builder = TSUpperPortDuctBuilder(
+        params, build_config, upper_port_koz, cryostat_ts_xz_boundary
+    )
     ts_upper_port = ts_builder.build()
-    vv_builder = VVUpperPortDuctBuilder(params, upper_port_koz, cryostat_ts_xz_boundary)
+    vv_builder = VVUpperPortDuctBuilder(
+        params, build_config, upper_port_koz, cryostat_ts_xz_boundary
+    )
     vv_upper_port = vv_builder.build()
     return ts_upper_port, vv_upper_port
 
@@ -375,9 +380,9 @@ def build_equatorial_port(
     :
         Equatorial port components
     """
-    builder = VVEquatorialPortDuctBuilder(params, cryostat_ts_xz_boundary)
+    builder = VVEquatorialPortDuctBuilder(params, build_config, cryostat_ts_xz_boundary)
     vv_eq_port = builder.build()
-    builder = TSEquatorialPortDuctBuilder(params, cryostat_ts_xz_boundary)
+    builder = TSEquatorialPortDuctBuilder(params, build_config, cryostat_ts_xz_boundary)
     ts_eq_port = builder.build()
     return ts_eq_port, vv_eq_port
 
@@ -511,6 +516,11 @@ def build_radiation_plugs(
 
 if __name__ == "__main__":
     set_log_level("INFO")
+
+    establish_material_cache([
+        Path(CONFIG_DIR, "materials.json"),
+        Path(CONFIG_DIR, "mixtures.json"),
+    ])
     reactor_config = ReactorConfig(BUILD_CONFIG_FILE_PATH, EUDEMOReactorParams)
     reactor = EUDEMO(
         "EUDEMO",

--- a/eudemo/eudemo/reactor.py
+++ b/eudemo/eudemo/reactor.py
@@ -517,15 +517,16 @@ def build_radiation_plugs(
 if __name__ == "__main__":
     set_log_level("INFO")
 
-    establish_material_cache([
-        Path(CONFIG_DIR, "materials.json"),
-        Path(CONFIG_DIR, "mixtures.json"),
-    ])
     reactor_config = ReactorConfig(BUILD_CONFIG_FILE_PATH, EUDEMOReactorParams)
     reactor = EUDEMO(
         "EUDEMO",
         n_sectors=reactor_config.global_params.n_TF.value,
     )
+
+    establish_material_cache([
+        reactor_config.config_for("materials_path")["materials"],
+        reactor_config.config_for("materials_path")["mixtures"],
+    ])
 
     radial_build(
         reactor_config.params_for("Radial build").global_params,

--- a/eudemo/eudemo/tf_coils/tf_coils.py
+++ b/eudemo/eudemo/tf_coils/tf_coils.py
@@ -50,7 +50,6 @@ from bluemira.magnetostatics.circuits import (
     ArbitraryPlanarRectangularXSCircuit,
     HelmholtzCage,
 )
-from bluemira.materials.cache import get_cached_material
 from bluemira.utilities.tools import get_class_from_module
 
 
@@ -742,9 +741,7 @@ class TFCoilBuilder(Builder):
         winding_pack = PhysicalComponent(
             self.WP,
             wp_solid,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.WP)
-            ),
+            material=self.get_material(self.WP),
         )
 
         apply_component_display_options(winding_pack, color=BLUE_PALETTE["TF"][1])
@@ -768,9 +765,7 @@ class TFCoilBuilder(Builder):
         insulation = PhysicalComponent(
             self.INS,
             ins_solid,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.INS)
-            ),
+            material=self.get_material(self.INS),
         )
 
         apply_component_display_options(insulation, color=BLUE_PALETTE["TF"][2])
@@ -825,9 +820,7 @@ class TFCoilBuilder(Builder):
         casing = PhysicalComponent(
             self.CASING,
             case_solid_hollow,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.CASING)
-            ),
+            material=self.get_material(self.CASING),
         )
 
         apply_component_display_options(casing, color=BLUE_PALETTE["TF"][0])

--- a/eudemo/eudemo/tf_coils/tf_coils.py
+++ b/eudemo/eudemo/tf_coils/tf_coils.py
@@ -742,7 +742,9 @@ class TFCoilBuilder(Builder):
         winding_pack = PhysicalComponent(
             self.WP,
             wp_solid,
-            material=get_cached_material(self.build_config.get("material").get(self.WP)),
+            material=get_cached_material(
+                self.build_config.get("material", {}).get(self.WP)
+            ),
         )
 
         apply_component_display_options(winding_pack, color=BLUE_PALETTE["TF"][1])
@@ -767,7 +769,7 @@ class TFCoilBuilder(Builder):
             self.INS,
             ins_solid,
             material=get_cached_material(
-                self.build_config.get("material").get(self.INS)
+                self.build_config.get("material", {}).get(self.INS)
             ),
         )
 
@@ -824,7 +826,7 @@ class TFCoilBuilder(Builder):
             self.CASING,
             case_solid_hollow,
             material=get_cached_material(
-                self.build_config.get("material").get(self.CASING)
+                self.build_config.get("material", {}).get(self.CASING)
             ),
         )
 

--- a/eudemo/eudemo/tf_coils/tf_coils.py
+++ b/eudemo/eudemo/tf_coils/tf_coils.py
@@ -50,6 +50,7 @@ from bluemira.magnetostatics.circuits import (
     ArbitraryPlanarRectangularXSCircuit,
     HelmholtzCage,
 )
+from bluemira.materials.cache import get_cached_material
 from bluemira.utilities.tools import get_class_from_module
 
 
@@ -738,7 +739,11 @@ class TFCoilBuilder(Builder):
             Winding pack x-y-z
         """
         wp_solid = sweep_shape(self.wp_cross_section, self.centreline)
-        winding_pack = PhysicalComponent(self.WP, wp_solid)
+        winding_pack = PhysicalComponent(
+            self.WP,
+            wp_solid,
+            material=get_cached_material(self.build_config["material"][self.WP]),
+        )
 
         apply_component_display_options(winding_pack, color=BLUE_PALETTE["TF"][1])
 
@@ -761,6 +766,7 @@ class TFCoilBuilder(Builder):
         insulation = PhysicalComponent(
             self.INS,
             ins_solid,
+            material=get_cached_material(self.build_config["material"][self.INS]),
         )
 
         apply_component_display_options(insulation, color=BLUE_PALETTE["TF"][2])
@@ -812,7 +818,11 @@ class TFCoilBuilder(Builder):
             case_solid, BluemiraSolid(ins_solid.boundary[0])
         )[0]
 
-        casing = PhysicalComponent(self.CASING, case_solid_hollow)
+        casing = PhysicalComponent(
+            self.CASING,
+            case_solid_hollow,
+            material=get_cached_material(self.build_config["material"][self.CASING]),
+        )
 
         apply_component_display_options(casing, color=BLUE_PALETTE["TF"][0])
 

--- a/eudemo/eudemo/tf_coils/tf_coils.py
+++ b/eudemo/eudemo/tf_coils/tf_coils.py
@@ -742,7 +742,7 @@ class TFCoilBuilder(Builder):
         winding_pack = PhysicalComponent(
             self.WP,
             wp_solid,
-            material=get_cached_material(self.build_config["material"][self.WP]),
+            material=get_cached_material(self.build_config.get("material").get(self.WP)),
         )
 
         apply_component_display_options(winding_pack, color=BLUE_PALETTE["TF"][1])
@@ -766,7 +766,9 @@ class TFCoilBuilder(Builder):
         insulation = PhysicalComponent(
             self.INS,
             ins_solid,
-            material=get_cached_material(self.build_config["material"][self.INS]),
+            material=get_cached_material(
+                self.build_config.get("material").get(self.INS)
+            ),
         )
 
         apply_component_display_options(insulation, color=BLUE_PALETTE["TF"][2])
@@ -821,7 +823,9 @@ class TFCoilBuilder(Builder):
         casing = PhysicalComponent(
             self.CASING,
             case_solid_hollow,
-            material=get_cached_material(self.build_config["material"][self.CASING]),
+            material=get_cached_material(
+                self.build_config.get("material").get(self.CASING)
+            ),
         )
 
         apply_component_display_options(casing, color=BLUE_PALETTE["TF"][0])

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -30,10 +30,7 @@ from bluemira.geometry.tools import (
     boolean_fuse,
     force_wire_to_spline,
 )
-from bluemira.materials.cache import (
-    Void,
-    get_cached_material_for_component,
-)
+from bluemira.materials.cache import Void
 from eudemo.comp_managers import PortManagerMixin
 from eudemo.maintenance.duct_connection import pipe_pipe_join
 
@@ -212,7 +209,7 @@ class VacuumVesselBuilder(Builder):
         body = PhysicalComponent(
             self.BODY,
             face,
-            material=get_cached_material_for_component(self.build_config, self.BODY),
+            material=self.get_material(),
         )
         vacuum = PhysicalComponent(
             self.VOID, BluemiraFace(inner_vv), material=Void("vacuum")
@@ -251,7 +248,7 @@ class VacuumVesselBuilder(Builder):
             [BLUE_PALETTE[self.VV][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material_for_component(self.build_config, self.BODY),
+                self.get_material(),
                 Void("vacuum"),
             ],
         )

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -30,7 +30,10 @@ from bluemira.geometry.tools import (
     boolean_fuse,
     force_wire_to_spline,
 )
-from bluemira.materials.cache import Void, get_cached_material
+from bluemira.materials.cache import (
+    Void,
+    get_cached_material_for_component,
+)
 from eudemo.comp_managers import PortManagerMixin
 from eudemo.maintenance.duct_connection import pipe_pipe_join
 
@@ -209,9 +212,7 @@ class VacuumVesselBuilder(Builder):
         body = PhysicalComponent(
             self.BODY,
             face,
-            material=get_cached_material(
-                self.build_config.get("material", {}).get(self.BODY)
-            ),
+            material=get_cached_material_for_component(self.build_config, self.BODY),
         )
         vacuum = PhysicalComponent(
             self.VOID, BluemiraFace(inner_vv), material=Void("vacuum")
@@ -234,7 +235,7 @@ class VacuumVesselBuilder(Builder):
 
     def build_xyz(
         self, vv_face: BluemiraFace, vacuum_face: BluemiraFace, degree: float = 360.0
-    ) -> PhysicalComponent:
+    ) -> list[PhysicalComponent]:
         """
         Build the x-y-z components of the vacuum vessel.
 
@@ -250,9 +251,7 @@ class VacuumVesselBuilder(Builder):
             [BLUE_PALETTE[self.VV][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material(
-                    self.build_config.get("material", {}).get(self.BODY)
-                ),
+                get_cached_material_for_component(self.build_config, self.BODY),
                 Void("vacuum"),
             ],
         )

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -209,7 +209,9 @@ class VacuumVesselBuilder(Builder):
         body = PhysicalComponent(
             self.BODY,
             face,
-            material=get_cached_material(self.build_config["material"][self.BODY]),
+            material=get_cached_material(
+                self.build_config.get("material").get(self.BODY)
+            ),
         )
         vacuum = PhysicalComponent(
             self.VOID, BluemiraFace(inner_vv), material=Void("vacuum")
@@ -248,7 +250,7 @@ class VacuumVesselBuilder(Builder):
             [BLUE_PALETTE[self.VV][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material(self.build_config["material"][self.BODY]),
+                get_cached_material(self.build_config.get("material").get(self.BODY)),
                 Void("vacuum"),
             ],
         )

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -210,7 +210,7 @@ class VacuumVesselBuilder(Builder):
             self.BODY,
             face,
             material=get_cached_material(
-                self.build_config.get("material").get(self.BODY)
+                self.build_config.get("material", {}).get(self.BODY)
             ),
         )
         vacuum = PhysicalComponent(
@@ -250,7 +250,9 @@ class VacuumVesselBuilder(Builder):
             [BLUE_PALETTE[self.VV][0], (0, 0, 0)],
             degree,
             material=[
-                get_cached_material(self.build_config.get("material").get(self.BODY)),
+                get_cached_material(
+                    self.build_config.get("material", {}).get(self.BODY)
+                ),
                 Void("vacuum"),
             ],
         )

--- a/eudemo/eudemo_tests/maintenance/test_upper_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_upper_port.py
@@ -122,7 +122,7 @@ class TestDuctConnection:
         self.params.tk_vv_single_wall.value = port_wall
         self.params.tk_vv_double_wall.value = port_wall * 2
         self.params.tf_wp_depth.value = y_offset
-        builder = VVUpperPortDuctBuilder(self.params, port_koz, port_koz)
+        builder = VVUpperPortDuctBuilder(self.params, {}, port_koz, port_koz)
         port = builder.build()
         xy = port.get_component("xy").get_component_properties("shape")
         diff = xy.wires[0].length - xy.wires[1].length
@@ -180,7 +180,7 @@ class TestDuctConnection:
         self.params.tk_vv_single_wall.value = 0
 
         with pytest.raises(ValueError):  # noqa: PT011
-            VVUpperPortDuctBuilder(self.params, self.port_koz, self.port_koz)
+            VVUpperPortDuctBuilder(self.params, {}, self.port_koz, self.port_koz)
 
     @pytest.mark.parametrize("end", [1, 5])
     def test_BuilderError_on_too_small_port(self, end):
@@ -188,7 +188,7 @@ class TestDuctConnection:
         self.params.tk_vv_single_wall.value = 0.5
         self.params.tk_vv_double_wall.value = end
         self.params.tf_wp_depth.value = 2.0
-        builder = VVUpperPortDuctBuilder(self.params, self.port_koz, self.port_koz)
+        builder = VVUpperPortDuctBuilder(self.params, {}, self.port_koz, self.port_koz)
 
         with pytest.raises(BuilderError):
             builder.build()


### PR DESCRIPTION
This PR setups the config and mechanics for specifying materials for each DEMO PhysicalCompoents in XYZ.

Part of the challenge in doing this is:
- Getting the necessary and correct material definitions data (in `materials.json`, `mixtures.json`)
- Specifying which components get what material

For some components, the geometry may need to be altered to define different parts of the component.
The breeding blanket for example does not have regions defined for the breeding zone, manifold etc.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
