### PR TITLE
🐛 Remove ismeshed check

### DIFF
--- a/bluemira/mesh/meshing.py
+++ b/bluemira/mesh/meshing.py
@@ -331,23 +331,19 @@ class Mesh:
         """
         from bluemira.geometry.tools import serialise_shape  # noqa: PLC0415
 
-        if not hasattr(obj, "ismeshed") or not obj.ismeshed:
-            if type(obj).__name__ not in SUPPORTED_GEOS:
-                raise ValueError(
-                    f"Mesh procedure not implemented for {obj.__class__.__name__} type."
-                )
+        if type(obj).__name__ not in SUPPORTED_GEOS:
+            raise ValueError(
+                f"Mesh procedure not implemented for {obj.__class__.__name__} type."
+            )
 
-            # object is serialised into a dictionary
-            buffer = serialise_shape(obj)
+        # object is serialised into a dictionary
+        buffer = serialise_shape(obj)
 
-            # Each object is recreated into gmsh. Here there is a trick: in order to
-            # allow the correct mesh in case of intersection, the procedure
-            # is made meshing the objects with increasing dimension.
-            for d in range(1, dim + 1, 1):
-                self.__convert_item_to_gmsh(buffer, d)
-            obj.ismeshed = True
-        else:
-            bluemira_print("Object already meshed")
+        # Each object is recreated into gmsh. Here there is a trick: in order to
+        # allow the correct mesh in case of intersection, the procedure
+        # is made meshing the objects with increasing dimension.
+        for d in range(1, dim + 1, 1):
+            self.__convert_item_to_gmsh(buffer, d)
         return buffer
 
     def __convert_item_to_gmsh(self, buffer: dict, dim: int):


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
The meshing check was malformed because the buffer was never returned if `ismeshed == True`. This seemed to be to avoid remeshing the same object although it would never have worked in the situation without some more code in the else statement.

For now removed but could be added back as part of #2999 

See https://github.com/Fusion-Power-Plant-Framework/bluemira/actions/runs/12989499919 for passing examples after fix

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
