### PR TITLE
Checks for bluemira capitalisation only at start of sentences

### DIFF
--- a/.github/workflows/check_release_due.yml
+++ b/.github/workflows/check_release_due.yml
@@ -1,4 +1,4 @@
-# Checks if a release of Bluemira is due, and opens an issue if it is.
+# Checks if a release of bluemira is due, and opens an issue if it is.
 name: Check If Release Due
 
 on:

--- a/bluemira/base/reactor.py
+++ b/bluemira/base/reactor.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
-"""Base class for a Bluemira reactor."""
+"""Base class for a bluemira reactor."""
 
 from __future__ import annotations
 

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -306,7 +306,7 @@ class CodesSolver(abc.ABC):
         solver.
 
         This class is where computations should be defined. This may be
-        something like calling a Bluemira problem, or executing some
+        something like calling a bluemira problem, or executing some
         external code or process.
         """
 
@@ -318,7 +318,7 @@ class CodesSolver(abc.ABC):
 
         This class should perform any clean-up operations required by
         the solver. This may be deleting temporary files, or could
-        involve mapping parameters from some external code to Bluemira
+        involve mapping parameters from some external code to bluemira
         parameters.
         """
 

--- a/bluemira/codes/process/_setup.py
+++ b/bluemira/codes/process/_setup.py
@@ -38,7 +38,7 @@ class Setup(CodesSetup):
     in_dat_path:
         The path to where the IN.DAT file should be written.
     problem_settings:
-        The PROCESS parameters that do not exist in Bluemira.
+        The PROCESS parameters that do not exist in bluemira.
     """
 
     MODELS: ClassVar = {

--- a/bluemira/equilibria/find_legs.py
+++ b/bluemira/equilibria/find_legs.py
@@ -573,7 +573,7 @@ def calculate_connection_length(
         If an invalid option calculation_method is selected.
         If no target is provided for FLT calculation_method - this is because the
         flux interception point found is not accurate enough to be used
-        on a seperatrix automatically found by Bluemira (n.b., the FLT can not
+        on a seperatrix automatically found by bluemira (n.b., the FLT can not
         distingish between open and closed flux).
 
     """

--- a/bluemira/geometry/placement.py
+++ b/bluemira/geometry/placement.py
@@ -236,7 +236,7 @@ class BluemiraPlacement:
         Returns
         -------
         :
-            A Bluemira placement from a FreeCAD placement.
+            A bluemira placement from a FreeCAD placement.
         """
         if isinstance(obj, cadapi.apiPlacement):
             placement = BluemiraPlacement(label=label)

--- a/bluemira/geometry/plane.py
+++ b/bluemira/geometry/plane.py
@@ -79,7 +79,7 @@ class BluemiraPlane:
         Returns
         -------
         :
-            A Bluemira plane.
+            A bluemira plane.
         """
         plane = BluemiraPlane()
         plane._shape = cadapi.make_plane_from_3_points(point_1, point_2, point_3)

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -109,7 +109,7 @@ class BluemiraGeoEncoder(json.JSONEncoder):
         Returns
         -------
         :
-            List from Bluemira shape or numpy array.
+            List from bluemira shape or numpy array.
         """
         if isinstance(obj, BluemiraGeo):
             return serialise_shape(obj)

--- a/bluemira/materials/tools.py
+++ b/bluemira/materials/tools.py
@@ -138,7 +138,7 @@ def to_openmc_material(
     temperature_to_neutronics_code: bool = True,
 ) -> openmc.Material:
     """
-    Convert Bluemira material to OpenMC material
+    Convert bluemira material to OpenMC material
 
     Returns
     -------
@@ -189,7 +189,7 @@ def to_openmc_material_mixture(
     *,
     temperature_to_neutronics_code: bool = True,
 ) -> openmc.Material:
-    """Convert Bluemira material mixture to OpenMC material mixture
+    """Convert bluemira material mixture to OpenMC material mixture
 
     Returns
     -------

--- a/documentation/developer/adr/0005-record-cache-vs-recreate.md
+++ b/documentation/developer/adr/0005-record-cache-vs-recreate.md
@@ -23,7 +23,7 @@ Options:
         * Higher computational cost (recreate upon each call of geometry)
         * Higher maintenance overhead
         * Reverse engineering of FreeCAD is presently imperfect
-            * An operation can work in FreeCAD but fail upon "reconstruction" in Bluemira
+            * An operation can work in FreeCAD but fail upon "reconstruction" in bluemira
             * NotClosedWireError, DisjointedFaceError, ...
 * Cache the FreeCAD shape
     * Pros:

--- a/documentation/source/base/parameter.rst
+++ b/documentation/source/base/parameter.rst
@@ -114,7 +114,7 @@ Units
 :py:class:`ParameterFrames` always enforce the same set of standard units :ref:`unit_convention`.
 :py:class:`Parameters` within a :py:class:`ParameterFrame` whose units are convertible to one of bluemira's standard units,
 have their values and converted to the corresponding standard unit.
-This keeps the units used within Bluemira consistent across classes and modules.
+This keeps the units used within bluemira consistent across classes and modules.
 
 For this reason, if your inputs use a non-standard unit,
 the value you put into a :py:class:`Parameter` will be different to the one you get out.

--- a/documentation/source/developer/logging.rst
+++ b/documentation/source/developer/logging.rst
@@ -1,4 +1,4 @@
-Logging in Bluemira
+Logging in bluemira
 -------------------
 
 To organise and have granularity in text (and potentially graphical) outputs

--- a/documentation/source/developer/release_workflow.rst
+++ b/documentation/source/developer/release_workflow.rst
@@ -4,7 +4,7 @@ Release Workflow
 Schedule
 --------
 
-A new version of Bluemira is tagged every 6 weeks; marking the end of a
+A new version of bluemira is tagged every 6 weeks; marking the end of a
 development cycle.
 When a new release is due, a scheduled GitHub Actions workflow opens an issue
 to create a release.

--- a/documentation/source/introduction.rst
+++ b/documentation/source/introduction.rst
@@ -31,7 +31,7 @@ leveraging the functionality of the above modules.
 
 .. _how to use:
 
-How to use ``Bluemira``
+How to use ``bluemira``
 -----------------------
 
 ``Bluemira`` is designed to be used by three different types of user.
@@ -40,12 +40,12 @@ How to use ``Bluemira``
     A Modeller will execute a reactor build workflow (created by a '`Reactor Designer`_'), to carry out studies on a reactor design. Modellers will need to know about the parameters of a design, and how to manipulate JSON files to modify those parameters.
 
   _`Reactor Designer`
-    A Reactor Designer will use ``Bluemira`` as a framework to create a design for a reactor.
+    A Reactor Designer will use ``bluemira`` as a framework to create a design for a reactor.
     To design a reactor, the design workflow strategy needs to be considered and codified.
     Using Designer and Builder objects, each component of the reactor can be created and collected into a full reactor design, or used individually.
 
   Developers
-    A developer of ``Bluemira`` will need to understand the program to a much more detailed level than a reactor designer. They will be involved with adding new features to ``Bluemira`` as well as helping a Reactor Designer or a Modeller to add a new feature or customisation option.
+    A developer of ``bluemira`` will need to understand the program to a much more detailed level than a reactor designer. They will be involved with adding new features to ``bluemira`` as well as helping a Reactor Designer or a Modeller to add a new feature or customisation option.
 
 High level Architecture
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/source/optimisation/optimisation_doc.rst
+++ b/documentation/source/optimisation/optimisation_doc.rst
@@ -261,7 +261,7 @@ for an implemented example of an :code:`OptimisationProblem`.
 Available Optimisation Algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are several optimisation algorithms that can be used within Bluemira.
+There are several optimisation algorithms that can be used within bluemira.
 Including gradient and non-gradient based.
 
 - SLSQP

--- a/documentation/source/radiation_transport/radiation.rst
+++ b/documentation/source/radiation_transport/radiation.rst
@@ -118,7 +118,7 @@ distance along the SOL, *L* is the total parallel distance from the upstream to 
 is the cross-sectional area of the SOL for power flow.
 
 The **radiation region** starts above the X-point, as most of the radiative loss occurs near the divertor,
-due to the steep parallel temperature gradients [Pitcher_1997]_. In ``Bluemira``, the actual position is
+due to the steep parallel temperature gradients [Pitcher_1997]_. In ``bluemira``, the actual position is
 a user choice. The temperature decay stops at the entrance to recycling region. As for the upstream
 temperature, the temperature at the start of the radiation region is calculated as function of the
 parallel distance:

--- a/documentation/source/utilities/utilities.rst
+++ b/documentation/source/utilities/utilities.rst
@@ -5,7 +5,7 @@ Toroidal coordinate transform
 ----------------------------------------
 
 This is a demonstration of the conversion between cylindrical and toroidal coordinate systems
-using the Bluemira functions `cylindrical_to_toroidal` and `toroidal_to_cylindrical`. We denote toroidal coordinates by (:math:`\tau`, :math:`\sigma`, :math:`\phi`) and cylindrical coordinates by (:math:`R`, :math:`z`, :math:`\phi`).
+using the bluemira functions `cylindrical_to_toroidal` and `toroidal_to_cylindrical`. We denote toroidal coordinates by (:math:`\tau`, :math:`\sigma`, :math:`\phi`) and cylindrical coordinates by (:math:`R`, :math:`z`, :math:`\phi`).
 
 The snippets in this document use these imports
     .. code-block:: python
@@ -64,7 +64,7 @@ where we have
 Converting a unit circle
 ^^^^^^^^^^^^^^^^^^^^^^^^
 We will start with an example of converting a unit circle in cylindrical coordinates to
-toroidal coordinates and then converting back to cylindrical using the Bluemira functions `cylindrical_to_toroidal` and `toroidal_to_cylindrical`.
+toroidal coordinates and then converting back to cylindrical using the bluemira functions `cylindrical_to_toroidal` and `toroidal_to_cylindrical`.
 This unit circle is centered at the point (2,0) in the poloidal plane.
 
 Original circle:

--- a/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
+++ b/examples/equilibria/Spherical_Approximation_how_it_works.ex.py
@@ -27,7 +27,7 @@ An example that shows how the Spherical Harmonic Approximation works
 # %% [markdown]
 # # Example of using Spherical Harmonic Approximation
 #
-# This example illustrates the inner workings of the Bluemira spherical harmonics
+# This example illustrates the inner workings of the bluemira spherical harmonics
 # approximation function (spherical_harmonic_approximation) which can be used in
 # coilset current and position optimisation for spherical tokamaks.
 # For an example of how spherical_harmonic_approximation is used

--- a/examples/equilibria/coilset_opt_problem_tutorial.ex.py
+++ b/examples/equilibria/coilset_opt_problem_tutorial.ex.py
@@ -98,7 +98,7 @@ from bluemira.equilibria.solve import DudsonConvergence, PicardIterator
 #   coilset state array.
 #   - Usually based on NLOpt.
 #   - There are several optimisation algorithms that can be used within
-#     Bluemira.
+#     bluemira.
 #     Including gradient and non-gradient based.
 #       - SLSQP
 #       - COBYLA

--- a/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
@@ -28,7 +28,7 @@ Usage of the 'spherical_harmonic_approximation' function.
 # # spherical_harmonic_approximation Function
 #
 # This example illustrates the input and output of the
-# Bluemira spherical harmonics approximation function
+# bluemira spherical harmonics approximation function
 # (spherical_harmonic_approximation) which can be used
 # in coilset current and position optimisation for spherical tokamaks.
 
@@ -79,7 +79,7 @@ plt.show()
 #
 # ### Required
 #
-# - eq = Our chosen Bluemira Equilibrium
+# - eq = Our chosen bluemira equilibrium
 #
 # ### Optional
 #

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Run Bluemira example files in sequence. Exit with code 1 if any errors.
+Run bluemira example files in sequence. Exit with code 1 if any errors.
 
 This will recursively search for python files within a given directory,
 and run them in sequence. It will report which ran without error, and


### PR DESCRIPTION
## Linked Issues

Closes #3694 

## Description

Went through the entire codebase and made sure bluemira was only capitalised at the start of sentences. This only applied to docs files, docstrings or comments. Exceptions to this are when it is a thing from the code ie BluemiraSolid in which case it was left as it was.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`


<!-- readthedocs-preview bluemira start -->
----
📚 Documentation preview 📚: https://bluemira--3714.org.readthedocs.build/en/3714/

<!-- readthedocs-preview bluemira end -->