### PR TITLE
Added tests for freecadapi from TODO list on circle and ellipse arcs

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -502,8 +502,6 @@ def make_circle(
     :
         FreeCAD wire that contains the arc or circle
     """
-    # TODO @ivanmaione: check the creation of the arc when start_angle < end_angle
-    # 3528
     output = Part.Circle()
     output.Radius = radius
     output.Center = Base.Vector(center)
@@ -538,8 +536,6 @@ def make_circle_arc_3P(  # noqa: N802
     :
         FreeCAD wire that contains the arc of circle
     """
-    # TODO @ivanmaione: check what happens when the 3 points are in a line
-    # 3528
     arc = Part.ArcOfCircle(Base.Vector(p1), Base.Vector(p2), Base.Vector(p3))
 
     # next steps are made to create an arc of circle that is consistent with that
@@ -590,8 +586,6 @@ def make_ellipse(
     :
         FreeCAD wire that contains the ellipse or arc of ellipse
     """
-    # TODO @ivanmaione: check the creation of the arc when start_angle < end_angle
-    # 3528
     s1 = Base.Vector(major_axis).normalize().multiply(major_radius) + Base.Vector(center)
     s2 = Base.Vector(minor_axis).normalize().multiply(minor_radius) + Base.Vector(center)
     center = Base.Vector(center)


### PR DESCRIPTION
## Linked Issues

Closes #3528 

## Description

Added tests that cover:

- arcs produced by make_circle (arc length, start point, end point)
- arcs produced by make_circle using start_angle > end_angle (points match equivalent arc for start<end)
- arcs produced by make_circle_arc_3P (points match previous arcs for equivalent shape, fails when 3 points in line)
- ellipse arcs produced by make_ellipse (length is correct to value calculated from complete elliptic integral)

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
