### PR TITLE
Beta_p approximation caution

### DIFF
--- a/bluemira/equilibria/constants.py
+++ b/bluemira/equilibria/constants.py
@@ -16,6 +16,10 @@ PSI_NORM_TOL = 1e-2
 #     Used as a convergence criterion for Picard iterations
 PSI_REL_TOL = 2e-3
 
+# Default psi_norm value [n. a.]
+#    Used in flux surface finding and masking functions.
+PSI_NORM = 1.0
+
 # Absolute tolerance on position [m]
 #     Used to determine whether O- and X-points are the "same"
 #     Used as an offset to determine if a point is "on" the edge of a coil

--- a/bluemira/equilibria/constants.py
+++ b/bluemira/equilibria/constants.py
@@ -16,10 +16,6 @@ PSI_NORM_TOL = 1e-2
 #     Used as a convergence criterion for Picard iterations
 PSI_REL_TOL = 2e-3
 
-# Default psi_norm value [n. a.]
-#    Used in flux surface finding and masking functions.
-PSI_NORM = 1.0
-
 # Absolute tolerance on position [m]
 #     Used to determine whether O- and X-points are the "same"
 #     Used as an offset to determine if a point is "on" the edge of a coil

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1666,7 +1666,7 @@ class Equilibrium(CoilSetMHDState):
         psi = self.psi()
         return calc_psi_norm(psi, *self.get_OX_psis(psi))
 
-    def pressure_map(self, pn=PSI_NORM) -> npt.NDArray[np.float64]:
+    def pressure_map(self, pn: float =PSI_NORM) -> npt.NDArray[np.float64]:
         """
         Parameters
         ----------
@@ -1684,7 +1684,7 @@ class Equilibrium(CoilSetMHDState):
         p = self.pressure(np.clip(self.psi_norm(), 0, 1))
         return p * mask
 
-    def _get_core_mask(self, pn=PSI_NORM) -> npt.NDArray[np.float64]:
+    def _get_core_mask(self, pn: float =PSI_NORM) -> npt.NDArray[np.float64]:
         """
         Parameters
         ----------

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -50,7 +50,7 @@ from bluemira.equilibria.limiter import Limiter
 from bluemira.equilibria.num_control import DummyController, VirtualController
 from bluemira.equilibria.physics import (
     EqSummary,
-    calc_li3minargs,
+    _calc_li3minargs,
     calc_psi_norm,
 )
 from bluemira.equilibria.plasma import NoPlasmaCoil, PlasmaCoil
@@ -1446,7 +1446,7 @@ class Equilibrium(CoilSetMHDState):
 
             plasma_psi = self._solver(rhs)
             self._update_plasma(plasma_psi, jtor_opt)
-            li = calc_li3minargs(
+            li = _calc_li3minargs(
                 self.x,
                 self.z,
                 self.psi(),
@@ -1666,18 +1666,19 @@ class Equilibrium(CoilSetMHDState):
         psi = self.psi()
         return calc_psi_norm(psi, *self.get_OX_psis(psi))
 
-    def pressure_map(self) -> npt.NDArray[np.float64]:
+    def pressure_map(self, pn=None) -> npt.NDArray[np.float64]:
         """
         Returns
         -------
         :
             Plasma pressure map.
         """
-        mask = self._get_core_mask()
-        p = self.pressure(np.clip(self.psi_norm(), 0, 1))
+        mask = self._get_core_mask(pn)
+        pn_max = pn or 1
+        p = self.pressure(np.clip(self.psi_norm(), 0, pn_max))
         return p * mask
 
-    def _get_core_mask(self) -> npt.NDArray[np.float64]:
+    def _get_core_mask(self, pn=None) -> npt.NDArray[np.float64]:
         """
         Returns
         -------
@@ -1685,9 +1686,14 @@ class Equilibrium(CoilSetMHDState):
             A 2-D masking array for the plasma core.
         """
         o_points, x_points = self.get_OX_points()
-        return in_plasma(
-            self.x, self.z, self.psi(), o_points=o_points, x_points=x_points
+        if pn is None:
+            return in_plasma(
+                self.x, self.z, self.psi(), o_points=o_points, x_points=x_points
+            )
+        zone = self.get_flux_surface(
+            pn, self.psi(), o_points=o_points, x_points=x_points
         )
+        return in_zone(self.x, self.z, zone.xz.T)
 
     def q(
         self,

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -27,7 +27,7 @@ from bluemira.base.file import get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_print_flush, bluemira_warn
 from bluemira.equilibria.boundary import FreeBoundary, apply_boundary
 from bluemira.equilibria.coils import CoilSet, symmetrise_coilset
-from bluemira.equilibria.constants import BLUEMIRA_DEFAULT_COCOS, PSI_NORM_TOL
+from bluemira.equilibria.constants import BLUEMIRA_DEFAULT_COCOS, PSI_NORM, PSI_NORM_TOL
 from bluemira.equilibria.diagnostics import EqBPlotParam
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.find import (
@@ -1666,20 +1666,33 @@ class Equilibrium(CoilSetMHDState):
         psi = self.psi()
         return calc_psi_norm(psi, *self.get_OX_psis(psi))
 
-    def pressure_map(self, pn=None) -> npt.NDArray[np.float64]:
+    def pressure_map(self, pn=PSI_NORM) -> npt.NDArray[np.float64]:
         """
+        Parameters
+        ----------
+        pn:
+            The normalised psi value for masking.
+            Values outside the closed pn flux surface will be masked.
+            Default is pn=1, i.e., the LCFS.
+
         Returns
         -------
         :
             Plasma pressure map.
         """
         mask = self._get_core_mask(pn)
-        pn_max = 1 if pn is None else pn
-        p = self.pressure(np.clip(self.psi_norm(), 0, pn_max))
+        p = self.pressure(np.clip(self.psi_norm(), 0, 1))
         return p * mask
 
-    def _get_core_mask(self, pn=None) -> npt.NDArray[np.float64]:
+    def _get_core_mask(self, pn=PSI_NORM) -> npt.NDArray[np.float64]:
         """
+        Parameters
+        ----------
+        pn:
+            The normalised psi value for masking.
+            Values outside the closed pn flux surface will be masked.
+            Default is pn=1, i.e., the LCFS.
+
         Returns
         -------
         :

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1674,7 +1674,7 @@ class Equilibrium(CoilSetMHDState):
             Plasma pressure map.
         """
         mask = self._get_core_mask(pn)
-        pn_max = pn or 1
+        pn_max = 1 if pn is None else pn
         p = self.pressure(np.clip(self.psi_norm(), 0, pn_max))
         return p * mask
 

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -1666,7 +1666,7 @@ class Equilibrium(CoilSetMHDState):
         psi = self.psi()
         return calc_psi_norm(psi, *self.get_OX_psis(psi))
 
-    def pressure_map(self, pn: float =PSI_NORM) -> npt.NDArray[np.float64]:
+    def pressure_map(self, pn: float = PSI_NORM) -> npt.NDArray[np.float64]:
         """
         Parameters
         ----------
@@ -1684,7 +1684,7 @@ class Equilibrium(CoilSetMHDState):
         p = self.pressure(np.clip(self.psi_norm(), 0, 1))
         return p * mask
 
-    def _get_core_mask(self, pn: float =PSI_NORM) -> npt.NDArray[np.float64]:
+    def _get_core_mask(self, pn: float = PSI_NORM) -> npt.NDArray[np.float64]:
         """
         Parameters
         ----------

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -597,6 +597,7 @@ def calc_beta_p(eq: Equilibrium) -> float:
         eq.pressure_map(PSI_NORM),
         eq.Bp(),
         eq._get_core_mask(PSI_NORM),
+        eq.x,
         eq.dx,
         eq.dz,
     )
@@ -625,7 +626,7 @@ def calc_beta_p_approximate(eq: Equilibrium) -> float:
     Ratio of plasma to poloidal magnetic pressure
     """
     return _calc_beta_p_approx(
-        eq.pressure_map(PSI_NORM), eq.get_LCFS(), eq.dx, eq.dz, eq.profiles.I_p
+        eq.pressure_map(PSI_NORM), eq.get_LCFS(), eq.x, eq.dx, eq.dz, eq.profiles.I_p
     )
 
 
@@ -708,7 +709,7 @@ def _calc_beta_p_approx(
     -------
     Ratio of plasma to poloidal magnetic pressure
     """
-    p_avg = calc_p_average(pressure_map, fs, x, dx, dz)
+    p_avg = _calc_p_average(pressure_map, fs, x, dx, dz)
     Bp = MU_0 * I_p / fs.length
     return 2 * MU_0 * p_avg / Bp**2
 

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -20,7 +20,6 @@ from scipy.interpolate import RectBivariateSpline
 from bluemira.base.constants import MU_0
 from bluemira.base.parameter_frame._frame import ParameterFrame
 from bluemira.base.parameter_frame._parameter import Parameter
-from bluemira.equilibria.constants import PSI_NORM
 from bluemira.equilibria.find import in_plasma
 from bluemira.equilibria.grid import revolved_volume, volume_integral
 
@@ -307,13 +306,13 @@ def calc_energy(eq: Equilibrium) -> float:
     ) / (2 * MU_0)
 
 
-def _calc_Li_from_energy(p_energy: float, i_p: float) -> float:
+def _calc_Li_from_energy(bp_energy: float, i_p: float) -> float:
     """
     Calculates the internal inductance of the plasma [H]
 
     Parameters
     ----------
-    p_energy:
+    bp_energy:
         Poloidal magnetic energy
     i_p:
         Plasma current
@@ -322,7 +321,7 @@ def _calc_Li_from_energy(p_energy: float, i_p: float) -> float:
     -------
         Internal inductance of the plasma
     """
-    return 2 * p_energy / i_p**2
+    return 2 * bp_energy / i_p**2
 
 
 def calc_Li(eq: Equilibrium) -> float:
@@ -340,8 +339,8 @@ def calc_Li(eq: Equilibrium) -> float:
     -------
         Internal inductance of the plasma
     """
-    p_energy = calc_energy(eq)
-    return _calc_Li_from_energy(p_energy, eq.profiles.I_p)
+    bp_energy = calc_energy(eq)
+    return _calc_Li_from_energy(bp_energy, eq.profiles.I_p)
 
 
 def _calc_li_from_Li(big_li: float, R_0: float) -> float:
@@ -481,7 +480,7 @@ def calc_p_average(eq: Equilibrium) -> float:
     The average plasma pressure [Pa]
     """
     return _calc_p_average(
-        eq.pressure_map(PSI_NORM),
+        eq.pressure_map(),
         eq.get_LCFS(),
         eq.x,
         eq.dz,
@@ -538,7 +537,7 @@ def calc_beta_t(eq: Equilibrium) -> float:
     Ratio of plasma to toroidal magnetic pressure
     """
     return _calc_beta_t(
-        eq.pressure_map(PSI_NORM), eq.get_LCFS(), eq.x, eq.dx, eq.dz, eq.profiles._B_0
+        eq.pressure_map(), eq.get_LCFS(), eq.x, eq.dx, eq.dz, eq.profiles._B_0
     )
 
 
@@ -594,9 +593,9 @@ def calc_beta_p(eq: Equilibrium) -> float:
     Ratio of plasma to magnetic pressure
     """
     return _calc_beta_p(
-        eq.pressure_map(PSI_NORM),
+        eq.pressure_map(),
         eq.Bp(),
-        eq._get_core_mask(PSI_NORM),
+        eq._get_core_mask(),
         eq.x,
         eq.dx,
         eq.dz,
@@ -626,7 +625,7 @@ def calc_beta_p_approximate(eq: Equilibrium) -> float:
     Ratio of plasma to poloidal magnetic pressure
     """
     return _calc_beta_p_approx(
-        eq.pressure_map(PSI_NORM), eq.get_LCFS(), eq.x, eq.dx, eq.dz, eq.profiles.I_p
+        eq.pressure_map(), eq.get_LCFS(), eq.x, eq.dx, eq.dz, eq.profiles.I_p
     )
 
 

--- a/bluemira/equilibria/physics.py
+++ b/bluemira/equilibria/physics.py
@@ -20,7 +20,7 @@ from scipy.interpolate import RectBivariateSpline
 from bluemira.base.constants import MU_0
 from bluemira.base.parameter_frame._frame import ParameterFrame
 from bluemira.base.parameter_frame._parameter import Parameter
-from bluemira.equilibria.find import in_plasma, in_zone
+from bluemira.equilibria.find import in_plasma
 from bluemira.equilibria.grid import revolved_volume, volume_integral
 
 if TYPE_CHECKING:
@@ -435,7 +435,6 @@ class EqSummary(ParameterFrame):
     li_3: Parameter[float]
     V: Parameter[float]
     beta_p: Parameter[float]
-    beta_p_95: Parameter[float]
     q_95: Parameter[float]
     kappa_95: Parameter[float]
     delta_95: Parameter[float]
@@ -467,12 +466,10 @@ class EqSummary(ParameterFrame):
         energy = calc_energy(eq)
         li_true = _calc_Li_from_energy(energy, I_p)
         pressure_map = eq.pressure_map()
-        pressure_map_95 = eq.pressure_map(0.95)
         Bp = eq.Bp()
         mask = in_plasma(
             eq.x, eq.z, eq.psi(), o_points=eq._o_points, x_points=eq._x_points
         )
-        mask_95 = in_zone(eq.x, eq.z, f95.coords.xz.T)
 
         if is_double_null:
             kappa_95 = f95.kappa
@@ -512,12 +509,6 @@ class EqSummary(ParameterFrame):
             beta_p=Parameter(
                 "beta_p",
                 calc_beta_p(pressure_map, Bp, mask, eq.x, eq.dx, eq.dz),
-                "",
-                eq_name,
-            ),
-            beta_p_95=Parameter(
-                "beta_p_95",
-                calc_beta_p(pressure_map_95, Bp, mask_95, eq.x, eq.dx, eq.dz),
                 "",
                 eq_name,
             ),

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -34,7 +34,7 @@ from bluemira.equilibria.find import (
     o_point_fallback_calculator,
 )
 from bluemira.equilibria.grid import integrate_dx_dz
-from bluemira.equilibria.physics import calc_beta_p_approx
+from bluemira.equilibria.physics import _calc_beta_p_approx
 from bluemira.equilibria.plotting import ProfilePlotter
 
 if TYPE_CHECKING:
@@ -587,7 +587,7 @@ class BetaIpProfile(Profile):
     \t:math:`{\\beta}_{p}=\\dfrac{\\langle p({\\beta_{0}})\\rangle}{\\langle B_{p}^{2}\\rangle_{\\psi_{a}}/2\\mu_{0}}`
 
     Please be careful, the beta_p approximation used here is less good for higher elongation plasmas,
-    see calc_beta_p_approx.
+    see _calc_beta_p_approx.
     """  # noqa: W505, E501
 
     # NOTE: For high betap >= 2, this can lead to there being no plasma current
@@ -644,7 +644,7 @@ class BetaIpProfile(Profile):
         Note
         ----
         Please be careful, the beta_p approximation used here is not good for high elongation plasmas,
-        see calc_beta_p_approx.
+        see _calc_beta_p_approx.
         """  # noqa: W505, E501, DOC201
         self.dx = x[1, 0] - x[0, 0]
         self.dz = z[0, 1] - z[0, 0]
@@ -673,7 +673,7 @@ class BetaIpProfile(Profile):
             lcfs, _ = find_LCFS_separatrix(
                 x, z, psi, o_points=o_points, x_points=x_points
             )
-            beta_p_actual = calc_beta_p_approx(
+            beta_p_actual = _calc_beta_p_approx(
                 pfunc, lcfs, x, self.dx, self.dz, self.I_p
             )
             lambd_beta0 = -self.betap / beta_p_actual * self.R_0

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -585,6 +585,9 @@ class BetaIpProfile(Profile):
     \t:math:`d{\\Omega}`\n
 
     \t:math:`{\\beta}_{p}=\\dfrac{\\langle p({\\beta_{0}})\\rangle}{\\langle B_{p}^{2}\\rangle_{\\psi_{a}}/2\\mu_{0}}`
+
+    Please be careful, the beta_p approximation used here is less good for higher elongation plasmas,
+    see calc_beta_p_approx.
     """  # noqa: W505, E501
 
     # NOTE: For high betap >= 2, this can lead to there being no plasma current

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -33,7 +33,8 @@ from bluemira.equilibria.find import (
     in_zone,
     o_point_fallback_calculator,
 )
-from bluemira.equilibria.grid import integrate_dx_dz, revolved_volume, volume_integral
+from bluemira.equilibria.grid import integrate_dx_dz
+from bluemira.equilibria.physics import calc_beta_p_approx
 from bluemira.equilibria.plotting import ProfilePlotter
 
 if TYPE_CHECKING:
@@ -636,6 +637,11 @@ class BetaIpProfile(Profile):
         \t:math:`\\lambda=\\dfrac{I_{p}-\\lambda{\\beta_{0}}\\bigg(\\int\\int\\dfrac{X}{R_{0}}f+\\int\\int\\dfrac{R_{0}}{X}f\\bigg)}{\\int\\int\\dfrac{R_{0}}{X}f}`
 
         Derivation: book 10, p 120
+
+        Note
+        ----
+        Please be careful, the beta_p approximation used here is not good for high elongation plasmas,
+        see calc_beta_p_approx.
         """  # noqa: W505, E501, DOC201
         self.dx = x[1, 0] - x[0, 0]
         self.dz = z[0, 1] - z[0, 0]
@@ -664,11 +670,9 @@ class BetaIpProfile(Profile):
             lcfs, _ = find_LCFS_separatrix(
                 x, z, psi, o_points=o_points, x_points=x_points
             )
-            v_plasma = revolved_volume(*lcfs.xz)
-            Bp = MU_0 * self.I_p / lcfs.length
-            p_avg = volume_integral(pfunc, x, self.dx, self.dz) / v_plasma
-            beta_p_actual = 2 * MU_0 * p_avg / Bp**2
-
+            beta_p_actual = calc_beta_p_approx(
+                pfunc, lcfs, x, self.dx, self.dz, self.I_p
+            )
             lambd_beta0 = -self.betap / beta_p_actual * self.R_0
 
         else:

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -368,7 +368,11 @@ plt.pause(PLT_PAUSE)
 sof_summary = sof.analyse_plasma()
 eof_summary = eof.analyse_plasma()
 
-bluemira_print(f"SOF: beta_p: {sof_summary.beta_p:.2f} l_i: {sof_summary.li_3:.2f}")
-bluemira_print(f"EOF: beta_p: {eof_summary.beta_p:.2f} l_i: {eof_summary.li_3:.2f}")
+bluemira_print(
+    f"SOF: beta_p: {sof_summary.beta_p.value:.2f} l_i: {sof_summary.li_3.value:.2f}"
+)
+bluemira_print(
+    f"EOF: beta_p: {eof_summary.beta_p.value:.2f} l_i: {eof_summary.li_3.value:.2f}"
+)
 
 plt.show(block=True)

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -63,7 +63,7 @@ from bluemira.equilibria.optimisation.problem import (
     OutboardBreakdownZoneStrategy,
     UnconstrainedTikhonovCurrentGradientCOP,
 )
-from bluemira.equilibria.physics import calc_beta_p, calc_li3, calc_psib
+from bluemira.equilibria.physics import calc_psib
 from bluemira.equilibria.profiles import (
     BetaIpProfile,
     BetaLiIpProfile,
@@ -364,8 +364,11 @@ eof_psi = 2 * np.pi * eof.psi(*eof._x_points[0][:2])
 ax[1].set_title("$\\psi_{b}$ = " + f"{sof_psi:.2f} V.s")
 plt.pause(PLT_PAUSE)
 
+# Get summary of key physics parameters
+sof_summary = sof.analyse_plasma()
+eof_summary = eof.analyse_plasma()
 
-bluemira_print(f"SOF: beta_p: {calc_beta_p(sof):.2f} l_i: {calc_li3(sof):.2f}")
-bluemira_print(f"EOF: beta_p: {calc_beta_p(eof):.2f} l_i: {calc_li3(eof):.2f}")
+bluemira_print(f"SOF: beta_p: {sof_summary.beta_p:.2f} l_i: {sof_summary.li_3:.2f}")
+bluemira_print(f"EOF: beta_p: {eof_summary.beta_p:.2f} l_i: {eof_summary.li_3:.2f}")
 
 plt.show(block=True)


### PR DESCRIPTION
## Linked Issues

Closes [#4020](https://github.com/Fusion-Power-Plant-Framework/bluemira/issues/4020)

## Description

At higher plasma elongations, so for spherical tokamaks, the approximation used in our BetaIpProfile class becomes less good (for DEMO-like elongation there is less than a 1% difference between the approximate and actual values but for a STEP-like elongation this is closer to 10%).

There is now a caution message in the relevant functions and the approximation calculation has been refactored so that is only in one location in the code.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
