### PR TITLE
__slots__ from CoilGroup added to Circuit

### DIFF
--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -880,7 +880,7 @@ class Circuit(CoilGroup):
         The current value, if not provided the first coil current is used
     """
 
-    __slots__ = ()
+    __slots__ = CoilGroup.__slots__
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

Coilset containing Circuit(s) was not working when used in a COP:

AttributeError: 'Circuit' object has no attribute '_coils'

Adding __slots__ from CoilGroup parent class to Circuit fixes the problem.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
