### PR TITLE
corrected mesh import from XDMF with dolfinx v0.9

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -58,6 +58,5 @@ jobs:
             -e 'plasmod_example' \
             -e 'equilibria/fem_fixed_boundary' \
             -e 'codes/ext_code_script' \
-            -e 'mesh/mesh_tutorial' \
             -e 'radiation_transport/run_cad_neutronics' \
             ${RUN_DAGMC_EX}

--- a/bluemira/mesh/tools.py
+++ b/bluemira/mesh/tools.py
@@ -15,11 +15,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import meshio
 import numpy as np
-from dolfinx.io import XDMFFile
-from dolfinx.mesh import Mesh
+import pyvista
+from dolfinx import io
+from dolfinx.plot import vtk_mesh
+
+if TYPE_CHECKING:
+    from dolfinx.mesh import Mesh
+
+from mpi4py import MPI
 from tabulate import tabulate
 
 from bluemira.base.look_and_feel import bluemira_debug, bluemira_warn
@@ -41,6 +48,30 @@ GMSH_BE = "gmsh:bounding_entities"
 DOMAIN_SUFFIX = "domain.xdmf"
 BOUNDARY_SUFFIX = "boundaries.xdmf"
 LINKFILE_SUFFIX = "linkfile.json"
+
+
+def plot_dolfinx_mesh(mesh, *, show: bool = True):
+    """
+    Plots the mesh structure, including nodes and faces.
+
+    Parameters
+    ----------
+    show : bool, optional
+        Flag to display the plot immediately (default is True).
+
+    Returns
+    -------
+    pyvista.Plotter
+        The PyVista plotter object with the mesh visualization.
+    """
+    plotter = pyvista.Plotter()
+    tdim = mesh.topology.dim
+    grid = pyvista.UnstructuredGrid(*vtk_mesh(mesh, tdim))
+    plotter.add_mesh(grid, show_edges=True)
+    plotter.view_xy()
+    if show:
+        plotter.show()
+    return plotter
 
 
 def msh_to_xdmf(
@@ -92,36 +123,37 @@ def import_mesh(
     file_prefix: str = "mesh", *, subdomains: bool = False, directory: str = "."
 ) -> tuple[Mesh, Mesh, Mesh, dict]:
     """
-    Import a dolfin mesh.
+    Import a Dolfinx v0.9 mesh and optional boundary/subdomain tags.
 
     Parameters
     ----------
     file_prefix:
-        File prefix to use when importing a mesh (defaults to 'mesh')
+        File prefix for the mesh (defaults to 'mesh')
     subdomains:
-        Whether or not to subdomains are present (defaults to False)
+        Whether subdomains are present (defaults to False)
     directory:
-        Directory in which the MSH file and XDMF files exist
+        Directory containing the mesh and tag files
 
     Returns
     -------
     mesh:
         Dolfin Mesh object containing the domain
     boundaries_mf:
-        Dolfin MeshFunctionSizet object containing the geometry
+        Dolfin MeshFunctionSizet object containing the boundaries
     subdomains_mf:
-        Dolfin MeshFunctionSizet object containing the geometry
+        Dolfin MeshFunctionSizet object containing the subdomains
     link_dict:
         Link dictionary between MSH and XDMF objects
 
     Raises
     ------
     FileNotFoundError
-        no mesh file(s) found
+        If required mesh files are missing
     """
     domain_file = Path(directory, f"{file_prefix}_{DOMAIN_SUFFIX}")
     boundary_file = Path(directory, f"{file_prefix}_{BOUNDARY_SUFFIX}")
     link_file = Path(directory, f"{file_prefix}_{LINKFILE_SUFFIX}")
+
     files = [domain_file, boundary_file, link_file]
     exists = [file.exists() for file in files]
 
@@ -131,25 +163,47 @@ def import_mesh(
         ])
         raise FileNotFoundError(f"No mesh file(s) found:\n {msg}")
 
-    mesh = Mesh()
+    # --- Read mesh
+    with io.XDMFFile(MPI.COMM_WORLD, domain_file.as_posix(), "r") as xdmf:
+        mesh = xdmf.read_mesh(name="Grid")
+        [mesh.topology.create_entities(i) for i in range(mesh.topology.dim)]
 
-    with XDMFFile(domain_file.as_posix()) as file:
-        file.read(mesh)
-
-    boundaries_mvc = None
-
-    with XDMFFile(boundary_file.as_posix()) as file:
-        file.read(boundaries_mvc, "boundaries")
-
+    # --- Read boundaries (if any)
     boundaries_mf = None
+    try:
+        with io.XDMFFile(MPI.COMM_WORLD, boundary_file.as_posix(), "r") as xdmf:
+            for name in ["boundaries", "FacetTags", "Grid", "boundaries", None]:
+                try:
+                    boundaries_mf = (
+                        xdmf.read_meshtags(mesh, name=name)
+                        if name is not None
+                        else xdmf.read_meshtags(mesh)
+                    )
+                    break
+                except RuntimeError:
+                    continue
+    except (OSError, RuntimeError):
+        boundaries_mf = None
 
+    # --- Read subdomains (optional)
+    subdomains_mf = None
     if subdomains:
-        subdomains_mvc = None
-        with XDMFFile(domain_file.as_posix()) as file:
-            file.read(subdomains_mvc, "subdomains")
-    else:
-        subdomains_mf = None
+        try:
+            with io.XDMFFile(MPI.COMM_WORLD, domain_file.as_posix(), "r") as xdmf:
+                for name in ["subdomains", "CellTags", "Grid", None]:
+                    try:
+                        subdomains_mf = (
+                            xdmf.read_meshtags(mesh, name=name)
+                            if name is not None
+                            else xdmf.read_meshtags(mesh)
+                        )
+                        break
+                    except RuntimeError:
+                        continue
+        except (OSError, RuntimeError):
+            subdomains_mf = None
 
+    # --- Read link dictionary
     with open(link_file) as file:
         link_dict = json.load(file)
 

--- a/examples/mesh/mesh_tutorial.ex.py
+++ b/examples/mesh/mesh_tutorial.ex.py
@@ -38,9 +38,6 @@ Some examples of using bluemira mesh module.
 # %%
 from pathlib import Path
 
-import dolfin
-import matplotlib.pyplot as plt
-
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.file import get_bluemira_path
 from bluemira.base.logs import set_log_level
@@ -49,7 +46,7 @@ from bluemira.geometry import tools
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.wire import BluemiraWire
 from bluemira.mesh import meshing
-from bluemira.mesh.tools import import_mesh, msh_to_xdmf
+from bluemira.mesh.tools import import_mesh, msh_to_xdmf, plot_dolfinx_mesh
 
 set_log_level("DEBUG")
 
@@ -117,7 +114,9 @@ c_coil_out = PhysicalComponent(name="coil_out", shape=coil_out, parent=c_coil)
 # Initialise and create the mesh
 
 # %%
-directory = get_bluemira_path("", subfolder="generated_data")
+directory = Path(get_bluemira_path("", subfolder="generated_data/"))
+directory = directory.joinpath("examples", "mesh_tutorial")
+directory.mkdir(parents=True, exist_ok=True)
 
 meshfiles = [Path(directory, p).as_posix() for p in ["Mesh.geo_unrolled", "Mesh.msh"]]
 m = meshing.Mesh(meshfile=meshfiles)
@@ -140,7 +139,7 @@ mesh, boundaries, subdomains, labels = import_mesh(
     directory=directory,
     subdomains=True,
 )
-dolfin.plot(mesh)
-plt.show()
 
-print(mesh.coordinates())
+plot_dolfinx_mesh(mesh)
+
+print(mesh.geometry.x)

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import pyvista as pv
 
 from bluemira.base.file import get_bluemira_path
 
@@ -124,6 +125,7 @@ def run_examples(
         # Disable CAD viewer by mocking out FreeCAD API's displayer.
         # Note that if we use a new CAD backend, this must be changed.
         mock.patch("bluemira.codes._freecadapi.show_cad").start()
+        mock.patch.object(pv.Plotter, "show", return_value=None).start()
 
     failed = []
     for example in example_files:

--- a/tests/mesh/test_meshing.py
+++ b/tests/mesh/test_meshing.py
@@ -41,7 +41,7 @@ class TestMeshing:
             subdomains=True,
         )
 
-        arr = boundaries.array()
+        arr = boundaries.values
         assert (arr == labels["poly"]).sum() == nodes_num
 
     @pytest.mark.xfail
@@ -70,5 +70,5 @@ class TestMeshing:
             subdomains=True,
         )
 
-        arr = boundaries.array()
+        arr = boundaries.values
         assert (arr == labels["poly"]).sum() == nodes_num * 2


### PR DESCRIPTION
## Linked Issues

Closes #3811 

## Description

This PR updates the import_mesh method in bluemira/mesh/tools.py to ensure compatibility with Dolfinx versions ≥ 0.9.0.
Note: mesh example and tests should be re-enabled in the CI pipeline (not done).

## Interface Changes

no interface changes

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
