### PR TITLE
Added documentation explaining which library takes precedence …

### DIFF
--- a/scripts/openmc_data_download/neutronics_data_downloader.py
+++ b/scripts/openmc_data_download/neutronics_data_downloader.py
@@ -166,11 +166,17 @@ def combine_xml(
     thermal_files: tuple[str, ...],
     thermal_prefix: Path,
 ):
-    """Combine xml files"""
+    """Combine cross_section.xml files from all libraries.
+
+    The cross_section.xml file is parsed in a way that, if there are duplicate isotopes,
+    the first appearance of this isotope will be used when extracting its cross-sections.
+    This behaviour is enforced by :meth:`openmc.data.library.DataLibrary.get_by_material`
+    where the first xml record with matching 'materials' string is returned.
+    """
     bluemira_print("Removing uneeded files")
     for i in thermal_files:
         Path(thermal_prefix / f"{i}.h5").unlink()
-    for file in ["bebeo", "obeo"]:
+    for file in ["bebeo", "obeo"]:  # acer files aren't needed.
         Path("endf-b7.1-ace", f"{file}.acer").unlink()
 
     bluemira_print("Combining cross section xml files")


### PR DESCRIPTION
…when multiple libraries with duplicate isotopes are used.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

Making it clearer which library takes precedence - in our default use case (where the data is automatically downloaded), TENDL takes precedence over ENDF-B VIII when combining the two libraries.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
