### PR TITLE
🐛 Fix some fast_ctd installation and running bugs

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -77,12 +77,6 @@ runs:
           pip install -U -e '.[dagmc]'
         fi
 
-    - name: Install OpenBLAS for Python 3.11
-      if: ${{ matrix.python-version == '3.11' }}
-      shell: bash -l {0}
-      run: |
-        sudo apt-get install libopenblas-dev
-
     - name: Freeze conda env
       if: ${{ inputs.with-artifact == 'true' }}
       shell: bash -l {0}

--- a/bluemira/codes/fast_ctd/pipeline.py
+++ b/bluemira/codes/fast_ctd/pipeline.py
@@ -151,6 +151,7 @@ def step_to_dagmc_pipeline(
         bluemira_print(
             f"Skipping materials files creation, using '{intm_materials_csv_file_path}'"
         )
+        mats_list = []
     else:
         bluemira_print("Running `step_to_brep`")
         comps_info = step_to_brep(

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -33,6 +33,7 @@ dependencies:
   - pybind11-global==2.13.6
   - pytools==2025.1.7
   - vtk==9.3.1
+  - libopenblas
   - pythonocc-core
   - pip
   - pip:


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Under python 3.11 openblas is seemingly not installed, adding it to the conda environment file and fixing a return bug on the fast_ctd pipeline around cahcing

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
