### PR TITLE
➕ Make sure ipywidgets is installed when running notebook related things

### DIFF
--- a/documentation/source/developer/faq.rst
+++ b/documentation/source/developer/faq.rst
@@ -50,6 +50,27 @@ On MacOS the ``envsubst`` command cannot be found
 
         brew install gettext
 
+.. _vscode:
+
+VSCode Notebook rendering
+-------------------------
+
+
+If you see this error when running VSCode notebook
+
+.. code-block:: bash
+
+    Could not render content for 'application/vnd.jupyter.widget-view+json'
+    {"model_id":"....","version_major":2,"version_minor":0}
+
+VSCode may require these additional settings to be added in order to display widgets (and therefore progress bars) properly.
+This is described in `this article <https://github.com/microsoft/vscode-jupyter/wiki/IPyWidget-Support-in-VS-Code-Python>`_ which states you should add the following to your vscode configuration json file.
+
+.. code-block:: json
+
+    "jupyter.widgetScriptSources": ["jsdelivr.com", "unpkg.com"],
+
+
 .. _wsl:
 
 WSL installation

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,21 @@ You should see a bunch of files, which correspond to what's in your bluemira dir
 
 You can stop the Jupyter server by double-pressing `ctrl+c` in your terminal.
 
+## Running Notebooks in VSCode
+
+If you see this error when running VSCode notebook
+
+```bash
+Could not render content for 'application/vnd.jupyter.widget-view+json'
+{"model_id":"...","version_major":2,"version_minor":0}
+```
+VSCode may require these additional settings to be added in order to display widgets (and therefore progress bars) properly.
+This is described in [this article](https://github.com/microsoft/vscode-jupyter/wiki/IPyWidget-Support-in-VS-Code-Python) which states you should add the following to your vscode configuration json file.
+
+```json
+"jupyter.widgetScriptSources": ["jsdelivr.com", "unpkg.com"],
+```
+
 ## Running Notebooks in Jupyter Notebook v7.x (nb7)
 
 Previous versions of Jupyter Notebook (a.k.a nb classic) will open python scripts and markdown documents as notebooks by default. From v7 onwards, to open and run a text notebook (.py or .md extension) as a notebook in Jupyter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "sphinx-rtd-theme>=2.0.0",
     "sybil",
 ]
-examples = ["notebook", "jupytext"]
+examples = ["notebook", "jupytext", "rich[jupyter]"]
 pinned = [
     "nlopt==2.7.1",
     "numba==0.63.1",

--- a/requirements/uv/all.txt
+++ b/requirements/uv/all.txt
@@ -64,7 +64,9 @@ click==8.3.1
     #   eqdsk
     #   jupyter-cache
 comm==0.2.3
-    # via ipykernel
+    # via
+    #   ipykernel
+    #   ipywidgets
 contourpy==1.3.2
     # via
     #   bluemira (pyproject.toml)
@@ -152,7 +154,10 @@ ipykernel==7.1.0
 ipython==8.37.0
     # via
     #   ipykernel
+    #   ipywidgets
     #   myst-nb
+ipywidgets==8.1.8
+    # via rich
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.2
@@ -217,6 +222,8 @@ jupyterlab-server==2.28.0
     # via
     #   jupyterlab
     #   notebook
+jupyterlab-widgets==3.0.16
+    # via ipywidgets
 jupytext==1.18.1
     # via bluemira (pyproject.toml)
 kiwisolver==1.4.9
@@ -605,6 +612,7 @@ traitlets==5.14.3
     # via
     #   ipykernel
     #   ipython
+    #   ipywidgets
     #   jupyter-client
     #   jupyter-core
     #   jupyter-events
@@ -666,5 +674,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.9.0
     # via jupyter-server
+widgetsnbextension==4.0.15
+    # via ipywidgets
 zipp==3.23.0
     # via importlib-metadata

--- a/requirements/uv/examples.txt
+++ b/requirements/uv/examples.txt
@@ -53,7 +53,9 @@ click==8.3.1
     #   bluemira (pyproject.toml)
     #   eqdsk
 comm==0.2.3
-    # via ipykernel
+    # via
+    #   ipykernel
+    #   ipywidgets
 contourpy==1.3.2
     # via
     #   bluemira (pyproject.toml)
@@ -113,7 +115,11 @@ imageio==2.37.2
 ipykernel==7.1.0
     # via jupyterlab
 ipython==8.37.0
-    # via ipykernel
+    # via
+    #   ipykernel
+    #   ipywidgets
+ipywidgets==8.1.8
+    # via rich
 isoduration==20.11.0
     # via jsonschema
 jedi==0.19.2
@@ -172,6 +178,8 @@ jupyterlab-server==2.28.0
     # via
     #   jupyterlab
     #   notebook
+jupyterlab-widgets==3.0.16
+    # via ipywidgets
 jupytext==1.18.1
     # via bluemira (pyproject.toml)
 kiwisolver==1.4.9
@@ -450,6 +458,7 @@ traitlets==5.14.3
     # via
     #   ipykernel
     #   ipython
+    #   ipywidgets
     #   jupyter-client
     #   jupyter-core
     #   jupyter-events
@@ -504,3 +513,5 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.9.0
     # via jupyter-server
+widgetsnbextension==4.0.15
+    # via ipywidgets


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
When running examples in notebooks this warning appears:
<img width="1023" height="133" alt="image" src="https://github.com/user-attachments/assets/ea4af9d7-ea79-4e84-b317-568a240eca29" />

we should avoid the warning, this adds ipywidgets to the install if you install the examples extra

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
