### PR TITLE
Unified max_iter and maxiter to the latter spelling.

### DIFF
--- a/bluemira/codes/plasmod/equilibrium_2d_coupling.py
+++ b/bluemira/codes/plasmod/equilibrium_2d_coupling.py
@@ -211,7 +211,7 @@ def solve_transport_fixed_boundary(
     kappa95_t: float,
     delta95_t: float,
     lcar_mesh: float = 0.15,
-    max_iter: int = 30,
+    maxiter: int = 30,
     iter_err_max: float = 1e-5,
     max_inner_iter: int = 20,
     inner_iter_err_max: float = 1e-4,
@@ -248,7 +248,7 @@ def solve_transport_fixed_boundary(
     lcar_mesh:
         Value of the characteristic length used to generate the mesh to solve the
         Grad-Shafranov problem
-    max_iter:
+    maxiter:
         Maximum number of iteration between Grad-Shafranov and the transport solver
     iter_err_max:
         Convergence maximum error to stop the iteration
@@ -310,7 +310,7 @@ def solve_transport_fixed_boundary(
     figname = "Transport iteration "
     f, ax = None, None
 
-    for n_iter in range(max_iter):
+    for n_iter in range(maxiter):
         transp_out_params, x, pprime, ffprime = _run_transport_solver(
             transport_solver, transport_params, transport_run_mode
         )
@@ -466,7 +466,7 @@ def solve_transport_fixed_boundary(
     else:
         # If we don't break we didn't converge
         message = bluemira_warn
-        line_1 = f"did not converge within {max_iter} iterations"
+        line_1 = f"did not converge within {maxiter} iterations"
         ltgt = ">"
 
     message(

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -73,6 +73,13 @@ class PROCESSTemplateBuilder:
     ):
         """
         Set optimisation numerics
+
+        Parameters
+        ----------
+        max_iterations:
+            maximum number of iteration/calculations in process.
+        toleratnce:
+            VMCON tolerance epsvmc
         """
         self.maxcal = max_iterations
         self.epsvmc = tolerance

--- a/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
+++ b/bluemira/equilibria/fem_fixed_boundary/fem_magnetostatic_2D.py
@@ -82,7 +82,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
         Major radius [m]. Used when saving to file.
     p_order:
         Order of the approximating polynomial basis functions
-    max_iter:
+    maxiter:
         Maximum number of iterations
     iter_err_max:
         Convergence criterion value
@@ -99,7 +99,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
         R_0: float | None = None,
         B_0: float | None = None,
         p_order: int = 2,
-        max_iter: int = 10,
+        maxiter: int = 10,
         iter_err_max: float = 1e-5,
         relaxation: float = 0.0,
     ):
@@ -122,7 +122,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
             self.set_mesh(mesh)
 
         self.iter_err_max = iter_err_max
-        self.max_iter = max_iter
+        self.maxiter = maxiter
         self.relaxation = relaxation
         self.k = 1
 
@@ -387,7 +387,7 @@ class FemGradShafranovFixedBoundary(FemMagnetostatic2d):
             f, ax, cax = self._setup_plot(debug=debug)
 
         diff = np.zeros(len(points))
-        for i in range(1, self.max_iter + 1):
+        for i in range(1, self.maxiter + 1):
             prev_psi = self.psi.x.array[:]
             prev = self.psi_norm_2d(points)
 

--- a/bluemira/radiation_transport/neutronics/radial_wall.py
+++ b/bluemira/radiation_transport/neutronics/radial_wall.py
@@ -267,7 +267,7 @@ class CellWalls:
         ) + partial_diff_of_volume([start_i, new_end, next_end], dir_i)
 
     def optimise_to_match_individual_volumes(
-        self, volume_list: Iterable[float], *, max_iter=1000
+        self, volume_list: Iterable[float], *, maxiter=1000
     ):
         """
         Allow the lengths of each wall to increase, so that the overall volumes are
@@ -299,7 +299,7 @@ class CellWalls:
         num_passes_counter = -1
         forward_pass_result = np.zeros(self.num_cells + 1)
 
-        while num_passes_counter < max_iter:
+        while num_passes_counter < maxiter:
             # do not allow length to decrease beyond their original value.
 
             def excess_volume(test_length, i=i):

--- a/eudemo/config/build_config.json
+++ b/eudemo/config/build_config.json
@@ -34,13 +34,13 @@
     },
     "fixed_equilibrium_settings": {
       "p_order": 2,
-      "max_iter": 30,
+      "maxiter": 30,
       "iter_err_max": 1e-3,
       "relaxation": 0.0
     },
     "transport_eq_settings": {
       "lcar_mesh": 0.2,
-      "max_iter": 15,
+      "maxiter": 15,
       "iter_err_max": 1e-1,
       "relaxation": 0.0,
       "plot": false,
@@ -72,7 +72,7 @@
     "file_path": "$path_expand:./equilibrium_eqdsk.json",
     "settings": {
       "iter_err_max": 1e-3,
-      "max_iter": 50,
+      "maxiter": 50,
       "relaxation": 0.15,
       "coil_discretisation": 0.3,
       "gamma": 1e-7

--- a/eudemo/eudemo/equilibria/_designer.py
+++ b/eudemo/eudemo/equilibria/_designer.py
@@ -387,7 +387,7 @@ class FixedEquilibriumDesigner(Designer[tuple[Coordinates, CustomProfile]]):
         # Solve converged transport - fixed boundary equilibrium
         defaults = {
             "lcar_mesh": 0.3,
-            "max_iter": 15,
+            "maxiter": 15,
             "iter_err_max": 1e-3,
             "relaxation": 0.0,
             "plot": False,
@@ -494,7 +494,7 @@ class FixedEquilibriumDesigner(Designer[tuple[Coordinates, CustomProfile]]):
         eq_settings = self.build_config.get("fixed_equilibrium_settings", {})
         defaults = {
             "p_order": 2,
-            "max_iter": 30,
+            "maxiter": 30,
             "iter_err_max": 1e-4,
             "relaxation": 0.05,
         }
@@ -695,7 +695,7 @@ class ReferenceFreeBoundaryEquilibriumDesigner(Designer[Equilibrium]):
             "coil_discretisation": 0.3,
             "gamma": 1e-8,
             "iter_err_max": 1e-2,
-            "max_iter": 30,
+            "maxiter": 30,
         }
         settings = self.build_config.get("settings", {})
         settings = {**defaults, **settings}
@@ -717,8 +717,8 @@ class ReferenceFreeBoundaryEquilibriumDesigner(Designer[Equilibrium]):
         )
 
         iter_err_max = settings.pop("iter_err_max")
-        max_iter = settings.pop("max_iter")
-        settings["maxiter"] = max_iter  # TODO: Standardise name in PicardIterator
+        maxiter = settings.pop("maxiter")
+        settings["maxiter"] = maxiter
         iterator_program = PicardIterator(
             eq,
             self.opt_problem,

--- a/examples/codes/equilibrium_plasmod_example.ex.py
+++ b/examples/codes/equilibrium_plasmod_example.ex.py
@@ -172,7 +172,7 @@ plasmod_solver = transport_code_solver(
 
 # %%
 fem_GS_fixed_boundary = FemGradShafranovFixedBoundary(
-    p_order=2, max_iter=30, iter_err_max=1e-3
+    p_order=2, maxiter=30, iter_err_max=1e-3
 )
 
 # %% [markdown]
@@ -190,7 +190,7 @@ equilibrium = solve_transport_fixed_boundary(
     kappa95_t=kappa_95,  # Target kappa_95
     delta95_t=delta_95,  # Target delta_95
     lcar_mesh=0.2,  # Best to not go lower than this!
-    max_iter=15,
+    maxiter=15,
     iter_err_max=1e-3,
     max_inner_iter=20,
     inner_iter_err_max=1e-3,

--- a/examples/equilibria/fixed_boundary.ex.py
+++ b/examples/equilibria/fixed_boundary.ex.py
@@ -103,7 +103,7 @@ solver = FemGradShafranovFixedBoundary(
     R_0=R_0,
     B_0=B_0,
     p_order=2,
-    max_iter=30,
+    maxiter=30,
     iter_err_max=1e-4,
     relaxation=0.05,
 )

--- a/tests/codes/plasmod/test_equilibrium.py
+++ b/tests/codes/plasmod/test_equilibrium.py
@@ -158,18 +158,18 @@ class TestSolveTransportFixedBoundary:
     transport_solver = DummyTransportSolver()
     gs_solver = FemGradShafranovFixedBoundary(
         p_order=2,
-        max_iter=30,
+        maxiter=30,
         iter_err_max=1.0,
         relaxation=0,
     )
 
     @pytest.mark.parametrize(
-        ("max_iter", "message"),
+        ("maxiter", "message"),
         [
             (1, "did not"),
         ],
     )
-    def test_full_run_through(self, max_iter, message, caplog, tmp_path):
+    def test_full_run_through(self, maxiter, message, caplog, tmp_path):
         johner_parameterisation = JohnerLCFS({
             "r_0": {"value": 8.9830e00},
             "a": {"value": 8.983 / 3.1},
@@ -186,7 +186,7 @@ class TestSolveTransportFixedBoundary:
             0.4,
             iter_err_max=1e-3,
             inner_iter_err_max=1,
-            max_iter=max_iter,
+            maxiter=maxiter,
             lcar_mesh=0.3,
             refine=True,
             num_levels=1,

--- a/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
+++ b/tests/equilibria/fem_fixed_boundary/test_fem_magnetostatic_2D.py
@@ -56,7 +56,7 @@ class TestFemGradShafranovFixedBoundary:
             "I_p": 17e6,
             "B_0": 5,
             "p_order": 1,
-            "max_iter": 2,
+            "maxiter": 2,
             "iter_err_max": 1.0,
             "relaxation": 0.0,
         }


### PR DESCRIPTION
## Linked Issues

Closes #3872 

## Description

## Interface Changes

all `max_iter` became `maxiter`.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
