### PR TITLE
Handled error when making arc from 3 colinear points.

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -539,8 +539,16 @@ def make_circle_arc_3P(  # noqa: N802
     -------
     :
         FreeCAD wire that contains the arc of circle
+
+    Raises
+    ------
+    FreeCADError
+        Raised if the three points are collinear.
     """
-    arc = Part.ArcOfCircle(Base.Vector(p1), Base.Vector(p2), Base.Vector(p3))
+    try:
+        arc = Part.ArcOfCircle(Base.Vector(p1), Base.Vector(p2), Base.Vector(p3))
+    except Part.OCCError as error:
+        raise FreeCADError(error.args[0]) from error
 
     # next steps are made to create an arc of circle that is consistent with that
     # created by 'make_circle'

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -759,12 +759,14 @@ def make_circle_arc_3P(  # noqa: N802
     Raises
     ------
     GeometryError
-        Wrapper for the Part.OCCError('Three points are collinear').
+        Raised if the three points are collinear.
     """
     try:
         output = cadapi.make_circle_arc_3P(p1, p2, p3, axis)
-    except RuntimeError as e:
-        raise GeometryError(e.args[0]) from e
+    except cadapi.FreeCADError as e:
+        raise GeometryError(
+            f"Failed to create BluemiraWire circle/arc from 3 points: {e}"
+        ) from None
     return BluemiraWire(output, label=label)
 
 

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -755,10 +755,16 @@ def make_circle_arc_3P(  # noqa: N802
     Returns
     -------
     Bluemira wire that contains the arc or circle
+
+    Raises
+    ------
+    GeometryError
+        Wrapper for the Part.OCCError('Three points are collinear').
     """
-    # TODO @ivanmaione: check what happens when the 3 points are in a line
-    # 3589
-    output = cadapi.make_circle_arc_3P(p1, p2, p3, axis)
+    try:
+        output = cadapi.make_circle_arc_3P(p1, p2, p3, axis)
+    except RuntimeError as e:
+        raise GeometryError(e.args[0]) from e
     return BluemiraWire(output, label=label)
 
 

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -311,7 +311,7 @@ class TestFreecadapi:
         assert np.allclose(
             cadapi.discretise(arc, 10), cadapi.discretise(arc3, 10)
         )  # check arc3 matches arc
-        with pytest.raises(Part.OCCError):
+        with pytest.raises(FreeCADError):
             cadapi.make_circle_arc_3P([1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
 
         # from make_ellipse

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -666,6 +666,13 @@ class TestMakeCircle:
         np.testing.assert_allclose(np.array(p1), np.array(points[0]), atol=EPS)
         np.testing.assert_allclose(np.array(p3), np.array(points[1]), atol=EPS)
 
+    def test_make_circle_from_colinear_points(self):
+        p1 = [1, 0, 2]
+        p2 = [2, 0, 4]
+        p3 = [3, 0, 6]
+        with pytest.raises(GeometryError):
+            make_circle_arc_3P(p1, p2, p3)
+
 
 class TestSavingCAD:
     STP_VERSION_RE = r"(processor)|(translator) [0-9]+\.[0-9]+"


### PR DESCRIPTION
## Linked Issues

Closes #3589

## Description

Answered to-do comment, deleted it.

## Interface Changes

Raised GeometryError when colinear, instead of passing Part.OCCError through to the user.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
