### PR TITLE
put the Monte Carlo back in the fuel cycle model

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -687,7 +687,3 @@ class RNGSeeds(Enum):
     """
 
     equilibria_harmonics = 2944412338698111642
-    timeline_tools_lognorm = 6613659347120864846
-    timeline_tools_truncnorm = 9523110846560405221
-    timeline_tools_expo = 15335509124046896388
-    timeline_outages = 5876826953682921855

--- a/bluemira/fuel_cycle/timeline.py
+++ b/bluemira/fuel_cycle/timeline.py
@@ -11,7 +11,7 @@ Partially randomised fusion reactor load signal object and tools
 import matplotlib.pyplot as plt
 import numpy as np
 
-from bluemira.base.constants import S_TO_YR, YR_TO_S, RNGSeeds
+from bluemira.base.constants import S_TO_YR, YR_TO_S
 from bluemira.fuel_cycle.timeline_tools import (
     LogNormalAvailabilityStrategy,
     OperationalAvailabilityStrategy,
@@ -174,7 +174,7 @@ class OperationPhase(Phase):
 
         dist += self.t_min_down
         self._dist = dist  # Store for plotting/debugging
-        rng = np.random.default_rng(RNGSeeds.timeline_outages.value)
+        rng = np.random.default_rng()
         return rng.permutation(dist)
 
     def plot_dist(self):

--- a/bluemira/fuel_cycle/timeline_tools.py
+++ b/bluemira/fuel_cycle/timeline_tools.py
@@ -14,7 +14,6 @@ from collections.abc import Iterable
 import numpy as np
 from scipy.optimize import brentq
 
-from bluemira.base.constants import RNGSeeds
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.fuel_cycle.error import FuelCycleError
 
@@ -72,7 +71,7 @@ def generate_lognorm_distribution(n: int, integral: float, sigma: float) -> np.n
     :
         The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng(RNGSeeds.timeline_tools_lognorm.value)
+    rng = np.random.default_rng()
 
     def f_integral(x):
         return np.sum(rng.lognormal(x, sigma, n)) - integral
@@ -103,7 +102,7 @@ def generate_truncnorm_distribution(n: int, integral: float, sigma: float) -> np
     :
         The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng(RNGSeeds.timeline_tools_truncnorm.value)
+    rng = np.random.default_rng()
     distribution = rng.normal(0, sigma, n)
     # Truncate distribution by 0-folding
     distribution = np.abs(distribution)
@@ -133,7 +132,7 @@ def generate_exponential_distribution(
     :
         The distribution of size n and of the correct integral value
     """
-    rng = np.random.default_rng(RNGSeeds.timeline_tools_expo.value)
+    rng = np.random.default_rng()
     distribution = rng.exponential(lambdda, n)
     # Correct distribution integral
     distribution /= np.sum(distribution)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Took me a while to debug this... I'm not sure of the motivations behind lumping fixed random seeds in an enum, but I can say for sure that it means the fuel cycle model can no longer be run Monte Carlo.

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
