### PR TITLE
Possibly a more proper way of fixing the floating point issue.

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -1184,9 +1184,9 @@ def split_wire(
         elif i == idx:
             parameter = edge.Curve.parameter(points[0][0])
             if (
-                not next_freecad_float(edge.ParameterRange[0])
+                not prev_freecad_float(edge.ParameterRange[0])
                 <= parameter
-                <= prev_freecad_float(edge.ParameterRange[1])
+                <= next_freecad_float(edge.ParameterRange[1])
             ) and isinstance(edge.Curve, Part.ArcOfConic | Part.Conic):
                 parameter += np.sign(edge.ParameterRange[0] - parameter) * ONE_PERIOD
             half_edge_1, half_edge_2 = _split_edge(edge, parameter)
@@ -1236,9 +1236,9 @@ def _split_edge(edge, parameter):
         Thrown if the provided parameter is outside of the edge's valid parameter range.
     """
     p0, p1 = edge.ParameterRange[0:2]
-    if next_freecad_float(p0) <= parameter <= prev_freecad_float(p0):
+    if prev_freecad_float(p0) <= parameter <= next_freecad_float(p0):
         return None, edge
-    if next_freecad_float(p1) <= parameter <= prev_freecad_float(p1):
+    if prev_freecad_float(p1) <= parameter <= next_freecad_float(p1):
         return edge, None
     if next_freecad_float(p0) < parameter < prev_freecad_float(p1):
         return edge.Curve.toShape(p0, parameter), edge.Curve.toShape(parameter, p1)

--- a/bluemira/codes/freecad_number.py
+++ b/bluemira/codes/freecad_number.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Code to deal with any floating point calculation inaccuracies in freecad."""
+
+import numpy as np
+
+
+def next_freecad_float(number: float):
+    """
+    Find the neighbouring float larger than the supplied number.
+
+    Parameters
+    ----------
+    number:
+        the reference number that we want to compare against.
+
+    Returns
+    -------
+    :
+        The number immediately larger than the reference number.
+        No float can exist between the reference number and this number due to the finite
+        precision of the computer.
+    """
+    return np.nextafter(np.float32(number), number * 1.1)
+
+
+def prev_freecad_float(number: float):
+    """
+    Find the neighbouring float smaller than the supplied number.
+
+    Parameters
+    ----------
+    number:
+        the reference number that we want to compare against.
+
+    Returns
+    -------
+    :
+        The number immediately smaller than the reference number.
+        No float can exist between the reference number and this number due to the finite
+        precision of the computer.
+    """
+    return np.nextafter(np.float32(number), number * 0.9)


### PR DESCRIPTION
(but it's quite verbose) - worth discussing whether this is necessary/ good.

## Linked PR

A more meticulous treatment of floating point numbers  than #3757 - but perhaps too pedantic?

## Description

Because the gap between floating point numbers scales up/down with the size of the float itself, using +/- EPS to create an interval might not yield the desired result (too big of an interval when the number is << 1.0, and zero-sized interval when the number is >>1.0).

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
