### PR TITLE
Constructor types for Geometry parameterisations

### DIFF
--- a/bluemira/equilibria/shapes.py
+++ b/bluemira/equilibria/shapes.py
@@ -10,6 +10,7 @@ Useful parameterisations for plasma flux surface shapes.
 
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import TypedDict
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +19,12 @@ from bluemira.geometry.coordinates import Coordinates, interpolate_points
 from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.tools import interpolate_bspline
 from bluemira.geometry.wire import BluemiraWire
-from bluemira.utilities.opt_variables import OptVariable, OptVariablesFrame, VarDictT, ov
+from bluemira.utilities.opt_variables import (
+    OptVarVarDictValueT,
+    OptVariable,
+    OptVariablesFrame,
+    ov,
+)
 
 __all__ = [
     "CunninghamLCFS",
@@ -178,6 +184,16 @@ class ZakharovLCFSOptVariables(OptVariablesFrame):
     )
 
 
+class ZakharovLCFSOptVarDictT(TypedDict, total=False):
+    """Typed Dict for ZakharovLCFSOptVariables"""
+
+    r_0: OptVarVarDictValueT
+    z_0: OptVarVarDictValueT
+    a: OptVarVarDictValueT
+    kappa: OptVarVarDictValueT
+    delta: OptVarVarDictValueT
+
+
 class ZakharovLCFS(GeometryParameterisation[ZakharovLCFSOptVariables]):
     """
     Zakharov last closed flux surface geometry parameterisation.
@@ -185,7 +201,7 @@ class ZakharovLCFS(GeometryParameterisation[ZakharovLCFSOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: ZakharovLCFSOptVarDictT | None = None):
         variables = ZakharovLCFSOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -294,6 +310,17 @@ class CunninghamLCFSOptVariables(OptVariablesFrame):
     )
 
 
+class CunninghamLCFSOptVarDictT(TypedDict, total=False):
+    """Typed Dict for CunninghamLCFSOptVariables"""
+
+    r_0: OptVarVarDictValueT
+    z_0: OptVarVarDictValueT
+    a: OptVarVarDictValueT
+    kappa: OptVarVarDictValueT
+    delta: OptVarVarDictValueT
+    delta2: OptVarVarDictValueT
+
+
 class CunninghamLCFS(GeometryParameterisation[CunninghamLCFSOptVariables]):
     """
     Cunningham last closed flux surface geometry parameterisation.
@@ -301,7 +328,7 @@ class CunninghamLCFS(GeometryParameterisation[CunninghamLCFSOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: CunninghamLCFSOptVarDictT | None = None):
         variables = CunninghamLCFSOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -411,6 +438,17 @@ class ManickamLCFSOptVariables(OptVariablesFrame):
     )
 
 
+class ManickamLCFSOptVarDictT(TypedDict, total=False):
+    """Typed Dict for ManickamLCFSOptVariables"""
+
+    r_0: OptVarVarDictValueT
+    z_0: OptVarVarDictValueT
+    a: OptVarVarDictValueT
+    kappa: OptVarVarDictValueT
+    delta: OptVarVarDictValueT
+    indent: OptVarVarDictValueT
+
+
 class ManickamLCFS(GeometryParameterisation[ManickamLCFSOptVariables]):
     """
     Manickam last closed flux surface geometry parameterisation.
@@ -418,7 +456,7 @@ class ManickamLCFS(GeometryParameterisation[ManickamLCFSOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: ManickamLCFSOptVarDictT | None = None):
         variables = ManickamLCFSOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -700,6 +738,19 @@ class KuiroukidisLCFSOptVariables(OptVariablesFrame):
     )
 
 
+class KuiroukidisLCFSOptVarDictT(TypedDict, total=False):
+    """Typed Dict for KuiroukidisLCFSOptVariables"""
+
+    r_0: OptVarVarDictValueT
+    z_0: OptVarVarDictValueT
+    a: OptVarVarDictValueT
+    kappa_u: OptVarVarDictValueT
+    kappa_l: OptVarVarDictValueT
+    delta_u: OptVarVarDictValueT
+    delta_l: OptVarVarDictValueT
+    n_power: OptVarVarDictValueT
+
+
 class KuiroukidisLCFS(GeometryParameterisation[KuiroukidisLCFSOptVariables]):
     """
     Kuiroukidis last closed flux surface geometry parameterisation (adjusted).
@@ -707,7 +758,7 @@ class KuiroukidisLCFS(GeometryParameterisation[KuiroukidisLCFSOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: KuiroukidisLCFSOptVarDictT | None = None):
         variables = KuiroukidisLCFSOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -1095,6 +1146,22 @@ class JohnerLCFSOptVariables(OptVariablesFrame):
     )
 
 
+class JohnerLCFSOptVarDictT(TypedDict, total=False):
+    """Typed Dict for JohnerLCFSOptVariables"""
+
+    r_0: OptVarVarDictValueT
+    z_0: OptVarVarDictValueT
+    a: OptVarVarDictValueT
+    kappa_u: OptVarVarDictValueT
+    kappa_l: OptVarVarDictValueT
+    delta_u: OptVarVarDictValueT
+    delta_l: OptVarVarDictValueT
+    phi_u_neg: OptVarVarDictValueT
+    phi_u_pos: OptVarVarDictValueT
+    phi_l_neg: OptVarVarDictValueT
+    phi_l_pos: OptVarVarDictValueT
+
+
 class JohnerLCFS(GeometryParameterisation[JohnerLCFSOptVariables]):
     """
     Johner last closed flux surface geometry parameterisation.
@@ -1102,7 +1169,7 @@ class JohnerLCFS(GeometryParameterisation[JohnerLCFSOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: JohnerLCFSOptVarDictT | None = None):
         variables = JohnerLCFSOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, TextIO, TypeVar
+from typing import TYPE_CHECKING, Generic, TextIO, TypeVar, TypedDict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -38,7 +38,12 @@ from bluemira.geometry.tools import (
     wire_closure,
 )
 from bluemira.geometry.wire import BluemiraWire
-from bluemira.utilities.opt_variables import OptVariable, OptVariablesFrame, VarDictT, ov
+from bluemira.utilities.opt_variables import (
+    OptVarVarDictValueT,
+    OptVariable,
+    OptVariablesFrame,
+    ov,
+)
 from bluemira.utilities.plot_tools import str_to_latex
 
 if TYPE_CHECKING:
@@ -528,6 +533,14 @@ class PrincetonDOptVariables(OptVariablesFrame):
     )
 
 
+class PrincetonDOptVarDictT(TypedDict, total=False):
+    """Typed Dict for PrincetonDOptVariables"""
+
+    x1: OptVarVarDictValueT
+    x2: OptVarVarDictValueT
+    dz: OptVarVarDictValueT
+
+
 class PrincetonD(GeometryParameterisation[PrincetonDOptVariables]):
     """
     Princeton D geometry parameterisation, with n_TF = ∞.
@@ -558,7 +571,7 @@ class PrincetonD(GeometryParameterisation[PrincetonDOptVariables]):
     __slots__ = ()
     n_ineq_constraints: int = 1
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: PrincetonDOptVarDictT | None = None):
         variables = PrincetonDOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -890,7 +903,7 @@ class PrincetonDDiscrete(PrincetonD):
 
     def __init__(
         self,
-        var_dict: VarDictT | None = None,
+        var_dict: PrincetonDOptVarDictT | None = None,
         n_TF: int | None = None,
         tf_wp_width: float | None = None,
         tf_wp_depth: float | None = None,
@@ -1026,6 +1039,18 @@ class TripleArcOptVaribles(OptVariablesFrame):
     )
 
 
+class TripleArcOptVarDictT(TypedDict, total=False):
+    """Typed Dict for TripleArcOptVaribles"""
+
+    x1: OptVarVarDictValueT
+    dz: OptVarVarDictValueT
+    sl: OptVarVarDictValueT
+    f1: OptVarVarDictValueT
+    f2: OptVarVarDictValueT
+    a1: OptVarVarDictValueT
+    a2: OptVarVarDictValueT
+
+
 class TripleArc(GeometryParameterisation[TripleArcOptVaribles]):
     """
     Triple-arc up-down symmetric geometry parameterisation.
@@ -1068,7 +1093,7 @@ class TripleArc(GeometryParameterisation[TripleArcOptVaribles]):
     __slots__ = ()
     n_ineq_constraints: int = 1
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: TripleArcOptVarDictT | None = None):
         variables = TripleArcOptVaribles()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -1285,6 +1310,23 @@ class SextupleArcOptVariables(OptVariablesFrame):
     )
 
 
+class SextupleArcOptVarDictT(TypedDict, total=False):
+    """Typed Dict for SextupleArcOptVariables"""
+
+    x1: OptVarVarDictValueT
+    z1: OptVarVarDictValueT
+    r1: OptVarVarDictValueT
+    r2: OptVarVarDictValueT
+    r3: OptVarVarDictValueT
+    r4: OptVarVarDictValueT
+    r5: OptVarVarDictValueT
+    a1: OptVarVarDictValueT
+    a2: OptVarVarDictValueT
+    a3: OptVarVarDictValueT
+    a4: OptVarVarDictValueT
+    a5: OptVarVarDictValueT
+
+
 def _project_centroid(
     xc: float, zc: float, xi: float, zi: float, ri: float
 ) -> tuple[float, float, npt.NDArray[np.float64]]:
@@ -1474,7 +1516,7 @@ class SextupleArc(GeometryParameterisation[SextupleArcOptVariables]):
     __slots__ = ()
     n_ineq_constraints: int = 1
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: SextupleArcOptVarDictT | None = None):
         variables = SextupleArcOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(variables)
@@ -1724,6 +1766,30 @@ class PolySplineOptVariables(OptVariablesFrame):
     )
 
 
+class PolySplineOptVarDictT(TypedDict, total=False):
+    """Typed Dict for PolySplineOptVariables"""
+
+    x1: OptVarVarDictValueT
+    x2: OptVarVarDictValueT
+    z2: OptVarVarDictValueT
+    height: OptVarVarDictValueT
+    top: OptVarVarDictValueT
+    upper: OptVarVarDictValueT
+    dz: OptVarVarDictValueT
+    flat: OptVarVarDictValueT
+    tilt: OptVarVarDictValueT
+    bottom: OptVarVarDictValueT
+    lower: OptVarVarDictValueT
+    l0s: OptVarVarDictValueT
+    l1s: OptVarVarDictValueT
+    l2s: OptVarVarDictValueT
+    l3s: OptVarVarDictValueT
+    l0e: OptVarVarDictValueT
+    l1e: OptVarVarDictValueT
+    l2e: OptVarVarDictValueT
+    l3e: OptVarVarDictValueT
+
+
 class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
     """
     Simon McIntosh's Poly-Bézier-spline geometry parameterisation (19 variables).
@@ -1773,7 +1839,7 @@ class PolySpline(GeometryParameterisation[PolySplineOptVariables]):
 
     __slots__ = ()
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: PolySplineOptVarDictT | None = None):
         variables = PolySplineOptVariables()
         variables.adjust_variables(var_dict, strict_bounds=False)
 
@@ -2539,6 +2605,22 @@ class PictureFrameOptVariables(OptVariablesFrame):
             self.z3.fixed = True
 
 
+class PictureFrameOptVarDictT(TypedDict, total=False):
+    """Typed Dict for PictureFrameOptVariables"""
+
+    x1: OptVarVarDictValueT
+    x2: OptVarVarDictValueT
+    z1: OptVarVarDictValueT
+    z2: OptVarVarDictValueT
+    ri: OptVarVarDictValueT
+    ro: OptVarVarDictValueT
+    x3: OptVarVarDictValueT
+    z1_peak: OptVarVarDictValueT
+    z2_peak: OptVarVarDictValueT
+    x4: OptVarVarDictValueT
+    z3: OptVarVarDictValueT
+
+
 class PictureFrame(
     GeometryParameterisation[PictureFrameOptVariables], PictureFrameTools
 ):
@@ -2604,7 +2686,7 @@ class PictureFrame(
 
     def __init__(
         self,
-        var_dict: VarDictT | None = None,
+        var_dict: PictureFrameOptVarDictT | None = None,
         *,
         upper: str | PFrameSection = PFrameSection.FLAT,
         lower: str | PFrameSection = PFrameSection.FLAT,

--- a/eudemo/eudemo/ivc/wall_silhouette_parameterisation.py
+++ b/eudemo/eudemo/ivc/wall_silhouette_parameterisation.py
@@ -10,8 +10,13 @@ Wall Silhouette Parameterisations
 import copy
 from typing import ClassVar
 
-from bluemira.geometry.parameterisations import PolySpline, PrincetonD
-from bluemira.utilities.opt_variables import OptVarVarDictValueT, VarDictT
+from bluemira.geometry.parameterisations import (
+    PolySpline,
+    PolySplineOptVarDictT,
+    PrincetonD,
+    PrincetonDOptVarDictT,
+)
+from bluemira.utilities.opt_variables import OptVarVarDictValueT
 
 
 class WallPolySpline(PolySpline):
@@ -33,7 +38,7 @@ class WallPolySpline(PolySpline):
         "bottom": {"value": 0.2},
     }
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: PolySplineOptVarDictT | None = None):
         defaults = copy.deepcopy(self._defaults)
         if var_dict:
             defaults.update(var_dict)
@@ -93,7 +98,7 @@ class WallPrincetonD(PrincetonD):
         "dz": {"value": -0.5},
     }
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: PrincetonDOptVarDictT | None = None):
         defaults = copy.deepcopy(self._defaults)
         if var_dict:
             defaults.update(var_dict)

--- a/eudemo/eudemo/tf_coils/tf_coil_parameterisations.py
+++ b/eudemo/eudemo/tf_coils/tf_coil_parameterisations.py
@@ -11,8 +11,7 @@ EU-DEMO parameterisations classes for TF Coils.
 import copy
 from typing import ClassVar
 
-from bluemira.geometry.parameterisations import PolySpline
-from bluemira.utilities.opt_variables import VarDictT
+from bluemira.geometry.parameterisations import PolySpline, PolySplineOptVarDictT
 
 
 class TFCoilPolySpline(PolySpline):
@@ -35,7 +34,7 @@ class TFCoilPolySpline(PolySpline):
         "flat": {"value": 0.0},
     }
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: PolySplineOptVarDictT | None = None):
         if var_dict is None:
             var_dict = {}
         defaults = copy.deepcopy(self._defaults)

--- a/examples/optimisation/geometry_optimisation_with_parameterisation.ex.py
+++ b/examples/optimisation/geometry_optimisation_with_parameterisation.ex.py
@@ -27,6 +27,7 @@
 
 # %%
 from dataclasses import dataclass
+from typing import TypedDict
 
 from bluemira.display import plot_2d
 from bluemira.display.plotter import PlotOptions
@@ -34,7 +35,12 @@ from bluemira.geometry.optimisation import optimise_geometry
 from bluemira.geometry.parameterisations import GeometryParameterisation
 from bluemira.geometry.tools import make_circle, make_polygon
 from bluemira.geometry.wire import BluemiraWire
-from bluemira.utilities.opt_variables import OptVariable, OptVariablesFrame, VarDictT, ov
+from bluemira.utilities.opt_variables import (
+    OptVarVarDictValueT,
+    OptVariable,
+    OptVariablesFrame,
+    ov,
+)
 
 
 @dataclass
@@ -46,10 +52,18 @@ class CircleOptVariables(OptVariablesFrame):
     centre_z: OptVariable = ov("centre_z", 0, 0, 10)
 
 
-class Circle(GeometryParameterisation):
+class CircleVarDict(TypedDict, total=False):
+    """Typed Dict for CircleVarDict"""
+
+    radius: OptVarVarDictValueT
+    centre_x: OptVarVarDictValueT
+    centre_z: OptVarVarDictValueT
+
+
+class Circle(GeometryParameterisation[CircleOptVariables]):
     """Geometry parameterisation for a circle in the xz-plane."""
 
-    def __init__(self, var_dict: VarDictT | None = None):
+    def __init__(self, var_dict: CircleVarDict | None = None):
         opt_variables = CircleOptVariables()
         opt_variables.adjust_variables(var_dict, strict_bounds=False)
         super().__init__(opt_variables)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3787 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Uses `TypedDict`s in constructors for:

- [x] `bluemira.equilibria.shapes.ZakharovLCFS`
- [x] `bluemira.equilibria.shapes.CunninghamLCFS`
- [x] `bluemira.equilibria.shapes.ManickamLCFS`
- [x] `bluemira.equilibria.shapes.KuiroukidisLCFS`
- [x] `bluemira.equilibria.shapes.JohnerLCFS`
- [x] `bluemira.geometry.parameterisation.PictureFrame`
- [x] `bluemira.geometry.parameterisation.PrincetonD`
- [x] `bluemira.geometry.parameterisation.TripleArc`
- [x] `bluemira.geometry.parameterisation.SextupleArc`
- [x] `bluemira.geometry.parameterisation.PolySpline`
- [x] `eudemo.eudemo.ivc.wall_silhouette_parameterisation.WallPolySpline`
- [x] `eudemo.eudemo.ivc.wall_silhouette_parameterisation.WallPrincetonD`
- [x] `eudemo.eudemo.tf_coils.tf_coil_parameterisation.TFCoilPolySpline`
- [x] `examples.optimisation.geometry_optimisation_with_parameterisation.Circle`

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
