### PR TITLE
Investigate why SOL radiation solver producing strange source term

### DIFF
--- a/bluemira/radiation_transport/radiation_profile.py
+++ b/bluemira/radiation_transport/radiation_profile.py
@@ -21,9 +21,10 @@ from scipy.interpolate import interp1d
 
 from bluemira.base import constants
 from bluemira.base.parameter_frame import Parameter, ParameterFrame, make_parameter_frame
-from bluemira.display.plotter import Zorder, plot_coordinates
+from bluemira.display.plotter import Zorder, plot_2d, plot_coordinates
 from bluemira.equilibria.physics import calc_psi_norm
 from bluemira.geometry.coordinates import Coordinates
+from bluemira.geometry.tools import make_polygon
 from bluemira.radiation_transport.flux_surfaces_maker import (
     analyse_first_wall_flux_surfaces,
 )
@@ -2243,7 +2244,7 @@ class RadiationSource:
 
         return self.x_tot, self.z_tot, self.rad_tot
 
-    def plot(self, ax=None) -> plt.Axes:
+    def plot(self, ax=None, *, plot_flux_tubes=False) -> plt.Axes:
         """
         Plot the RadiationSolver results.
 
@@ -2275,5 +2276,28 @@ class RadiationSource:
         )
 
         fig.colorbar(cm, label=r"$[MW.m^{-3}]$")
+
+        if plot_flux_tubes:
+            # for Debugging issue #3944
+            # plot the flux tube surfaces as well
+            core_rad_flux_tube_contours = [
+                make_polygon(flux_tube, closed=True)
+                for flux_tube in self.core_rad.flux_tubes
+            ]
+            sol_rad_flux_tubes = functools.reduce(
+                operator.iadd,
+                [
+                    self.sol_rad.flux_tubes_lfs_low,
+                    self.sol_rad.flux_tubes_hfs_low,
+                    self.sol_rad.flux_tubes_lfs_up,
+                    self.sol_rad.flux_tubes_hfs_up,
+                ],
+                [],
+            )
+            sol_rad_flux_tube_contours = [
+                make_polygon(flux_tube.coords) for flux_tube in sol_rad_flux_tubes
+            ]
+            plot_2d(core_rad_flux_tube_contours, ax=ax, show=False)
+            plot_2d(sol_rad_flux_tube_contours, ax=ax, show=False)
 
         return ax


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3944


## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
I came to believe that, The grid-like behaviour is not coming from the interpolation, but actually originated from the source term itself. 

The flux-surfaces are so close to each other near the sol-region, that the (x,z) coords on them appear to create a grid, while they are actually creating different flux lines.

![Image](https://github.com/user-attachments/assets/7f942f8b-7e14-4175-bc92-eccc1768e8c7)

![Image](https://github.com/user-attachments/assets/7f685a57-2a1b-400c-ade8-df27475bed85)

To understand that, in the branch ```anilima/papercut_#1944``` I have added an optional argument in ```RadiationSource.plot()``` so that you can also plot the corresponding flux lines while plotting the "source". 

plot the source term using ```plot_flux_tubes=True``` to reproduce the above images

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
