### PR TITLE
Add labels for height top upper dz flat bottom lower for PolySpline

### DIFF
--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1692,24 +1692,26 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
             annotate_offset_x += 0.5
 
         # Label annotation for flat
-        if flat != 0:
-            xcors = [
-                x2 - flat * height * 0.5 * np.sin(np.deg2rad(tilt)),
-                x2 + flat * height * 0.5 * np.sin(np.deg2rad(tilt)),
-            ]
-            zcors = [
-                (z2 - flat * np.cos(np.deg2rad(tilt))) * height * 0.5 + dz,
-                (z2 + flat * np.cos(np.deg2rad(tilt))) * height * 0.5 + dz,
-            ]
 
-            self._annotator(
-                ax,
-                "flat \\times height",
-                (xcors[0], zcors[0]),
-                (xcors[1], zcors[1]),
-                (x2 + 0.5, z2 * height * 0.5 + dz + 0.5),
-                arrowstyle="|-|",
-            )
+        xcors = [
+            x2 - flat * height * 0.5 * np.sin(np.deg2rad(tilt)),
+            x2 + flat * height * 0.5 * np.sin(np.deg2rad(tilt)),
+        ]
+        zcors = [
+            (z2 - flat * np.cos(np.deg2rad(tilt))) * height * 0.5 + dz,
+            (z2 + flat * np.cos(np.deg2rad(tilt))) * height * 0.5 + dz,
+        ]
+
+        self._annotator(
+            ax,
+            "flat \\times height",
+            (xcors[0], zcors[0]),
+            (xcors[1], zcors[1]),
+            (np.mean(xcors) + 0.2, np.mean(zcors)),
+            arrowstyle="|-|",
+        )
+        if flat == 0:
+            ax.plot(xcors[0], zcors[0], "*", color="r")
 
 
 class PictureFrameTools:

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1410,9 +1410,9 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
     height: float
         Full height [m]
     top: float
-        Horizontal shift [m]
+        Horizontal shift []
     upper: float
-        Vertical shift [m]
+        Vertical shift []
     dz: float
         Vertical offset [m]
     flat: float
@@ -1420,9 +1420,9 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
     tilt: float
         Outboard angle [degrees]
     bottom: float
-        Lower horizontal shift [m]
+        Lower horizontal shift []
     lower: float
-        Lower vertical shift [m]
+        Lower vertical shift []
     l0s - l3s: float
         Tension variable segment start
     l0e - l3e: float

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1554,7 +1554,7 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
             parameterisation wire
 
         """
-        # TODO @vr2150: add labels for tilt l0s - l3s l0e - l3e
+        # TODO @athoynilimanew: add labels for tilt l0s - l3s l0e - l3e
         # 3587
 
         (

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -1571,8 +1571,6 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
             lower,
         ) = self.variables.values[:11]
 
-        ax.grid(visible=True)
-
         # Label for xs
         annotate_offset_z = 0
         for v, name in zip(


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3587 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

Adds labels for height, top, upper, dz, flat, bottom, lower for PolySpline.

Since flat, upper, lower, top, bottom are fractions, labels for the lengths are used where these fractions are multiplied with the height.

Example labels after plotting

![image](https://github.com/user-attachments/assets/5fa19b8e-b3c0-4d35-b6ff-73d348d027d7)

To reproduce the above plot:

```
from bluemira.geometry.parameterisations import PolySpline
test_spline = PolySpline(
    {
        "flat": {
            "value": 0.3,
            "lower_bound" : 0,
            "upper_bound" : 1,
            "description": "Fraction of straight outboard leg",
        },
        "z2": {
            "value": 0.3,
            "lower_bound" : -2,
            "upper_bound" : 2,
            "description": "Outer note vertical shift",
        },
        "tilt": {
            "value": 25,
            "lower_bound" : -45,
            "upper_bound" : 45,
            "description": "Outboard angle [degrees]",
        }

    }
)
import matplotlib.pyplot as plt

f, ax = plt.subplots()
test_spline.plot(ax=ax, labels=True)

points = test_spline.create_shape().vertexes.T
from bluemira.display.plotter import PointsPlotter
pp = PointsPlotter()
for point in points:
    pp.plot_2d(point, ax=ax, show=False)

ax.grid(visible=True)
plt.show()
```
## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
