### PR TITLE
🎨 Princeton D fix and xfailing test

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -481,7 +481,9 @@ class PrincetonD(GeometryParameterisation[PrincetonDOptVariables]):
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
 
-    def create_shape(self, label: str = "", n_points: int = 2000) -> BluemiraWire:
+    def create_shape(
+        self, label: str = "", n_points: int = 2000, *, with_tangency: bool = False
+    ) -> BluemiraWire:
         """
         Make a CAD representation of the Princeton D.
 
@@ -508,8 +510,11 @@ class PrincetonD(GeometryParameterisation[PrincetonDOptVariables]):
         outer_arc = interpolate_bspline(
             xyz.T,
             label="outer_arc",
-            # start_tangent=[0, 0, 1],
-            # end_tangent=[0, 0, -1],
+            **(
+                {"start_tangent": [0, 0, 1], "end_tangent": [0, 0, -1]}
+                if with_tangency
+                else {}
+            ),
         )
         # TODO @CoronelBuendia: Enforce tangency of this bspline...
         # causing issues with offsetting


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3671 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
It seems like this problem is no longer a problem with the recent dependency upgrades. Removing the comment.
Also adds a x failing test for #3586 that should pass when it is fixed

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
