### PR TITLE
Papercut: standardise self.ax use

### DIFF
--- a/documentation/source/geometry/semi_circle_chord.py
+++ b/documentation/source/geometry/semi_circle_chord.py
@@ -103,7 +103,7 @@ class AngleAnnotation(Arc):
             annotation_clip=True,
         )
         self.kw.update(text_kw or {})
-        self.text = self.ax.annotate(text, xy=self._center, **self.kw)
+        self.text = ax.annotate(text, xy=self._center, **self.kw)
 
     def get_size(self):  # noqa: D102
         factor = 1.0

--- a/documentation/source/geometry/semi_circle_chord.py
+++ b/documentation/source/geometry/semi_circle_chord.py
@@ -103,7 +103,7 @@ class AngleAnnotation(Arc):
             annotation_clip=True,
         )
         self.kw.update(text_kw or {})
-        self.text = ax.annotate(text, xy=self._center, **self.kw)
+        self.text = self.ax.annotate(text, xy=self._center, **self.kw)
 
     def get_size(self):  # noqa: D102
         factor = 1.0

--- a/tests/codes/plasmod/test_profiles.py
+++ b/tests/codes/plasmod/test_profiles.py
@@ -215,45 +215,47 @@ class TestPLASMODVerificationCurrentProfiles(PLASMODVerificationRawData):
             "F": F,
             "FFprime": ff_prime,
         }
-        cls.f, cls.ax = plt.subplots(2, 4)
+        cls.f, cls.axes = plt.subplots(2, 4)
 
     @classmethod
     def teardown_class(cls):
-        for i, a in enumerate(cls.ax.flat):
+        for i, a in enumerate(cls.axes.flat):
             if i < 4:
                 a.legend()
             else:
                 a.set_xlabel("x")
-        cls.ax[1, 0].set_ylabel("PLASMOD-bluemira")
+        cls.axes[1, 0].set_ylabel("PLASMOD-bluemira")
 
     def test_plasma_current(self):
         # 15/03/23: Max relative difference: 4.71793662e-05
         np.testing.assert_allclose(self.results["I_p"], self.I_p, rtol=5e-5)
 
     def test_psi(self):
-        self.ax[0, 0].plot(self.rho, self.psi, label="PLASMOD")
-        self.ax[0, 0].plot(self.rho, self.results["psi_1D"], ls="--", label="bluemira")
-        self.ax[0, 0].set_title("$\\psi$")
-        self.ax[1, 0].plot(self.rho, self.psi - self.results["psi_1D"])
+        self.axes[0, 0].plot(self.rho, self.psi, label="PLASMOD")
+        self.axes[0, 0].plot(self.rho, self.results["psi_1D"], ls="--", label="bluemira")
+        self.axes[0, 0].set_title("$\\psi$")
+        self.axes[1, 0].plot(self.rho, self.psi - self.results["psi_1D"])
         np.testing.assert_allclose(self.results["psi_1D"], self.psi, rtol=0.01)
 
     def test_phi(self):
-        self.ax[0, 1].plot(self.rho, self.phi, label="PLASMOD")
-        self.ax[0, 1].plot(self.rho, self.results["phi_1D"], ls="--", label="bluemira")
-        self.ax[0, 1].set_title("$\\phi$")
-        self.ax[1, 1].plot(self.rho, self.phi - self.results["phi_1D"])
+        self.axes[0, 1].plot(self.rho, self.phi, label="PLASMOD")
+        self.axes[0, 1].plot(self.rho, self.results["phi_1D"], ls="--", label="bluemira")
+        self.axes[0, 1].set_title("$\\phi$")
+        self.axes[1, 1].plot(self.rho, self.phi - self.results["phi_1D"])
         np.testing.assert_allclose(self.results["phi_1D"][1:], self.phi[1:], rtol=0.0175)
 
     def test_pprime(self):
-        self.ax[0, 2].plot(self.rho, self.pprime, label="PLASMOD")
-        self.ax[0, 2].plot(self.rho, self.results["pprime"], ls="--", label="bluemira")
-        self.ax[0, 2].set_title("$p^{'}$")
-        self.ax[1, 2].plot(self.rho, self.pprime - self.results["pprime"])
+        self.axes[0, 2].plot(self.rho, self.pprime, label="PLASMOD")
+        self.axes[0, 2].plot(self.rho, self.results["pprime"], ls="--", label="bluemira")
+        self.axes[0, 2].set_title("$p^{'}$")
+        self.axes[1, 2].plot(self.rho, self.pprime - self.results["pprime"])
         np.testing.assert_allclose(self.results["pprime"], self.pprime, rtol=0.35)
 
     def test_ffprime(self):
-        self.ax[0, 3].plot(self.rho, self.ffprime, label="PLASMOD")
-        self.ax[0, 3].plot(self.rho, self.results["FFprime"], ls="--", label="bluemira")
-        self.ax[0, 3].set_title("$FF^{'}$")
-        self.ax[1, 3].plot(self.rho, self.ffprime - self.results["FFprime"])
+        self.axes[0, 3].plot(self.rho, self.ffprime, label="PLASMOD")
+        self.axes[0, 3].plot(
+            self.rho, self.results["FFprime"], ls="--", label="bluemira"
+        )
+        self.axes[0, 3].set_title("$FF^{'}$")
+        self.axes[1, 3].plot(self.rho, self.ffprime - self.results["FFprime"])
         np.testing.assert_allclose(self.results["FFprime"], self.ffprime, rtol=0.25)

--- a/tests/equilibria/test_shapes.py
+++ b/tests/equilibria/test_shapes.py
@@ -29,7 +29,7 @@ from bluemira.equilibria.shapes import (
 class TestCunningham:
     @classmethod
     def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(4, 2)
+        cls.f, cls.axes = plt.subplots(4, 2)
 
     @pytest.mark.parametrize(
         ("kappa", "delta", "delta2", "ax", "label"),
@@ -56,9 +56,9 @@ class TestCunningham:
     def test_cunningham(self, kappa, delta, delta2, ax, label):
         ax0, ax1 = ax
         f_s = flux_surface_cunningham(9, 0, 3, kappa, delta, delta2=delta2, n=100)
-        self.ax[ax0, ax1].plot(f_s.x, f_s.z, label=label)
-        self.ax[ax0, ax1].set_aspect("equal")
-        self.ax[ax0, ax1].legend()
+        self.axes[ax0, ax1].plot(f_s.x, f_s.z, label=label)
+        self.axes[ax0, ax1].set_aspect("equal")
+        self.axes[ax0, ax1].legend()
 
     @classmethod
     def teardown_class(cls):
@@ -69,7 +69,7 @@ class TestCunningham:
 class TestHirschman:
     @classmethod
     def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(2, 2)
+        cls.f, cls.axes = plt.subplots(2, 2)
 
     @pytest.mark.parametrize(
         ("a", "kappa", "ax", "label"),
@@ -108,9 +108,9 @@ class TestHirschman:
         f_s = flux_surface_hirshman(9, 0, a, kappa, n=100)
 
         ax0, ax1 = ax
-        self.ax[ax0, ax1].plot(f_s.x, f_s.z, label=label)
-        self.ax[ax0, ax1].set_aspect("equal")
-        self.ax[ax0, ax1].legend()
+        self.axes[ax0, ax1].plot(f_s.x, f_s.z, label=label)
+        self.axes[ax0, ax1].set_aspect("equal")
+        self.axes[ax0, ax1].legend()
 
     @classmethod
     def teardown_class(cls):
@@ -121,7 +121,7 @@ class TestHirschman:
 class TestManickam:
     @classmethod
     def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(4, 2)
+        cls.f, cls.axes = plt.subplots(4, 2)
 
     @pytest.mark.parametrize(
         ("kappa", "delta", "indent", "ax", "label"),
@@ -149,9 +149,9 @@ class TestManickam:
         f_s = flux_surface_manickam(9, 0, 3, kappa, delta, indent=indent, n=100)
 
         ax0, ax1 = ax
-        self.ax[ax0, ax1].plot(f_s.x, f_s.z, label=label)
-        self.ax[ax0, ax1].set_aspect("equal")
-        self.ax[ax0, ax1].legend()
+        self.axes[ax0, ax1].plot(f_s.x, f_s.z, label=label)
+        self.axes[ax0, ax1].set_aspect("equal")
+        self.axes[ax0, ax1].legend()
 
     @classmethod
     def teardown_class(cls):
@@ -171,7 +171,7 @@ class TestKuiroukidis:
 
     @classmethod
     def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(2, 3)
+        cls.f, cls.axes = plt.subplots(2, 3)
 
     @pytest.mark.parametrize(
         ("R_0", "A", "kappa_u", "kappa_l", "delta_u", "delta_l", "ax"),
@@ -196,10 +196,10 @@ class TestKuiroukidis:
         z_outer = 0.0
 
         n1, n2 = ax
-        self.ax[n1, n2].plot(flux_surface.x, flux_surface.z)
-        self.ax[n1, n2].set_xlabel("x")
-        self.ax[n1, n2].set_ylabel("z")
-        self.ax[n1, n2].set_aspect("equal")
+        self.axes[n1, n2].plot(flux_surface.x, flux_surface.z)
+        self.axes[n1, n2].set_xlabel("x")
+        self.axes[n1, n2].set_ylabel("z")
+        self.axes[n1, n2].set_aspect("equal")
 
         np.testing.assert_allclose(
             np.array([x_lower, z_lower]), flux_surface.xz.T[arg_lower]
@@ -284,16 +284,16 @@ johner_params = [
 class TestJohner:
     @classmethod
     def setup_class(cls):
-        cls.f, cls.ax = plt.subplots(4, 2)
+        cls.f, cls.axes = plt.subplots(4, 2)
 
     @pytest.mark.parametrize("kwargs", johner_params)
     def test_johner(self, kwargs):
         ax0, ax1 = kwargs.pop("ax")
         label = kwargs.pop("label")
         f_s = flux_surface_johner(9, 0, 9 / 3, n=100, **kwargs)
-        self.ax[ax0, ax1].plot(f_s.x, f_s.z, label=label)
-        self.ax[ax0, ax1].set_aspect("equal")
-        self.ax[ax0, ax1].legend()
+        self.axes[ax0, ax1].plot(f_s.x, f_s.z, label=label)
+        self.axes[ax0, ax1].set_aspect("equal")
+        self.axes[ax0, ax1].legend()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3807

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`


<!-- readthedocs-preview bluemira start -->
----
📚 Documentation preview 📚: https://bluemira--3859.org.readthedocs.build/en/3859/

<!-- readthedocs-preview bluemira end -->