### PR TITLE
Improve logging style

### DIFF
--- a/bluemira/base/logs.py
+++ b/bluemira/base/logs.py
@@ -24,7 +24,6 @@ from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from bluemira.base.constants import ANSI_COLOR, EXIT_COLOR
 from bluemira.base.error import LogsError
 
 if TYPE_CHECKING:
@@ -182,25 +181,6 @@ class LoggerAdapter(logging.Logger):
         """Unmodified logging"""
         func = getattr(super(), LogLevel(loglevel).name.lower())
         self._base(func, msg, *args, flush=flush, _clean=True, **kwargs)
-
-
-def _print_colour(string: str, colour: str) -> str:
-    """
-    Create text to print. NOTE: Does not call print command
-
-    Parameters
-    ----------
-    string:
-        The text to colour
-    colour:
-        The colour to make the colour-string for
-
-    Returns
-    -------
-    :
-        The string with ANSI colour decoration
-    """
-    return f"{ANSI_COLOR[colour]}{string}{EXIT_COLOR}"
 
 
 class BluemiraRichHandler(RichHandler):

--- a/bluemira/base/logs.py
+++ b/bluemira/base/logs.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from rich.traceback import Traceback
 
 # TODO @je-cook: Remove on culmination of rich fix
-#
+# 3802
 jp.JUPYTER_HTML_FORMAT = (
     '<pre style="white-space:pre;overflow-x:auto;line-height:normal;'
     "margin:0;"  # this is the change
@@ -281,7 +281,7 @@ def logger_setup(
     # what will be written to a file
     # TODO @je-cook: force_jupyter and force_terminal shouldnt be needed
     #                but there is a bug in rich
-    #
+    # 3803
     recorded_handler = BluemiraRichFileHandler(
         console=Console(
             file=open(logfilename, "a"),  # noqa: SIM115

--- a/bluemira/base/look_and_feel.py
+++ b/bluemira/base/look_and_feel.py
@@ -244,9 +244,7 @@ def bluemira_debug(string: str):
     LOGGER.debug(string, stacklevel=4)
 
 
-def _bluemira_clean_flush(
-    string,
-):
+def _bluemira_clean_flush(string: str, *, progress_timeout: float = 4):
     """
     Print and flush string. Useful for updating information.
 
@@ -255,10 +253,10 @@ def _bluemira_clean_flush(
     string:
         The string to colour flush print
     """
-    LOGGER.clean(string, flush=True, stacklevel=4)
+    LOGGER.clean(string, flush=True, stacklevel=4, progress_timeout=progress_timeout)
 
 
-def bluemira_print_flush(string: str):
+def bluemira_print_flush(string: str, *, progress_timeout: float = 4):
     """
     Print a coloured, boxed line to the console and flushes it. Useful for
     updating information.
@@ -268,10 +266,10 @@ def bluemira_print_flush(string: str):
     string:
         The string to colour flush print
     """
-    LOGGER.info(string, flush=True, stacklevel=4)
+    LOGGER.info(string, flush=True, stacklevel=4, progress_timeout=progress_timeout)
 
 
-def bluemira_debug_flush(string: str):
+def bluemira_debug_flush(string: str, *, progress_timeout: float = 4):
     """
     Print a coloured, boxed line to the console and flushes it. Useful for
     updating information when running at the debug logging level.
@@ -281,7 +279,7 @@ def bluemira_debug_flush(string: str):
     string:
         The string to colour flush print for debug messages.
     """
-    LOGGER.debug(string, flush=True, stacklevel=4)
+    LOGGER.debug(string, flush=True, stacklevel=4, progress_timeout=progress_timeout)
 
 
 def bluemira_print_clean(string: str):

--- a/bluemira/base/look_and_feel.py
+++ b/bluemira/base/look_and_feel.py
@@ -15,6 +15,9 @@ import subprocess  # noqa: S404
 from getpass import getuser
 from pathlib import Path
 
+from rich.console import Console
+from rich.panel import Panel
+
 from bluemira import __version__
 from bluemira.base.file import get_bluemira_path, get_bluemira_root
 from bluemira.base.logs import LogLevel, logger_setup
@@ -190,7 +193,7 @@ def bluemira_critical(string: str):
     string:
         The string to log at critical level
     """
-    LOGGER.critical(string)
+    LOGGER.critical(string, stacklevel=4)
 
 
 def bluemira_error(string: str):
@@ -202,7 +205,7 @@ def bluemira_error(string: str):
     string:
         The string to log at error level
     """
-    LOGGER.error(string)
+    LOGGER.error(string, stacklevel=4)
 
 
 def bluemira_warn(string: str):
@@ -214,7 +217,7 @@ def bluemira_warn(string: str):
     string:
         The string to log at warning level
     """
-    LOGGER.warning(string)
+    LOGGER.warning(string, stacklevel=4)
 
 
 def bluemira_print(string: str):
@@ -226,7 +229,7 @@ def bluemira_print(string: str):
     string:
         The string to log at info level
     """
-    LOGGER.info(string)
+    LOGGER.info(string, stacklevel=4)
 
 
 def bluemira_debug(string: str):
@@ -238,7 +241,7 @@ def bluemira_debug(string: str):
     string:
         The string to log at debug level
     """
-    LOGGER.debug(string)
+    LOGGER.debug(string, stacklevel=4)
 
 
 def _bluemira_clean_flush(
@@ -252,7 +255,7 @@ def _bluemira_clean_flush(
     string:
         The string to colour flush print
     """
-    LOGGER.clean(string, flush=True)
+    LOGGER.clean(string, flush=True, stacklevel=4)
 
 
 def bluemira_print_flush(string: str):
@@ -265,7 +268,7 @@ def bluemira_print_flush(string: str):
     string:
         The string to colour flush print
     """
-    LOGGER.info(string, flush=True)
+    LOGGER.info(string, flush=True, stacklevel=4)
 
 
 def bluemira_debug_flush(string: str):
@@ -278,7 +281,7 @@ def bluemira_debug_flush(string: str):
     string:
         The string to colour flush print for debug messages.
     """
-    LOGGER.debug(string, flush=True)
+    LOGGER.debug(string, flush=True, stacklevel=4)
 
 
 def bluemira_print_clean(string: str):
@@ -291,7 +294,7 @@ def bluemira_print_clean(string: str):
     string:
         The string to print
     """
-    LOGGER.clean(string)
+    LOGGER.clean(string, stacklevel=4)
 
 
 def bluemira_error_clean(string: str):
@@ -304,7 +307,7 @@ def bluemira_error_clean(string: str):
     string:
         The string to colour print
     """
-    LOGGER.clean(string, loglevel=LogLevel.ERROR)
+    LOGGER.clean(string, loglevel=LogLevel.ERROR, stacklevel=4)
 
 
 # =============================================================================
@@ -312,21 +315,22 @@ def bluemira_error_clean(string: str):
 # =============================================================================
 
 
-BLUEMIRA_ASCII = r"""+-------------------------------------------------------------------------+
-|  _     _                      _                                         |
-| | |   | |                    (_)                                        |
-| | |__ | |_   _  ___ _ __ ___  _ _ __ __ _ __                            |
-| | '_ \| | | | |/ _ \ '_ ` _ \| | '__/ _| |_ \                           |
-| | |_) | | |_| |  __/ | | | | | | | | (_| |_) |                          |
-| |_.__/|_|\__,_|\___|_| |_| |_|_|_|  \__|_|__/                           |
-+-------------------------------------------------------------------------+"""  # noqa: E501
+BLUEMIRA_ASCII = r""" _     _                      _
+| |   | |                    (_)
+| |__ | |_   _  ___ _ __ ___  _ _ __ __ _ __
+| '_ \| | | | |/ _ \ '_ ` _ \| | '__/ _| |_ \
+| |_) | | |_| |  __/ | | | | | | | | (_| |_) |
+|_.__/|_|\__,_|\___|_| |_| |_|_|_|  \__|_|__/
+"""
 
 
 def print_banner():
     """
     Print the initial banner to the console upon running the bluemira code.
     """
-    LOGGER.info(BLUEMIRA_ASCII, fmt=False)
+    Console(force_terminal=True).print(
+        Panel(f"[blue][bold]{BLUEMIRA_ASCII}", style="blue")
+    )
     v = version_banner()
     v.extend(user_banner())
     bluemira_print("\n".join(v))
@@ -347,19 +351,19 @@ def version_banner() -> list[str]:
     root = get_bluemira_root()
     if not Path(f"{root}/.git").is_dir() or shutil.which("git") is None:
         return [
-            f"Version    : {__version__}",
-            "git branch : docker",
-            "SLOC      : N/A",
+            f"Bluemira Version : {__version__}",
+            "git branch       : docker",
+            "SLOC             : N/A",
         ]
     branch = get_git_branch(root)
     sloc = count_slocs(get_bluemira_path().rstrip(os.sep), branch)
     v = str(get_git_version(root))
 
-    output = [f"Version    : {v[2:-1]}", f"git branch : {branch}"]
+    output = [f"Bluemira Version : {v[2:-1]}", f"git branch       : {branch}"]
 
     for k, v in mapping.items():
         if sloc[v] > 0:
-            line = k + " " * (11 - len(k)) + f": {int(sloc[v])}"
+            line = k + " " * (17 - len(k)) + f": {int(sloc[v])}"
             output.append(line)
     return output
 
@@ -374,6 +378,6 @@ def user_banner() -> list[str]:
         The text for the banner containing user and platform information
     """
     return [
-        f"User       : {getuser()}",
-        f"Platform   : {get_platform()}",
+        f"User             : {getuser()}",
+        f"Platform         : {get_platform()}",
     ]

--- a/bluemira/display/palettes.py
+++ b/bluemira/display/palettes.py
@@ -17,6 +17,8 @@ import numpy as np
 import seaborn as sns
 from matplotlib import colors
 
+from bluemira.base.constants import ANSI_COLOR, EXIT_COLOR
+
 if TYPE_CHECKING:
     from matplotlib.typing import ColorType
 
@@ -302,6 +304,25 @@ def make_alpha_palette(
     return ColorPalette({
         f"{color_name}_{i}": col_val for i, col_val in enumerate(color_values)
     })
+
+
+def _print_colour(string: str, colour: str) -> str:
+    """
+    Create text to print. NOTE: Does not call print command
+
+    Parameters
+    ----------
+    string:
+        The text to colour
+    colour:
+        The colour to make the colour-string for
+
+    Returns
+    -------
+    :
+        The string with ANSI colour decoration
+    """
+    return f"{ANSI_COLOR[colour]}{string}{EXIT_COLOR}"
 
 
 # This is specifically NOT the MATLAB color palette.

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1349,7 +1349,6 @@ class Equilibrium(CoilSetMHDState):
         # Speed optimisations
         o_points, x_points = self.get_OX_points(psi=psi, force_update=True)
         mask = in_plasma(self.x, self.z, psi, o_points=o_points, x_points=x_points)
-        print()  # flusher  # noqa: T201
 
         def minimise_dli(x):
             """

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -348,7 +348,6 @@ def find_OX_points(
     o_points, x_points = triage_OX_points(f_psi, points)
 
     if len(o_points) == 0:
-        print()  # stdout flusher  # noqa: T201
         bluemira_warn(
             "EQUILIBRIA::find_OX: No O-points found during an iteration. Defaulting to"
             " grid centre."
@@ -366,7 +365,6 @@ def find_OX_points(
     if len(x_points) == 0:
         # There is an O-point, but no X-points or L-points, so we will take the grid
         # as a boundary
-        print()  # stdout flusher  # noqa: T201
         bluemira_warn(
             "EQUILIBRIA::find_OX: No X-points found during an iteration, using grid"
             " boundary to limit the plasma."

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -535,11 +535,9 @@ class PicardIterator:
             try:
                 next(iterator)
             except StopIteration:  # noqa: PERF203
-                print()  # noqa: T201
                 bluemira_print("EQUILIBRIA G-S converged value found.")
                 break
         else:
-            print()  # noqa: T201
             bluemira_warn(
                 "EQUILIBRIA G-S unable to find converged value after"
                 f" {self.i} iterations."

--- a/tests/base/test_logs.py
+++ b/tests/base/test_logs.py
@@ -122,41 +122,24 @@ class TestLoggerClass:
         cls.LOGGER = logging.getLogger("bluemira")
         set_log_level("NOTSET")
 
-    @classmethod
-    def teardown_class(cls):
-        set_log_level(cls.original_level.name)
+    def teardown_method(self):
+        set_log_level(self.original_level.name)
 
     @pytest.mark.parametrize(
         "logfunc",
         [LOGGER.debug, LOGGER.info, LOGGER.warning, LOGGER.error, LOGGER.critical],
     )
     @pytest.mark.parametrize("flush", [False, True])
-    @pytest.mark.parametrize("fmt", [True, False])
-    def test_basics(self, logfunc, flush, fmt, caplog):
-        caplog.set_level("DEBUG")
-        logfunc("string1", flush=flush, fmt=fmt)
-        logfunc("string2", flush=flush, fmt=fmt)
+    def test_basics(self, logfunc, flush, caplog):
+        set_log_level("DEBUG")
+        logfunc("string1", flush=flush)
+        logfunc("string2", flush=flush)
 
-        if flush:
-            assert all(c.startswith("\r") for c in caplog.messages)
-        else:
-            assert all(not c.startswith("\r") for c in caplog.messages)
+        assert all("string" in c for c in caplog.messages)
 
-        if fmt:
-            if flush:
-                assert all(len(c.split("|")) == 3 for c in caplog.messages)
-            else:
-                assert all(c.split("\n")[1].endswith("|") for c in caplog.messages)
-        else:
-            assert any("|" not in c for c in caplog.messages)
-
-    @pytest.mark.parametrize("flush", [False, True])
     @pytest.mark.parametrize("loglevel", ["info", "error"])
+    @pytest.mark.parametrize("flush", [False, True])
     def test_clean(self, flush, loglevel, caplog):
         self.LOGGER.clean("string1", flush=flush, loglevel=loglevel)
         self.LOGGER.clean("string2", flush=flush, loglevel=loglevel)
-        if flush:
-            assert all(c.startswith("\r") for c in caplog.messages)
-        else:
-            assert all(not c.startswith("\r") for c in caplog.messages)
-        assert any("|" not in c for c in caplog.messages)
+        assert any("string" in c for c in caplog.messages)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3399 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Changes to use rich handler for the logging. 
Removes the need for custom boxing and dealing with new lines patching for progress bars.
Logging entries now have a link to which line in which file they were called from.
The colours now reflect your terminal colour theme.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
Progress bars dont automatically stop but timeout after a given number of seconds or until the next normal log call.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
