### PR TITLE
✨ Move to hatch for build backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ tests/bluemira/test_generated_data
 cross_section_data
 plasmod_*.dat
 tmp_env.yml
+bluemira/_version.py
 
 # openmc outputs
 *.svg

--- a/bluemira/__init__.py
+++ b/bluemira/__init__.py
@@ -13,6 +13,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("bluemira")
 except PackageNotFoundError:
-    from setuptools_scm import get_version
-
-    __version__ = get_version()
+    __version__ = "0.0.0.Unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,14 @@ description = """An integrated inter-disciplinary design tool for future fusion
 readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ['version']
+license = "LGPL-2.1-or-later"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU Lesser General Public License v2.1 or later (LGPLv2.1+)",
+    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
     "Operating System :: POSIX :: Linux",
 ]
+
 dependencies = [
     "anytree>=2.5",
     "asteval>=1.0",
@@ -101,14 +103,18 @@ dagmc = [
 ]
 
 [build-system]
-requires = ["setuptools>=62", "setuptools_scm[toml]>=7.0"]
+requires      = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["bluemira*"]
-exclude = ["tests*"]
+[tool.hatch.version]
+source           = "vcs"
+fallback-version = "0.0.0"
 
-[tool.setuptools_scm]
+[tool.hatch.build.hooks.vcs]
+version-file = "bluemira/_version.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true  # remove after reference published
 
 [tool.coverage.report]
 "exclude_also" = [


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Hatch seems to be more stable than the combination of setuptools and setuptools-scm even though hatch-vcs uses setuptools-scm under the hood. This should alleviate any last Attribute not found `__version__` on import.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
