### PR TITLE
📌 Change default python version to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: "Cache pre-commit"
         uses: actions/cache@v4
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/workflows/actions/build
         with:
           os: ubuntu-latest
-          python-version: "3.10"
+          python-version: "3.12"
           bm-private-data-key: ${{ secrets.BLUEMIRA_PRIVATE_DATA_DEPLOY_KEY }}
 
       - name: Test Documentation code snippets

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       RESULT: ${{ github.event.workflow_run.conclusion }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PYTHON_VERSION: "3.11"
     steps:
       - name: "Get information about the current run"
         uses: potiuk/get-workflow-origin@v1_5
@@ -34,7 +35,7 @@ jobs:
       - name: Download reference test report
         if: env.RESULT == 'success' && steps.workflow-run-info.outputs.pullRequestNumber != ''
         env:
-          FILE_NAME: "test-report-json_3.10_ubuntu-latest"
+          FILE_NAME: "test-report-json_${{ env.PYTHON_VERSION }}_ubuntu-latest"
         run: |
           artifact_url="$( \
             gh api repos/${{ github.repository }}/actions/artifacts?per_page=100 --jq '.artifacts[] | select(.name == "${{ env.FILE_NAME }}") | select(.workflow_run.head_sha == "${{ steps.base_sha.outputs.base_sha}}") | .archive_download_url' | head -1)"
@@ -48,7 +49,7 @@ jobs:
       - name: Download PR test report
         if: env.RESULT == 'success' && steps.workflow-run-info.outputs.pullRequestNumber != ''
         env:
-          FILE_NAME: "test-report-json_3.10_ubuntu-latest"
+          FILE_NAME: "test-report-json_${{ env.PYTHON_VERSION }}_ubuntu-latest"
         run: |
           artifact_url="$( \
             gh api repos/${{ github.repository }}/actions/artifacts?per_page=100 --jq '.artifacts[] | select(.name == "${{ env.FILE_NAME }}") | select(.workflow_run.head_sha == "${{ github.event.workflow_run.head_sha }}") | .archive_download_url')"

--- a/scripts/install-conda.sh
+++ b/scripts/install-conda.sh
@@ -1,6 +1,6 @@
 set -e
 
-PYTHON_VERSION="3.10"
+PYTHON_VERSION="3.11"
 ENVIRONMENT="bluemira"
 while getopts "e:p:" flag
 do


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This changes the default python version of bluemira to 3.11, 3.10 is still supported but now in a legacy mode.
We now also build the docs and lint with 3.12 (see #3857 for why)

Our new neutronics functionality around fast_ctd is not supported on python 3.10. All other functionality is currently still supported on 3.10 while our 3.10 support continues.

 

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
