### PR TITLE
🐛 Fix pint warning

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -77,13 +77,6 @@ class BMUnitRegistry(UnitRegistry):
             ],
         )
 
-        # Extra units
-        self.define("displacements_per_atom  = count = dpa")
-        self.define("full_power_year = year = fpy")
-        self.define("atomic_parts_per_million = appm = ppm")
-        # Other currencies need to be set up in a new context
-        self.define("USD = [currency]")
-
         self._gas_flow_temperature = None
         self._contexts_added = False
 
@@ -114,6 +107,12 @@ class BMUnitRegistry(UnitRegistry):
         self._add_contexts(contexts)
 
         super().enable_contexts(*[*self.contexts, *contexts], **kwargs)
+        # Extra units
+        self.define("displacements_per_atom  = count = dpa")
+        self.define("full_power_year = year = fpy")
+        self.define("@alias ppm = atomic_parts_per_million = appm")
+        # Other currencies need to be set up in a new context
+        self.define("USD = [currency]")
 
     def _energy_temperature_context(self):
         """


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Pint was warning about redefinition of ppm. The unit set it is in is enabled on context activation.

I have moved the extra unit definitions to there so ppm is available to be aliased to

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
