### PR TITLE
Use temp dir over generated_data to enable pip install

### DIFF
--- a/bluemira/base/file.py
+++ b/bluemira/base/file.py
@@ -11,6 +11,9 @@ File I/O functions and some path operations
 import os
 from contextlib import contextmanager
 from pathlib import Path
+from tempfile import gettempdir
+
+from bluemira.base.look_and_feel import bluemira_print
 
 BM_ROOT = "!BM_ROOT!"
 SUB_DIRS = ["equilibria", "neutronics", "systems_code", "CAD", "plots", "geometry"]
@@ -20,7 +23,12 @@ def _get_relpath(folder: str, subfolder: str) -> str:
     path = Path(folder, subfolder)
     if path.is_dir():
         return path.as_posix()
-    raise ValueError(f"{path} Not a valid folder.")
+
+    tmp_root = Path(gettempdir()) / "bluemira"
+    tmp_sub = tmp_root / subfolder
+    tmp_sub.mkdir(parents=True, exist_ok=True)  # create /tmp/bluemira/{subfolder}
+    bluemira_print(f'"{path}" not found. Using temporary folder: "{tmp_sub}"')
+    return tmp_sub.as_posix()
 
 
 def get_bluemira_root() -> str:

--- a/bluemira/base/file.py
+++ b/bluemira/base/file.py
@@ -13,8 +13,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from tempfile import gettempdir
 
-from bluemira.base.look_and_feel import bluemira_print
-
 BM_ROOT = "!BM_ROOT!"
 SUB_DIRS = ["equilibria", "neutronics", "systems_code", "CAD", "plots", "geometry"]
 
@@ -27,6 +25,10 @@ def _get_relpath(folder: str, subfolder: str) -> str:
     tmp_root = Path(gettempdir()) / "bluemira"
     tmp_sub = tmp_root / subfolder
     tmp_sub.mkdir(parents=True, exist_ok=True)  # create /tmp/bluemira/{subfolder}
+
+    # avoid circular import with lazy import
+    from bluemira.base.look_and_feel import bluemira_print  # noqa: PLC0415
+
     bluemira_print(f'"{path}" not found. Using temporary folder: "{tmp_sub}"')
     return tmp_sub.as_posix()
 

--- a/bluemira/base/file.py
+++ b/bluemira/base/file.py
@@ -22,15 +22,17 @@ def _get_relpath(folder: str, subfolder: str) -> str:
     if path.is_dir():
         return path.as_posix()
 
-    tmp_root = Path(gettempdir()) / "bluemira"
-    tmp_sub = tmp_root / subfolder
-    tmp_sub.mkdir(parents=True, exist_ok=True)  # create /tmp/bluemira/{subfolder}
+    if subfolder == "generated_data":
+        tmp_sub = Path(gettempdir()) / "bluemira" / subfolder
+        tmp_sub.mkdir(parents=True, exist_ok=True)
 
-    # avoid circular import with lazy import
-    from bluemira.base.look_and_feel import bluemira_print  # noqa: PLC0415
+        # avoid circular import with lazy import
+        from bluemira.base.look_and_feel import bluemira_print  # noqa: PLC0415
 
-    bluemira_print(f'"{path}" not found. Using temporary folder: "{tmp_sub}"')
-    return tmp_sub.as_posix()
+        bluemira_print(f'"{path}" not found. Using temporary folder: "{tmp_sub}"')
+        return tmp_sub.as_posix()
+
+    raise ValueError(f"{path} Not a valid folder.")
 
 
 def get_bluemira_root() -> str:

--- a/tests/base/test_file.py
+++ b/tests/base/test_file.py
@@ -7,6 +7,7 @@
 import os
 import tempfile
 from pathlib import Path
+from tempfile import gettempdir
 
 import pytest
 
@@ -251,3 +252,14 @@ def test_working_dir_context_manager():
     final_cwd = Path.cwd()
     assert cwd != changed_cwd
     assert cwd == final_cwd
+
+
+def test_tmp_generated_data(monkeypatch, tmp_path):
+    fake_root = tmp_path / "bluemira"  # fake root using tmp_path fixture
+    monkeypatch.setattr("bluemira.base.file.get_bluemira_root", lambda: str(fake_root))
+    result = try_get_bluemira_path(subfolder="generated_data")
+    tmp_path_expected = Path(gettempdir()) / "bluemira" / "generated_data"
+
+    if result:
+        assert Path(result).is_dir()
+        assert result == str(tmp_path_expected)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3806 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Some methods try to get the ``generated_data`` directory to save figures/gifs to.
If the code has been pip installed, this directory doesn't exist, and if it's a system install, then it can't be created under site-packages.
So, instead, create a temporary directory to store the data and output the path to the console for the user.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
