### PR TITLE
TODO to NOTE

### DIFF
--- a/bluemira/structural/transformation.py
+++ b/bluemira/structural/transformation.py
@@ -53,9 +53,8 @@ def _direction_cosine_matrix(dx: float, dy: float, dz: float) -> np.ndarray:
     b = dy / length
     c = dz / length
     d = np.hypot(a, b)
-    # TODO @CoronelBuendia: Why does the less intuitive,
+    # NOTE: Why does the less intuitive,
     # simpler algebra form work better??
-    # 3666
     # https://ocw.mit.edu/courses/civil-and-environmental-engineering/1-571-structural-analysis-and-control-spring-2004/readings/connor_ch5.pdf
     if np.isclose(a, 0) and np.isclose(b, 0):
         dcm = np.array([


### PR DESCRIPTION
## Linked Issues

Closed papercut #3666

## Description

"Why does the less intuitive, simpler algebra form work better??"

Not certain of the answer, but as we have the safe _direction_cosine_matrix_debugging version to compare to the speedier _direction_cosine_matrix, it seems ok to remove it from papercut TODO's.

Have left as a NOTE in comments.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
