### PR TITLE
Changing '!=0' in geometry testcoordinates bug

### DIFF
--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -551,7 +551,7 @@ def get_centroid_2d(x: np.ndarray, z: np.ndarray) -> list[float]:
         cx += (x[i] + x[i + 1]) * a
         cz += (z[i] + z[i + 1]) * a
 
-    if area != 0:
+    if not np.isclose(area, 0.0):
         # Zero division protection
         cx /= 6 * area
         cz /= 6 * area

--- a/tests/geometry/test_coordinates.py
+++ b/tests/geometry/test_coordinates.py
@@ -326,7 +326,7 @@ class TestCoordinates:
         assert not c.check_ccw(axis=[0, 1, 0])
 
     def test_complicated(self):
-        xyz = trace_torus_orbit(50, 1, 10, 999)
+        xyz = trace_torus_orbit(5, 1, 10, 999)
         c = Coordinates(xyz)
 
         assert not c.is_planar

--- a/tests/geometry/test_coordinates.py
+++ b/tests/geometry/test_coordinates.py
@@ -326,7 +326,7 @@ class TestCoordinates:
         assert not c.check_ccw(axis=[0, 1, 0])
 
     def test_complicated(self):
-        xyz = trace_torus_orbit(5, 1, 10, 999)
+        xyz = trace_torus_orbit(50, 1, 10, 999)
         c = Coordinates(xyz)
 
         assert not c.is_planar


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4204

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Changes an if statement in get_centroid_2d of 
`if area != 0:`
to 
`if not np.isclose(area, 0.0):`
as very close to 0 values were passing through and causing errors down the line in Coordinates.check_ccw()

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
