### PR TITLE
Use numba-scipy hash

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -26,6 +26,11 @@ dependencies:
   - openmc>=0.14.0
   - mpi4py
   - graphviz
+  - h5py==3.13.0
+  - pybind11==2.13.6
+  - pybind11-global==2.13.6
+  - pytools==2025.1.1
+  - vtk==9.3.1
   - pip
   - pip:
       - -r ../requirements/uv/all.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "neutronics-material-maker>=1.1.4",
     "nlopt",
     "numba",
-    "numba-scipy",
+    # we should remove this once numba-scipy starts to be more regularly maintained
+    "numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787",
     "numpy",
     "pint",
     "periodictable",
@@ -76,7 +77,7 @@ examples = ["notebook", "jupytext"]
 pinned = [
     "nlopt==2.7.1",
     "numba==0.61.0",
-    "numba-scipy==0.4.0",
+    "numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787",
     "numpy==1.26.4",
     "matplotlib==3.10.0",
     "scipy==1.10.1",

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,5 @@
 gmsh-interop==2024.1
-h5py==3.12.1
+h5py==3.13.0
 pybind11==2.13.6
 pybind11-global==2.13.6
 pytools==2025.1.1

--- a/requirements/uv/all.txt
+++ b/requirements/uv/all.txt
@@ -291,7 +291,7 @@ numba==0.61.0
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
-numba-scipy==0.4.0
+numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787
     # via bluemira (pyproject.toml)
 numexpr==2.10.2
     # via

--- a/requirements/uv/base.txt
+++ b/requirements/uv/base.txt
@@ -74,7 +74,7 @@ numba==0.61.0
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
-numba-scipy==0.4.0
+numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787
     # via bluemira (pyproject.toml)
 numexpr==2.10.2
     # via

--- a/requirements/uv/develop.txt
+++ b/requirements/uv/develop.txt
@@ -195,7 +195,7 @@ numba==0.61.0
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
-numba-scipy==0.4.0
+numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787
     # via bluemira (pyproject.toml)
 numexpr==2.10.2
     # via

--- a/requirements/uv/examples.txt
+++ b/requirements/uv/examples.txt
@@ -226,7 +226,7 @@ numba==0.61.0
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
-numba-scipy==0.4.0
+numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787
     # via bluemira (pyproject.toml)
 numexpr==2.10.2
     # via


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Numba-scipy is holding us back with some dependencies. This PR uses my commit from my fork where I have cleaned up the repo and removed the pin on scipy. 

It should be removed in future.

This will allow the upgrade of scipy and possibly numpy (unless process is required)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
