### PR TITLE
Used better optimal bounding box

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -803,6 +803,16 @@ def bounding_box(obj: apiShape) -> tuple[float, float, float, float, float, floa
     return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax
 
 
+def optimal_bounding_box(
+    obj: apiShape,
+) -> tuple[float, float, float, float, float, float]:
+    """Object's optimal bounding box"""  # noqa: DOC201
+    box = _get_api_attr(obj, "optimalBoundingBox")(
+        # default: useTriangulation = True, useShapeTolerance = False
+    )
+    return box.XMin, box.YMin, box.ZMin, box.XMax, box.YMax, box.ZMax
+
+
 def tessellate(obj: apiShape, tolerance: float) -> tuple[np.ndarray, np.ndarray]:
     """
     Tessellate a geometry object.

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -188,8 +188,9 @@ class BluemiraGeo(ABC, meshing.Meshable):
 
         Notes
         -----
-        If your shape is complicated, this has the potential to not be very accurate.
-        Consider using :meth:`~bluemira.geometry.base.get_optimal_bounding_box`.
+        If your shape is complicated, i.e. contains splines, this method is potentially
+        less accurate. Consider using
+        :meth:`~bluemira.geometry.base.get_optimal_bounding_box` instead.
         """
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.bounding_box(self.shape)
         return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
@@ -197,7 +198,8 @@ class BluemiraGeo(ABC, meshing.Meshable):
     def get_optimal_bounding_box(self) -> BoundingBox:
         """
         Get the optimised bounding box of the shape, via freecad's optimalBoundingBox
-        method. This is a more
+        method. This is a more accurate method than bounding box, but takes slightly
+        longer.
 
         Parameters
         ----------
@@ -210,17 +212,10 @@ class BluemiraGeo(ABC, meshing.Meshable):
         :
             The optimised bounding box of the shape.
         """
-        bound = self.shape.optimalBoundingBox(
-            # default: useTriangulation = True, useShapeTolerance = False
+        x_min, y_min, z_min, x_max, y_max, z_max = cadapi.optimal_bounding_box(
+            self.shape
         )
-        return BoundingBox(
-            bound.XMin,
-            bound.XMax,
-            bound.YMin,
-            bound.YMax,
-            bound.ZMin,
-            bound.ZMax,
-        )
+        return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
 
     def is_null(self) -> bool:
         """

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -199,8 +199,8 @@ class BluemiraGeo(ABC, meshing.Meshable):
     def optimal_bounding_box(self) -> BoundingBox:
         """
         Get the optimised bounding box of the shape, via freecad's optimalBoundingBox
-        method. This is a more accurate method than bounding box, but takes slightly
-        longer.
+        method. This is a more accurate method than bounding box, but takes about 10x
+        longer (e.g., one PolySpline took 230 μs instead of 13 μs).
 
         Parameters
         ----------

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -194,10 +194,10 @@ class BluemiraGeo(ABC, meshing.Meshable):
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.bounding_box(self.shape)
         return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
 
-    def get_optimal_bounding_box(self, tolerance: float = 1.0) -> BoundingBox:
+    def get_optimal_bounding_box(self) -> BoundingBox:
         """
-        Get the optimised bounding box of the shape, via tesselation of the underlying
-        geometry.
+        Get the optimised bounding box of the shape, via freecad's optimalBoundingBox
+        method. This is a more
 
         Parameters
         ----------
@@ -210,9 +210,17 @@ class BluemiraGeo(ABC, meshing.Meshable):
         :
             The optimised bounding box of the shape.
         """
-        auto_copy = self.deepcopy()
-        auto_copy._tessellate(tolerance)
-        return auto_copy.bounding_box
+        bound = self.shape.optimalBoundingBox(
+            # default: useTriangulation = True, useShapeTolerance = False
+        )
+        return BoundingBox(
+            bound.XMin,
+            bound.XMax,
+            bound.YMin,
+            bound.YMax,
+            bound.ZMin,
+            bound.ZMax,
+        )
 
     def is_null(self) -> bool:
         """

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -190,12 +190,13 @@ class BluemiraGeo(ABC, meshing.Meshable):
         -----
         If your shape is complicated, i.e. contains splines, this method is potentially
         less accurate. Consider using
-        :meth:`~bluemira.geometry.base.get_optimal_bounding_box` instead.
+        :meth:`~bluemira.geometry.base.optimal_bounding_box` instead.
         """
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.bounding_box(self.shape)
         return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
 
-    def get_optimal_bounding_box(self) -> BoundingBox:
+    @property
+    def optimal_bounding_box(self) -> BoundingBox:
         """
         Get the optimised bounding box of the shape, via freecad's optimalBoundingBox
         method. This is a more accurate method than bounding box, but takes slightly

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -190,7 +190,7 @@ class BluemiraGeo(ABC, meshing.Meshable):
         -----
         If your shape is complicated, i.e. contains splines, this method is potentially
         less accurate. Consider using
-        :meth:`~bluemira.geometry.base.optimal_bounding_box` instead.
+        :attr:`~bluemira.geometry.base.BluemiraGeo.optimal_bounding_box` instead.
         """
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.bounding_box(self.shape)
         return BoundingBox(x_min, x_max, y_min, y_max, z_min, z_max)
@@ -199,8 +199,7 @@ class BluemiraGeo(ABC, meshing.Meshable):
     def optimal_bounding_box(self) -> BoundingBox:
         """
         Get the optimised bounding box of the shape, via freecad's optimalBoundingBox
-        method. This is a more accurate method than bounding box, but takes about 10x
-        longer (e.g., one PolySpline took 230 μs instead of 13 μs).
+        method.
 
         Parameters
         ----------
@@ -212,6 +211,13 @@ class BluemiraGeo(ABC, meshing.Meshable):
         -------
         :
             The optimised bounding box of the shape.
+
+        Notes
+        -----
+        For more complicated geometries, this gives a tighter bounding box, but is
+        slower. For simpler geometries where no tigher bounding box can be found, the
+        time taken by this is the same as
+        :attr:`~bluemira.geometry.base.BluemiraGeo.bounding_box`.
         """
         x_min, y_min, z_min, x_max, y_max, z_max = cadapi.optimal_bounding_box(
             self.shape

--- a/tests/geometry/test_bound_box.py
+++ b/tests/geometry/test_bound_box.py
@@ -63,13 +63,13 @@ class TestHardBoundingBox:
         assert np.isclose(self.wire.bounding_box.z_min, -5.0)
 
     def test_opt_bounding_box(self):
-        bb = self.wire.get_optimal_bounding_box()
+        bb = self.wire.optimal_bounding_box
         assert np.isclose(bb.z_min, -5.0)
 
     def test_opt_bounding_box_solid(self):
         solid = self.solid.deepcopy()
         vertices, indices = solid._tessellate(1.0)
-        bb = self.solid.get_optimal_bounding_box()
+        bb = self.solid.optimal_bounding_box
         vertices2, indices2 = solid._tessellate(1.0)
         assert np.isclose(bb.z_min, -5.0)
         # Test that bounding box via tesselation did not modify properties

--- a/tests/geometry/test_bound_box.py
+++ b/tests/geometry/test_bound_box.py
@@ -62,16 +62,14 @@ class TestHardBoundingBox:
     def test_bad_bounding_box(self):
         assert np.isclose(self.wire.bounding_box.z_min, -5.0)
 
-    @pytest.mark.parametrize("tol", [10.0, 1.0, 0.1, 0.001])
-    def test_opt_bounding_box(self, tol):
-        bb = self.wire.get_optimal_bounding_box(tolerance=tol)
+    def test_opt_bounding_box(self):
+        bb = self.wire.get_optimal_bounding_box()
         assert np.isclose(bb.z_min, -5.0)
 
-    @pytest.mark.parametrize("tol", [10.0, 1.0, 0.1, 0.01])
-    def test_opt_bounding_box_solid(self, tol):
+    def test_opt_bounding_box_solid(self):
         solid = self.solid.deepcopy()
         vertices, indices = solid._tessellate(1.0)
-        bb = self.solid.get_optimal_bounding_box(tolerance=tol)
+        bb = self.solid.get_optimal_bounding_box()
         vertices2, indices2 = solid._tessellate(1.0)
         assert np.isclose(bb.z_min, -5.0)
         # Test that bounding box via tesselation did not modify properties
@@ -79,8 +77,3 @@ class TestHardBoundingBox:
         np.testing.assert_allclose(indices, indices2)
         vertices3, _ = solid._tessellate(0.01)
         assert vertices3.shape != vertices2.shape
-
-    @pytest.mark.parametrize("tol", [0.0, -1e-9])
-    def test_bad_tolerace(self, tol):
-        with pytest.raises(ValueError):  # noqa: PT011
-            self.wire.get_optimal_bounding_box(tolerance=tol)


### PR DESCRIPTION
## Linked Issues

Closes #3818 

## Description

Updated the "optimal_bounding_box" attribute to one that uses FreeCAD's built-in "optimalBoundingBox" (added in the updated version of freecad.), as a property of BluemiraGeo, rather than a method.

## Interface Changes

`get_optimal_bounding_box()` (a method) -> `optimal_bounding_box` (a property)
Removed the need for the tolerance parameter as well.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
