### PR TITLE
Beta_p profile classes: use full calculation rather than approximation

### DIFF
--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -28,13 +28,12 @@ from bluemira.equilibria.error import EquilibriaError
 from bluemira.equilibria.find import (
     OPointCalcOptions,
     Opoint,
-    find_LCFS_separatrix,
     in_plasma,
     in_zone,
     o_point_fallback_calculator,
 )
 from bluemira.equilibria.grid import integrate_dx_dz
-from bluemira.equilibria.physics import _calc_beta_p, _calc_beta_p_approx
+from bluemira.equilibria.physics import _calc_beta_p
 from bluemira.equilibria.plotting import ProfilePlotter
 
 if TYPE_CHECKING:
@@ -599,11 +598,8 @@ class BetaIpProfile(Profile):
         R_0: float,
         B_0: float,
         shape: ShapeFunction | None = None,
-        *,
-        use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
         self.betap = betap
-        self.use_approx_beta_p = use_approx_beta_p
         self.I_p = I_p
         self._fvac = R_0 * B_0
         self.R_0 = R_0
@@ -672,34 +668,25 @@ class BetaIpProfile(Profile):
 
         if x_points != []:  # NOTE: Necessary un-pythonic formulation
             # More accurate beta_p constraint calculation
-            # This is the Freidberg approximation
-            lcfs, _ = find_LCFS_separatrix(
-                x, z, psi, o_points=o_points, x_points=x_points
+            psi_func = RectBivariateSpline(x[:, 0], z[0, :], psi)
+
+            def _Bx_func(x, z):
+                return -psi_func(x, z, dy=1, grid=False) / x
+
+            def _Bz_func(x, z):
+                return psi_func(x, z, dx=1, grid=False) / x
+
+            Bx = _Bx_func(x, z)
+            Bz = _Bz_func(x, z)
+            Bp = np.hypot(Bx, Bz)
+            beta_p_actual = _calc_beta_p(
+                pfunc,
+                Bp,
+                mask,
+                x,
+                self.dx,
+                self.dz,
             )
-            if self.use_approx_beta_p:
-                beta_p_actual = _calc_beta_p_approx(
-                    pfunc, lcfs, x, self.dx, self.dz, self.I_p
-                )
-            else:
-                psi_func = RectBivariateSpline(x[:, 0], z[0, :], psi)
-
-                def _Bx_func(x, z):
-                    return -psi_func(x, z, dy=1, grid=False) / x
-
-                def _Bz_func(x, z):
-                    return psi_func(x, z, dx=1, grid=False) / x
-
-                Bx = _Bx_func(x, z)
-                Bz = _Bz_func(x, z)
-                Bp = np.hypot(Bx, Bz)
-                beta_p_actual = _calc_beta_p(
-                    pfunc,
-                    Bp,
-                    mask,
-                    x,
-                    self.dx,
-                    self.dz,
-                )
 
             lambd_beta0 = -self.betap / beta_p_actual * self.R_0
 
@@ -774,11 +761,13 @@ class BetaLiIpProfile(BetaIpProfile):
         shape: ShapeFunction | None = None,
         li_rel_tol: float = 0.015,
         li_min_iter: int = 5,
-        *,
-        use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
         super().__init__(
-            betap, I_p, R_0, B_0, shape=shape, use_approx_beta_p=use_approx_beta_p
+            betap,
+            I_p,
+            R_0,
+            B_0,
+            shape=shape,
         )
         self._l_i_target = l_i
         self._l_i_rel_tol = li_rel_tol

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -599,6 +599,7 @@ class BetaIpProfile(Profile):
         R_0: float,
         B_0: float,
         shape: ShapeFunction | None = None,
+        *,
         use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
         self.betap = betap
@@ -773,6 +774,7 @@ class BetaLiIpProfile(BetaIpProfile):
         shape: ShapeFunction | None = None,
         li_rel_tol: float = 0.015,
         li_min_iter: int = 5,
+        *,
         use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
         super().__init__(

--- a/bluemira/equilibria/profiles.py
+++ b/bluemira/equilibria/profiles.py
@@ -18,7 +18,7 @@ import numba as nb
 import numpy as np
 from eqdsk import EQDSKInterface
 from scipy.integrate import quad
-from scipy.interpolate import interp1d
+from scipy.interpolate import RectBivariateSpline, interp1d
 from scipy.optimize import curve_fit
 
 from bluemira.base.constants import MU_0
@@ -34,7 +34,7 @@ from bluemira.equilibria.find import (
     o_point_fallback_calculator,
 )
 from bluemira.equilibria.grid import integrate_dx_dz
-from bluemira.equilibria.physics import _calc_beta_p_approx
+from bluemira.equilibria.physics import _calc_beta_p, _calc_beta_p_approx
 from bluemira.equilibria.plotting import ProfilePlotter
 
 if TYPE_CHECKING:
@@ -599,8 +599,10 @@ class BetaIpProfile(Profile):
         R_0: float,
         B_0: float,
         shape: ShapeFunction | None = None,
+        use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
         self.betap = betap
+        self.use_approx_beta_p = use_approx_beta_p
         self.I_p = I_p
         self._fvac = R_0 * B_0
         self.R_0 = R_0
@@ -673,9 +675,31 @@ class BetaIpProfile(Profile):
             lcfs, _ = find_LCFS_separatrix(
                 x, z, psi, o_points=o_points, x_points=x_points
             )
-            beta_p_actual = _calc_beta_p_approx(
-                pfunc, lcfs, x, self.dx, self.dz, self.I_p
-            )
+            if self.use_approx_beta_p:
+                beta_p_actual = _calc_beta_p_approx(
+                    pfunc, lcfs, x, self.dx, self.dz, self.I_p
+                )
+            else:
+                psi_func = RectBivariateSpline(x[:, 0], z[0, :], psi)
+
+                def _Bx_func(x, z):
+                    return -psi_func(x, z, dy=1, grid=False) / x
+
+                def _Bz_func(x, z):
+                    return psi_func(x, z, dx=1, grid=False) / x
+
+                Bx = _Bx_func(x, z)
+                Bz = _Bz_func(x, z)
+                Bp = np.hypot(Bx, Bz)
+                beta_p_actual = _calc_beta_p(
+                    pfunc,
+                    Bp,
+                    mask,
+                    x,
+                    self.dx,
+                    self.dz,
+                )
+
             lambd_beta0 = -self.betap / beta_p_actual * self.R_0
 
         else:
@@ -749,8 +773,11 @@ class BetaLiIpProfile(BetaIpProfile):
         shape: ShapeFunction | None = None,
         li_rel_tol: float = 0.015,
         li_min_iter: int = 5,
+        use_approx_beta_p: bool = False,  # noqa: FBT001, FBT002
     ):
-        super().__init__(betap, I_p, R_0, B_0, shape=shape)
+        super().__init__(
+            betap, I_p, R_0, B_0, shape=shape, use_approx_beta_p=use_approx_beta_p
+        )
         self._l_i_target = l_i
         self._l_i_rel_tol = li_rel_tol
         self._l_i_min_iter = li_min_iter

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -29,14 +29,12 @@ Attempt at recreating the EU-DEMO 2017 reference equilibria from a known coilset
 # # EU-DEMO 2017 reference breakdown and equilibrium benchmark
 
 # %%
-import contextlib
 import json
 from copy import deepcopy
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
-from IPython import get_ipython
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_print
@@ -79,8 +77,8 @@ from bluemira.equilibria.solve import PicardIterator
 # %%
 plot_defaults()
 
-with contextlib.suppress(AttributeError):
-    get_ipython().run_line_magic("matplotlib", "qt")
+# with contextlib.suppress(AttributeError):
+#    get_ipython().run_line_magic("matplotlib", "qt")
 
 
 path = get_bluemira_path("equilibria", subfolder="examples")
@@ -247,7 +245,15 @@ profiles = CustomProfile(
 shape = DoublePowerFunc([2, 1])
 profiles = BetaIpProfile(beta_p, I_p, R_0, B_0, shape=shape)
 profiles = BetaLiIpProfile(
-    beta_p, l_i, I_p, R_0, B_0, shape=shape, li_min_iter=0, li_rel_tol=0.001
+    beta_p,
+    l_i,
+    I_p,
+    R_0,
+    B_0,
+    shape=shape,
+    li_min_iter=0,
+    li_rel_tol=0.001,
+    use_approx_beta_p=True,
 )
 
 

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -29,12 +29,14 @@ Attempt at recreating the EU-DEMO 2017 reference equilibria from a known coilset
 # # EU-DEMO 2017 reference breakdown and equilibrium benchmark
 
 # %%
+import contextlib
 import json
 from copy import deepcopy
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from IPython import get_ipython
 
 from bluemira.base.file import get_bluemira_path
 from bluemira.base.look_and_feel import bluemira_print
@@ -77,8 +79,8 @@ from bluemira.equilibria.solve import PicardIterator
 # %%
 plot_defaults()
 
-# with contextlib.suppress(AttributeError):
-#    get_ipython().run_line_magic("matplotlib", "qt")
+with contextlib.suppress(AttributeError):
+    get_ipython().run_line_magic("matplotlib", "qt")
 
 
 path = get_bluemira_path("equilibria", subfolder="examples")

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -255,7 +255,6 @@ profiles = BetaLiIpProfile(
     shape=shape,
     li_min_iter=0,
     li_rel_tol=0.001,
-    use_approx_beta_p=True,
 )
 
 

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -278,15 +278,13 @@ class TestSolveEquilibrium:
         assert program.check_converged()
 
     @pytest.mark.parametrize("shape", shape_funcs)
-    @pytest.mark.parametrize("use_approx_beta_p", [True, False])
-    def test_betaip_profile(self, shape, use_approx_beta_p):
+    def test_betaip_profile(self, shape):
         profiles = BetaIpProfile(
             self.beta_p,
             self.I_p,
             self.R_0,
             self.B_0,
             shape=shape,
-            use_approx_beta_p=use_approx_beta_p,
         )
         eq = Equilibrium(deepcopy(self.coilset), self.grid, deepcopy(profiles))
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
@@ -306,8 +304,7 @@ class TestSolveEquilibrium:
         "o_point_fallback", [OPointCalcOptions.GRID_CENTRE, OPointCalcOptions.RAISE]
     )
     @pytest.mark.parametrize("shape", shape_funcs)
-    @pytest.mark.parametrize("use_approx_beta_p", [True, False])
-    def test_betapliip_profile(self, shape, o_point_fallback, use_approx_beta_p):
+    def test_betapliip_profile(self, shape, o_point_fallback):
         rel_tol = 0.015
         profiles = BetaLiIpProfile(
             self.beta_p,
@@ -318,7 +315,6 @@ class TestSolveEquilibrium:
             shape=shape,
             li_min_iter=0,
             li_rel_tol=rel_tol,
-            use_approx_beta_p=use_approx_beta_p,
         )
         eq = Equilibrium(
             deepcopy(self.coilset),

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -278,8 +278,16 @@ class TestSolveEquilibrium:
         assert program.check_converged()
 
     @pytest.mark.parametrize("shape", shape_funcs)
-    def test_betaip_profile(self, shape):
-        profiles = BetaIpProfile(self.beta_p, self.I_p, self.R_0, self.B_0, shape=shape)
+    @pytest.mark.parametrize("use_approx_beta_p", [True, False])
+    def test_betaip_profile(self, shape, use_approx_beta_p):
+        profiles = BetaIpProfile(
+            self.beta_p,
+            self.I_p,
+            self.R_0,
+            self.B_0,
+            shape=shape,
+            use_approx_beta_p=use_approx_beta_p,
+        )
         eq = Equilibrium(deepcopy(self.coilset), self.grid, deepcopy(profiles))
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
             eq.coilset, eq, self.targets, gamma=1e-8
@@ -298,7 +306,8 @@ class TestSolveEquilibrium:
         "o_point_fallback", [OPointCalcOptions.GRID_CENTRE, OPointCalcOptions.RAISE]
     )
     @pytest.mark.parametrize("shape", shape_funcs)
-    def test_betapliip_profile(self, shape, o_point_fallback):
+    @pytest.mark.parametrize("use_approx_beta_p", [True, False])
+    def test_betapliip_profile(self, shape, o_point_fallback, use_approx_beta_p):
         rel_tol = 0.015
         profiles = BetaLiIpProfile(
             self.beta_p,
@@ -309,6 +318,7 @@ class TestSolveEquilibrium:
             shape=shape,
             li_min_iter=0,
             li_rel_tol=rel_tol,
+            use_approx_beta_p=use_approx_beta_p,
         )
         eq = Equilibrium(
             deepcopy(self.coilset),

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -332,7 +332,7 @@ class TestSolveEquilibrium:
         program = PicardIterator(
             eq,
             opt_problem,
-            convergence=DudsonConvergence(1e-1),
+            convergence=DudsonConvergence(1e-2),
             fixed_coils=True,
             relaxation=0.2,
         )


### PR DESCRIPTION
## Linked Issues

Closes #4098

## Description

Added the full beta_p calculation in the profile class (previously used an approx. that was not good for high elongation plasmas).

~~Now we use the full calculation as default. Option to use the approximation is still available (although time saved is not likely to be significant)~~. -> Removed approximation from the profile class calculations as time saved not significant. 

beta_p calculation time for three test equilibria:

Device | Grid Size | Full calc time (s) | Approx. calc time (s)
-- | -- |-- | --
STEP-like | 129x257  | 0.10 | 0.06
STEP-like | 65x65 | 0.5 | 0.03
MAST-U-like | 165x165  | 0.07 | 0.04
DEMO | 65x65 | 0.01 | 0.01

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
