### PR TITLE
MagneticConstraintSet - remove and avoid a couple of pertinent deepcopies

### DIFF
--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -11,7 +11,6 @@ Equilibrium optimisation constraint classes
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -54,7 +53,7 @@ def _get_dummy_equilibrium(equilibrium: Equilibrium):
     # TODO @hsaunders1904: Add passive coil contributions here
     # 3579
     dummy = equilibrium.plasma
-    dummy.coilset = deepcopy(equilibrium.coilset)
+    dummy.coilset = equilibrium.coilset
     return dummy
 
 

--- a/bluemira/equilibria/run.py
+++ b/bluemira/equilibria/run.py
@@ -449,7 +449,6 @@ class PulsedCoilsetDesign(ABC):
             gamma=self.eq_config.gamma,
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=deepcopy(self.eq_config.convergence),
             relaxation=self.eq_config.relaxation,
@@ -470,7 +469,6 @@ class PulsedCoilsetDesign(ABC):
         )
 
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=deepcopy(self.eq_config.convergence),
             relaxation=self.eq_config.relaxation,
@@ -554,7 +552,7 @@ class PulsedCoilsetDesign(ABC):
 
         return opt_problems
 
-    def converge_equilibrium(self, eq: Equilibrium, problem: CoilsetOptimisationProblem):
+    def converge_equilibrium(self, problem: EqCoilsetOptimisationProblem):
         """Converge an equilibrium problem from a 'frozen' plasma optimised state.
 
         Returns
@@ -563,7 +561,6 @@ class PulsedCoilsetDesign(ABC):
             The iterator
         """
         program = PicardIterator(
-            eq,
             problem,
             fixed_coils=True,
             convergence=deepcopy(self.eq_config.convergence),
@@ -575,15 +572,19 @@ class PulsedCoilsetDesign(ABC):
 
     def converge_and_snapshot(
         self,
-        sub_opt_problems: Iterable[CoilsetOptimisationProblem],
+        sub_opt_problems: Iterable[EqCoilsetOptimisationProblem],
         problem_names: Iterable[str] = (SOF, EOF),
     ):
         """Converge equilibrium optimisation problems and take snapshots."""
         for snap, problem in zip(problem_names, sub_opt_problems, strict=False):
-            eq = problem.eq
-            program = self.converge_equilibrium(eq, problem)
+            program = self.converge_equilibrium(problem)
             self.take_snapshot(
-                snap, eq, eq.coilset, problem, eq.profiles, iterator=program
+                snap,
+                problem.eq,
+                problem.eq.coilset,
+                problem,
+                problem.eq.profiles,
+                iterator=program,
             )
 
     def plot(self):

--- a/bluemira/equilibria/run.py
+++ b/bluemira/equilibria/run.py
@@ -453,7 +453,6 @@ class PulsedCoilsetDesign(ABC):
             eq, MagneticConstraintSet(self.eq_constraints), gamma=self.eq_config.gamma
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=deepcopy(self.eq_config.convergence),
             relaxation=self.eq_config.relaxation,
@@ -474,7 +473,6 @@ class PulsedCoilsetDesign(ABC):
         )
 
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=deepcopy(self.eq_config.convergence),
             relaxation=self.eq_config.relaxation,
@@ -559,7 +557,7 @@ class PulsedCoilsetDesign(ABC):
 
         return opt_problems
 
-    def converge_equilibrium(self, eq: Equilibrium, problem: CoilsetOptimisationProblem):
+    def converge_equilibrium(self, problem: EqCoilsetOptimisationProblem):
         """Converge an equilibrium problem from a 'frozen' plasma optimised state.
 
         Returns
@@ -568,7 +566,6 @@ class PulsedCoilsetDesign(ABC):
             The iterator
         """
         program = PicardIterator(
-            eq,
             problem,
             fixed_coils=True,
             convergence=deepcopy(self.eq_config.convergence),
@@ -580,15 +577,19 @@ class PulsedCoilsetDesign(ABC):
 
     def converge_and_snapshot(
         self,
-        sub_opt_problems: Iterable[CoilsetOptimisationProblem],
+        sub_opt_problems: Iterable[EqCoilsetOptimisationProblem],
         problem_names: Iterable[str] = (SOF, EOF),
     ):
         """Converge equilibrium optimisation problems and take snapshots."""
         for snap, problem in zip(problem_names, sub_opt_problems, strict=False):
-            eq = problem.eq
-            program = self.converge_equilibrium(eq, problem)
+            program = self.converge_equilibrium(problem)
             self.take_snapshot(
-                snap, eq, eq.coilset, problem, eq.profiles, iterator=program
+                snap,
+                problem.eq,
+                problem.eq.coilset,
+                problem,
+                problem.eq.profiles,
+                iterator=program,
             )
 
     def plot(self):

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
-    from bluemira.equilibria.equilibrium import Equilibrium
-    from bluemira.equilibria.optimisation.problem import CoilsetOptimisationProblem
+    from bluemira.equilibria.optimisation.problem import EqCoilsetOptimisationProblem
     from bluemira.equilibria.optimisation.problem.base import CoilsetOptimiserResult
 
 __all__ = [
@@ -440,8 +439,6 @@ class PicardIterator:
 
     Parameters
     ----------
-    eq:
-        The equilibrium to solve for
     optimisation_problem:
         The optimisation problem to use when iterating
     convergence:
@@ -460,8 +457,7 @@ class PicardIterator:
 
     def __init__(
         self,
-        eq: Equilibrium,
-        optimisation_problem: CoilsetOptimisationProblem,
+        optimisation_problem: EqCoilsetOptimisationProblem,
         diagnostic_plotting: PicardDiagnosticOptions | None = None,
         convergence: ConvergenceCriterion | None = None,
         *,
@@ -469,7 +465,7 @@ class PicardIterator:
         relaxation: float = 0,
         maxiter: int = 30,
     ):
-        self.eq = eq
+        self.eq = optimisation_problem.eq
         self.coilset = self.eq.coilset
         self.opt_prob = optimisation_problem
         if isinstance(convergence, ConvergenceCriterion):

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
-    from bluemira.equilibria.equilibrium import Equilibrium
-    from bluemira.equilibria.optimisation.problem import CoilsetOptimisationProblem
+    from bluemira.equilibria.optimisation.problem import EqCoilsetOptimisationProblem
     from bluemira.equilibria.optimisation.problem.base import CoilsetOptimiserResult
 
 __all__ = [
@@ -440,8 +439,6 @@ class PicardIterator:
 
     Parameters
     ----------
-    eq:
-        The equilibrium to solve for
     optimisation_problem:
         The optimisation problem to use when iterating
     convergence:
@@ -460,8 +457,7 @@ class PicardIterator:
 
     def __init__(
         self,
-        eq: Equilibrium,
-        optimisation_problem: CoilsetOptimisationProblem,
+        optimisation_problem: EqCoilsetOptimisationProblem,
         diagnostic_plotting: PicardDiagnosticOptions | None = None,
         convergence: ConvergenceCriterion | None = None,
         *,
@@ -471,7 +467,7 @@ class PicardIterator:
         keep_history: bool = False,
         check_constraints: bool = False,
     ):
-        self.eq = eq
+        self.eq = optimisation_problem.eq
         self.coilset = self.eq.coilset
         self.opt_prob = optimisation_problem
         if isinstance(convergence, ConvergenceCriterion):

--- a/eudemo/eudemo/equilibria/_designer.py
+++ b/eudemo/eudemo/equilibria/_designer.py
@@ -158,7 +158,6 @@ class EquilibriumDesigner(Designer[Equilibrium]):
         eq = self._make_equilibrium()
         opt_problem = self._make_opt_problem(eq)
         iterator_program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(),
             relaxation=0.2,
@@ -722,7 +721,6 @@ class ReferenceFreeBoundaryEquilibriumDesigner(Designer[Equilibrium]):
 
         iter_err_max = settings.pop("iter_err_max")
         iterator_program = PicardIterator(
-            eq,
             self.opt_problem,
             convergence=DudsonConvergence(iter_err_max),
             diagnostic_plotting=self.diagnostic_plotting,

--- a/eudemo/eudemo/equilibria/_designer.py
+++ b/eudemo/eudemo/equilibria/_designer.py
@@ -154,7 +154,6 @@ class EquilibriumDesigner(Designer[Equilibrium]):
         eq = self._make_equilibrium()
         opt_problem = self._make_opt_problem(eq)
         iterator_program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(),
             relaxation=0.2,
@@ -710,7 +709,6 @@ class ReferenceFreeBoundaryEquilibriumDesigner(Designer[Equilibrium]):
 
         iter_err_max = settings.pop("iter_err_max")
         iterator_program = PicardIterator(
-            eq,
             self.opt_problem,
             convergence=DudsonConvergence(iter_err_max),
             diagnostic_plotting=self.diagnostic_plotting,

--- a/examples/design/optimised_reactor.ex.py
+++ b/examples/design/optimised_reactor.ex.py
@@ -184,7 +184,6 @@ def ref_eq(R_0, A) -> Equilibrium:  # noqa: D103
     )
     diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
     program = PicardIterator(
-        eq,
         current_opt_problem,
         fixed_coils=True,
         relaxation=0.2,

--- a/examples/design/optimised_reactor.ex.py
+++ b/examples/design/optimised_reactor.ex.py
@@ -192,7 +192,6 @@ def ref_eq(R_0, A) -> Equilibrium:  # noqa: D103
     )
     diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
     program = PicardIterator(
-        eq,
         current_opt_problem,
         fixed_coils=True,
         relaxation=0.2,

--- a/examples/equilibria/Toroidal_Harmonics_Optimisation_Set_Up.ex.py
+++ b/examples/equilibria/Toroidal_Harmonics_Optimisation_Set_Up.ex.py
@@ -160,7 +160,6 @@ current_opt_problem = TikhonovCurrentCOP(
 )
 
 program = PicardIterator(
-    th_current_opt_eq,
     current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-3),

--- a/examples/equilibria/Toroidal_Harmonics_Optimisation_Set_Up.ex.py
+++ b/examples/equilibria/Toroidal_Harmonics_Optimisation_Set_Up.ex.py
@@ -154,7 +154,6 @@ current_opt_problem = TikhonovCurrentCOP(
 )
 
 program = PicardIterator(
-    th_current_opt_eq,
     current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-3),

--- a/examples/equilibria/coilset_opt_problem_tutorial.ex.py
+++ b/examples/equilibria/coilset_opt_problem_tutorial.ex.py
@@ -294,7 +294,6 @@ unconstrained_cop = UnconstrainedTikhonovCurrentGradientCOP(
     eq, magnetic_targets, gamma=1e-8
 )
 unconstrained_iterator = PicardIterator(
-    eq,
     unconstrained_cop,
     fixed_coils=True,
     relaxation=0.3,
@@ -375,7 +374,6 @@ opt_problem = TikhonovCurrentCOP(
     constraints=[field_constraints, x_point, lcfs_isoflux, legs_isoflux],
 )
 constrained_iterator = PicardIterator(
-    eq,
     opt_problem,
     fixed_coils=True,
     relaxation=0.1,

--- a/examples/equilibria/coilset_opt_problem_tutorial.ex.py
+++ b/examples/equilibria/coilset_opt_problem_tutorial.ex.py
@@ -298,7 +298,6 @@ unconstrained_cop = UnconstrainedTikhonovCurrentGradientCOP(
     eq, magnetic_targets, gamma=1e-8
 )
 unconstrained_iterator = PicardIterator(
-    eq,
     unconstrained_cop,
     fixed_coils=True,
     relaxation=0.3,
@@ -380,7 +379,6 @@ opt_problem = TikhonovCurrentCOP(
     constraints=[field_constraints, x_point, lcfs_isoflux, legs_isoflux],
 )
 constrained_iterator = PicardIterator(
-    eq,
     opt_problem,
     fixed_coils=True,
     relaxation=0.1,

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -298,7 +298,7 @@ ref_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
     gamma=1e-7,
 )
 
-program = PicardIterator(reference_eq, ref_opt_problem, fixed_coils=True, relaxation=0.2)
+program = PicardIterator(ref_opt_problem, fixed_coils=True, relaxation=0.2)
 program()
 
 sof_psi_boundary = PsiBoundaryConstraint(
@@ -319,7 +319,6 @@ sof_opt_problem = MinimalCurrentCOP(
 )
 
 iterator = PicardIterator(
-    sof,
     sof_opt_problem,
     fixed_coils=True,
     relaxation=0.2,
@@ -345,7 +344,6 @@ eof_opt_problem = MinimalCurrentCOP(
 
 diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 iterator = PicardIterator(
-    eof,
     eof_opt_problem,
     relaxation=0.2,
     fixed_coils=True,

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -270,7 +270,7 @@ ref_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
     reference_eq, MagneticConstraintSet([isoflux, x_point]), gamma=1e-7
 )
 
-program = PicardIterator(reference_eq, ref_opt_problem, fixed_coils=True, relaxation=0.2)
+program = PicardIterator(ref_opt_problem, fixed_coils=True, relaxation=0.2)
 program()
 
 sof_psi_boundary = PsiBoundaryConstraint(
@@ -287,7 +287,11 @@ sof_opt_problem = MinimalCurrentCOP(
     constraints=[sof_psi_boundary, x_point],
 )
 
-iterator = PicardIterator(sof, sof_opt_problem, fixed_coils=True, relaxation=0.2)
+iterator = PicardIterator(
+    sof_opt_problem,
+    fixed_coils=True,
+    relaxation=0.2,
+)
 iterator()
 
 
@@ -306,7 +310,6 @@ eof_opt_problem = MinimalCurrentCOP(
 
 diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 iterator = PicardIterator(
-    eof,
     eof_opt_problem,
     relaxation=0.2,
     fixed_coils=True,

--- a/examples/equilibria/freegsnke_mastu_comparison.ex.py
+++ b/examples/equilibria/freegsnke_mastu_comparison.ex.py
@@ -193,7 +193,6 @@ current_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
 )
 
 program = PicardIterator(
-    eq,
     current_opt_problem,
     fixed_coils=True,
     diagnostic_plotting=PicardDiagnosticOptions(PicardDiagnostic.EQ),

--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -244,7 +244,6 @@ current_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
 )
 diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 program = PicardIterator(
-    eq,
     current_opt_problem,
     convergence=DudsonConvergence(1e-3),
     fixed_coils=True,
@@ -294,7 +293,6 @@ current_opt_problem = TikhonovCurrentCOP(
     constraints=[x_point, field_constraints, force_constraints],
 )
 program = PicardIterator(
-    eq,
     current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -326,7 +324,6 @@ minimal_current_opt_problem = MinimalCurrentCOP(
 )
 
 program = PicardIterator(
-    minimal_current_eq,
     minimal_current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -511,7 +508,6 @@ for problem in [current_opt_problem_sof, current_opt_problem_eof]:
 
 # %%
 program = PicardIterator(
-    sof,
     current_opt_problem_sof,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -521,7 +517,6 @@ program = PicardIterator(
 program()
 
 program = PicardIterator(
-    eof,
     current_opt_problem_eof,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),

--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -236,7 +236,6 @@ current_opt_problem = UnconstrainedTikhonovCurrentGradientCOP(
 )
 diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
 program = PicardIterator(
-    eq,
     current_opt_problem,
     convergence=DudsonConvergence(1e-3),
     fixed_coils=True,
@@ -282,7 +281,6 @@ current_opt_problem = TikhonovCurrentCOP(
     constraints=[x_point, field_constraints, force_constraints],
 )
 program = PicardIterator(
-    eq,
     current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -314,7 +312,6 @@ minimal_current_opt_problem = MinimalCurrentCOP(
 )
 
 program = PicardIterator(
-    minimal_current_eq,
     minimal_current_opt_problem,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -489,7 +486,6 @@ for problem in [current_opt_problem_sof, current_opt_problem_eof]:
 
 # %%
 program = PicardIterator(
-    sof,
     current_opt_problem_sof,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),
@@ -499,7 +495,6 @@ program = PicardIterator(
 program()
 
 program = PicardIterator(
-    eof,
     current_opt_problem_eof,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-4),

--- a/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
@@ -194,7 +194,6 @@ sh_con_len_opt = MinimalCurrentCOP(
 
 # SOLVE
 program = PicardIterator(
-    sh_eq_solved,
     sh_con_len_opt,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-2),

--- a/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
+++ b/examples/equilibria/spherical_harmonic_approximation_basic_use.ex.py
@@ -185,7 +185,6 @@ sh_con_len_opt = MinimalCurrentCOP(
 
 # SOLVE
 program = PicardIterator(
-    sh_eq_solved,
     sh_con_len_opt,
     fixed_coils=True,
     convergence=DudsonConvergence(1e-2),

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -63,7 +63,7 @@ class TestFields:
 
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(eq, targets, gamma=1e-8)
 
-        program = PicardIterator(eq, opt_problem, relaxation=0.1)
+        program = PicardIterator(opt_problem, relaxation=0.1)
         program()
         cls.eq = eq
 
@@ -266,7 +266,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-1),
             fixed_coils=True,
@@ -289,7 +288,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-1),
             fixed_coils=True,
@@ -324,7 +322,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-2),
             fixed_coils=True,

--- a/tests/equilibria/test_equilibrium.py
+++ b/tests/equilibria/test_equilibrium.py
@@ -73,7 +73,7 @@ class TestFields:
 
         opt_problem = UnconstrainedTikhonovCurrentGradientCOP(eq, targets, gamma=1e-8)
 
-        program = PicardIterator(eq, opt_problem, relaxation=0.1)
+        program = PicardIterator(opt_problem, relaxation=0.1)
         program()
         cls.eq = eq
 
@@ -276,7 +276,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-1),
             fixed_coils=True,
@@ -293,7 +292,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-1),
             fixed_coils=True,
@@ -328,7 +326,6 @@ class TestSolveEquilibrium:
             eq, self.targets, gamma=1e-8
         )
         program = PicardIterator(
-            eq,
             opt_problem,
             convergence=DudsonConvergence(1e-2),
             fixed_coils=True,

--- a/tests/equilibria/test_optimisation.py
+++ b/tests/equilibria/test_optimisation.py
@@ -64,7 +64,7 @@ def test_isoflux_constrained_tikhonov_current_optimisation(request):
     opt_problem = TikhonovCurrentCOP(eq, targets, gamma=1e-8)
     diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
     program = add_plot_title(PicardIterator, request)(
-        eq, opt_problem, relaxation=0.1, diagnostic_plotting=diagnostic_plotting
+        opt_problem, relaxation=0.1, diagnostic_plotting=diagnostic_plotting
     )
     program()
     np.testing.assert_almost_equal(

--- a/tests/equilibria/test_optimisation.py
+++ b/tests/equilibria/test_optimisation.py
@@ -68,7 +68,7 @@ def test_isoflux_constrained_tikhonov_current_optimisation(request):
     opt_problem = TikhonovCurrentCOP(eq, targets, gamma=1e-8)
     diagnostic_plotting = PicardDiagnosticOptions(plot=PicardDiagnostic.EQ)
     program = add_plot_title(PicardIterator, request)(
-        eq, opt_problem, relaxation=0.1, diagnostic_plotting=diagnostic_plotting
+        opt_problem, relaxation=0.1, diagnostic_plotting=diagnostic_plotting
     )
     program()
     np.testing.assert_almost_equal(

--- a/tests/equilibria/test_st_equilibrium.py
+++ b/tests/equilibria/test_st_equilibrium.py
@@ -193,7 +193,6 @@ class TestSTEquilibrium:
         criterion = DudsonConvergence(build_tweaks["fbe_convergence_crit"])
 
         fbe_iterator = PicardIterator(
-            eq,
             opt_problem,
             relaxation=0.3,
             maxiter=400,

--- a/tests/equilibria/test_st_equilibrium.py
+++ b/tests/equilibria/test_st_equilibrium.py
@@ -189,7 +189,10 @@ class TestSTEquilibrium:
         criterion = DudsonConvergence(build_tweaks["fbe_convergence_crit"])
 
         fbe_iterator = PicardIterator(
-            eq, opt_problem, relaxation=0.3, maxiter=400, convergence=criterion
+            opt_problem,
+            relaxation=0.3,
+            maxiter=400,
+            convergence=criterion,
         )
         fbe_iterator()
         self.eq = eq


### PR DESCRIPTION
## Description

Constraints/Targets not updating - deepcopy in dummy eq set up, and if deepcopy of eq used between setting up optimisation problem and the Picard iterator resulted in disconnection.

## Interface Changes

PicardIterator no longer takes eq as input. Does not need to, as we have the COP (with relevant eq) as input.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
