### PR TITLE
Coilset issue 3993

### DIFF
--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -1249,7 +1249,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         # For SymmetricCircuits, the list names will be returned
         # in circuit pairs in order of primary coil name.
         self._control_ind = np.sort(control_ind)
-        self._control = [names[c] for c in np.sort(self._control_ind)]
+        self._control = [names[c] for c in self._control_ind]
 
     def get_control_coils(self) -> CoilSet:
         """Get control coils"""  # noqa: DOC201

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -67,17 +67,7 @@ def symmetrise_coilset(
     EquilibriaError
         Superposition of coils or unrecognised type
     """
-<<<<<<< HEAD
-=======
-    if not check_coilset_symmetric(coilset):
-        bluemira_warn(
-            "Symmetrising a CoilSet which is not purely symmetric about z=0. This can"
-            " result in undesirable behaviour."
-        )
-
->>>>>>> f006131a (Modify symmetric circuits loop and add coil naming)
     coilset = deepcopy(coilset)
-    sym_stack, sym_inds = _get_symmetric_coils(coilset)
 
     _, counts, indexes = _get_symmetric_coils(coilset, rtol=rtol)
     new_coils = []
@@ -96,31 +86,6 @@ def symmetrise_coilset(
                 raise EquilibriaError(f"Unrecognised class {type(coil).__name__}")
         else:
             raise EquilibriaError("There are super-posed Coils in this CoilSet.")
-=======
-    counts = np.array(sym_stack, dtype=object).T[1]
-    if np.array(counts).any() > 2:  # noqa: PLR2004
-        raise EquilibriaError("There are super-posed Coils in this CoilSet.")
-
-    circuit_inds = np.arange(len(coilset._coils))
-    new_coils = []
-    i = 0
-    for j, coil in enumerate(coilset._coils):
-        if (circuit_inds[j] in sym_inds) and (i <= len(sym_inds) - 1):
-            if counts[i] == 1:
-                new_coils.append(coil)
-            if counts[i] == 2:  # noqa: PLR2004
-                if isinstance(coil, SymmetricCircuit):
-                    new_coils.append(coil)
-                    circuit_inds[j + 1 :] += 1
-                elif isinstance(coil, Coil):
-                    new_coils.append(SymmetricCircuit(coil))
-                else:
-                    raise EquilibriaError(
-                        f"Unrecognised class {coil.__class__.__name__}"
-                    )
-
-            i += 1
->>>>>>> f006131a (Modify symmetric circuits loop and add coil naming)
 
     return CoilSet(*new_coils)
 

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -1407,6 +1407,9 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def n_current_optimisable_coils(self) -> int:
         """
         Get the number of all current optimisable coils.
+
+        This will only count the primary coil in the case of
+        a SymmetricCircuit pair or coils.
         """
         return len(self.current_optimisable_coil_names)
 
@@ -1414,6 +1417,9 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def current_optimisable_coil_names(self) -> list[str]:
         """
         Get the names of all current optimisable coils.
+
+        This will be the primary coil in the case of
+        a SymmetricCircuit pair or coils.
         """
         optimisable_coil_names = [
             c.primary_coil.name if isinstance(c, Circuit) else c.name
@@ -1564,6 +1570,9 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def n_position_optimisable_coils(self) -> int:
         """
         Get the number of coils that can be position optimised.
+
+        This will only count the primary coil in the case of
+        a SymmetricCircuit pair or coils.
         """
         return len(self.position_optimisable_coil_names)
 
@@ -1571,6 +1580,9 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def position_optimisable_coil_names(self) -> list[str]:
         """
         Get the names of the coils that can be position optimised.
+
+        This will be the primary coil in the case of
+        a SymmetricCircuit pair or coils.
         """
         optimisable_coil_names = (
             c.primary_coil.name if isinstance(c, SymmetricCircuit) else c.name

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -70,7 +70,7 @@ def symmetrise_coilset(
     """
     coilset = deepcopy(coilset)
 
-    _, counts, indexes = _get_symmetric_coils(coilset, rtol=rtol)
+    _, counts, indexes = _get_symmetric_coils(coilset, rtol=rtol or 1e-5)
     new_coils = []
     coils = coilset._coils
     for count, index in zip(counts, indexes, strict=True):

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -272,10 +272,7 @@ class CoilGroup(CoilGroupFieldsMixin):
         If a nested coilgroup is empty it is also removed from the parent coilgroup
 
         """
-        names = [
-            c.primary_coil.name if isinstance(c, Circuit) else c.name
-            for c in self._coils
-        ]
+        names = self.name
 
         if _top_level and (remainder := set(coil_name) - set(names)):
             raise EquilibriaError(f"Unknown coils {remainder}")

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 def symmetrise_coilset(
-    coilset: CoilSet, *, rtol: float = 1e-5, symmetrise_singular: bool = False
+    coilset: CoilSet, *, rtol: float | None = None, symmetrise_singular: bool = False
 ) -> CoilSet:
     """
     Symmetrise a CoilSet by converting any coils that are up-down symmetric about
@@ -52,8 +52,9 @@ def symmetrise_coilset(
         CoilSet to symmetrise
     rtol:
         Relative tolerance used when comparing coil values.
-        If rtol > 1.e-5 then the values for the secondary coil
-        in the pair will be set to be equal to the primary coil values.
+        The values for the secondary coil in the pair will be
+        set to be equal to the primary coil values if they are
+        within rtol.
     symmetrise_singular:
         make singular coils symmetric about z=0
 
@@ -1223,7 +1224,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     @property
     def n_control(self) -> float:
         """Number of coils being actively controlled"""
-        return len(self._control)
+        return len(self.control)
 
     @property
     def control(self) -> list[str]:

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 def symmetrise_coilset(
-    coilset: CoilSet, *, symmetrise_singular: bool = False
+    coilset: CoilSet, *, rtol: float = 1e-5, symmetrise_singular: bool = False
 ) -> CoilSet:
     """
     Symmetrise a CoilSet by converting any coils that are up-down symmetric about
@@ -50,6 +50,10 @@ def symmetrise_coilset(
     ----------
     coilset:
         CoilSet to symmetrise
+    rtol:
+        Relative tolerance used when comparing coil values.
+        If rtol > 1.e-5 then the values for the secondary coil
+        in the pair will be set to be equal to the primary coil values.
     symmetrise_singular:
         make singular coils symmetric about z=0
 
@@ -75,8 +79,7 @@ def symmetrise_coilset(
     coilset = deepcopy(coilset)
     sym_stack, sym_inds = _get_symmetric_coils(coilset)
 
-<<<<<<< HEAD
-    _, counts, indexes = _get_symmetric_coils(coilset)
+    _, counts, indexes = _get_symmetric_coils(coilset, rtol=rtol)
     new_coils = []
     coils = coilset._coils
     for count, index in zip(counts, indexes, strict=True):

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -63,8 +63,19 @@ def symmetrise_coilset(
     EquilibriaError
         Superposition of coils or unrecognised type
     """
-    coilset = deepcopy(coilset)
+<<<<<<< HEAD
+=======
+    if not check_coilset_symmetric(coilset):
+        bluemira_warn(
+            "Symmetrising a CoilSet which is not purely symmetric about z=0. This can"
+            " result in undesirable behaviour."
+        )
 
+>>>>>>> f006131a (Modify symmetric circuits loop and add coil naming)
+    coilset = deepcopy(coilset)
+    sym_stack, sym_inds = _get_symmetric_coils(coilset)
+
+<<<<<<< HEAD
     _, counts, indexes = _get_symmetric_coils(coilset)
     new_coils = []
     coils = coilset._coils
@@ -82,6 +93,31 @@ def symmetrise_coilset(
                 raise EquilibriaError(f"Unrecognised class {type(coil).__name__}")
         else:
             raise EquilibriaError("There are super-posed Coils in this CoilSet.")
+=======
+    counts = np.array(sym_stack, dtype=object).T[1]
+    if np.array(counts).any() > 2:  # noqa: PLR2004
+        raise EquilibriaError("There are super-posed Coils in this CoilSet.")
+
+    circuit_inds = np.arange(len(coilset._coils))
+    new_coils = []
+    i = 0
+    for j, coil in enumerate(coilset._coils):
+        if (circuit_inds[j] in sym_inds) and (i <= len(sym_inds) - 1):
+            if counts[i] == 1:
+                new_coils.append(coil)
+            if counts[i] == 2:  # noqa: PLR2004
+                if isinstance(coil, SymmetricCircuit):
+                    new_coils.append(coil)
+                    circuit_inds[j + 1 :] += 1
+                elif isinstance(coil, Coil):
+                    new_coils.append(SymmetricCircuit(coil))
+                else:
+                    raise EquilibriaError(
+                        f"Unrecognised class {coil.__class__.__name__}"
+                    )
+
+            i += 1
+>>>>>>> f006131a (Modify symmetric circuits loop and add coil naming)
 
     return CoilSet(*new_coils)
 
@@ -956,6 +992,11 @@ class SymmetricCircuit(Circuit):
     ):
         if len(coils) == 1:
             coils = (coils[0], deepcopy(coils[0]))
+            if "U" in coils[0].name:
+                coils[1].name = coils[0].name.replace("U", "L")
+            else:
+                coils[1].name = coils[0].name + "L"
+                coils[0].name += "U"
         if len(coils) != 2:  # noqa: PLR2004
             raise EquilibriaError(
                 f"Wrong number of coils to create a {type(self).__name__}"

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -961,11 +961,6 @@ class SymmetricCircuit(Circuit):
     ):
         if len(coils) == 1:
             coils = (coils[0], deepcopy(coils[0]))
-            if "U" in coils[0].name:
-                coils[1].name = coils[0].name.replace("U", "L")
-            else:
-                coils[1].name = coils[0].name + "L"
-                coils[0].name += "U"
         if len(coils) != 2:  # noqa: PLR2004
             raise EquilibriaError(
                 f"Wrong number of coils to create a {type(self).__name__}"

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -272,7 +272,10 @@ class CoilGroup(CoilGroupFieldsMixin):
         If a nested coilgroup is empty it is also removed from the parent coilgroup
 
         """
-        names = self.name
+        names = [
+            c.primary_coil.name if isinstance(c, Circuit) else c.name
+            for c in self._coils
+        ]
 
         if _top_level and (remainder := set(coil_name) - set(names)):
             raise EquilibriaError(f"Unknown coils {remainder}")

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -1253,6 +1253,11 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         return removed_coils
 
     @property
+    def n_control(self) -> float:
+        """Number of coils being actively controlled"""
+        return len(self._control)
+
+    @property
     def control(self) -> list[str]:
         """Get control coil names"""
         return self._control
@@ -1355,6 +1360,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     ) -> CoilSetOptimisationState:
         """
         Get the state of the CoilSet for optimisation.
+        If control coils are set then this is accounted for.
 
         Parameters
         ----------
@@ -1368,9 +1374,8 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         CoilSetOptimisationState
             The state of the CoilSet for optimisation
         """
-        cc = self.get_control_coils()
-        xs, zs = cc._get_opt_positions(position_coil_names)
-        currents = cc._opt_currents / current_scale
+        xs, zs = self._get_opt_positions(position_coil_names)
+        currents = self._opt_currents / current_scale
         return CoilSetOptimisationState(
             currents=currents,
             xs=xs,
@@ -1385,6 +1390,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     ):
         """
         Set the state of the CoilSet, post optimisation.
+        If control coils are set then this is accounted for.
 
         Used in conjunction with `get_optimisation_state`.
 
@@ -1397,16 +1403,16 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         current_scale:
             The scale of the currents
         """
-        cc = self.get_control_coils()
         if opt_currents is not None:
-            cc._opt_currents = opt_currents * current_scale
+            self._opt_currents = opt_currents * current_scale
         if coil_position_map is not None:
-            cc._set_opt_positions(coil_position_map)
+            self._set_opt_positions(coil_position_map)
 
     @property
     def n_current_optimisable_coils(self) -> int:
         """
         Get the number of all current optimisable coils.
+        If control coils are set then this is accounted for.
 
         This will only count the primary coil in the case of
         a SymmetricCircuit pair or coils.
@@ -1417,13 +1423,14 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def current_optimisable_coil_names(self) -> list[str]:
         """
         Get the names of all current optimisable coils.
+        If control coils are set then this is accounted for.
 
         This will be the primary coil in the case of
         a SymmetricCircuit pair or coils.
         """
         optimisable_coil_names = [
             c.primary_coil.name if isinstance(c, Circuit) else c.name
-            for c in self._coils
+            for c in self.get_control_coils()._coils
         ]
         return [*flatten_iterable(optimisable_coil_names)]
 
@@ -1431,14 +1438,16 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def all_current_optimisable_coils(self) -> list[Coil]:
         """
         Get a list of all coils that can be current optimised.
+        If control coils are set then this is accounted for.
         """
         return [self[cn] for cn in self.current_optimisable_coil_names]
 
     def get_current_optimisable_coils(
         self, coil_names: list[str] | None = None
-    ) -> list[Coil]:
+    ) -> CoilSet:
         """
-        Get a list of coils that can be current optimised.
+        Get a coils that can be current optimised.
+        If control coils are set then this is accounted for.
 
         If coil_names is given, only the coils with those names are returned.
         Names in coil_names must be a subset of current optimisable coils.
@@ -1455,22 +1464,23 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
             If a name in `coil_names` in not in `all_current_optimisable_coils`.
         """  # noqa: DOC201
         if coil_names is None:
-            return self.all_current_optimisable_coils
+            return CoilSet(*self.all_current_optimisable_coils)
 
         opt_coils_map = {c.name: c for c in self.all_current_optimisable_coils}
-        rtn = []
+        coils = []
         for cn in coil_names:
             c = opt_coils_map.get(cn)
             if c is not None:
-                rtn.append(c)
+                coils.append(c)
             else:
                 raise ValueError(f"Coil {cn} is not a current optimisable coil")
-        return rtn
+        return CoilSet(*coils)
 
     @property
     def _opt_currents_inds(self) -> list[int]:
         """
         Get the indices of the coils that can be optimised.
+        If control coils are set then this is accounted for.
 
         These indices are used to extract the optimisable currents from the CoilSet
         and are based on the index of the coils in the name array.
@@ -1497,29 +1507,14 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         ValueError
             Number of optimisable coils not equal number of groups/coils
         """
-        cc = self.get_control_coils()
-
-        n_all_coils = cc.n_coils()
-        n_opt_coils = cc.n_current_optimisable_coils
-        n_distinct_coils_and_groupings = len(cc._coils)
-
-        if not cc._contains_circuits:
-            return np.eye(n_all_coils)
-
-        # this should be true as, at the top level, the number
-        # of coil or group objects should be the same as the no
-        # of optimisable coils
-        if n_opt_coils != n_distinct_coils_and_groupings:
-            raise ValueError(
-                "The number of optimisable coils does not match the number "
-                "of distinct coils and groupings. Something's gone wrong."
-            )
+        if not self._contains_circuits:
+            return np.eye(self.n_control)
 
         # you are putting 1's in the col. corresponding
         # to all coils in the same Circuit
-        mat = np.zeros((n_all_coils, n_opt_coils))
+        mat = np.zeros((self.n_control, self.n_current_optimisable_coils))
         i_row = 0
-        for i_col, c in enumerate(cc._coils):
+        for i_col, c in enumerate(self.get_control_coils()._coils):
             if isinstance(c, Circuit):
                 n_coils_in_group = c.n_coils()
                 for n in range(n_coils_in_group):
@@ -1534,6 +1529,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def _opt_currents(self) -> np.ndarray:
         """
         Get the currents for the optimisable coils.
+        If control coils are set then this is accounted for.
         """
         return self.current[self._opt_currents_inds]
 
@@ -1541,20 +1537,19 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def _opt_currents(self, values: np.ndarray):
         """
         Set the currents for the optimisable coils.
+        If control coils are set then this is accounted for.
 
         Raises
         ------
         ValueError
             Number of values not equal to number of optimisable currents
         """
-        n_all_coils = self.n_coils()
-
-        n_vals = values.shape[0]
         n_curr_opt_coils = self.n_current_optimisable_coils
+        n_vals = values.shape[0]
 
         if n_vals == 1:
             c = values[0]
-            self.current = np.ones(n_all_coils) * c
+            self.current = np.ones(self.n_control) * c
             return
 
         if n_vals != n_curr_opt_coils:
@@ -1570,6 +1565,7 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def n_position_optimisable_coils(self) -> int:
         """
         Get the number of coils that can be position optimised.
+        If control coils are set then this is accounted for.
 
         This will only count the primary coil in the case of
         a SymmetricCircuit pair or coils.
@@ -1580,13 +1576,14 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def position_optimisable_coil_names(self) -> list[str]:
         """
         Get the names of the coils that can be position optimised.
+        If control coils are set then this is accounted for.
 
         This will be the primary coil in the case of
         a SymmetricCircuit pair or coils.
         """
         optimisable_coil_names = (
             c.primary_coil.name if isinstance(c, SymmetricCircuit) else c.name
-            for c in self._coils
+            for c in self.get_control_coils()._coils
         )
         return [*flatten_iterable(optimisable_coil_names)]
 
@@ -1594,14 +1591,16 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
     def all_position_optimisable_coils(self) -> list[Coil]:
         """
         Get the names of all coils that can be position optimised.
+        If control coils are set then this is accounted for.
         """
         return [self[cn] for cn in self.position_optimisable_coil_names]
 
     def get_position_optimisable_coils(
         self, coil_names: list[str] | None = None
-    ) -> list[Coil]:
+    ) -> CoilSet:
         """
         Get the coils that can be position optimised.
+        If control coils are set then this is accounted for.
 
         Parameters
         ----------
@@ -1615,17 +1614,17 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
             Coil's position not optimisable
         """  # noqa: DOC201
         if coil_names is None:
-            return self.all_position_optimisable_coils
+            return CoilSet(*self.all_position_optimisable_coils)
 
         opt_coils_map = {c.name: c for c in self.all_position_optimisable_coils}
-        rtn = []
+        coils = []
         for cn in coil_names:
             c = opt_coils_map.get(cn)
             if c is not None:
-                rtn.append(c)
+                coils.append(c)
             else:
                 raise ValueError(f"Coil {cn} is not a position optimisable coil")
-        return rtn
+        return CoilSet(*coils)
 
     def _get_opt_positions(
         self, position_coil_names: list[str] | None = None
@@ -1646,15 +1645,14 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         :
             The z coordinates
         """
-        coils = self.get_position_optimisable_coils(position_coil_names)
-        x, z = [c.x for c in coils], [c.z for c in coils]
-        return np.asarray(x), np.asarray(z)
+        pos_coilset = self.get_position_optimisable_coils(position_coil_names)
+        return pos_coilset.x, pos_coilset.z
 
     def _set_opt_positions(self, coil_position_map: dict[str, np.ndarray]) -> None:
         """
         Set the positions of the position optimisable coils.
         """
-        pos_opt_coil_names = self.get_control_coils().position_optimisable_coil_names
+        pos_opt_coil_names = self.position_optimisable_coil_names
         for coil_name, position in coil_position_map.items():
             if coil_name in pos_opt_coil_names:
                 c = self.get_coil_or_group_with_coil_name(coil_name)

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -1512,22 +1512,25 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         ValueError
             Number of values not equal to number of optimisable currents
         """
-        n_curr_opt_coils = self.n_current_optimisable_coils
+        n_opt, n_cc = self.n_current_optimisable_coils, self.n_control
+        all_currents = deepcopy(self.current)
         n_vals = values.shape[0]
 
         if n_vals == 1:
             c = values[0]
-            self.current = np.ones(self.n_control) * c
+            all_currents[self._control_ind] = np.ones(n_cc) * c
+            self.current = all_currents
             return
 
-        if n_vals != n_curr_opt_coils:
+        if n_vals != n_opt:
             raise ValueError(
                 f"The number of current elements {n_vals} "
                 "does not match the number of "
-                f"optimisable currents: {n_curr_opt_coils}"
+                f"optimisable currents: {n_opt}"
             )
 
-        self.current = self._opt_currents_expand_mat @ values
+        all_currents[self._control_ind] = self._opt_currents_expand_mat @ values
+        self.current = all_currents
 
     @property
     def n_position_optimisable_coils(self) -> int:

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -87,7 +87,7 @@ def symmetrise_coilset(
         else:
             raise EquilibriaError("There are super-posed Coils in this CoilSet.")
 
-    return CoilSet(*new_coils)
+    return CoilSet(*new_coils, control_names=coilset.control)
 
 
 class CoilGroup(CoilGroupFieldsMixin):
@@ -1243,12 +1243,17 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         """
         names = self.name
         if isinstance(control_names, list):
-            self._control_ind = [names.index(c) for c in control_names]
+            control_ind = [names.index(c) for c in control_names]
         elif control_names or control_names is None:
-            self._control_ind = np.arange(len(names)).tolist()
+            control_ind = np.arange(len(names)).tolist()
         else:
-            self._control_ind = []
-        self._control = [names[c] for c in self._control_ind]
+            control_ind = []
+        # Sort to match self.names - so that we are not changing
+        # the order based on the input control_names ordering.
+        # For SymmetricCircuits, the list names will be returned
+        # in circuit pairs in order of primary coil name.
+        self._control_ind = np.sort(control_ind)
+        self._control = [names[c] for c in np.sort(self._control_ind)]
 
     def get_control_coils(self) -> CoilSet:
         """Get control coils"""  # noqa: DOC201

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -109,7 +109,6 @@ def _get_symmetric_coils(
     from bluemira.equilibria.coils._grouping import SymmetricCircuit  # noqa: PLC0415
 
     x, z, dx, dz, currents = coilset.to_group_vecs()
-    ind = [coilset.name.index(cn) for cn in coilset.name]
     coil_matrix = np.array([x, np.abs(z), dx, dz, currents]).T
 
     sym_stack = [[coil_matrix[0], 1, [0]]]

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -99,6 +99,7 @@ def _get_symmetric_coils(
     from bluemira.equilibria.coils._grouping import SymmetricCircuit  # noqa: PLC0415
 
     x, z, dx, dz, currents = coilset.to_group_vecs()
+    ind = [coilset.name.index(cn) for cn in coilset.name]
     coil_matrix = np.array([x, np.abs(z), dx, dz, currents]).T
 
     sym_stack = [[coil_matrix[0], 1, [0]]]

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -83,7 +83,7 @@ def make_mutual_inductance_matrix(coilset: CoilSet) -> np.ndarray:
 
 def _get_symmetric_coils(
     coilset: CoilSet,
-    rtol: float | None = None,
+    rtol: float = 1e-5
 ) -> tuple[list[npt.NDArray], npt.NDArray, list[list[int]]]:
     """
     Coilset symmetry utility

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -82,8 +82,7 @@ def make_mutual_inductance_matrix(coilset: CoilSet) -> np.ndarray:
 
 
 def _get_symmetric_coils(
-    coilset: CoilSet,
-    rtol: float = 1e-5
+    coilset: CoilSet, rtol: float = 1e-5
 ) -> tuple[list[npt.NDArray], npt.NDArray, list[list[int]]]:
     """
     Coilset symmetry utility
@@ -140,7 +139,7 @@ def _get_symmetric_coils(
     return coil_data.tolist(), np.array(count, dtype=int), indexes
 
 
-def check_coilset_symmetric(coilset: CoilSet, rtol: float) -> bool:
+def check_coilset_symmetric(coilset: CoilSet, rtol: float | None = None) -> bool:
     """
     Check whether or not a CoilSet is purely symmetric about z=0.
 
@@ -153,7 +152,7 @@ def check_coilset_symmetric(coilset: CoilSet, rtol: float) -> bool:
     -------
     Whether or not the CoilSet is symmetric about z=0
     """
-    coils, counts, _ = _get_symmetric_coils(coilset, rtol=rtol)
+    coils, counts, _ = _get_symmetric_coils(coilset, rtol=rtol or 1e-5)
     for coil, count in zip(coils, counts, strict=True):
         if count != 2 and not np.isclose(coil[1], 0.0):  # noqa: PLR2004
             # therefore z = 0

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -110,7 +110,6 @@ def _get_symmetric_coils(
     """
     from bluemira.equilibria.coils._grouping import SymmetricCircuit  # noqa: PLC0415
 
-    rtol = rtol or 1e-5
     x, z, dx, dz, currents = coilset.to_group_vecs()
     coil_matrix = np.array([x, np.abs(z), dx, dz, currents]).T
 

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -83,7 +83,7 @@ def make_mutual_inductance_matrix(coilset: CoilSet) -> np.ndarray:
 
 def _get_symmetric_coils(
     coilset: CoilSet,
-    rtol: float,
+    rtol: float | None = None,
 ) -> tuple[list[npt.NDArray], npt.NDArray, list[list[int]]]:
     """
     Coilset symmetry utility
@@ -93,9 +93,11 @@ def _get_symmetric_coils(
     coilset:
         CoilSet to get symmetric coils from
     rtol:
-        Relative tolerance used when comparing coil values.
-        If rtol > 1.e-5 then the values for the secondary coil
-        in the pair will be set to be equal to the primary coil values.
+        Relative tolerance used when comparing coil values,
+        rtol = 1.e-5 is the default value for np.allclose.
+        The values for the secondary coil in the pair will be
+        set to be equal to the primary coil values if they are
+        within rtol.
 
     Returns
     -------
@@ -108,6 +110,7 @@ def _get_symmetric_coils(
     """
     from bluemira.equilibria.coils._grouping import SymmetricCircuit  # noqa: PLC0415
 
+    rtol = rtol or 1e-5
     x, z, dx, dz, currents = coilset.to_group_vecs()
     coil_matrix = np.array([x, np.abs(z), dx, dz, currents]).T
 
@@ -117,8 +120,7 @@ def _get_symmetric_coils(
 
         for j, sym_coil in enumerate(sym_stack):
             if np.allclose(coil, sym_coil[0], rtol=rtol):
-                if rtol > 1e-5:  # noqa: PLR2004
-                    coil = sym_coil[0]
+                coil = sym_coil[0]
                 sym_stack[j][1] += 1
                 sym_coil[2].append(i)
                 break

--- a/bluemira/equilibria/coils/_tools.py
+++ b/bluemira/equilibria/coils/_tools.py
@@ -83,9 +83,19 @@ def make_mutual_inductance_matrix(coilset: CoilSet) -> np.ndarray:
 
 def _get_symmetric_coils(
     coilset: CoilSet,
+    rtol: float,
 ) -> tuple[list[npt.NDArray], npt.NDArray, list[list[int]]]:
     """
     Coilset symmetry utility
+
+    Parameters
+    ----------
+    coilset:
+        CoilSet to get symmetric coils from
+    rtol:
+        Relative tolerance used when comparing coil values.
+        If rtol > 1.e-5 then the values for the secondary coil
+        in the pair will be set to be equal to the primary coil values.
 
     Returns
     -------
@@ -107,7 +117,9 @@ def _get_symmetric_coils(
         coil = coil_matrix[i]
 
         for j, sym_coil in enumerate(sym_stack):
-            if np.allclose(coil, sym_coil[0]):
+            if np.allclose(coil, sym_coil[0], rtol=rtol):
+                if rtol > 1e-5:  # noqa: PLR2004
+                    coil = sym_coil[0]
                 sym_stack[j][1] += 1
                 sym_coil[2].append(i)
                 break
@@ -128,7 +140,7 @@ def _get_symmetric_coils(
     return coil_data.tolist(), np.array(count, dtype=int), indexes
 
 
-def check_coilset_symmetric(coilset: CoilSet) -> bool:
+def check_coilset_symmetric(coilset: CoilSet, rtol: float) -> bool:
     """
     Check whether or not a CoilSet is purely symmetric about z=0.
 
@@ -141,7 +153,7 @@ def check_coilset_symmetric(coilset: CoilSet) -> bool:
     -------
     Whether or not the CoilSet is symmetric about z=0
     """
-    coils, counts, _ = _get_symmetric_coils(coilset)
+    coils, counts, _ = _get_symmetric_coils(coilset, rtol=rtol)
     for coil, count in zip(coils, counts, strict=True):
         if count != 2 and not np.isclose(coil[1], 0.0):  # noqa: PLR2004
             # therefore z = 0

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -505,7 +505,7 @@ class CoilSetMHDState(MHDState):
         qpsi_positive: bool | None = None,
         user_coils: CoilSet | None = None,
         force_symmetry: bool = False,
-        force_symmetry_rtol: float = 1e-5,
+        force_symmetry_rtol: float | None = None,
         full_coil: bool = False,
         **kwargs,
     ) -> tuple[EQDSKInterface, Grid, CoilSet, Limiter | None]:
@@ -529,10 +529,10 @@ class CoilSetMHDState(MHDState):
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
         force_symmetry_rtol:
-            The relative tolerance used when comparing coil values
-            for force_symmetry=True. If rtol > 1.e-5 then the values
-            for the secondary coil in the pair will be set to be
-            equal to the primary coil values.
+            Relative tolerance used when comparing coil values.
+            The values for the secondary coil in the pair will be
+            set to be equal to the primary coil values if they are
+            within force_symmetry_rtol.
         full_coil:
             Whether the eqdsk dxc and dzc represents
             the full coil width or half coil width

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -505,6 +505,7 @@ class CoilSetMHDState(MHDState):
         qpsi_positive: bool | None = None,
         user_coils: CoilSet | None = None,
         force_symmetry: bool = False,
+        force_symmetry_rtol: float = 1e-5,
         full_coil: bool = False,
         **kwargs,
     ) -> tuple[EQDSKInterface, Grid, CoilSet, Limiter | None]:
@@ -527,6 +528,11 @@ class CoilSetMHDState(MHDState):
             Set current, j_max and b_max to zero in user_coils.
         force_symmetry:
             Whether or not to force symmetrisation in the CoilSet
+        force_symmetry_rtol:
+            The relative tolerance used when comparing coil values
+            for force_symmetry=True. If rtol > 1.e-5 then the values
+            for the secondary coil in the pair will be set to be
+            equal to the primary coil values.
         full_coil:
             Whether the eqdsk dxc and dzc represents
             the full coil width or half coil width
@@ -553,7 +559,7 @@ class CoilSetMHDState(MHDState):
         )
         coilset = user_coils if user_coils is not None else CoilSet.from_group_vecs(e)
         if force_symmetry:
-            coilset = symmetrise_coilset(coilset)
+            coilset = symmetrise_coilset(coilset, rtol=force_symmetry_rtol)
 
         limiter = None if e.nlim > 5 or e.nlim == 0 else Limiter(e.xlim, e.zlim)  # noqa: PLR2004
 

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -270,8 +270,8 @@ class CoilFieldConstraints(FieldConstraints):
 
     @staticmethod
     def _get_constraint_points(coilset):
-        coilset = coilset.get_control_coils()
-        return coilset.x - coilset.dx, coilset.z
+        cc = coilset.get_control_coils()
+        return cc.x - cc.dx, cc.z
 
     def prepare(
         self,

--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -256,8 +256,7 @@ class CoilFieldConstraints(FieldConstraints):
         B_max: float | np.ndarray,
         tolerance: float | np.ndarray | None = None,
     ):
-        cc = coilset.get_control_coils()
-        n_coils = cc.n_coils()
+        n_coils = coilset.n_control
         if is_num(B_max):
             B_max *= np.ones(n_coils)
         if len(B_max) != n_coils:
@@ -928,7 +927,7 @@ class MagneticConstraintSet:
         """
         Build the control response matrix used in optimisation.
         """
-        self.A = np.zeros((len(self), len(self.coilset.control)))
+        self.A = np.zeros((len(self), self.coilset.n_control))
 
         i = 0
         for constraint in self.constraints:

--- a/bluemira/equilibria/optimisation/problem/_breakdown.py
+++ b/bluemira/equilibria/optimisation/problem/_breakdown.py
@@ -242,7 +242,7 @@ class BreakdownCOP(EqCoilsetOptimisationProblem):
             x0 = np.clip(x0 / self.scale, *self.bounds)
 
         objective = MaximiseFluxObjective(**self._args)
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             f_objective=objective.f_objective,
             df_objective=objective.df_objective,

--- a/bluemira/equilibria/optimisation/problem/_minimal_current.py
+++ b/bluemira/equilibria/optimisation/problem/_minimal_current.py
@@ -111,7 +111,7 @@ class MinimalCurrentCOP(EqCoilsetOptimisationProblem):
 
         objective = CoilCurrentsObjective()
 
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             algorithm=self.opt_algorithm,
             f_objective=objective.f_objective,

--- a/bluemira/equilibria/optimisation/problem/_nested_position.py
+++ b/bluemira/equilibria/optimisation/problem/_nested_position.py
@@ -57,7 +57,7 @@ class NestedCoilsetPositionCOP(EqCoilsetOptimisationProblem):
     sub_opt:
         Coilset OptimisationProblem to use for the optimisation of
         coil currents at each trial set of coil positions.
-        sub_opt.coilset must exist, and will be modified
+        sub_opt.coilset will be modified
         during the optimisation.
     eq:
         Equilibrium object used to update magnetic field targets.
@@ -132,7 +132,7 @@ class NestedCoilsetPositionCOP(EqCoilsetOptimisationProblem):
         if x0 is None:
             x0 = self._get_initial_vector()
 
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             f_objective=self.objective,
             x0=x0,
@@ -222,7 +222,7 @@ class PulsedNestedPositionCOP(CoilsetOptimisationProblem):
         if initial_currents:
             self.initial_currents = initial_currents / self.sub_opt_problems[0].scale
         else:
-            self.initial_currents = np.zeros(coilset.get_control_coils().n_coils())
+            self.initial_currents = np.zeros(self.coilset.n_control)
         self.debug = {0: debug}
         self.iter = {0: 0.0}
         opt_dimension = self.position_mapper.dimension
@@ -341,7 +341,7 @@ class PulsedNestedPositionCOP(CoilsetOptimisationProblem):
         if x0 is None:
             x0 = self._get_initial_vector()
 
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             f_objective=lambda vector: self.objective(vector, verbose=verbose),
             x0=x0,

--- a/bluemira/equilibria/optimisation/problem/_nested_position.py
+++ b/bluemira/equilibria/optimisation/problem/_nested_position.py
@@ -222,7 +222,7 @@ class PulsedNestedPositionCOP(CoilsetOptimisationProblem):
         if initial_currents:
             self.initial_currents = initial_currents / self.sub_opt_problems[0].scale
         else:
-            self.initial_currents = np.zeros(self.coilset.n_control)
+            self.initial_currents = np.zeros(coilset.get_control_coils().n_coils())
         self.debug = {0: debug}
         self.iter = {0: 0.0}
         opt_dimension = self.position_mapper.dimension

--- a/bluemira/equilibria/optimisation/problem/_position.py
+++ b/bluemira/equilibria/optimisation/problem/_position.py
@@ -34,7 +34,8 @@ class CoilsetPositionCOP(EqCoilsetOptimisationProblem):
     Parameters
     ----------
     eq:
-        Equilibrium object used to update magnetic field targets.
+        Equilibrium object (used to update magnetic field targets)
+        with Coilset to optimise.
     targets:
         Set of magnetic field targets to use in objective function.
     position_mapper:
@@ -112,7 +113,7 @@ class CoilsetPositionCOP(EqCoilsetOptimisationProblem):
             )
             x0 = np.concatenate((initial_mapped_positions, cs_opt_state.currents))
 
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             f_objective=self.objective,
             x0=x0,
@@ -194,7 +195,7 @@ class CoilsetPositionCOP(EqCoilsetOptimisationProblem):
             np.zeros(opt_dimension),
             np.ones(opt_dimension),
         )
-        current_bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+        current_bounds = self.get_current_bounds(max_currents, self.scale)
 
         return (
             np.concatenate((lower_pos_bounds, current_bounds[0])),

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -8,7 +8,6 @@
 import numpy as np
 import numpy.typing as npt
 
-from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.optimisation.constraints import (
     MagneticConstraintSet,
@@ -34,7 +33,8 @@ class TikhonovCurrentCOP(EqCoilsetOptimisationProblem):
     Parameters
     ----------
     eq:
-        Equilibrium object used to update magnetic field targets.
+        Equilibrium object (used to update magnetic field targets)
+        with Coilset to optimise.
     targets:
         Set of magnetic field targets to use in objective function.
     gamma:
@@ -111,9 +111,9 @@ class TikhonovCurrentCOP(EqCoilsetOptimisationProblem):
             a_mat=a_mat,
             b_vec=b_vec,
             gamma=self.gamma,
-            currents_expand_mat=self.eq.coilset._opt_currents_expand_mat,
+            currents_expand_mat=self.coilset._opt_currents_expand_mat,
         )
-        eq_constraints, ineq_constraints = self._make_numerical_constraints(self.coilset)
+        eq_constraints, ineq_constraints = self._make_numerical_constraints()
         opt_result = optimise(
             f_objective=objective.f_objective,
             df_objective=getattr(objective, "df_objective", None),
@@ -144,10 +144,9 @@ class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
 
     Parameters
     ----------
-    coilset:
-        CoilSet object to optimise with
     eq:
-        Equilibrium object to optimise for
+        Equilibrium object (used to update magnetic field targets)
+        with Coilset to optimise.
     targets:
         Set of magnetic constraints to minimise the error for
     gamma:
@@ -156,13 +155,11 @@ class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
 
     def __init__(
         self,
-        coilset: CoilSet,
         eq: Equilibrium,
         targets: MagneticConstraintSet,
         gamma: float,
     ):
-        self.coilset = coilset
-        self.eq = eq
+        super().__init__(coilset_mhd_state=eq)
         self.targets = targets
         self.gamma = gamma
 
@@ -182,23 +179,24 @@ class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
         self.targets(self.eq, I_not_dI=False)
         _, a_mat, b_vec = self.targets.get_weighted_arrays()
 
-        c_cs = self.eq.coilset.get_control_coils()
-
         # Optimise currents using analytic expression for optimum.
         current_adjustment = tikhonov(
-            a_mat, b_vec, self.gamma, currents_expand_mat=c_cs._opt_currents_expand_mat
+            a_mat,
+            b_vec,
+            self.gamma,
+            currents_expand_mat=self.coilset._opt_currents_expand_mat,
         )
 
         # Update parameterisation (coilset).
-        opt_currents = c_cs._opt_currents + current_adjustment
-        c_cs.set_optimisation_state(opt_currents=opt_currents, current_scale=1.0)
+        opt_currents = self.coilset._opt_currents + current_adjustment
+        self.coilset.set_optimisation_state(opt_currents=opt_currents, current_scale=1.0)
 
         f_x = floatify(
-            np.linalg.norm(a_mat @ c_cs.current - b_vec)
-            + np.linalg.norm(self.gamma * c_cs.current)
+            np.linalg.norm(a_mat @ opt_currents - b_vec)
+            + np.linalg.norm(self.gamma * opt_currents)
         )
         return CoilsetOptimiserResult(
-            coilset=c_cs,
+            coilset=self.coilset,
             f_x=f_x,
             n_evals=0,
             history=[],

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -15,7 +15,6 @@ from bluemira.equilibria.optimisation.constraints import (
 )
 from bluemira.equilibria.optimisation.objectives import RegularisedLsqObjective, tikhonov
 from bluemira.equilibria.optimisation.problem.base import (
-    CoilsetOptimisationProblem,
     CoilsetOptimiserResult,
     EqCoilsetOptimisationProblem,
 )
@@ -135,7 +134,7 @@ class TikhonovCurrentCOP(EqCoilsetOptimisationProblem):
         return CoilsetOptimiserResult.from_opt_result(self.coilset, opt_result)
 
 
-class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
+class UnconstrainedTikhonovCurrentGradientCOP(EqCoilsetOptimisationProblem):
     """
     Unbounded, unconstrained, analytically optimised current gradient vector for minimal
     error to the L2-norm of a set of magnetic constraints (used here as targets).
@@ -158,9 +157,20 @@ class UnconstrainedTikhonovCurrentGradientCOP(CoilsetOptimisationProblem):
         eq: Equilibrium,
         targets: MagneticConstraintSet,
         gamma: float,
+        opt_algorithm: AlgorithmType = Algorithm.SLSQP,
+        opt_conditions: dict[str, float | int] | None = None,
+        opt_parameters: dict[str, float] | None = None,
+        max_currents: npt.ArrayLike | None = None,
     ):
-        super().__init__(coilset_mhd_state=eq)
-        self.targets = targets
+        super().__init__(
+            eq,
+            opt_algorithm,
+            max_currents=max_currents,
+            opt_conditions=opt_conditions,
+            constraints=None,
+            opt_parameters={"initial_step": 0.03, **(opt_parameters or {})},
+            targets=targets,
+        )
         self.gamma = gamma
 
     def optimise(self, **_) -> CoilsetOptimiserResult:

--- a/bluemira/equilibria/optimisation/problem/_tikhonov.py
+++ b/bluemira/equilibria/optimisation/problem/_tikhonov.py
@@ -201,9 +201,13 @@ class UnconstrainedTikhonovCurrentGradientCOP(EqCoilsetOptimisationProblem):
         opt_currents = self.coilset._opt_currents + current_adjustment
         self.coilset.set_optimisation_state(opt_currents=opt_currents, current_scale=1.0)
 
+        # if the coilset contains circuits, we need to 'expand' the current vector,
+        # which repeats the currents for each circuit in the coilset.
+        opt_currents_sym = self.coilset._opt_currents_expand_mat @ opt_currents
+
         f_x = floatify(
-            np.linalg.norm(a_mat @ opt_currents - b_vec)
-            + np.linalg.norm(self.gamma * opt_currents)
+            np.linalg.norm(a_mat @ opt_currents_sym - b_vec)
+            + np.linalg.norm(self.gamma * opt_currents_sym)
         )
         return CoilsetOptimiserResult(
             coilset=self.coilset,

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.optimisation.constraints import (
     MagneticConstraintSet,
@@ -83,45 +82,6 @@ class CoilsetOptimisationProblem(abc.ABC):
     returns an optimised coilset object, optimised according
     to a specific objective function for that subclass.
     """
-
-    def __init__(
-        self,
-        coilset: CoilSet,
-        opt_algorithm: AlgorithmType,
-        *,
-        max_currents: npt.ArrayLike | None = None,
-        targets: MagneticConstraintSet | None = None,
-        constraints: list[UpdateableConstraint] | None = None,
-        opt_conditions: dict[str, float | int] | None = None,
-        opt_parameters: dict[str, float] | None = None,
-    ):
-        self._coilset = coilset
-        self.max_currents = max_currents
-        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
-
-        self.targets = targets or MagneticConstraintSet([])
-        self.constraints = constraints or []
-
-        self.opt_algorithm = opt_algorithm
-        self.opt_conditions = self._opt_condition_defaults({
-            "max_eval": 100,
-            **(opt_conditions or {}),
-        })
-        self.opt_parameters = {} if opt_parameters is None else opt_parameters
-
-    @property
-    def coilset(self) -> CoilSet:
-        """The optimisation problem coilset"""
-        return self._coilset
-
-    @coilset.setter
-    def coilset(self, value: CoilSet):
-        self._coilset = value
-
-    @property
-    def scale(self) -> float:
-        """Problem scaling value"""
-        return 1e6
 
     def __init__(
         self,

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -96,7 +96,7 @@ class CoilsetOptimisationProblem(abc.ABC):
     ):
         self._coilset = coilset
         self.max_currents = max_currents
-        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+        self.bounds = self.get_current_bounds(max_currents, self.scale)
 
         self.targets = targets or MagneticConstraintSet([])
         self.constraints = constraints or []

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -148,8 +148,6 @@ class CoilsetOptimisationProblem(abc.ABC):
 
         Parameters
         ----------
-        coilset:
-            Coilset to fetch current bounds for.
         max_currents:
             Maximum magnitude of currents in each coil [A] permitted during optimisation.
             If max_current is supplied as a float, the float will be set as the

--- a/bluemira/equilibria/optimisation/problem/base.py
+++ b/bluemira/equilibria/optimisation/problem/base.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from bluemira.equilibria.coils import CoilSet
 from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.optimisation.constraints import (
     MagneticConstraintSet,
@@ -122,6 +123,45 @@ class CoilsetOptimisationProblem(abc.ABC):
         """Problem scaling value"""
         return 1e6
 
+    def __init__(
+        self,
+        coilset: CoilSet,
+        opt_algorithm: AlgorithmType,
+        *,
+        max_currents: npt.ArrayLike | None = None,
+        targets: MagneticConstraintSet | None = None,
+        constraints: list[UpdateableConstraint] | None = None,
+        opt_conditions: dict[str, float | int] | None = None,
+        opt_parameters: dict[str, float] | None = None,
+    ):
+        self._coilset = coilset
+        self.max_currents = max_currents
+        self.bounds = self.get_current_bounds(self.coilset, max_currents, self.scale)
+
+        self.targets = targets or MagneticConstraintSet([])
+        self.constraints = constraints or []
+
+        self.opt_algorithm = opt_algorithm
+        self.opt_conditions = self._opt_condition_defaults({
+            "max_eval": 100,
+            **(opt_conditions or {}),
+        })
+        self.opt_parameters = {} if opt_parameters is None else opt_parameters
+
+    @property
+    def coilset(self) -> CoilSet:
+        """The optimisation problem coilset"""
+        return self._coilset
+
+    @coilset.setter
+    def coilset(self, value: CoilSet):
+        self._coilset = value
+
+    @property
+    def scale(self) -> float:
+        """Problem scaling value"""
+        return 1e6
+
     def _opt_condition_defaults(
         self, default_cond: dict[str, float | int]
     ) -> dict[str, float | int]:
@@ -140,9 +180,8 @@ class CoilsetOptimisationProblem(abc.ABC):
     def optimise(self, **kwargs) -> CoilsetOptimiserResult:
         """Run the coilset optimisation."""
 
-    @staticmethod
     def get_current_bounds(
-        coilset: CoilSet, max_currents: npt.ArrayLike | None, current_scale: float
+        self, max_currents: npt.ArrayLike | None, current_scale: float
     ) -> tuple[np.ndarray, np.ndarray]:
         """
         Gets the scaled current vector bounds. Must be called prior to optimise.
@@ -172,9 +211,7 @@ class CoilsetOptimisationProblem(abc.ABC):
         EquilibriaError
             Number of max currents not equal to number of optimisable currents
         """
-        cc = coilset.get_control_coils()
-
-        n_cc_opt_currents = cc.n_current_optimisable_coils
+        n_cc_opt_currents = self.coilset.n_current_optimisable_coils
         scaled_input_current_limits = np.inf * np.ones(n_cc_opt_currents)
 
         if max_currents is not None:
@@ -198,7 +235,9 @@ class CoilsetOptimisationProblem(abc.ABC):
         # if a coil is not fixed (sized) and it has jmax, then the current is limited
         # by the max current provided or defaults to inf
 
-        opt_coils_max_currents = cc.get_max_current()[cc._opt_currents_inds]
+        opt_coils_max_currents = (
+            self.coilset.get_current_optimisable_coils().get_max_current()
+        )
 
         # Limit the control current magnitude by the smaller of the two limits
         control_current_limits = np.minimum(
@@ -220,8 +259,7 @@ class CoilsetOptimisationProblem(abc.ABC):
         ValueError
             Length of max current vector must be equal to controls
         """
-        n_control_currents = len(self.coilset.current[self.coilset._control_ind])
-        if len(max_currents) != n_control_currents:
+        if len(max_currents) != self.coilset.n_current_optimisable_coils:
             raise ValueError(
                 "Length of maximum current vector must be equal to the number of"
                 " controls."
@@ -234,7 +272,7 @@ class CoilsetOptimisationProblem(abc.ABC):
         self.bounds = (lower_bounds, upper_bounds)
 
     def _make_numerical_constraints(
-        self, coilset: CoilSet
+        self,
     ) -> tuple[list[ConstraintT], list[ConstraintT]]:
         """Build the numerical equality and inequality constraint dictionaries.
 
@@ -255,7 +293,7 @@ class CoilsetOptimisationProblem(abc.ABC):
             f_c = f.f_constraint
             df_c = getattr(f, "df_constraint", None)
 
-            if coilset._contains_circuits:
+            if self.coilset._contains_circuits:
                 # if the coilset contains circuits, we need to wrap the constraint
                 # functions (f_c) and 'expand' the current vector, which repeats
                 # the currents for each circuit in the coilset.
@@ -269,7 +307,7 @@ class CoilsetOptimisationProblem(abc.ABC):
                 # wrap the constraint function
                 @functools.wraps(f.f_constraint)
                 def wrapped_f_c(x, f=f):
-                    return f.f_constraint(coilset._opt_currents_expand_mat @ x)
+                    return f.f_constraint(self.coilset._opt_currents_expand_mat @ x)
 
                 f_c = wrapped_f_c
 
@@ -277,8 +315,10 @@ class CoilsetOptimisationProblem(abc.ABC):
                     # wrap the derivative function
                     @functools.wraps(f.df_constraint)
                     def wrapped_df_c(x, f=f):
-                        df_res = f.df_constraint(coilset._opt_currents_expand_mat @ x)
-                        return df_res @ coilset._opt_currents_expand_mat
+                        df_res = f.df_constraint(
+                            self.coilset._opt_currents_expand_mat @ x
+                        )
+                        return df_res @ self.coilset._opt_currents_expand_mat
 
                     df_c = wrapped_df_c
 

--- a/bluemira/equilibria/run.py
+++ b/bluemira/equilibria/run.py
@@ -444,7 +444,6 @@ class PulsedCoilsetDesign(ABC):
             o_point_fallback=self.eq_config.o_point_fallback,
         )
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            coilset,
             eq,
             MagneticConstraintSet(self.eq_constraints),
             gamma=self.eq_config.gamma,

--- a/eudemo/eudemo/equilibria/_designer.py
+++ b/eudemo/eudemo/equilibria/_designer.py
@@ -244,9 +244,7 @@ class EquilibriumDesigner(Designer[Equilibrium]):
             lower=True,
             n=100,
         )
-        return UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, eq_targets, gamma=1e-8
-        )
+        return UnconstrainedTikhonovCurrentGradientCOP(eq, eq_targets, gamma=1e-8)
 
 
 def _make_tf_boundary(
@@ -804,9 +802,7 @@ class ReferenceFreeBoundaryEquilibriumDesigner(Designer[Equilibrium]):
             Optimisation problem
         """
         eq_targets = ReferenceConstraints(lcfs_shape, n_points)
-        return UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, eq_targets, gamma=gamma
-        )
+        return UnconstrainedTikhonovCurrentGradientCOP(eq, eq_targets, gamma=gamma)
 
     def _update_params_from_eq(self, eq: Equilibrium):
         self.params.update_values(plasma_data(eq), source=type(self).__name__)

--- a/examples/design/optimised_reactor.ex.py
+++ b/examples/design/optimised_reactor.ex.py
@@ -188,7 +188,7 @@ def ref_eq(R_0, A) -> Equilibrium:  # noqa: D103
         tolerance=1e-4,  # [T]
     )
     current_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-        coilset, eq, MagneticConstraintSet([isoflux, x_point]), gamma=1e-7
+        eq, MagneticConstraintSet([isoflux, x_point]), gamma=1e-7
     )
     diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
     program = PicardIterator(

--- a/examples/equilibria/coilset_opt_problem_tutorial.ex.py
+++ b/examples/equilibria/coilset_opt_problem_tutorial.ex.py
@@ -291,7 +291,7 @@ magnetic_targets = MagneticConstraintSet([lcfs_isoflux, legs_isoflux])
 # %%
 
 unconstrained_cop = UnconstrainedTikhonovCurrentGradientCOP(
-    coilset, eq, magnetic_targets, gamma=1e-8
+    eq, magnetic_targets, gamma=1e-8
 )
 unconstrained_iterator = PicardIterator(
     eq,

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -293,7 +293,6 @@ x_point = FieldNullConstraint(
 )
 
 ref_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-    reference_eq.coilset,
     reference_eq,
     MagneticConstraintSet([isoflux, x_point]),
     gamma=1e-7,

--- a/examples/equilibria/quick_look_at_example_coilsets.ex.py
+++ b/examples/equilibria/quick_look_at_example_coilsets.ex.py
@@ -116,5 +116,3 @@ print(new_mastu_coils)
 print("DEMO DN")
 print("------")
 print(new_demo_dn_coils)
-
-# %%

--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -240,7 +240,7 @@ x_point = FieldNullConstraint(
 
 # %%
 current_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-    coilset, eq, MagneticConstraintSet([isoflux, x_point]), gamma=1e-7
+    eq, MagneticConstraintSet([isoflux, x_point]), gamma=1e-7
 )
 diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 program = PicardIterator(
@@ -290,7 +290,7 @@ current_opt_problem = TikhonovCurrentCOP(
     opt_algorithm="SLSQP",
     opt_conditions={"max_eval": 2000, "ftol_rel": 1e-6},
     opt_parameters={},
-    max_currents=coilset.get_max_current(0.0),
+    max_currents=eq.coilset.get_max_current(0.0),
     constraints=[x_point, field_constraints, force_constraints],
 )
 program = PicardIterator(
@@ -317,7 +317,6 @@ program()
 
 # %%
 minimal_current_eq = deepcopy(eq)
-minimal_current_coilset = deepcopy(coilset)
 minimal_current_opt_problem = MinimalCurrentCOP(
     minimal_current_eq,
     opt_algorithm="SLSQP",
@@ -335,8 +334,8 @@ program = PicardIterator(
 )
 program()
 
-control_coils = coilset.get_control_coils()
-min_control_coils = minimal_current_coilset.get_control_coils()
+control_coils = eq.coilset.get_control_coils()
+min_control_coils = minimal_current_eq.coilset.get_control_coils()
 
 print(
     "Total currents from minimal error optimisation problem:"
@@ -403,7 +402,7 @@ current_opt_problem_sof = TikhonovCurrentCOP(
     opt_algorithm="SLSQP",
     opt_conditions={"max_eval": 2000, "ftol_rel": 1e-6, "xtol_rel": 1e-6},
     opt_parameters={},
-    max_currents=coilset.get_max_current(I_p),
+    max_currents=sof.coilset.get_max_current(I_p),
     constraints=[sof_psi_boundary, x_point, field_constraints, force_constraints],
 )
 
@@ -414,7 +413,7 @@ current_opt_problem_eof = TikhonovCurrentCOP(
     opt_algorithm="SLSQP",
     opt_conditions={"max_eval": 5000, "ftol_rel": 1e-6, "xtol_rel": 1e-6},
     opt_parameters={},
-    max_currents=coilset.get_max_current(I_p),
+    max_currents=eof.coilset.get_max_current(I_p),
     constraints=[eof_psi_boundary, x_point, field_constraints, force_constraints],
 )
 
@@ -445,12 +444,11 @@ current_opt_problem_eof = TikhonovCurrentCOP(
 # coil regions, but demonstrates the principle with acceptable run-times.
 
 # %%
-# We'll store these so that we can look at them again later
-old_coilset = deepcopy(coilset)
+# We'll store this so that we can look at them again later
 old_eq = deepcopy(eq)
 
 region_interpolators = {}
-pf_coils = coilset.get_coiltype("PF")
+pf_coils = eq.coilset.get_coiltype("PF")
 for x, z, name in zip(pf_coils.x, pf_coils.z, pf_coils.name, strict=False):
     region = make_polygon(
         {"x": [x - 1, x + 1, x + 1, x - 1], "z": [z - 1, z - 1, z + 1, z + 1]},
@@ -461,7 +459,7 @@ for x, z, name in zip(pf_coils.x, pf_coils.z, pf_coils.name, strict=False):
 position_mapper = PositionMapper(region_interpolators)
 
 position_opt_problem = PulsedNestedPositionCOP(
-    coilset,
+    eq.coilset,
     position_mapper,
     sub_opt_problems=[current_opt_problem_sof, current_opt_problem_eof],
     opt_algorithm="COBYLA",
@@ -538,7 +536,7 @@ program()
 
 # %%
 f, ax = plt.subplots()
-x_old, z_old = old_coilset.position
+x_old, z_old = old_eq.coilset.position
 x_new, z_new = sof.coilset.position
 plot_coordinates(old_eq.get_LCFS(), ax=ax, edgecolor="b", fill=False)
 plot_coordinates(sof.get_LCFS(), ax=ax, edgecolor="r", fill=False)
@@ -561,7 +559,7 @@ plt.show()
 f, (ax_1, ax_2, ax_3) = plt.subplots(1, 3)
 
 old_eq.plot(ax=ax_1)
-old_coilset.plot(ax=ax_1, label=True)
+old_eq.coilset.plot(ax=ax_1, label=True)
 
 sof.plot(ax=ax_2)
 sof.coilset.plot(ax=ax_2, label=True)

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -572,14 +572,10 @@ class TestCoilSet:
         np.testing.assert_allclose(coilset.get_max_current(), [np.inf, np.inf, np.inf])
 
     def test_get_position_optimisable_coils(self):
-        all_c_opt_coils = [
-            c.name for c in self.coilset_w_sc.get_position_optimisable_coils()
-        ]
-        pf1_c_opt_coils = [
-            c.name for c in self.coilset_w_sc.get_position_optimisable_coils(["PF_1"])
-        ]
-        assert all_c_opt_coils == ["PF_1", "PF_2"]
-        assert pf1_c_opt_coils == ["PF_1"]
+        all_c_opt_coils = self.coilset_w_sc.get_position_optimisable_coils()
+        pf1_c_opt_coils = self.coilset_w_sc.get_position_optimisable_coils(["PF_1"])
+        assert all_c_opt_coils.name == ["PF_1", "PF_2"]
+        assert pf1_c_opt_coils.name == ["PF_1"]
 
         assert self.coilset_w_sc.n_position_optimisable_coils == 2
 

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -622,7 +622,7 @@ class TestCoilSetSymmetry:
         ],
     )
     def test_symmetry_check(self, coilset, is_sym):
-        assert check_coilset_symmetric(coilset) is is_sym
+        assert check_coilset_symmetric(coilset, rtol=1e-5) is is_sym
 
     @pytest.mark.parametrize(
         ("coilset", "n_coils", "n_sym_coils", "n_sing_coils"),

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -61,9 +61,7 @@ class TestFields:
 
         targets = MagneticConstraintSet([isoflux, x_point])
 
-        opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, targets, gamma=1e-8
-        )
+        opt_problem = UnconstrainedTikhonovCurrentGradientCOP(eq, targets, gamma=1e-8)
 
         program = PicardIterator(eq, opt_problem, relaxation=0.1)
         program()
@@ -265,7 +263,7 @@ class TestSolveEquilibrium:
         )
         eq = Equilibrium(deepcopy(self.coilset), self.grid, deepcopy(profiles))
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, self.targets, gamma=1e-8
+            eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
             eq,
@@ -288,7 +286,7 @@ class TestSolveEquilibrium:
         )
         eq = Equilibrium(deepcopy(self.coilset), self.grid, deepcopy(profiles))
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, self.targets, gamma=1e-8
+            eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
             eq,
@@ -323,7 +321,7 @@ class TestSolveEquilibrium:
             o_point_fallback=o_point_fallback,
         )
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, self.targets, gamma=1e-8
+            eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
             eq,

--- a/tests/equilibria/test_optimiser.py
+++ b/tests/equilibria/test_optimiser.py
@@ -186,9 +186,9 @@ class TestCoilsetOptimiser:
             coilset_opt_state.zs,
             coilset_opt_state.currents,
         )
-        x += 1.1
-        z += 0.6
-        currents += 0.99
+        x = x + 1.1  # noqa: PLR6104
+        z = z + 0.6  # noqa: PLR6104
+        currents = currents + 0.99  # noqa: PLR6104
         # Update
         self.optimiser_partial.coilset.set_optimisation_state(
             currents,
@@ -223,7 +223,6 @@ class TestCoilsetOptimiser:
         assert n_control_currents == len(coilset_current_limits)
 
         optimiser_current_bounds = self.optimiser_partial.get_current_bounds(
-            self.optimiser_partial.coilset,
             user_max_current,
             self.optimiser_partial.scale,
         )
@@ -249,15 +248,13 @@ class TestCoilsetOptimiser:
         self.optimiser_sym.update_magnetic_constraints(I_not_dI=True, fixed_coils=False)
 
         eq_constraints_none, ineq_constraints_none = (
-            self.optimiser_none._make_numerical_constraints(self.optimiser_none.coilset)
+            self.optimiser_none._make_numerical_constraints()
         )
         eq_constraints_part, ineq_constraints_part = (
-            self.optimiser_partial._make_numerical_constraints(
-                self.optimiser_partial.coilset
-            )
+            self.optimiser_partial._make_numerical_constraints()
         )
         eq_constraints_sym, ineq_constraints_sym = (
-            self.optimiser_sym._make_numerical_constraints(self.optimiser_sym.coilset)
+            self.optimiser_sym._make_numerical_constraints()
         )
 
         # make sure things make sense

--- a/tests/equilibria/test_st_equilibrium.py
+++ b/tests/equilibria/test_st_equilibrium.py
@@ -187,7 +187,7 @@ class TestSTEquilibrium:
             coilset, grid, self.profiles, force_symmetry=True, psi=initial_psi
         )
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            eq.coilset, eq, constraint_set, gamma=build_tweaks["tikhonov_gamma"]
+            eq, constraint_set, gamma=build_tweaks["tikhonov_gamma"]
         )
 
         criterion = DudsonConvergence(build_tweaks["fbe_convergence_crit"])
@@ -281,7 +281,7 @@ class TestSTEquilibrium:
             coilset_temp, grid, self.profiles, force_symmetry=True, psi=None
         )
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
-            coilset, eq, constraint_set, gamma=tikhonov_gamma
+            eq, constraint_set, gamma=tikhonov_gamma
         )
         opt_problem.optimise()
 


### PR DESCRIPTION
## Linked Issues

Closes #3993

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`

## Notes

Name | Details | User
-- | -- | --
control | property:   returns control coil names   setter: sets   control coil names | Set or change   the coils that are being actively controlled before an optimisation.
n_control | property:   returns number of control coils |  
remove_coil | Removes named   coil(s), will remove in pairs for symmetric circuits. |  
get_control_coils | Returns a   coilset of only control coils | Post optimisation   analysis,   Plotting,   Designers,   Spherical and   Toroidal Harmonic Approximations,   CoilFieldConstraints   and CoilForceConstraints (neither are set up for Circuits, so can’t use the   current optimisable coil functions)
_sum | Gets coil   responses, optionally for just control coils |  
from_group_vecs | All coils   that are not implicitly passive to control coils. |  
get_optimisation_state | Get the state   of the CoilSet for optimisation (inc. CC) |  
set_optimisation_state | Set the state   of the CoilSet, post optimisation (in. CC) |  
current_optimisable_coil_names | returns coil   names, will return the primary coil name if a Circuit (coils with shared   current) is found (inc. CC) |  
n_current_optimisable_coils | total number   of coils that can be used in a current optimisation (inc. CC) |  
all_current_optimisable_coils | list of coils   that can be used in a current optimisation (inc. CC) |  
get_current_optimisable_coils | Returns a   coilset of coils that can be used in a current optimisation (inc. CC)   Optional: from   an inputted list of coil names |  
_opt_currents_inds | indices of   the coils that can be current optimised (inc CC) |  
_opt_currents_expand_mat | currents   expansion matrix   for current optimisable   coils (inc. CC), used when dealing with Circuits |  
_opt_currents | property:   returns currents for the current optimisable coils   setter: sets currents   for the current optimisable coils   (inc. CC) |  
position_optimisable_coil_names | returns coil   names, will return the primary coil name if a SymmetricCircuit (coils with   shared current and symmetric position) is found (in. CC) |  
n_position_optimisable_coils | total number   of coils that can be used in a position optimisation (inc. CC) |  
all_position_optimisable_coils | list of coils   that can be used in a position optimisation (inc. CC) |  
get_position_optimisable_coils | Returns a   coilset of coils that can be used in a position optimisation (inc. CC)   Optional: from   an inputted list of coil names |  
_get_opt_positions | positions of   the position optimisable coils (inc. CC) |  
_set_opt_positions | Set the positions   of the position optimisable coils (inc. CC) |  
