### PR TITLE
👷 Enable py3.12 process CI tests, remove py3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         with-process: ["v3.2.1", "process_disabled"]
         include:
           - os: "ubuntu-latest"
-            python-version: "3.12"
+            python-version: "3.10"
             with-process: "process_disabled"
 
       fail-fast: false

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         process-version: ["v3.2.1"]
         include:
           - os: "ubuntu-latest"
-            python-version: "3.12"
+            python-version: "3.10"
             process-version: "process_disabled"
 
       fail-fast: false


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
python 3.10 is being deprecated. The CI will continue to be run until something major breaks. At that point we will drop 3.10 support completely or when security updates finish for 3.10 next year which ever happens first

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
