### PR TITLE
Fix loadspec index error

### DIFF
--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -992,7 +992,17 @@ def get_module(name: str) -> ModuleType:
 
     Returns
     -------
-    Loaded module
+    :
+        Loaded module
+
+    Raises
+    ------
+    ImportError
+        Unable to import module
+    FileNotFoundError
+        Cant find specified module file
+    ModuleNotFoundError
+        Cant find module
     """
     try:
         module = imp(name)
@@ -1013,7 +1023,8 @@ def _loadfromspec(name: str) -> ModuleType:
 
     Returns
     -------
-    Loaded module
+    :
+        Loaded module
 
     Raises
     ------
@@ -1093,12 +1104,17 @@ def get_class_from_module(name: str, default_module: str = "") -> type:
 
     Returns
     -------
-    Loaded class
+    :
+        Loaded class
 
     Raises
     ------
     ImportError
         Unable to import class from module
+    FileNotFoundError
+        Cant find specified module file
+    ModuleNotFoundError
+        Cant find module
     """
     module = default_module
     class_name = name

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -999,15 +999,14 @@ def get_module(name: str) -> ModuleType:
     ------
     ImportError
         Unable to import module
-    FileNotFoundError
-        Cant find specified module file
-    ModuleNotFoundError
-        Cant find module
     """
     try:
         module = imp(name)
     except ImportError:
-        module = _loadfromspec(name)
+        try:
+            module = _loadfromspec(name)
+        except (FileNotFoundError, ModuleNotFoundError) as load_err:
+            raise ImportError(load_err.args[0]) from load_err
     bluemira_debug(f"Loaded module {module.__name__}")
     return module
 
@@ -1111,10 +1110,6 @@ def get_class_from_module(name: str, default_module: str = "") -> type:
     ------
     ImportError
         Unable to import class from module
-    FileNotFoundError
-        Cant find specified module file
-    ModuleNotFoundError
-        Cant find module
     """
     module = default_module
     class_name = name

--- a/bluemira/utilities/tools.py
+++ b/bluemira/utilities/tools.py
@@ -1025,6 +1025,8 @@ def _loadfromspec(name: str) -> ModuleType:
         Cant find module
     """
     full_dirname = name.rsplit("/", 1)
+    if len(full_dirname) < 2:  # noqa: PLR2004
+        full_dirname = ["", full_dirname[0]]
     dirname = Path("." if len(full_dirname[0]) == 0 else full_dirname[0])
     path = Path(full_dirname[1])
 

--- a/tests/utilities/test_tools.py
+++ b/tests/utilities/test_tools.py
@@ -310,6 +310,10 @@ class TestGetModule:
         with pytest.raises(ImportError):
             get_module(Path(get_bluemira_path(), "../README.md").as_posix())
 
+        # Not a module and no path
+        with pytest.raises(FileNotFoundError):
+            get_module("TEST")
+
     def test_get_weird_ext_python_file(self, tmp_path):
         path1 = tmp_path / "file"
         path2 = tmp_path / "file.hello"


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Loadspec used in get_module fialed with an index error if you passed in the string eg 'OCC'. It should have failed with a descriptive error.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
