### PR TITLE
♻️ Improve commutative unit reconstruction

### DIFF
--- a/bluemira/base/constants.py
+++ b/bluemira/base/constants.py
@@ -71,7 +71,9 @@ class BMUnitRegistry(UnitRegistry):
         # space before on % so that M% is not a thing
         # M$ makes sense if a bit non-standard
         super().__init__(
-            fmt_locale="en_GB", preprocessors=[lambda x: x.replace("$", "USD ")]
+            fmt_locale="en_GB",
+            preprocessors=[lambda x: x.replace("$", "USD ")],
+            system="SI",
         )
 
         self._gas_flow_temperature = None
@@ -258,19 +260,25 @@ base_unit_defaults = {
     "[current]": CURRENT,
     "[temperature]": TEMP,
     "[substance]": QUANTITY,
-    "[luminosity]": "candela",
+    "[luminosity]": ureg.candela,
     "[angle]": ANGLE,
 }
 
 combined_unit_defaults = {
-    "[energy]": "joules",
-    "[pressure]": "pascal",
-    "[magnetic_field]": "tesla",
-    "[electric_potential]": "volt",
-    "[power]": "watt",
-    "[force]": "newton",
-    "[resistance]": "ohm",
+    "[energy]": ureg.joules,
+    "[pressure]": ureg.pascal,
+    "[magnetic_field]": ureg.tesla,
+    "[electric_potential]": ureg.volt,
+    "[power]": ureg.watt,
+    "[force]": ureg.newton,
+    "[resistance]": ureg.ohm,
 }
+
+ureg.default_preferred_units = [
+    *combined_unit_defaults.values(),
+    *base_unit_defaults.values(),
+]
+
 
 combined_unit_dimensions = {
     "[energy]": {"[length]": 2, "[mass]": 1, "[time]": -2},
@@ -281,19 +289,6 @@ combined_unit_dimensions = {
     "[force]": {"[length]": 2, "[mass]": 1, "[time]": -3},
     "[resistance]": {"[current]": -2, "[length]": 2, "[mass]": 1, "[time]": -3},
 }
-
-ANGLE_UNITS = [
-    "radian",
-    "turn",
-    "degree",
-    "arcminute",
-    "arcsecond",
-    "milliarcsecond",
-    "grade",
-    # "mil",  # this break milli conversion with current implementation
-    "steradian",
-    "square_degree",
-]
 
 # =============================================================================
 # Physical constants

--- a/bluemira/base/parameter_frame/_frame.py
+++ b/bluemira/base/parameter_frame/_frame.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import copy
 import json
-from contextlib import suppress
 from dataclasses import dataclass, fields
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, ClassVar, get_args, get_type_hints
@@ -15,21 +14,14 @@ from typing import TYPE_CHECKING, Any, ClassVar, get_args, get_type_hints
 import pint
 from tabulate import tabulate
 
-from bluemira.base.constants import (
-    ANGLE_UNITS,
-    base_unit_defaults,
-    combined_unit_defaults,
-    combined_unit_dimensions,
-    raw_uc,
-    units_compatible,
-    ureg,
-)
+from bluemira.base.constants import units_compatible, ureg
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.base.parameter_frame._parameter import (
     ParamDictT,
     Parameter,
     ParameterValueType,
 )
+from bluemira.base.parameter_frame._units import _validate_units
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -296,7 +288,7 @@ class ParameterFrame:
         for field in cls.__dataclass_fields__:
             try:
                 kwargs[field] = getattr(frame, field)
-            except AttributeError:  # noqa: PERF203
+            except AttributeError:
                 raise ValueError(
                     "Cannot create ParameterFrame from other. "
                     f"Other frame does not contain field '{field}'."
@@ -380,7 +372,7 @@ class ParameterFrame:
         for member in cls.__dataclass_fields__:
             try:
                 kwargs[member]
-            except KeyError as e:  # noqa: PERF203
+            except KeyError as e:
                 raise ValueError(f"Data for parameter '{member}' not found.") from e
 
         return cls(**kwargs)
@@ -403,7 +395,7 @@ class ParameterFrame:
         """
         value_type = _validate_parameter_field(member, cls._get_types()[member])
         try:
-            _validate_units(member_param_data, value_type)
+            member_param_data = _validate_units(member_param_data, value_type)
         except pint.errors.PintError as pe:
             raise ValueError(
                 f"Unit conversion failed for {member} from {member_param_data['unit']}"
@@ -571,213 +563,6 @@ def _validate_parameter_field(field, member_type: type) -> tuple[type, ...]:
     ):
         raise TypeError(f"Field '{field}' does not have type Parameter.")
     return get_args(member_type)
-
-
-def _validate_units(param_data: ParamDictT, value_type: Iterable[type]):
-    try:
-        quantity = ureg.Quantity(param_data["value"], param_data["unit"])
-    except ValueError:
-        try:
-            quantity = ureg.Quantity(f"{param_data['value']}*{param_data['unit']}")
-        except pint.errors.PintError as pe:
-            if param_data["value"] is None:
-                quantity = ureg.Quantity(
-                    1 if param_data["unit"] in {None, ""} else param_data["unit"]
-                )
-                param_data["source"] = f"{param_data.get('source', '')}\nMAD UNIT 🤯 😭:"
-            else:
-                raise ValueError("Unit conversion failed") from pe
-        else:
-            param_data["value"] = quantity.magnitude
-        param_data["unit"] = quantity.units
-    except KeyError as ke:
-        raise ValueError("Parameters need a value and a unit") from ke
-    except TypeError:
-        if param_data["value"] is None:
-            # dummy for None values
-            quantity = ureg.Quantity(
-                1 if param_data["unit"] in {None, ""} else param_data["unit"]
-            )
-        elif isinstance(param_data["value"], bool | str):
-            param_data["unit"] = "dimensionless"
-            return
-        else:
-            raise
-
-    if dimensionality := quantity.units.dimensionality:
-        unit = _fix_combined_units(_remake_units(dimensionality))
-    else:
-        unit = quantity.units
-
-    unit = _fix_weird_units(unit, quantity.units)
-
-    if unit != quantity.units and param_data["value"] is not None:
-        val = raw_uc(quantity.magnitude, quantity.units, unit)
-        if isinstance(param_data["value"], int) and int in value_type:
-            val = int(val)
-        param_data["value"] = val
-
-    param_data["unit"] = f"{unit:~P}"
-
-    if "MAD UNIT" in param_data.get("source", ""):
-        param_data["source"] += f"{quantity.magnitude}{param_data['unit']}"
-
-
-def _remake_units(dimensionality: dict | pint.util.UnitsContainer) -> pint.Unit:
-    """
-    Reconstruct unit from its dimensionality.
-
-    Parameters
-    ----------
-    dimensionality:
-        The dimensionality of the unit
-
-    Returns
-    -------
-    :
-        The reconstructed unit
-    """
-    dim_list = list(map(base_unit_defaults.get, dimensionality.keys()))
-    dim_pow = list(dimensionality.values())
-    return ureg.Unit(
-        ".".join([f"{j[0]}^{j[1]}" for j in zip(dim_list, dim_pow, strict=False)])
-    )
-
-
-def _fix_combined_units(unit: pint.Unit) -> pint.Unit:
-    """Converts base unit to a composite unit if they exist in the defaults.
-
-    Parameters
-    ----------
-    unit:
-        The unit to convert
-
-    Returns
-    -------
-    :
-        The converted unit
-    """
-    dim_keys = list(combined_unit_dimensions.keys())
-    dim_val = list(combined_unit_dimensions.values())
-    with suppress(ValueError):
-        return ureg.Unit(
-            combined_unit_defaults[dim_keys[dim_val.index(unit.dimensionality)]]
-        )
-    return ureg.Unit(unit)
-
-
-def _convert_angle_units(
-    modified_unit: pint.Unit, orig_unit_str: str, angle_unit: str
-) -> pint.Unit:
-    """
-    Converts angle units to the base unit default for angles.
-
-    Angles are dimensionless therefore dimensionality conversion
-    from pint doesn't work. Conversions between angle units is also not
-    very robust.
-
-    Parameters
-    ----------
-    modified_unit
-        reconstructed unit without the angle
-    orig_unit_str
-        the user supplied unit (without spaces)
-    angle_unit
-        the angle unit in `orig_unit`
-
-    Returns
-    -------
-    :
-        The converted unit
-    """
-    breaking_units = ["steradian", "square_degree"]
-    new_angle_unit = base_unit_defaults["[angle]"]
-    for b in breaking_units:
-        if b in orig_unit_str:
-            raise NotImplementedError(f"{breaking_units} not supported for conversion")
-    if f"{angle_unit}**" in orig_unit_str:
-        raise NotImplementedError("Exponent angles >1, <-1 are not supported")
-    unit_list = orig_unit_str.split("/", 1)
-    exp = "." if angle_unit in unit_list[0] else "/"
-    modified_unit = "".join(str(modified_unit).split(angle_unit))
-    return ureg.Unit(f"{modified_unit}{exp}{new_angle_unit}")
-
-
-def _fix_weird_units(modified_unit: pint.Unit, orig_unit: pint.Unit) -> pint.Unit:
-    """
-    Essentially a crude unit parser for when we have no dimensions
-    or non-commutative dimensions.
-
-    Full power years (dimension [time]) and displacements per atom (dimensionless)
-    need to be readded to units as they will be removed by the dimensionality conversion.
-
-    Angle units are dimensionless and conversions between them are not robust
-
-    Returns
-    -------
-    :
-        The fixed unit
-
-    Raises
-    ------
-    ValueError
-        Multiple angle units provided
-    """
-    unit_str = f"{orig_unit:C}"
-
-    ang_unit = [ang for ang in ANGLE_UNITS if ang in unit_str]
-    if len(ang_unit) > 1:
-        raise ValueError(f"More than one angle unit not supported...🤯 {orig_unit}")
-    ang_unit = ang_unit[0] if len(ang_unit) == 1 else None
-
-    fpy = "full_power_year" in unit_str
-    dpa = "displacements_per_atom" in unit_str
-
-    if not (fpy or dpa) and ang_unit is None:
-        return ureg.Unit(modified_unit)
-
-    new_unit = _non_comutative_unit_conversion(
-        dict(modified_unit.dimensionality), unit_str.split("/", 1)[0], dpa, fpy
-    )
-
-    # Deal with angles
-    return _convert_angle_units(new_unit, unit_str, ang_unit) if ang_unit else new_unit
-
-
-def _non_comutative_unit_conversion(dimensionality, numerator, dpa, fpy):
-    """
-    Full power years (dimension [time]) and displacements per atom (dimensionless)
-    need to be readded to units as they will be removed by the dimensionality conversion.
-
-    Full power years even though time based is not the same as straight 'time' and
-    is therefore dealt with after other standard unit conversions.
-
-    Only first order of both of these units is dealt with.
-
-    Returns
-    -------
-    :
-        The converted unit
-    """
-    dpa_str = (
-        ("dpa." if "displacements_per_atom" in numerator else "dpa^-1.") if dpa else ""
-    )
-    if fpy:
-        if "full_power_year" in numerator:
-            dimensionality["[time]"] += -1
-            fpy_str = "fpy."
-        else:
-            dimensionality["[time]"] += 1
-            fpy_str = "fpy^-1."
-
-        if dimensionality["[time]"] == 0:
-            del dimensionality["[time]"]
-    else:
-        fpy_str = ""
-
-    return ureg.Unit(
-        f"{dpa_str}{fpy_str}{_fix_combined_units(_remake_units(dimensionality))}"
-    )
 
 
 @dataclass

--- a/bluemira/base/parameter_frame/_parameter.py
+++ b/bluemira/base/parameter_frame/_parameter.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar, TypedDict
+from typing import Any, Generic, Required, TypeVar, TypedDict
 
 import numpy as np
 import pint
@@ -37,12 +37,12 @@ config.typecheck_fail_callback = type_fail
 ParameterValueType = TypeVar("ParameterValueType")
 
 
-class ParamDictT(TypedDict):
+class ParamDictT(TypedDict, total=False):
     """Typed dictionary for a Parameter."""
 
     name: str
-    value: ParameterValueType
-    unit: str
+    value: Required[ParameterValueType]
+    unit: Required[str]
     source: str
     description: str
     long_name: str

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -142,6 +142,7 @@ def _remake_units(quantity: Quantity) -> pint.Quantity:
             # is not commutative or is angle (as they're dimensionless in pint)
             fix_list.append(no)
         else:
+            # commumtative parts
             ind_list.append(no)
         unit_list.append(ureg.Quantity(f"{q.magnitude}({q.units})^{multiplier}"))
 
@@ -153,7 +154,12 @@ def _remake_units(quantity: Quantity) -> pint.Quantity:
 def _convert_non_commutative(
     unit_list: list[Quantity], filter_index: list[int]
 ) -> Quantity:
-    """Converts angle units and combines non commutative units"""  # noqa: DOC201
+    """Converts angle units and combines non commutative units
+
+    Notes
+    -----
+    Commutative here means units that we dont want to combine eg time and full power year
+    """  # noqa: DOC201
 
     # There is only one unit in _units of 'i' therefore extract the key/value
     def get_key(i: Quantity) -> str:
@@ -170,6 +176,7 @@ def _convert_non_commutative(
 
             filtered_list[no] = i.to(ureg.Unit(f"{ANGLE}**{get_exp(i)}"))
 
+    # multiplies all quantities together
     return math.prod(filtered_list)
 
 
@@ -182,15 +189,19 @@ def _combine_commutative(unit_list: list[Quantity], filter_index: list[int]) -> 
     Uses pints milp optimisation which can over combine eg W/m^2 -> kg/s^3.
     The optimisation minimises combinations eg the "knapsack problem".
     This function prioritise shorter original over new which could be improved in future
+
+    Commutative here means units that we dont want to combine eg time and full power year
     """  # noqa: DOC201
     filtered_list = [unit_list[i] for i in filter_index]
 
     quantity = math.prod(filtered_list)
     if not isinstance(quantity, ureg.Quantity):
+        # is quantity now a number
         return quantity
 
     # Prefer the users SI converted unit
     # if the number of constituent units is <= the number in the new unit
+    # this one line does a lot for us in the reconstruction
     pq = quantity.to_preferred()
     if len(quantity._units.keys()) <= len(pq._units.keys()):
         return quantity

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import pint
+
+from bluemira.base.constants import ANGLE, raw_uc, ureg
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from pint import Quantity
+
+    from bluemira.base.parameter_frame._parameter import ParamDictT
+
+
+def _validate_units(param_data: ParamDictT, value_type: Iterable[type]):
+    try:
+        quantity = ureg.Quantity(param_data["value"], param_data["unit"])
+    except ValueError:
+        try:
+            quantity = ureg.Quantity(f"{param_data['value']}*{param_data['unit']}")
+        except pint.errors.PintError as pe:
+            if param_data["value"] is None:
+                quantity = ureg.Quantity(
+                    1 if param_data["unit"] in {None, ""} else param_data["unit"]
+                )
+            else:
+                raise ValueError("Unit conversion failed") from pe
+        else:
+            param_data["value"] = quantity.magnitude
+        param_data["unit"] = quantity.units
+    except KeyError as ke:
+        raise ValueError("Parameters need a value and a unit") from ke
+    except TypeError:
+        if param_data["value"] is None:
+            # dummy for None values
+            quantity = ureg.Quantity(
+                1 if param_data["unit"] in {None, ""} else param_data["unit"]
+            )
+        elif isinstance(param_data["value"], bool | str):
+            param_data["unit"] = "dimensionless"
+            return param_data
+        else:
+            raise
+
+    return _ensure_SI_unit_system(quantity, param_data, value_type)
+
+
+def _ensure_SI_unit_system(
+    quantity: Quantity, param_data: ParamDictT, value_type: Iterable[type]
+) -> ParamDictT:
+
+    if quantity.units != ureg.dimensionless:
+        unit_q = _remake_units(quantity)
+    else:
+        unit_q = quantity
+
+    if unit_q.units != quantity.units and param_data["value"] is not None:
+        val = raw_uc(quantity.magnitude, quantity.units, unit_q.units)
+        if isinstance(param_data["value"], int) and int in value_type:
+            val = int(val)
+        param_data["value"] = val
+
+    param_data["unit"] = f"{unit_q.units:~P}"
+    return param_data
+
+
+def _remake_units(quantity: Quantity) -> pint.Quantity:
+    """
+    Reconstruct unit from its dimensionality.
+
+    Parameters
+    ----------
+    quantity:
+        The quantity to reconstruct
+
+    Returns
+    -------
+    :
+        The quantity in new units
+
+    Notes
+    -----
+    The quantity of the conversion is not important here.
+    We just want the custom SI version of the input
+    The value conversion is done later.
+    """
+    unit_list, ind_list, fix_list = [], [], []
+    for no, (unit, multiplier) in enumerate(quantity.units._units.items()):
+        q = ureg.Quantity(unit)
+        if q.units not in {ureg.fpy, ureg.dpa}:
+            q = q.to_preferred()  # individually preferred (SI)
+        if q.units in {ureg.fpy, ureg.dpa} or not q.dimensionality:
+            # is not commutative or is angle (as their dimensionless in pint)
+            fix_list.append(no)
+        else:
+            ind_list.append(no)
+        unit_list.append(ureg.Quantity(f"{q.magnitude}{q.units}^{multiplier}"))
+
+    return _combine_commutative(unit_list, ind_list) * _convert_non_commutative(
+        unit_list, fix_list
+    )
+
+
+def _convert_non_commutative(
+    unit_list: list[Quantity], filter_index: list[int]
+) -> Quantity:
+    """Converts angle units and combines non commutative units"""  # noqa: DOC201
+
+    def get_key(i: Quantity) -> str:
+        return next(iter(i._units.keys()))
+
+    def get_exp(i: Quantity) -> str:
+        return next(iter(i._units.values()))
+
+    filtered_list = [unit_list[i] for i in filter_index]
+    for no, i in enumerate(filtered_list):
+        if not i.dimensionality and get_key(i) != ureg.dpa:
+            if get_key(i) in {ureg.steradian, ureg.square_degree}:
+                raise NotImplementedError("Solid angle conversion not supported")
+
+            filtered_list[no] = i.to(ureg.Unit(f"{ANGLE}**{get_exp(i)}"))
+
+    return math.prod(filtered_list)
+
+
+def _combine_commutative(unit_list: list[Quantity], filter_index: list[int]) -> Quantity:
+    """
+    Combine commutative units
+
+    Notes
+    -----
+    Uses pints milp optimisation which can over combine eg W/m^2 -> kg/s^3.
+    The optimisation minimises combinations eg the "knapsack problem".
+    This function prioritise shorter original over new which could be improved in future
+    """  # noqa: DOC201
+    filtered_list = [unit_list[i] for i in filter_index]
+
+    quantity = math.prod(filtered_list)
+    if not isinstance(quantity, ureg.Quantity):
+        return quantity
+
+    pq = quantity.to_preferred()
+    if len(quantity._units.keys()) <= len(pq._units.keys()):
+        return quantity
+    return pq

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -46,9 +46,13 @@ def _validate_units(param_data: ParamDictT, value_type: Iterable[type]) -> Param
     try:
         quantity = ureg.Quantity(param_data["value"], param_data["unit"])
     except ValueError:
+        # eg with param_data["unit"] = 1e19m^2
+        # this is checked before the value so we need to do the same value check as below
+        # for unset values
         try:
             quantity = ureg.Quantity(f"{param_data['value']}*{param_data['unit']}")
         except pint.errors.PintError as pe:
+            # eg 'None*1e19m^2' -> UndefinedUnitError not a type error
             if param_data["value"] is None:
                 quantity = ureg.Quantity(
                     1 if param_data["unit"] in {None, ""} else param_data["unit"]
@@ -61,6 +65,7 @@ def _validate_units(param_data: ParamDictT, value_type: Iterable[type]) -> Param
     except KeyError as ke:
         raise ValueError("Parameters need a value and a unit") from ke
     except TypeError:
+        # eg param_data["value"] in {None, bool, ...}
         if param_data["value"] is None:
             # dummy for None values
             quantity = ureg.Quantity(
@@ -78,14 +83,27 @@ def _validate_units(param_data: ParamDictT, value_type: Iterable[type]) -> Param
 def _ensure_SI_unit_system(
     quantity: Quantity, param_data: ParamDictT, value_type: Iterable[type]
 ) -> ParamDictT:
+    """
+    Enforces our SI unit system and updates the value accordingly
 
+    Returns
+    -------
+    :
+        Parameter dictionary
+
+    Notes
+    -----
+    Also deals with the case where a unit is collapsed to dimensionless with
+    some scaling factor, then the value should be updated
+    """
     if quantity.units != ureg.dimensionless:
         unit_q = _remake_units(quantity)
     else:
         unit_q = quantity
 
     if unit_q.units != quantity.units and param_data["value"] is not None:
-        # Convert to new units
+        # converts the old value to the new units and sets it to the correct
+        # type and on the param_data dictionary
         val = raw_uc(quantity.magnitude, quantity.units, unit_q.units)
         if isinstance(param_data["value"], int) and int in value_type:
             val = int(val)

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -20,7 +20,29 @@ if TYPE_CHECKING:
     from bluemira.base.parameter_frame._parameter import ParamDictT
 
 
-def _validate_units(param_data: ParamDictT, value_type: Iterable[type]):
+def _validate_units(param_data: ParamDictT, value_type: Iterable[type]) -> ParamDictT:
+    """Validates the user input units and enforces our version of SI units
+
+    Returns
+    -------
+    :
+        Parameter dictionary
+
+    Raises
+    ------
+    ValueError
+        If a value raises value error on a Quantity
+        If a value doesnt have a unit
+    TypeError
+        When trying to convert offset or logarithmic units or strings/bools/None
+
+
+    Notes
+    -----
+    Firstly this ensures that scaling factors are folded into the value.
+    Deals with empty values (None) and strings for parameters
+    Finally where not one of the above converts to our opinionated SI units
+    """
     try:
         quantity = ureg.Quantity(param_data["value"], param_data["unit"])
     except ValueError:

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -63,6 +63,7 @@ def _ensure_SI_unit_system(
         unit_q = quantity
 
     if unit_q.units != quantity.units and param_data["value"] is not None:
+        # Convert to new units
         val = raw_uc(quantity.magnitude, quantity.units, unit_q.units)
         if isinstance(param_data["value"], int) and int in value_type:
             val = int(val)
@@ -98,7 +99,7 @@ def _remake_units(quantity: Quantity) -> pint.Quantity:
         if q.units not in {ureg.fpy, ureg.dpa}:
             q = q.to_preferred()  # individually preferred (SI)
         if q.units in {ureg.fpy, ureg.dpa} or not q.dimensionality:
-            # is not commutative or is angle (as their dimensionless in pint)
+            # is not commutative or is angle (as they're dimensionless in pint)
             fix_list.append(no)
         else:
             ind_list.append(no)
@@ -114,6 +115,7 @@ def _convert_non_commutative(
 ) -> Quantity:
     """Converts angle units and combines non commutative units"""  # noqa: DOC201
 
+    # There is only one unit in _units of 'i' therefore extract the key/value
     def get_key(i: Quantity) -> str:
         return next(iter(i._units.keys()))
 
@@ -147,6 +149,8 @@ def _combine_commutative(unit_list: list[Quantity], filter_index: list[int]) -> 
     if not isinstance(quantity, ureg.Quantity):
         return quantity
 
+    # Prefer the users SI converted unit
+    # if the number of constituent units is <= the number in the new unit
     pq = quantity.to_preferred()
     if len(quantity._units.keys()) <= len(pq._units.keys()):
         return quantity

--- a/bluemira/base/parameter_frame/_units.py
+++ b/bluemira/base/parameter_frame/_units.py
@@ -102,7 +102,7 @@ def _remake_units(quantity: Quantity) -> pint.Quantity:
             fix_list.append(no)
         else:
             ind_list.append(no)
-        unit_list.append(ureg.Quantity(f"{q.magnitude}{q.units}^{multiplier}"))
+        unit_list.append(ureg.Quantity(f"{q.magnitude}({q.units})^{multiplier}"))
 
     return _combine_commutative(unit_list, ind_list) * _convert_non_commutative(
         unit_list, fix_list

--- a/bluemira/base/tools.py
+++ b/bluemira/base/tools.py
@@ -14,10 +14,9 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypeVar, TypedDict
 
 from matproplib.library.fluids import Void
-from typing_extensions import NotRequired
 
 from bluemira.base.components import (
     Component,

--- a/bluemira/codes/interface.py
+++ b/bluemira/codes/interface.py
@@ -378,7 +378,7 @@ class CodesSolver(abc.ABC):
         for key, val in send_recv.items():
             try:
                 p_map = param_mappings[key]
-            except KeyError:  # noqa: PERF203
+            except KeyError:
                 bluemira_warn(f"No mapping known for '{key}' in '{self.name}'.")
             else:
                 for sr_key, sr_val in val.items():

--- a/bluemira/equilibria/coils/_field.py
+++ b/bluemira/equilibria/coils/_field.py
@@ -424,7 +424,7 @@ class CoilGroupFieldsMixin:
         ind = np.nonzero(_quad_weight)
         out = np.zeros((*x.shape, *_quad_x.shape))
 
-        out[(*(slice(None) for _ in x.shape), *ind)] = greens(
+        out[*(slice(None) for _ in x.shape), *ind] = greens(
             _quad_x[ind][np.newaxis],
             _quad_z[ind][np.newaxis],
             x[..., np.newaxis],

--- a/bluemira/equilibria/solve.py
+++ b/bluemira/equilibria/solve.py
@@ -531,7 +531,7 @@ class PicardIterator:
         while self.i < self.maxiter:
             try:
                 next(iterator)
-            except StopIteration:  # noqa: PERF203
+            except StopIteration:
                 bluemira_print("EQUILIBRIA G-S converged value found.")
                 break
         else:

--- a/bluemira/geometry/coordinates.py
+++ b/bluemira/geometry/coordinates.py
@@ -2028,7 +2028,7 @@ def get_intersect(
     for i in range(n):
         try:
             xz[:, i] = np.linalg.solve(a_m[:, :, i], b_m[:, i])
-        except np.linalg.LinAlgError:  # noqa: PERF203
+        except np.linalg.LinAlgError:
             # Parallel segments. Will raise numpy RuntimeWarnings
             xz[0, i] = np.nan
     in_range = (xz[0, :] >= 0) & (xz[1, :] >= 0) & (xz[0, :] <= 1) & (xz[1, :] <= 1)

--- a/bluemira/geometry/optimisation/_optimise.py
+++ b/bluemira/geometry/optimisation/_optimise.py
@@ -6,10 +6,9 @@
 import copy
 from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
-from typing import Any, Generic, TypeVar, TypedDict
+from typing import Any, Generic, NotRequired, TypeVar, TypedDict
 
 import numpy as np
-from typing_extensions import NotRequired
 
 from bluemira.geometry.optimisation import _tools
 from bluemira.geometry.optimisation._tools import KeepOutZone

--- a/bluemira/geometry/optimisation/typed.py
+++ b/bluemira/geometry/optimisation/typed.py
@@ -5,10 +5,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Typing for the geometry optimisation module"""
 
-from typing import Protocol, TypedDict
+from typing import NotRequired, Protocol, TypedDict
 
 import numpy as np
-from typing_extensions import NotRequired
 
 from bluemira.geometry.parameterisations import GeometryParameterisation
 

--- a/bluemira/materials/cache.py
+++ b/bluemira/materials/cache.py
@@ -75,7 +75,7 @@ class MaterialCache:
         for p in package:
             try:
                 self._material_packages.append(get_module(p))
-            except ImportError:  # noqa: PERF203
+            except ImportError:
                 bluemira_warn(f"Can't import {p}, skipping")
 
     def _get_material(self, name):

--- a/bluemira/optimisation/typed.py
+++ b/bluemira/optimisation/typed.py
@@ -5,10 +5,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Types for the optimisation module."""
 
-from typing import Protocol, TypedDict
+from typing import NotRequired, Protocol, TypedDict
 
 import numpy as np
-from typing_extensions import NotRequired
 
 
 class ObjectiveCallable(Protocol):

--- a/bluemira/utilities/opt_variables.py
+++ b/bluemira/utilities/opt_variables.py
@@ -14,11 +14,10 @@ import json
 import operator
 from dataclasses import MISSING, Field, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TextIO, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TextIO, TypedDict
 
 import numpy as np
 from tabulate import tabulate
-from typing_extensions import NotRequired
 
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.utilities.error import OptVariablesError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # we should remove this once numba-scipy starts to be more regularly maintained
     "numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787",
     "numpy>=1.26.0",
-    "pint[scipy]>=0.26",
+    "pint[scipy]>=0.25.3",
     "periodictable>=1.4",
     "pyclipper>=1.3.0.post5",
     "pydantic>=2.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # we should remove this once numba-scipy starts to be more regularly maintained
     "numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787",
     "numpy>=1.26.0",
-    "pint>=0.24",
+    "pint[scipy]>=0.26",
     "periodictable>=1.4",
     "pyclipper>=1.3.0.post5",
     "pydantic>=2.11.0",
@@ -155,7 +155,7 @@ filterwarnings = ['ignore:Matplotlib is currently using agg:UserWarning',
 pythonpath = ['.', 'eudemo']
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 89
 output-format= "concise"
 exclude = [
@@ -318,7 +318,8 @@ ignore-names = [
     "*_F",
     "*eV*",
     "I_not_dI",
-    "*Li*"
+    "*Li*",
+    "*SI*"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/requirements/uv/all.txt
+++ b/requirements/uv/all.txt
@@ -525,6 +525,7 @@ scipy==1.17.1
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
+    #   pint
     #   scikit-learn
 scooby==0.11.0
     # via pyvista

--- a/requirements/uv/base.txt
+++ b/requirements/uv/base.txt
@@ -193,6 +193,7 @@ scipy==1.17.1
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
+    #   pint
     #   scikit-learn
 scooby==0.11.0
     # via pyvista

--- a/requirements/uv/develop.txt
+++ b/requirements/uv/develop.txt
@@ -389,6 +389,7 @@ scipy==1.17.1
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
+    #   pint
     #   scikit-learn
 scooby==0.11.0
     # via pyvista

--- a/requirements/uv/examples.txt
+++ b/requirements/uv/examples.txt
@@ -418,6 +418,7 @@ scipy==1.17.1
     # via
     #   bluemira (pyproject.toml)
     #   numba-scipy
+    #   pint
     #   scikit-learn
 scooby==0.11.0
     # via pyvista

--- a/scripts/format_warning_report.py
+++ b/scripts/format_warning_report.py
@@ -90,7 +90,7 @@ def format_warnings_list(warnings: Iterable[Warning]) -> list[str]:
     for warning in warnings:
         try:
             whens[warning.when].append(warning)
-        except KeyError:  # noqa: PERF203
+        except KeyError:
             whens[warning.when] = [warning]
     lines = []
     for when, warns in whens.items():

--- a/scripts/openmc_data_download/multithreaded_download.py
+++ b/scripts/openmc_data_download/multithreaded_download.py
@@ -13,7 +13,7 @@ import requests
 from rich.progress import Progress
 
 
-async def get_size(url: str, timeout: int = 10) -> int:
+async def get_size(url: str, timeout: int = 10) -> int:  # noqa: ASYNC109
     """Get size of file
 
     Returns
@@ -52,7 +52,7 @@ async def _download(
     output: Path,
     *,
     chunk_size: int = 10000000,
-    timeout: int = 10,
+    timeout: int = 10,  # noqa: ASYNC109
 ):
     """Downloader event loop
 
@@ -64,7 +64,8 @@ async def _download(
     if not url.startswith(("http:", "https:")):
         raise ValueError("Must be an http or https url")
 
-    file_size = await get_size(url)
+    async with asyncio.timeout(timeout):
+        file_size = await get_size(url, timeout=timeout)
 
     if output.is_file() and output.stat().st_size == file_size:
         return

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -77,7 +77,7 @@ def skipif_import_error(*module_name: str) -> pytest.MarkDecorator:
         try:
             __import__(m)
             skip.append(False)
-        except ImportError:  # noqa: PERF203
+        except ImportError:
             skip.append(True)
 
     if len(module_name) == 1:

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -637,6 +637,10 @@ class TestParameterFrameUnits:
         assert frame.wtf3.unit == "m⁵/deg/dpa/fpy/s"
 
     def test_combined_units(self):
+        """Tests that the reconstruction of the units combines to sane values
+
+        For example W/m² can resolve to kg/s3 which is much less commonly used
+        """
         frame = CombinedFrame.from_dict(self.COMBINED_FRAME_DATA)
         assert frame.test1.value == 5
         assert frame.test1.unit == "W/m²"

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -524,6 +524,7 @@ class UnitFrame5(ParameterFrame):
     wtf1: Parameter[float]
     wtf2: Parameter[float]
     wtf3: Parameter[float]
+    wtf4: Parameter[float]
 
 
 @dataclass

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -531,6 +531,7 @@ class CombinedFrame(ParameterFrame):
     test1: Parameter[float]
     test2: Parameter[float]
     test3: Parameter[float]
+    test4: Parameter[float]
 
 
 class TestParameterFrameUnits:
@@ -574,6 +575,7 @@ class TestParameterFrameUnits:
         "test1": {"value": 5, "unit": "W/m^2"},
         "test2": {"value": 5, "unit": "W/in^2"},
         "test3": {"value": 5, "unit": "degree/radian"},
+        "test4": {"value": 5, "unit": "A/W/m^2"},
     }
 
     def test_simple_units_to_defaults(self):
@@ -642,6 +644,8 @@ class TestParameterFrameUnits:
         assert frame.test2.unit == "W/m²"
         assert frame.test3.value == pytest.approx(0.0872665)
         assert frame.test3.unit == ""
+        assert frame.test4.value == 5
+        assert frame.test4.unit == "1/m²/V"  # is this a conversion we want?
 
     def test_bad_unit(self):
         frame_data = deepcopy(self.SIMPLE_FRAME_DATA)

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -404,7 +404,7 @@ class TestParameterFrame:
             for ind in data_values[dvi]:
                 try:
                     assert tr[headers.index(ind)] == frame_data[data_keys[no]][ind]
-                except ValueError as ve:  # noqa: PERF203
+                except ValueError as ve:
                     if ind in head_keys:
                         raise
                 except AssertionError as ae:
@@ -526,6 +526,13 @@ class UnitFrame5(ParameterFrame):
     wtf3: Parameter[float]
 
 
+@dataclass
+class CombinedFrame(ParameterFrame):
+    test1: Parameter[float]
+    test2: Parameter[float]
+    test3: Parameter[float]
+
+
 class TestParameterFrameUnits:
     SIMPLE_FRAME_DATA: ClassVar = {
         "length": {"value": 180.5, "unit": "in"},
@@ -561,6 +568,12 @@ class TestParameterFrameUnits:
         "wtf1": {"value": 5, "unit": "m^2/grade.W/(Pa.fpy)"},
         "wtf2": {"value": 5, "unit": "dpa.m^2/rad.W/(Pa.fpy)"},
         "wtf3": {"value": 5, "unit": "dpa^-1.m^2/turn.W/(Pa.fpy)"},
+    }
+
+    COMBINED_FRAME_DATA: ClassVar = {
+        "test1": {"value": 5, "unit": "W/m^2"},
+        "test2": {"value": 5, "unit": "W/in^2"},
+        "test3": {"value": 5, "unit": "degree/radian"},
     }
 
     def test_simple_units_to_defaults(self):
@@ -620,6 +633,15 @@ class TestParameterFrameUnits:
         assert frame.wtf2.unit == "dpa·m⁵/deg/fpy/s"
         assert frame.wtf3.value == pytest.approx(0.01388888)
         assert frame.wtf3.unit == "m⁵/deg/dpa/fpy/s"
+
+    def test_combined_units(self):
+        frame = CombinedFrame.from_dict(self.COMBINED_FRAME_DATA)
+        assert frame.test1.value == 5
+        assert frame.test1.unit == "W/m²"
+        assert frame.test2.value == pytest.approx(7750.0155)
+        assert frame.test2.unit == "W/m²"
+        assert frame.test3.value == pytest.approx(0.0872665)
+        assert frame.test3.unit == ""
 
     def test_bad_unit(self):
         frame_data = deepcopy(self.SIMPLE_FRAME_DATA)

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -569,6 +569,7 @@ class TestParameterFrameUnits:
         "wtf1": {"value": 5, "unit": "m^2/grade.W/(Pa.fpy)"},
         "wtf2": {"value": 5, "unit": "dpa.m^2/rad.W/(Pa.fpy)"},
         "wtf3": {"value": 5, "unit": "dpa^-1.m^2/turn.W/(Pa.fpy)"},
+        "wtf4": {"value": 1, "unit": "mW/MW"},
     }
 
     COMBINED_FRAME_DATA: ClassVar = {
@@ -635,6 +636,8 @@ class TestParameterFrameUnits:
         assert frame.wtf2.unit == "dpa·m⁵/deg/fpy/s"
         assert frame.wtf3.value == pytest.approx(0.01388888)
         assert frame.wtf3.unit == "m⁵/deg/dpa/fpy/s"
+        assert frame.wtf4.value == pytest.approx(1e-9)
+        assert frame.wtf4.unit == ""
 
     def test_combined_units(self):
         """Tests that the reconstruction of the units combines to sane values

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -45,7 +45,7 @@ class TestPlotOptions:
         for no, d in enumerate(d_view):
             try:
                 assert o_view[no] == d
-            except ValueError:  # noqa: PERF203
+            except ValueError:
                 assert all(o_view[no] == d)
 
     def test_options(self):
@@ -62,7 +62,7 @@ class TestPlotOptions:
                 for no, d in enumerate(getattr(self.default, key)):
                     try:
                         assert val[no] == d
-                    except ValueError:  # noqa: PERF203
+                    except ValueError:
                         assert all(val[no] == d)
             else:
                 assert val == getattr(self.default, key)
@@ -79,7 +79,7 @@ class TestPlotOptions:
                 for no, d in enumerate(getattr(self.default, key)):
                     try:
                         assert val[no] != d
-                    except ValueError:  # noqa: PERF203
+                    except ValueError:
                         assert all(val[no] == d)
                 assert val is not the_placement
             else:
@@ -99,7 +99,7 @@ class TestPlotOptions:
                 for no, d in enumerate(getattr(self.default, key)):
                     try:
                         assert val[no] == d
-                    except ValueError:  # noqa: PERF203
+                    except ValueError:
                         assert all(val[no] == d)
             else:
                 assert val == getattr(self.default, key)
@@ -136,7 +136,7 @@ class TestPlotOptions:
                 for no, d in enumerate(getattr(self.default, key)):
                     try:
                         assert val[no] == d
-                    except ValueError:  # noqa: PERF203
+                    except ValueError:
                         assert all(val[no] == d)
             else:
                 assert getattr(the_options, key) == val
@@ -157,7 +157,7 @@ class TestPlotOptions:
                 for no, d in enumerate(getattr(self.default, key)):
                     try:
                         assert val[no] == d
-                    except ValueError:  # noqa: PERF203
+                    except ValueError:
                         assert all(val[no] == d)
             elif key.endswith("options") or key == "number_points":
                 assert getattr(the_options, key) == val

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -375,7 +375,7 @@ class TestSolidFacePlaneIntersect:
             try:
                 assert np.isclose(sl.length / self.twopi, self.big)
                 no_big += 1
-            except AssertionError:  # noqa: PERF203
+            except AssertionError:
                 assert np.isclose(sl.length / self.twopi, self.small)
                 no_small += 1
         assert no_big == len(_slice) // 2


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4052 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This PR simplifies and refactors the unit reconstruction in parameterframe to more closely follow the original intent of the input units.

pint's `to_preferred` which works the same as our previous construction sometimes over collapses units as detailed in the issue this closes. I've worked around this by extracting our non commutative units and trying to reconstruct the remaining units into a more standard SI representation.

This needs to wait until pint has its next release, 0.25.3 (otherwise `to_preferred` can crash) and the #4154 as the newer versions of pint drop support for python3.10 (which that PR does).

To test you'll need to install pint from the repo. Probably a few more edge cases can be found to test too.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
