### PR TITLE
Ocean/periodic wire types fix

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1183,7 +1183,9 @@ def split_wire(
         elif i == idx:
             parameter = edge.Curve.parameter(points[0][0])
             if (
-                not edge.ParameterRange[0] <= parameter <= edge.ParameterRange[1]
+                not edge.ParameterRange[0] - EPS_FREECAD
+                <= parameter
+                <= edge.ParameterRange[1] + EPS_FREECAD
             ) and isinstance(edge.Curve, Part.ArcOfConic | Part.Conic):
                 parameter += np.sign(edge.ParameterRange[0] - parameter) * ONE_PERIOD
             half_edge_1, half_edge_2 = _split_edge(edge, parameter)
@@ -1233,11 +1235,11 @@ def _split_edge(edge, parameter):
         Thrown if the provided parameter is outside of the edge's valid parameter range.
     """
     p0, p1 = edge.ParameterRange[0:2]
-    if parameter == p0:
+    if np.isclose(parameter, p0, rtol=0, atol=EPS_FREECAD):
         return None, edge
-    if parameter == p1:
+    if np.isclose(parameter, p1, rtol=0, atol=EPS_FREECAD):
         return edge, None
-    if p0 < parameter < p1:
+    if p0 + EPS_FREECAD < parameter < p1 - EPS_FREECAD:
         return edge.Curve.toShape(p0, parameter), edge.Curve.toShape(parameter, p1)
     raise FreeCADError(
         f"The splitting parameter {parameter} exists beyond the allowed parameter "


### PR DESCRIPTION
## Linked Issues

Closes #2010 

## Description

This should fix the specific problem of "splitting an arc-of-circle at angle=0 erroneously yields a full-circle + the original arc".

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
