### PR TITLE
Fix overplotting

### DIFF
--- a/bluemira/equilibria/analysis.py
+++ b/bluemira/equilibria/analysis.py
@@ -547,7 +547,7 @@ class EqAnalysis:
             raise BluemiraError(
                 "This function can only be used for Free Boundary Equilbria."
             )
-        core_results, ax = eq.analyse_core(ax=ax)
+        core_results, ax = eq.analyse_core(plot=True, ax=ax)
         plt.suptitle(eq.label)
         return core_results, ax
 
@@ -1163,6 +1163,7 @@ class MultiEqAnalysis:
         core_results = self.make_eq_dataclass_list(analyse_plasma_core, n_points)
 
         if ax is None:
+            _ = plt.figure()
             r, c = int((len(core_results[0].__dict__) - 1) / 2) + 1, 2
             gs = GridSpec(r, c)
             ax = [plt.subplot(gs[i]) for i in range(r * c)]

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -147,7 +147,7 @@ class Plotter:
                 else:
                     self.ax = ax
                     self.f = self.ax.get_figure()
-                self.ax.set_xlabel(str_to_latex("psi_n"))
+                self.ax.set_xlabel(str_to_latex(r"\psi_n"))
                 self.ax.set_aspect("equal")
 
             case EqSubplots.XZ_COMPONENT_PSI:
@@ -164,12 +164,21 @@ class Plotter:
                 if ax is None:
                     self.f = plt.figure()
                     gs = GridSpec(nrows, ncols)
-                    self.ax = [plt.subplot(gs[i]) for i in range(nrows * ncols)]
+                    self.ax = []
+                    for col in range(ncols):
+                        i = col * nrows
+                        ax = [plt.subplot(gs[i])]
+                        [
+                            ax.append(plt.subplot(gs[j], sharex=ax[0]))
+                            for j in range(i + 1, i + nrows)
+                        ]
+                        [a.set_xticks([]) for a in ax[1:nrows]]
+                        self.ax = [*self.ax, *ax]
                 else:
                     self.ax = ax
                     self.f = self.ax[0].get_figure()
-                for c in range(1, ncols):
-                    self.ax[(nrows * ncols) - c].set_xlabel(str_to_latex("psi_n"))
+                for c in range(1, ncols + 1):
+                    self.ax[(nrows * ncols) - c].set_xlabel(str_to_latex(r"\psi_n"))
 
             case EqSubplots.VS_X:
                 if ax is None:
@@ -1639,7 +1648,7 @@ class CorePlotter(Plotter):
             ccycle = cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
             for i, (k, v) in enumerate(results.to_dict(latex_unit=True).items()):
                 color = next(ccycle)
-                self.ax[i].plot(results.psi_n, v, label=f"${k}$", color=color)
+                self.ax[i].plot(results.psi_n, v, label=f"{k}", color=color)
                 self.ax[i].legend()
         else:
             for i, (k, v) in enumerate(results.to_dict(latex_unit=True).items()):

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.axes import Axes
 from matplotlib.gridspec import GridSpec
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from scipy.interpolate import RectBivariateSpline
@@ -47,6 +46,7 @@ from bluemira.utilities.plot_tools import (
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+    from matplotlib.axes import Axes
 
     from bluemira.equilibria.diagnostics import EqDiagnosticOptions
     from bluemira.equilibria.equilibrium import (
@@ -133,57 +133,57 @@ class Plotter:
         match subplots:
             case EqSubplots.XZ:
                 if ax is None:
-                    _, self.ax = plt.subplots()
+                    self.f, self.ax = plt.subplots()
                 else:
                     self.ax = ax
+                    self.f = self.ax.get_figure()
                 self.ax.set_xlabel("$x$ [m]")
                 self.ax.set_ylabel("$z$ [m]")
                 self.ax.set_aspect("equal")
 
             case EqSubplots.VS_PSI_NORM:
                 if ax is None:
-                    _, self.ax = plt.subplots()
+                    self.f, self.ax = plt.subplots()
                 else:
                     self.ax = ax
+                    self.f = self.ax.get_figure()
                 self.ax.set_xlabel(str_to_latex("psi_n"))
                 self.ax.set_aspect("equal")
 
             case EqSubplots.XZ_COMPONENT_PSI:
                 if ax is None:
-                    _, self.ax = plt.subplots(
+                    self.f, self.ax = plt.subplots(
                         nrows=nrows, ncols=ncols, sharex=True, sharey=True
                     )
                 else:
                     self.ax = ax
+                    self.f = self.ax.get_figure()
                 set_ax_for_psi_components(self.ax)
-            # TODO @geograham: review use of self.ax in BM
-            # 3807
+
             case EqSubplots.VS_PSI_NORM_STACK:
                 if ax is None:
+                    self.f = plt.figure()
                     gs = GridSpec(nrows, ncols)
                     self.ax = [plt.subplot(gs[i]) for i in range(nrows * ncols)]
                 else:
                     self.ax = ax
+                    self.f = self.ax[0].get_figure()
                 for c in range(1, ncols):
                     self.ax[(nrows * ncols) - c].set_xlabel(str_to_latex("psi_n"))
 
             case EqSubplots.VS_X:
                 if ax is None:
+                    self.f = plt.figure()
                     gs = GridSpec(nrows, ncols)
                     self.ax = [plt.subplot(gs[i]) for i in range(nrows * ncols)]
                 else:
                     self.ax = ax
+                    self.f = self.ax[0].get_figure()
                 for a in self.ax:
                     a.set_xlabel("$x$ [m]")
 
             case _:
                 raise BluemiraError(f"{subplots} is not a valid option for subplots.")
-
-        # Set figure for use in
-        if isinstance(self.ax, Axes):
-            self.f = self.ax.get_figure()
-        else:
-            self.f = self.ax[0].get_figure()
 
 
 class GridPlotter(Plotter):

--- a/examples/equilibria/anaylsis_toolbox_examples.ex.py
+++ b/examples/equilibria/anaylsis_toolbox_examples.ex.py
@@ -302,6 +302,7 @@ table = multi_analysis.physics_info_table()
 # %%
 # Plot physics parameters for the plasma core
 # Note that a list with the results is also output
+
 core_results, ax = multi_analysis.plot_core_physics()
 
 # %%


### PR DESCRIPTION
The physics analysis plots where overpotting onto the previous plots when run as a python file rather than a notebook. This should remove this problem in the examples found in BM, BM training and STEP.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
