### PR TITLE
Update documentation about BluemiraWire construction

### DIFF
--- a/bluemira/geometry/wire.py
+++ b/bluemira/geometry/wire.py
@@ -39,9 +39,16 @@ class BluemiraWire(BluemiraGeo):
     Parameters
     ----------
     boundary:
-        List of wires from which to make the BluemiraWire
+        List of wires from which to make the BluemiraWire. The wires should be passed in
+        "end-to-start", i.e. the end point of the current wire in the list should match
+        the start point of the next wire in the list.
     label:
         Label to assign to the wire
+
+    Note
+    ----
+    The construction of the BluemiraWire can usually handle one wire that is not in the
+    correct order in the :code:`boundary` argument, but it is best not to test your luck.
     """
 
     def __init__(self, boundary: list[cadapi.apiWire | BluemiraWire], label: str = ""):

--- a/examples/geometry/geometry_tutorial.ex.py
+++ b/examples/geometry/geometry_tutorial.ex.py
@@ -148,6 +148,10 @@ wire_plotter.plot_2d(closed_wire)
 print(f"wire is closed: {closed_wire.is_closed()}")
 
 # %% [markdown]
+# Also, note that the sub-wires have been passed in "end-to-start": the end point of the
+# current wire in the list should match the start point of the next wire in the list.
+
+# %% [markdown]
 # ## Geometry creation (2-D and 3-D)
 #
 # A closed planar 1-D geometry can be used as boundary to generate a 2-D face.


### PR DESCRIPTION
## Linked Issues

Figured this was small enough not to warrant an issue. Let me know if you would like one to be raised.

## Description

In the process of doing some work on the STEP first wall, it came to my attention that `BluemiraWire` creation can fail if you do not pass the boundary wires in the correct "end-to-start" order. This was not documented anywhere in the Bluemira docs, so I have added a few sentences to the `BluemiraWire` class docstring and the geometry tutorial.

## Interface Changes

None.

## Checklist

I confirm that I have completed the following checks:

- [ ] ~~Tests run locally and pass `pytest tests --reactor`~~ (didn't touch any tests)
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
