### PR TITLE
Fixed the calculation of e_mult to use a less vulnerable definition of total power in output.py

### DIFF
--- a/bluemira/codes/openmc/output.py
+++ b/bluemira/codes/openmc/output.py
@@ -225,8 +225,9 @@ class OpenMCCSGResult(OpenMCResultBase):
             statepoint, src_rate, "vacuum vessel power"
         )
 
-        total_power, total_power_err = cls._load_filter_power_err(
-            statepoint, src_rate, "total power"
+        total_power = blanket_power + divertor_power + vessel_power
+        total_power_err = np.sqrt(
+            blanket_power_err**2 + divertor_power_err**2 + vessel_power_err**2
         )
 
         dt_n_power = cls.dt_neuton_power(src_triton_rate)

--- a/bluemira/codes/openmc/output.py
+++ b/bluemira/codes/openmc/output.py
@@ -224,10 +224,8 @@ class OpenMCCSGResult(OpenMCResultBase):
         vessel_power, vessel_power_err = cls._load_filter_power_err(
             statepoint, src_rate, "vacuum vessel power"
         )
-
-        total_power = blanket_power + divertor_power + vessel_power
-        total_power_err = np.sqrt(
-            blanket_power_err**2 + divertor_power_err**2 + vessel_power_err**2
+        total_power, total_power_err = cls._load_filter_power_err(
+            statepoint, src_rate, "total power"
         )
 
         dt_n_power = cls.dt_neuton_power(src_triton_rate)
@@ -310,7 +308,9 @@ class OpenMCCSGResult(OpenMCResultBase):
         """Load the heating (sorted by material) dataframe"""
         # mean and std. dev. are given in eV per source particle,
         # so we don't need to show them to the user.
-        heating_df = cls._load_dataframe_from_statepoint(statepoint, "total power")
+        heating_df = cls._load_dataframe_from_statepoint(
+            statepoint, "total power in known materials"
+        )
         heating_df["material_name"] = heating_df["material"].map(mat_names)
         heating_df["mean(W)"] = raw_uc(
             heating_df["mean"].to_numpy() * src_rate, "eV/s", "W"

--- a/bluemira/codes/openmc/tallying.py
+++ b/bluemira/codes/openmc/tallying.py
@@ -79,7 +79,8 @@ def csg_filter_cells(
     return (
         ("TBR", "(n,Xt)", []),  # theoretical maximum TBR only, obviously.
         # Powers
-        ("total power", "heating", [mat_filter, cell_filter]),
+        ("total power in known materials", "heating", [mat_filter, cell_filter]),
+        ("total power", "heating", [cell_filter]),
         ("divertor power", "heating", [div_cell_filter]),
         ("vacuum vessel power", "heating", [vv_filter]),
         ("breeding blanket power", "heating", [blanket_cell_filter]),


### PR DESCRIPTION
## Linked Issues

Part of #4193 

## Description

Total power calculated with a new tally.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
