### PR TITLE
Change algorithm used for EOF optimisation in single_null.ex.py 

### DIFF
--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -246,6 +246,7 @@ diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 program = PicardIterator(
     eq,
     current_opt_problem,
+    convergence=DudsonConvergence(1e-3),
     fixed_coils=True,
     relaxation=0.2,
     diagnostic_plotting=diagnostic_plotting,
@@ -410,7 +411,7 @@ current_opt_problem_eof = TikhonovCurrentCOP(
     eof,
     targets=MagneticConstraintSet([isoflux]),
     gamma=1e-12,
-    opt_algorithm="COBYLA",
+    opt_algorithm="SLSQP",
     opt_conditions={"max_eval": 5000, "ftol_rel": 1e-6, "xtol_rel": 1e-6},
     opt_parameters={},
     max_currents=coilset.get_max_current(I_p),


### PR DESCRIPTION
## Linked Issues

Closes #4131

## Description

Use SLSQP rather than COBLYA, EOF optimisation was unsuccessful with COBYLA. 
Both SOF and EOF optimisation problems will now use the same algorithm. 

## Checklist

I confirm that I have completed the following checks:

- [X] Tests run locally and pass `pytest tests --reactor`
- [X] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [X] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
