### PR TITLE
Ocean/pc 3040 docstring

### DIFF
--- a/bluemira/codes/openmc/make_csg.py
+++ b/bluemira/codes/openmc/make_csg.py
@@ -118,7 +118,7 @@ class CellStage:
         # self.universe.volume = total_universe_volume
 
         outer_boundary_volume = to_cm3(
-            polygon_revolve_signed_volume(ext_vertices[:, ::2])
+            polygon_revolve_signed_volume(ext_vertices[:, ::2].T)
         )
         ext_void_volume = total_universe_volume - outer_boundary_volume
         if self.tf_coils:
@@ -1233,7 +1233,7 @@ class BlanketCell(openmc.Cell):
             ),
         )
 
-        self.volume = to_cm3(polygon_revolve_signed_volume(vertices[::2].T))
+        self.volume = to_cm3(polygon_revolve_signed_volume(vertices[::2]))
         if self.volume <= 0:
             raise GeometryError("Wrong ordering of vertices!")
 

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -1144,7 +1144,7 @@ class CoilSetOptimisationState:
 
     @property
     def positions(self) -> np.ndarray:
-        """Get the positions as a (2,N) array"""
+        """Get the positions as a (2, N) array"""
         return np.array([self.xs, self.zs])
 
     @property

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -936,7 +936,7 @@ def normal_vector(side_vectors: np.ndarray) -> np.ndarray:
     Parameters
     ----------
     side_vectors:
-        The side vectors of a polygon (shape: (N, 2)).
+        The side vectors of a polygon (shape: (2, N)).
 
     Returns
     -------

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -1023,7 +1023,7 @@ def polygon_revolve_signed_volume(polygon: npt.ArrayLike) -> float:
     Raises
     ------
     ValueError
-        shape must be (N, 2)
+        shape must be (2, N)
 
     Returns
     -------
@@ -1045,9 +1045,9 @@ def polygon_revolve_signed_volume(polygon: npt.ArrayLike) -> float:
     abs(signed volume)= the volume of the polygon after being revolved around the z-axis.
     """
     polygon = np.asarray(polygon)
-    if np.ndim(polygon) != 2 or np.shape(polygon)[1] != 2:  # noqa: PLR2004
-        raise ValueError("This function takes in an np.ndarray of shape (N, 2).")
-    previous_points, current_points = polygon, np.roll(polygon, -1, axis=0)
+    if np.ndim(polygon) != 2 or np.shape(polygon)[0] != 2:  # noqa: PLR2004
+        raise ValueError("This function takes in an np.ndarray of shape (2, N).")
+    previous_points, current_points = polygon.T, np.roll(polygon.T, -1, axis=0)
     px, pz = previous_points[:, 0], previous_points[:, -1]
     cx, cz = current_points[:, 0], current_points[:, -1]
     volume_3_over_pi = (pz - cz) * (px**2 + px * cx + cx**2)

--- a/bluemira/radiation_transport/neutronics/radial_wall.py
+++ b/bluemira/radiation_transport/neutronics/radial_wall.py
@@ -201,7 +201,7 @@ class CellWalls:
         volume: float
         """
         return polygon_revolve_signed_volume(
-            np.concatenate([self.cell_walls[i], self.cell_walls[i + 1][::-1]])
+            np.concatenate([self.cell_walls[i], self.cell_walls[i + 1][::-1]]).T
         )
 
     @property
@@ -238,17 +238,21 @@ class CellWalls:
         start_i, dir_i = self.starts[i], self.directions[i]
         new_end = start_i + dir_i * test_length
         prev_wall, next_wall = self.cell_walls[i - 1 : i + 2 : 2]
-        return polygon_revolve_signed_volume([
-            prev_wall[0],
-            prev_wall[1],
-            new_end,
-            start_i,
-        ]) + polygon_revolve_signed_volume([
-            start_i,
-            new_end,
-            next_wall[1],
-            next_wall[0],
-        ])
+        return polygon_revolve_signed_volume(
+            np.array([
+                prev_wall[0],
+                prev_wall[1],
+                new_end,
+                start_i,
+            ]).T
+        ) + polygon_revolve_signed_volume(
+            np.array([
+                start_i,
+                new_end,
+                next_wall[1],
+                next_wall[0],
+            ]).T
+        )
 
     def volume_derivative_of_cells_neighbouring(self, i, test_length):
         """


### PR DESCRIPTION
## Linked Issues

Closes #3040 

## Description

Minor docstring changes, and modified one function (used only in neutronics) to use the (2, N) signature instead of (N, 2).

## Interface Changes

`bluemira.geometry.tools.polygon_revolve_signed_volume`'s input requires transposing.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
