### PR TITLE
🐛 Fix bug in interpolate_bspline related to tangents

### DIFF
--- a/bluemira/codes/_freecadapi.py
+++ b/bluemira/codes/_freecadapi.py
@@ -454,11 +454,12 @@ def interpolate_bspline(
             raise InvalidCADInputsError(_err)
 
     kwargs = {}
-    if start_tangent and end_tangent:
+    start_tang_present = start_tangent is not None
+    end_tang_present = end_tangent is not None
+    if start_tang_present and end_tang_present:
         kwargs["InitialTangent"] = Base.Vector(start_tangent)
         kwargs["FinalTangent"] = Base.Vector(end_tangent)
-
-    if (start_tangent and not end_tangent) or (end_tangent and not start_tangent):
+    elif start_tang_present or end_tang_present:
         bluemira_warn(
             "You must set both start and end tangencies or neither when creating a "
             "bspline. Start and end tangencies ignored."


### PR DESCRIPTION
## Linked Issues

Quickly getting this in so no related issue.

## Description

The start and end point tangents for the FreeCAD API function `interpolate_bspline` were actually able to be set because of faulty logic. Fix of the logic has been made here.

## Interface Changes

N/A

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
