### PR TITLE
🏗️ Qtapp robustness improvement

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -2923,7 +2923,7 @@ def show_cad(
         light.intensity = 1.2
 
         viewer.show()
-        app.exec_()
+        app.exec()
 
 
 def rotate_into_position(

--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -36,7 +36,6 @@ import FreeCADGui
 import Part
 import numpy as np
 from FreeCAD import Base
-from PySide6.QtWidgets import QApplication
 from matplotlib import colors
 
 try:
@@ -52,7 +51,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes._freecadconfig import _freecad_save_config
 from bluemira.codes.error import FreeCADError, InvalidCADInputsError
 from bluemira.geometry.constants import EPS_FREECAD, MINIMUM_LENGTH
-from bluemira.utilities.tools import ColourDescriptor, floatify
+from bluemira.utilities.tools import ColourDescriptor, floatify, qtapp_instance
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -2897,9 +2896,7 @@ def show_cad(
             "there are parts to display."
         )
 
-    app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
+    app = qtapp_instance()
 
     root = coin.SoSeparator()
 

--- a/bluemira/display/auto_config.py
+++ b/bluemira/display/auto_config.py
@@ -16,10 +16,10 @@ from multiprocessing import TimeoutError as mpTimeoutError
 
 import numpy as np
 import seaborn as sns
-from PySide6 import QtWidgets
 
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_warn
 from bluemira.display.palettes import BLUEMIRA_PALETTE
+from bluemira.utilities.tools import qtapp_instance
 
 
 @functools.lru_cache(1)
@@ -74,13 +74,7 @@ def _get_primary_screen_size():
         return None, None
 
     # IPython detection (of sorts)
-    app = QtWidgets.QApplication.instance()
-    if app is None:
-        # if IPython isn't open then a QApplication is created to get screen size
-        app = QtWidgets.QApplication([])
-        rect = app.primaryScreen().availableGeometry()
-    else:
-        rect = app.primaryScreen().availableGeometry()
+    rect = qtapp_instance().primaryScreen().availableGeometry()
 
     return rect.width(), rect.height()
 

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 import nlopt
 import numpy as np
 import numpy.typing as npt
+from PySide6.QtWidgets import QApplication
 from matplotlib import colors
 
 from bluemira.base.constants import E_I, E_IJ, E_IJK
@@ -1190,3 +1191,20 @@ def deprecation_wrapper(
         return _decorate(message)
 
     return _decorate
+
+
+def qtapp_instance() -> QApplication:
+    """Get at QtWidgets.QApplication instance
+
+    Can be used as a crude way to detect ipython/jupyter instances
+
+    Returns
+    -------
+    :
+        QApplication instance
+    """
+    try:
+        app = QApplication([])
+    except RuntimeError:
+        app = QApplication.instance()
+    return app

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -1206,5 +1206,6 @@ def qtapp_instance() -> QApplication:
     try:
         app = QApplication([])
     except RuntimeError:
+        bluemira_debug("QApplication instance already exists")
         app = QApplication.instance()
     return app


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
There has been some reports of the qt cad viewer crashing with

```
QWidget: Must construct a QApplication before a QWidget
Aborted (core dumped)
```
this is not great and it is hard to see what we are doing wrong. So I've extracted all QApplication calls to one place and made it a try except instead.

Still needs a bit of checking

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->
None

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
