### PR TITLE
✨ Regrid eqdsk after read in

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -24,7 +24,11 @@ from scipy.optimize import minimize
 
 from bluemira.base.constants import MU_0, raw_uc
 from bluemira.base.file import get_bluemira_path
-from bluemira.base.look_and_feel import bluemira_print_flush, bluemira_warn
+from bluemira.base.look_and_feel import (
+    bluemira_print,
+    bluemira_print_flush,
+    bluemira_warn,
+)
 from bluemira.equilibria.boundary import FreeBoundary, apply_boundary
 from bluemira.equilibria.coils import CoilSet, symmetrise_coilset
 from bluemira.equilibria.constants import BLUEMIRA_DEFAULT_COCOS, PSI_NORM_TOL
@@ -149,7 +153,7 @@ class MHDState:
         full_coil: bool = False,
         regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
-    ) -> tuple[EQDSKInterface, Grid]:
+    ) -> tuple[EQDSKInterface, Grid, tuple[int, int] | None]:
         """
         Get eqdsk data from file for read in
 
@@ -167,6 +171,8 @@ class MHDState:
         full_coil:
             Whether the eqdsk dxc and dzc represents
             the full coil width or half coil width
+        regrid_nx_nz:
+            Modify grid to use new nx and nz values
 
         Returns
         -------
@@ -201,8 +207,15 @@ class MHDState:
 
         grid = Grid.from_eqdsk(e)
         if regrid_nx_nz is not None:
-            grid = grid.regrid(*regrid_nx_nz)
-        return e, grid
+            if (grid.nx, grid.nz) == regrid_nx_nz:
+                regrid_nx_nz = None
+            else:
+                bluemira_print(
+                    "NOTE: Loading an Equilibrium from a file using a different grid "
+                    "will result in changes with respect to the original data."
+                )
+                grid = grid.regrid(*regrid_nx_nz)
+        return e, grid, regrid_nx_nz
 
     def to_eqdsk(
         self,
@@ -320,8 +333,10 @@ class FixedPlasmaEquilibrium(MHDState):
         full_coil:
             Whether the eqdsk dxc and dzc represents
             the full coil width or half coil width
+        regrid_nx_nz:
+            Modify grid to use new nx and nz values
         """  # noqa: DOC201
-        e, grid = super()._get_eqdsk(
+        e, grid, regrid_nx_nz = super()._get_eqdsk(
             filename,
             from_cocos=from_cocos,
             full_coil=full_coil,
@@ -499,13 +514,13 @@ class CoilSetMHDState(MHDState):
         from_cocos: int | None = 11,
         *,
         qpsi_positive: bool | None = None,
+        full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         user_coils: CoilSet | None = None,
         force_symmetry: bool = False,
         force_symmetry_rtol: float | None = None,
-        full_coil: bool = False,
-        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
-    ) -> tuple[EQDSKInterface, Grid, CoilSet, Limiter | None]:
+    ) -> tuple[EQDSKInterface, Grid, tuple[int, int] | None, CoilSet, Limiter | None]:
         """
         Get eqdsk data from file for read in
 
@@ -520,6 +535,11 @@ class CoilSetMHDState(MHDState):
         qpsi_positive:
             Whether qpsi is positive or not, required for identification
             when qpsi is not present in the file.
+        full_coil:
+            Whether the eqdsk dxc and dzc represents
+            the full coil width or half coil width
+        regrid_nx_nz:
+            Modify grid to use new nx and nz values
         user_coils:
             Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
@@ -530,9 +550,6 @@ class CoilSetMHDState(MHDState):
             The values for the secondary coil in the pair will be
             set to be equal to the primary coil values if they are
             within force_symmetry_rtol.
-        full_coil:
-            Whether the eqdsk dxc and dzc represents
-            the full coil width or half coil width
 
         Returns
         -------
@@ -540,6 +557,9 @@ class CoilSetMHDState(MHDState):
             Instance if EQDSKInterface with the EQDSK file read in
         psi:
             psi array
+        regrid_nx_nz:
+            modified regrid argument, possibly overwritten if previous grid
+            states matched
         coilset:
             Coilset from eqdsk
         grid:
@@ -547,7 +567,7 @@ class CoilSetMHDState(MHDState):
         limiter:
             Limiter instance if any limiters are in file
         """
-        e, grid = super()._get_eqdsk(
+        e, grid, regrid_nx_nz = super()._get_eqdsk(
             filename,
             from_cocos=from_cocos,
             qpsi_positive=qpsi_positive,
@@ -561,7 +581,7 @@ class CoilSetMHDState(MHDState):
 
         limiter = None if e.nlim > 5 or e.nlim == 0 else Limiter(e.xlim, e.zlim)  # noqa: PLR2004
 
-        return e, grid, coilset, limiter
+        return e, grid, regrid_nx_nz, coilset, limiter
 
     def _remap_greens(self):
         """
@@ -692,10 +712,10 @@ class Breakdown(CoilSetMHDState):
         from_cocos: int | None = 11,
         *,
         qpsi_positive: bool | None = None,
-        force_symmetry: bool,
-        user_coils: CoilSet | None = None,
         full_coil: bool = False,
         regrid_nx_nz: tuple[int, int] | None = None,
+        force_symmetry: bool,
+        user_coils: CoilSet | None = None,
         **kwargs,
     ):
         """
@@ -713,16 +733,18 @@ class Breakdown(CoilSetMHDState):
         qpsi_positive:
             Whether qpsi is positive or not, required for identification
             when qpsi is not present in the file.
+        full_coil:
+            Whether the eqdsk dxc and dzc represents
+            the full coil width or half coil width
+        regrid_nx_nz:
+            Modify grid to use new nx and nz values
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
         user_coils:
             Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
-        full_coil:
-            Whether the eqdsk dxc and dzc represents
-            the full coil width or half coil width
         """  # noqa: DOC201
-        eqdsk, grid, coilset, limiter = super()._get_eqdsk(
+        eqdsk, grid, _, coilset, limiter = super()._get_eqdsk(
             filename,
             from_cocos,
             qpsi_positive=qpsi_positive,
@@ -1051,11 +1073,11 @@ class Equilibrium(CoilSetMHDState):
         from_cocos: int | None = 11,
         *,
         qpsi_positive: bool | None = None,
+        full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         force_symmetry: bool = False,
         user_coils: CoilSet | None = None,
-        full_coil: bool = False,
         o_point_fallback: OPointCalcOptions = OPointCalcOptions.GRID_CENTRE,
-        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ):
         """
@@ -1077,16 +1099,18 @@ class Equilibrium(CoilSetMHDState):
         qpsi_positive:
             Whether qpsi is positive or not, required for identification
             when qpsi is not present in the file.
+        full_coil:
+            Whether the eqdsk dxc and dzc represents
+            the full coil width or half coil width
+        regrid_nx_nz:
+            Modify grid to use new nx and nz values
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
         user_coils:
             Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
-        full_coil:
-            Whether the eqdsk dxc and dzc represents
-            the full coil width or half coil width
         """  # noqa: DOC201
-        e, grid, coilset, limiter = super()._get_eqdsk(
+        e, grid, regrid_nx_nz, coilset, limiter = super()._get_eqdsk(
             filename,
             from_cocos=from_cocos,
             qpsi_positive=qpsi_positive,
@@ -1098,10 +1122,7 @@ class Equilibrium(CoilSetMHDState):
         )
 
         if regrid_nx_nz:
-            xn, zn = np.meshgrid(grid.x[:, 0], grid.z[0, :], indexing="ij")
-            psi = interpolate_psi(
-                x_old=e.x, z_old=e.z, psi_old=e.psi, x_new=xn, z_new=zn
-            )
+            psi = interpolate_psi(psi=e.psi, psi_grid=Grid.from_eqdsk(e), new_grid=grid)
         else:
             psi = e.psi
 

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -146,6 +146,7 @@ class MHDState:
         *,
         qpsi_positive: bool | None = None,
         full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ) -> tuple[EQDSKInterface, Grid]:
         """
@@ -197,7 +198,10 @@ class MHDState:
             e.dxc /= 2
             e.dzc /= 2
 
-        return e, Grid.from_eqdsk(e)
+        grid = Grid.from_eqdsk(e)
+        if regrid_nx_nz is not None:
+            grid = grid.regrid(*regrid_nx_nz)
+        return e, grid
 
     def to_eqdsk(
         self,
@@ -294,6 +298,7 @@ class FixedPlasmaEquilibrium(MHDState):
         *,
         qpsi_positive: bool | None = None,
         full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ):
         """
@@ -320,8 +325,10 @@ class FixedPlasmaEquilibrium(MHDState):
             from_cocos=from_cocos,
             full_coil=full_coil,
             qpsi_positive=qpsi_positive,
+            regrid_nx_nz=regrid_nx_nz,
             **kwargs,
         )
+
         psi_ax = e.psimag
         psi_b = e.psibdry
         lcfs = Coordinates({"x": e.xbdry, "z": e.zbdry})
@@ -495,6 +502,7 @@ class CoilSetMHDState(MHDState):
         force_symmetry: bool = False,
         force_symmetry_rtol: float | None = None,
         full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ) -> tuple[EQDSKInterface, Grid, CoilSet, Limiter | None]:
         """
@@ -543,6 +551,7 @@ class CoilSetMHDState(MHDState):
             from_cocos=from_cocos,
             qpsi_positive=qpsi_positive,
             full_coil=full_coil,
+            regrid_nx_nz=regrid_nx_nz,
             **kwargs,
         )
         coilset = user_coils if user_coils is not None else CoilSet.from_group_vecs(e)
@@ -685,6 +694,7 @@ class Breakdown(CoilSetMHDState):
         force_symmetry: bool,
         user_coils: CoilSet | None = None,
         full_coil: bool = False,
+        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ):
         """
@@ -718,8 +728,10 @@ class Breakdown(CoilSetMHDState):
             force_symmetry=force_symmetry,
             user_coils=user_coils,
             full_coil=full_coil,
+            regrid_nx_nz=regrid_nx_nz,
             **kwargs,
         )
+
         self = cls(coilset, grid, limiter=limiter, psi=eqdsk.psi, filename=filename)
         self._eqdsk = eqdsk
         return self
@@ -1042,6 +1054,7 @@ class Equilibrium(CoilSetMHDState):
         user_coils: CoilSet | None = None,
         full_coil: bool = False,
         o_point_fallback: OPointCalcOptions = OPointCalcOptions.GRID_CENTRE,
+        regrid_nx_nz: tuple[int, int] | None = None,
         **kwargs,
     ):
         """
@@ -1079,6 +1092,7 @@ class Equilibrium(CoilSetMHDState):
             force_symmetry=force_symmetry,
             user_coils=user_coils,
             full_coil=full_coil,
+            regrid_nx_nz=regrid_nx_nz,
             **kwargs,
         )
 

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -38,6 +38,7 @@ from bluemira.equilibria.find import (
     find_flux_surf,
     in_plasma,
     in_zone,
+    interpolate_psi,
 )
 from bluemira.equilibria.flux_surfaces import (
     ClosedFluxSurface,
@@ -1096,11 +1097,19 @@ class Equilibrium(CoilSetMHDState):
             **kwargs,
         )
 
+        if regrid_nx_nz:
+            xn, zn = np.meshgrid(grid.x[:, 0], grid.z[0, :], indexing="ij")
+            psi = interpolate_psi(
+                x_old=e.x, z_old=e.z, psi_old=e.psi, x_new=xn, z_new=zn
+            )
+        else:
+            psi = e.psi
+
         profiles = CustomProfile.from_eqdsk(e)
         o_points, x_points = find_OX_points(
             grid.x,
             grid.z,
-            e.psi,
+            psi,
             limiter=limiter,
             o_point_fallback=o_point_fallback,
             R_0=profiles.R_0,
@@ -1108,7 +1117,7 @@ class Equilibrium(CoilSetMHDState):
         jtor = profiles.jtor(
             grid.x,
             grid.z,
-            e.psi,
+            psi,
             o_points=o_points,
             x_points=x_points,
             o_point_fallback=o_point_fallback,
@@ -1120,7 +1129,7 @@ class Equilibrium(CoilSetMHDState):
             profiles=profiles,
             vcontrol=None,
             limiter=limiter,
-            psi=e.psi,
+            psi=psi,
             jtor=jtor,
             filename=filename,
             o_point_fallback=o_point_fallback,
@@ -1274,15 +1283,55 @@ class Equilibrium(CoilSetMHDState):
 
         self._solver = GSSolver(grid, force_symmetry=self.force_symmetry)
 
-    def reset_grid(self, grid: Grid, **kwargs):
+    def _calculate_jtor(self, grid, psi_plasma):
         """
-        Yeah, yeah...
+        Compute jtor from plasma psi.
+
+        Returns
+        -------
+        :
+            Recalculated jtor.
         """
-        super().reset_grid(grid, **kwargs)
+        o_points, x_points = self.get_OX_points(
+            psi=psi_plasma,
+            force_update=True,
+        )
+        return self.profiles.jtor(
+            grid.x,
+            grid.z,
+            psi_plasma,
+            o_points=o_points,
+            x_points=x_points,
+        )
+
+    def reset_grid(
+        self, grid: Grid, psi: npt.NDArray[np.float64] | None = None, **kwargs
+    ):
+        """
+        Reset the grid for the Equilibrium.
+
+        Parameters
+        ----------
+        grid:
+            The grid to set the Equilibrium on
+        psi:
+            Psi array to use
+        """
+        self.set_grid(grid)
+        self.boundary = FreeBoundary(grid)
+
+        self._clear_OX_points()
+        if psi is not None:
+            self._jtor = self._calculate_jtor(grid, psi)
+            self._remap_greens()
+            psi -= self.coilset.psi(grid.x, grid.z)
+            self._update_plasma(psi, self._jtor)
+        else:
+            self._set_init_plasma(grid)
+            self._jtor = self._calculate_jtor(grid, self.plasma.psi())
+            self._update_plasma(self.plasma.psi(), self._jtor)
         vcontrol = kwargs.get("vcontrol", self._kwargs["vcontrol"])
         self.set_vcontrol(vcontrol)
-        # TODO @CoronelBuendia: reinit psi and jtor?
-        # 3658
 
     def _set_init_plasma(
         self,

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import numba as nb
 import numpy as np
 from contourpy import LineType, contour_generator
-from scipy.interpolate import RectBivariateSpline, RegularGridInterpolator
+from scipy.interpolate import RectBivariateSpline
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import B_TOLERANCE, X_TOLERANCE
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
+    from bluemira.equilibria.grid import Grid
     from bluemira.equilibria.limiter import Limiter
 
 __all__ = [
@@ -1106,42 +1107,15 @@ def _in_plasma(
     return mask
 
 
-def interpolate_psi(
-    x_old: np.ndarray,
-    z_old: np.ndarray,
-    psi_old: np.ndarray,
-    x_new: np.ndarray,
-    z_new: np.ndarray,
-    *,
-    bounds_error: bool = False,
-    fill_value: float | None = None,
-):
+def interpolate_psi(psi, psi_grid: Grid, new_grid: Grid):
     """
-    Interpolates a psi(x, z) field from an old grid to a new grid.
-
-    Parameters
-    ----------
-    x_old, z_old:
-        1D arrays defining the original regular grid (shape [Nx], [Nz])
-    psi_old:
-        2D psi field on the old grid (shape [Nx, Nz])
-    x_new, z_new:
-        2D meshgrid arrays defining the target grid
-    bounds_error:
-        Passed to RegularGridInterpolator
-    fill_value:
-        Passed to RegularGridInterpolator
+    Interpolate psi over new comparison grid
 
     Returns
     -------
-    psi_new:
-        2D array psi evaluated on (x_new, z_new)
-    """
-    interpolator = RegularGridInterpolator(
-        (x_old, z_old),
-        psi_old,
-        bounds_error=bounds_error,
-        fill_value=fill_value,
-    )
+    :
+        interpolated psi values
 
-    return interpolator((x_new, z_new))
+    """
+    psi_func = RectBivariateSpline(psi_grid.x[:, 0], psi_grid.z[0, :], psi)
+    return psi_func.ev(new_grid.x, new_grid.z)

--- a/bluemira/equilibria/find.py
+++ b/bluemira/equilibria/find.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import numba as nb
 import numpy as np
 from contourpy import LineType, contour_generator
-from scipy.interpolate import RectBivariateSpline
+from scipy.interpolate import RectBivariateSpline, RegularGridInterpolator
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.constants import B_TOLERANCE, X_TOLERANCE
@@ -1104,3 +1104,44 @@ def _in_plasma(
             if in_polygon(x[i, j], z[i, j], sep, include_edges):
                 mask[i, j] = 1
     return mask
+
+
+def interpolate_psi(
+    x_old: np.ndarray,
+    z_old: np.ndarray,
+    psi_old: np.ndarray,
+    x_new: np.ndarray,
+    z_new: np.ndarray,
+    *,
+    bounds_error: bool = False,
+    fill_value: float | None = None,
+):
+    """
+    Interpolates a psi(x, z) field from an old grid to a new grid.
+
+    Parameters
+    ----------
+    x_old, z_old:
+        1D arrays defining the original regular grid (shape [Nx], [Nz])
+    psi_old:
+        2D psi field on the old grid (shape [Nx, Nz])
+    x_new, z_new:
+        2D meshgrid arrays defining the target grid
+    bounds_error:
+        Passed to RegularGridInterpolator
+    fill_value:
+        Passed to RegularGridInterpolator
+
+    Returns
+    -------
+    psi_new:
+        2D array psi evaluated on (x_new, z_new)
+    """
+    interpolator = RegularGridInterpolator(
+        (x_old, z_old),
+        psi_old,
+        bounds_error=bounds_error,
+        fill_value=fill_value,
+    )
+
+    return interpolator((x_new, z_new))

--- a/bluemira/equilibria/grid.py
+++ b/bluemira/equilibria/grid.py
@@ -133,6 +133,23 @@ class Grid:
             [(nx - 1, z) for z in range(nz)],
         ])
 
+    def regrid(self, nx: int, nz: int) -> Grid:
+        """Reinitialise the grid with different x and z discretisation
+
+        Parameters
+        ----------
+        nx:
+            number of x grid points
+        nz:
+            number of z grid points
+
+        Returns
+        -------
+        :
+            New grid object
+        """
+        return type(self)(self.x_min, self.x_max, self.z_min, self.z_max, nx, nz)
+
     @classmethod
     def from_eqdict(cls, e) -> Grid:
         """

--- a/bluemira/equilibria/grid.py
+++ b/bluemira/equilibria/grid.py
@@ -148,6 +148,11 @@ class Grid:
         :
             New grid object
         """
+        if (self.nx, self.nz) == (nx, nz):
+            bluemira_warn(
+                "No regridding undertaken, previous number of grid points is the same"
+            )
+            return self
         return type(self)(self.x_min, self.x_max, self.z_min, self.z_max, nx, nz)
 
     @classmethod

--- a/bluemira/equilibria/plasma.py
+++ b/bluemira/equilibria/plasma.py
@@ -284,7 +284,7 @@ class PlasmaCoil:
         :
             A simple string representation of the PlasmaCoil.
         """
-        n_filaments = len(np.nonzero(self._j_tor > 0)[0])
+        n_filaments = np.count_nonzero(self._j_tor)
         return f"{self.__class__.__name__}: {n_filaments} filaments"
 
 

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -40,6 +40,7 @@ from bluemira.equilibria.find import (
     _in_plasma,
     get_contours,
     grid_2d_contour,
+    interpolate_psi,
 )
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.physics import calc_psi
@@ -1304,33 +1305,20 @@ class EquilibriumComparisonPostOptPlotter(EquilibriumComparisonBasePlotter):
             nz = np.max([ref_grid.nz, input_grid.nz])
         return Grid(x_min, x_max, z_min, z_max, nx, nz)
 
-    def interpolate_psi(self, psi, psi_grid):
-        """
-        Interpolate psi over new comparison grid
-
-        Returns
-        -------
-        :
-            interpolated psi values
-
-        """
-        psi_func = RectBivariateSpline(psi_grid.x[:, 0], psi_grid.z[0, :], psi)
-        return psi_func.ev(self.grid.x, self.grid.z)
-
     def _interpolate_psi_for_comparison(self):
         """Interpolate all psi components over new grid."""
-        self.ref_coilset_psi = self.interpolate_psi(
-            self.ref_coilset_psi, self.reference.grid
+        self.ref_coilset_psi = interpolate_psi(
+            self.ref_coilset_psi, self.reference.grid, self.grid
         )
-        self.ref_plasma_psi = self.interpolate_psi(
-            self.ref_plasma_psi, self.reference.grid
+        self.ref_plasma_psi = interpolate_psi(
+            self.ref_plasma_psi, self.reference.grid, self.grid
         )
-        self.ref_total_psi = self.interpolate_psi(
-            self.ref_total_psi, self.reference.grid
+        self.ref_total_psi = interpolate_psi(
+            self.ref_total_psi, self.reference.grid, self.grid
         )
-        self.coilset_psi = self.interpolate_psi(self.coilset_psi, self.eq.grid)
-        self.plasma_psi = self.interpolate_psi(self.plasma_psi, self.eq.grid)
-        self.total_psi = self.interpolate_psi(self.total_psi, self.eq.grid)
+        self.coilset_psi = interpolate_psi(self.coilset_psi, self.eq.grid, self.grid)
+        self.plasma_psi = interpolate_psi(self.plasma_psi, self.eq.grid, self.grid)
+        self.total_psi = interpolate_psi(self.total_psi, self.eq.grid, self.grid)
 
     def _make_lcfs_mask(self, mask_type):
         """

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -426,6 +426,17 @@ class TestEqReadWrite:
             d2.pop("coil_names")
         assert compare_dicts(d1, d2, almost_equal=True)
 
+    def test_regrid_on_read(self):
+        data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
+        file_name = "eqref_OOB.json"
+
+        eq_ng = Equilibrium.from_eqdsk(Path(data_path, file_name), from_cocos=7)
+        eq = Equilibrium.from_eqdsk(
+            Path(data_path, file_name), from_cocos=7, regrid_nx_nz=(100, 100)
+        )
+
+        raise NotImplementedError
+
 
 @pytest.mark.private
 class TestQBenchmark:

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -17,6 +17,7 @@ from bluemira.base.file import get_bluemira_path, try_get_bluemira_private_data_
 from bluemira.equilibria.coils import CoilGroup, CoilSet
 from bluemira.equilibria.diagnostics import EqBPlotParam
 from bluemira.equilibria.equilibrium import Equilibrium, FixedPlasmaEquilibrium
+from bluemira.equilibria.find import find_OX_points, interpolate_psi
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.optimisation.constraints import (
     FieldNullConstraint,
@@ -39,6 +40,15 @@ from bluemira.equilibria.shapes import flux_surface_kuiroukidis
 from bluemira.equilibria.solve import DudsonConvergence, PicardIterator
 from bluemira.utilities.tools import abs_rel_difference, compare_dicts
 from tests.equilibria.setup_methods import _coilset_setup
+
+
+def closest_dist(a_pts, b_pts):
+    if not a_pts or not b_pts:
+        return np.inf
+    A = np.array([(p.x, p.z) for p in a_pts])
+    B = np.array([(p.x, p.z) for p in b_pts])
+    d = np.sqrt(((A[:, None, :] - B[None, :, :]) ** 2).sum(axis=2))
+    return np.min(d)
 
 
 class TestFields:
@@ -426,16 +436,135 @@ class TestEqReadWrite:
             d2.pop("coil_names")
         assert compare_dicts(d1, d2, almost_equal=True)
 
-    def test_regrid_on_read(self):
+    @pytest.fixture
+    def eq_data(self):
         data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
-        file_name = "eqref_OOB.json"
+        return Path(data_path, "eqref_OOB.json")
 
-        eq_ng = Equilibrium.from_eqdsk(Path(data_path, file_name), from_cocos=7)
-        eq = Equilibrium.from_eqdsk(
-            Path(data_path, file_name), from_cocos=7, regrid_nx_nz=(100, 100)
+    @pytest.fixture
+    def eq_ng(self, eq_data):
+        return Equilibrium.from_eqdsk(eq_data, from_cocos=7)
+
+    @pytest.fixture
+    def eq_rg(self, eq_data):
+        return Equilibrium.from_eqdsk(eq_data, from_cocos=7, regrid_nx_nz=(100, 100))
+
+    def test_regrid_changes_resolution(self, eq_ng, eq_rg):
+        assert eq_ng.grid.nx != eq_rg.grid.nx
+        assert eq_ng.grid.nz != eq_rg.grid.nz
+        assert np.isclose(eq_ng.grid.x_min, eq_rg.grid.x_min)
+        assert np.isclose(eq_ng.grid.x_max, eq_rg.grid.x_max)
+        assert np.isclose(eq_ng.grid.z_min, eq_rg.grid.z_min)
+        assert np.isclose(eq_ng.grid.z_max, eq_rg.grid.z_max)
+
+    def test_regrid_preserves_psi_range(self, eq_ng, eq_rg):
+        assert eq_rg.psi().shape == (eq_rg.grid.nx, eq_rg.grid.nz)
+        assert np.isclose(np.nanmin(eq_ng.psi()), np.nanmin(eq_rg.psi()), rtol=1e-2)
+        assert np.isclose(np.nanmax(eq_ng.psi()), np.nanmax(eq_rg.psi()), rtol=1e-2)
+
+    def test_regrid_interpolation_back(self, eq_ng, eq_rg):
+        x_new, z_new = eq_rg.grid.x[:, 0], eq_rg.grid.z[0, :]
+        x_old, z_old = np.meshgrid(eq_ng.grid.x[:, 0], eq_ng.grid.z[0, :], indexing="ij")
+        psi_back = interpolate_psi(
+            x_old=x_new, z_old=z_new, psi_old=eq_rg.psi(), x_new=x_old, z_new=z_old
+        )
+        diff = psi_back - eq_ng.psi()
+        max_abs = np.nanmax(np.abs(diff))
+        mean_abs = np.nanmean(np.abs(diff))
+        rel_l2 = np.linalg.norm(diff.ravel()) / np.linalg.norm(eq_ng.psi().ravel())
+
+        assert rel_l2 < 0.03
+        assert mean_abs < 1.0
+        assert max_abs < 10.0
+
+    def test_regrid_preserves_ox_points(self, eq_ng, eq_rg):
+        o_old, x_old_pts = find_OX_points(eq_ng.grid.x, eq_ng.grid.z, eq_ng.psi())
+        o_new, x_new_pts = find_OX_points(eq_rg.grid.x, eq_rg.grid.z, eq_rg.psi())
+        assert closest_dist(o_old, o_new) < 0.05
+        assert closest_dist(x_old_pts, x_new_pts) < 0.1
+
+    def test_regrid_preserves_total_current(self, eq_ng, eq_rg):
+        o_old, x_old_pts = find_OX_points(eq_ng.grid.x, eq_ng.grid.z, eq_ng.psi())
+        o_new, x_new_pts = find_OX_points(eq_rg.grid.x, eq_rg.grid.z, eq_rg.psi())
+
+        j_old = eq_ng.profiles.jtor(
+            eq_ng.grid.x, eq_ng.grid.z, eq_ng.psi(), o_points=o_old, x_points=x_old_pts
+        )
+        j_new = eq_rg.profiles.jtor(
+            eq_rg.grid.x, eq_rg.grid.z, eq_rg.psi(), o_points=o_new, x_points=x_new_pts
         )
 
-        raise NotImplementedError
+        i_old = np.nansum(j_old) * eq_ng.grid.dx * eq_ng.grid.dz
+        i_new = np.nansum(j_new) * eq_rg.grid.dx * eq_rg.grid.dz
+        assert np.isclose(i_old, i_new, rtol=5e-2)
+
+
+class TestResetGrid:
+    @pytest.fixture
+    def eq_data(self):
+        data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
+        return Path(data_path, "eqref_OOB.json")
+
+    @pytest.fixture
+    def eq_ng(self, eq_data):
+        return Equilibrium.from_eqdsk(eq_data, from_cocos=7)
+
+    @pytest.fixture
+    def new_grid(self, eq_ng):
+        old = eq_ng.grid
+        return Grid(old.x_min, old.x_max, old.z_min, old.z_max, nx=120, nz=140)
+
+    @pytest.fixture
+    def interpolated_psi(self, eq_ng, new_grid):
+        x_old, z_old = eq_ng.grid.x[:, 0], eq_ng.grid.z[0, :]
+        xn, zn = np.meshgrid(new_grid.x[:, 0], new_grid.z[0, :], indexing="ij")
+        return interpolate_psi(
+            x_old=x_old, z_old=z_old, psi_old=eq_ng.psi(), x_new=xn, z_new=zn
+        )
+
+    def test_reset_grid_updates_grid(self, eq_ng, new_grid, interpolated_psi):
+        eq_ng.reset_grid(new_grid, psi=interpolated_psi)
+
+        assert eq_ng.grid.nx == 120
+        assert eq_ng.grid.nz == 140
+
+    def test_reset_grid_remaps_fields(self, eq_ng, new_grid, interpolated_psi):
+        eq_ng.reset_grid(new_grid, psi=interpolated_psi)
+        psi = eq_ng.psi()
+        jtor = eq_ng._jtor
+
+        assert psi.shape == (120, 140)
+        assert jtor.shape == (120, 140)
+        assert np.isfinite(psi).any()
+
+    def test_reset_grid_recomputes_OX_points(self, eq_ng, new_grid, interpolated_psi):
+        o_old, x_old = eq_ng.get_OX_points()
+        eq_ng.reset_grid(new_grid, psi=interpolated_psi)
+        o_new, x_new = eq_ng.get_OX_points()
+
+        assert closest_dist(o_old, o_new) < 0.05
+        assert closest_dist(x_old, x_new) < 0.1
+
+    def test_reset_grid_preserves_total_current(self, eq_ng, new_grid, interpolated_psi):
+        j_old = eq_ng._jtor
+        i_old = np.nansum(j_old) * eq_ng.grid.dx * eq_ng.grid.dz
+
+        eq_ng.reset_grid(new_grid, psi=interpolated_psi)
+
+        j_new = eq_ng._jtor
+        i_new = np.nansum(j_new) * eq_ng.grid.dx * eq_ng.grid.dz
+
+        assert np.isclose(i_new, i_old, rtol=5e-2)
+
+    def test_reset_grid_initialises_plasma(self, eq_ng, new_grid):
+        eq_ng.reset_grid(new_grid, psi=None)
+
+        psi = eq_ng.psi()
+        jtor = eq_ng._jtor
+
+        assert psi.shape == (120, 140)
+        assert jtor.shape == (120, 140)
+        assert np.isfinite(psi).any()
 
 
 @pytest.mark.private

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -404,6 +404,17 @@ class TestEquilibrium:
         self.dn.plot(plasma=plasma)
 
 
+@pytest.fixture
+def eq_data():
+    data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
+    return Path(data_path, "eqref_OOB.json")
+
+
+@pytest.fixture
+def eq_ng(eq_data):
+    return Equilibrium.from_eqdsk(eq_data, from_cocos=7)
+
+
 class TestEqReadWrite:
     @pytest.mark.parametrize("qpsi_calcmode", [0, 1])
     @pytest.mark.parametrize("file_format", ["json", "eqdsk"])
@@ -437,15 +448,6 @@ class TestEqReadWrite:
         assert compare_dicts(d1, d2, almost_equal=True)
 
     @pytest.fixture
-    def eq_data(self):
-        data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
-        return Path(data_path, "eqref_OOB.json")
-
-    @pytest.fixture
-    def eq_ng(self, eq_data):
-        return Equilibrium.from_eqdsk(eq_data, from_cocos=7)
-
-    @pytest.fixture
     def eq_rg(self, eq_data):
         return Equilibrium.from_eqdsk(eq_data, from_cocos=7, regrid_nx_nz=(100, 100))
 
@@ -463,19 +465,15 @@ class TestEqReadWrite:
         assert np.isclose(np.nanmax(eq_ng.psi()), np.nanmax(eq_rg.psi()), rtol=1e-2)
 
     def test_regrid_interpolation_back(self, eq_ng, eq_rg):
-        x_new, z_new = eq_rg.grid.x[:, 0], eq_rg.grid.z[0, :]
-        x_old, z_old = np.meshgrid(eq_ng.grid.x[:, 0], eq_ng.grid.z[0, :], indexing="ij")
-        psi_back = interpolate_psi(
-            x_old=x_new, z_old=z_new, psi_old=eq_rg.psi(), x_new=x_old, z_new=z_old
-        )
+        psi_back = interpolate_psi(eq_rg.psi(), eq_rg.grid, eq_ng.grid)
         diff = psi_back - eq_ng.psi()
         max_abs = np.nanmax(np.abs(diff))
         mean_abs = np.nanmean(np.abs(diff))
         rel_l2 = np.linalg.norm(diff.ravel()) / np.linalg.norm(eq_ng.psi().ravel())
 
-        assert rel_l2 < 0.03
-        assert mean_abs < 1.0
-        assert max_abs < 10.0
+        assert rel_l2 < 1e-6
+        assert mean_abs < 6e-6
+        assert max_abs < 2e-4
 
     def test_regrid_preserves_ox_points(self, eq_ng, eq_rg):
         o_old, x_old_pts = find_OX_points(eq_ng.grid.x, eq_ng.grid.z, eq_ng.psi())
@@ -501,26 +499,13 @@ class TestEqReadWrite:
 
 class TestResetGrid:
     @pytest.fixture
-    def eq_data(self):
-        data_path = get_bluemira_path("equilibria/test_data", subfolder="tests")
-        return Path(data_path, "eqref_OOB.json")
-
-    @pytest.fixture
-    def eq_ng(self, eq_data):
-        return Equilibrium.from_eqdsk(eq_data, from_cocos=7)
+    def interpolated_psi(self, eq_ng, new_grid):
+        return interpolate_psi(eq_ng.psi(), eq_ng.grid, new_grid)
 
     @pytest.fixture
     def new_grid(self, eq_ng):
         old = eq_ng.grid
         return Grid(old.x_min, old.x_max, old.z_min, old.z_max, nx=120, nz=140)
-
-    @pytest.fixture
-    def interpolated_psi(self, eq_ng, new_grid):
-        x_old, z_old = eq_ng.grid.x[:, 0], eq_ng.grid.z[0, :]
-        xn, zn = np.meshgrid(new_grid.x[:, 0], new_grid.z[0, :], indexing="ij")
-        return interpolate_psi(
-            x_old=x_old, z_old=z_old, psi_old=eq_ng.psi(), x_new=xn, z_new=zn
-        )
 
     def test_reset_grid_updates_grid(self, eq_ng, new_grid, interpolated_psi):
         eq_ng.reset_grid(new_grid, psi=interpolated_psi)


### PR DESCRIPTION
## Linked issue

Hopefully closes #3658 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This PR regrid an eqdsk after it has been read into an equilibrium object. 
TODO 
- [x] rescale psi
- [x] needs testing

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
