### PR TITLE
Allow for PROCESS to be used with equality constraints

### DIFF
--- a/bluemira/codes/process/_inputs.py
+++ b/bluemira/codes/process/_inputs.py
@@ -531,7 +531,7 @@ class ProcessInputs:
     # IFE
 
     # Heat transport
-    p_plant_electric_base_mw: float | None = None
+    p_plant_electric_base: float | None = None
     crypw_max: float | None = None
     f_crypmw: float | None = None
     etatf: float | None = None

--- a/bluemira/codes/process/_inputs.py
+++ b/bluemira/codes/process/_inputs.py
@@ -66,6 +66,7 @@ class ProcessInputs:
     fw_armour_thickness: float | None = None
     i_blanket_type: int | None = None
     i_blkt_inboard: int | None = None
+    i_blkt_dual_coolant: int | None = None
     f_blkt_li6_enrichment: float | None = None
     breeder_f: float | None = None
     breeder_multiplier: float | None = None
@@ -543,7 +544,7 @@ class ProcessInputs:
     i_shld_primary_heat: int | None = None
     pinjmax: float | None = None
     pflux_plant_floor_electric: float | None = None
-    p_tritium_plant_elec_mw: float | None = None
+    p_tritium_plant_electric_mw: float | None = None
     vachtmw: float | None = None
     i_hcd_calculations: int | None = None
     # Water usage

--- a/bluemira/codes/process/_inputs.py
+++ b/bluemira/codes/process/_inputs.py
@@ -38,6 +38,7 @@ class ProcessInputs:
     maxcal: int | None = None
     minmax: int | None = None
     epsvmc: float | None = None
+    neqns: int | None = None
     ioptimz: int | None = None
     output_costs: int | None = None
     isweep: int | None = None

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -55,6 +55,7 @@ class PROCESSTemplateBuilder:
         self.ioptimiz: int = 0
         self.maxcal: int = 1000
         self.epsvmc: float = 1.0e-8
+        self.neqns: int = 0
 
     def set_run_title(self, run_title: str):
         """
@@ -81,6 +82,17 @@ class PROCESSTemplateBuilder:
         """
         self.maxcal = maxiter
         self.epsvmc = tolerance
+
+    def set_number_equality_constraints(self, num_equality_cons: int = 0):
+        """
+        Set numbert of equality constraints used
+
+        Parameters
+        ----------
+        num_equality_cons:
+            Number of equality constraints used in process
+        """
+        self.neqns = num_equality_cons
 
     def set_minimisation_objective(self, objective: Objective):
         """
@@ -120,10 +132,10 @@ class PROCESSTemplateBuilder:
             bluemira_warn(
                 f"Constraint {constraint.name} is already in the constraint list."
             )
-
-        if constraint.value in FV_CONSTRAINT_ITVAR_MAPPING:
+        if (constraint.value in FV_CONSTRAINT_ITVAR_MAPPING) and (self.neqns == 0):
             # Sensible (?) defaults. bounds are standard PROCESS for f-values for _most_
-            # f-value constraints.
+            # f-value constraints. If equality constraints are used then no f-values
+            # are enforced so the config consistencey is not checked
             self.add_fvalue_constraint(constraint, None, None, None)
         else:
             self._constraints.append(constraint)
@@ -328,6 +340,7 @@ class PROCESSTemplateBuilder:
             ioptimz=self.ioptimiz,
             epsvmc=self.epsvmc,
             maxcal=self.maxcal,
+            neqns=self.neqns,
             f_nd_impurity_electrons=self.f_nd_impurity_electrons,
             **self.values,
             **models,

--- a/examples/data/codes/process/ST_IN.DAT
+++ b/examples/data/codes/process/ST_IN.DAT
@@ -167,7 +167,7 @@ f_fw_peak = 2.0 * peaking factor for first wall heat loads (15/11/27)
 runtitle = Michael's test file
 verbose = 1
 *-------------Heat Transport Variables-------------*
-p_plant_electric_base_mw   = 55.0d6 * Base plant electric load (w)
+p_plant_electric_base   = 55.0d6 * Base plant electric load (w)
 
 *------------------Ife Variables-------------------*
 *------------Impurity Radiation Module-------------*

--- a/tests/codes/process/test_template_builder.py
+++ b/tests/codes/process/test_template_builder.py
@@ -232,6 +232,7 @@ class TestInDatOneForOne:
         template_builder = PROCESSTemplateBuilder()
         template_builder.set_optimisation_algorithm(PROCESSOptimisationAlgorithm.VMCON)
         template_builder.set_optimisation_numerics(maxiter=1000, tolerance=1e-8)
+        template_builder.set_number_equality_constraints(num_equality_cons=0)
 
         template_builder.set_minimisation_objective(Objective.MAJOR_RADIUS)
 


### PR DESCRIPTION
## Linked Issues

Closes #4113

## Description

Adds `neqns` into the PROCESS template builder. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
