### PR TITLE
🐛 Skip uv version for transient dependency pins

### DIFF
--- a/.github/workflows/pin_dependencies.yml
+++ b/.github/workflows/pin_dependencies.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install uv
+          pip install uv!=0.7.17
           uv pip compile pyproject.toml --upgrade --resolution=highest --python-version=3.10 --extra pinned -o requirements/uv/base.txt
           uv pip compile pyproject.toml --upgrade --resolution=highest --python-version=3.10 --extra pinned -o requirements/uv/develop.txt --extra dev
           uv pip compile pyproject.toml --upgrade --resolution=highest --python-version=3.10 --extra pinned -o requirements/uv/examples.txt --extra examples


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
uv 0.7.17 has a bug (14367) for finding links to dependencies. This avoids that version

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
