### PR TITLE
Updated template builder for process v330

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,6 +56,5 @@ jobs:
             -e 'plasmod_example' \
             -e 'equilibria/fem_fixed_boundary' \
             -e 'codes/ext_code_script' \
-            -e 'radiation_transport/run_cad_neutronics' \
-            -e 'codes/run_process_example'
+            -e 'radiation_transport/run_cad_neutronics'
             ${RUN_DAGMC_EX}

--- a/bluemira/codes/process/equation_variable_mapping.py
+++ b/bluemira/codes/process/equation_variable_mapping.py
@@ -55,15 +55,12 @@ class ConstraintSelection:
         List of required inputs for the constraint
     description:
         Short description of the model constraint
-    equality:
-        If true, the constraint is an equality
     """
 
     _value_: int
     requires_variables: tuple[int] = field(default_factory=tuple)
     requires_values: tuple[str] = field(default_factory=tuple)
     description: str = ""
-    equality: bool = False
 
 
 class Constraint(ConstraintSelection, Model):
@@ -71,56 +68,49 @@ class Constraint(ConstraintSelection, Model):
     Enum for PROCESS constraints
     """
 
-    BETA_CONSISTENCY = (1, (5,), (), "Beta consistency", True)
+    BETA_CONSISTENCY = (1, (5,), (), "Beta consistency")
     GLOBAL_POWER_CONSISTENCY = (
         2,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "Global Power Balance Consistency",
-        True,
     )
     ION_POWER_CONSISTENCY = (
         3,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "DEPRECATED - Ion Power Balance Consistency",
-        True,
     )
     ELECTRON_POWER_CONSISTENCY = (
         4,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "DEPRECATED - Electron Power Balance Consistency",
-        True,
     )
     DENSITY_UPPER_LIMIT = (
         5,
         (1, 2, 3, 4, 6),
         (),
         "Density Upper Limit (Greenwald)",
-        False,
     )
     EPS_BETA_POL_UPPER_LIMIT = (
         6,
         (1, 2, 3, 4, 6, 8),
         ("epbetmax",),
         "Equation for epsilon beta-poloidal upper limit",
-        False,
     )
-    HOT_BEAM_ION_DENSITY = (7, (7,), (), "Equation for hot beam ion density", True)
+    HOT_BEAM_ION_DENSITY = (7, (7,), (), "Equation for hot beam ion density")
     NWL_UPPER_LIMIT = (
         8,
         (1, 2, 3, 4, 6),
         ("pflux_fw_neutron_max_mw",),
         "Neutron wall load upper limit",
-        False,
     )
     FUSION_POWER_UPPER_LIMIT = (
         9,
         (1, 2, 3, 4, 6),
         ("p_fusion_total_max_mw",),
         "Equation for fusion power upper limit",
-        False,
     )
     # 10 NOT USED
     RADIAL_BUILD_CONSISTENCY = (
@@ -128,216 +118,186 @@ class Constraint(ConstraintSelection, Model):
         (1, 3, 13, 16, 29, 42, 61),
         (),
         "Radial Build Consistency",
-        True,
     )
     VS_LOWER_LIMIT = (
         12,
         (1, 2, 3),
         (),
         "Equation for volt-second capability lower limit",
-        False,
     )
     BURN_TIME_LOWER_LIMIT = (
         13,
         (1, 2, 3, 6, 16, 17, 19, 29, 42, 44, 61),
         (),
         "Burn time lower limit",
-        False,
     )
     NBI_LAMBDA_CENTRE = (
         14,
         (),
         (),
         "Equation to fix number of NBI decay lengths to plasma centre",
-        True,
     )
-    LH_THRESHHOLD_LIMIT = (15, (), (), "L-H Power ThresHhold Limit", False)
+    LH_THRESHHOLD_LIMIT = (15, (), (), "L-H Power ThresHhold Limit")
     NET_ELEC_LOWER_LIMIT = (
         16,
         (1, 2, 3),
         ("p_plant_electric_net_required_mw",),
         "Net electric power lower limit",
-        False,
     )
     RAD_POWER_UPPER_LIMIT = (
         17,
         (),
         (),
         "Equation for radiation power upper limit",
-        False,
     )
     DIVERTOR_HEAT_UPPER_LIMIT = (
         18,
         (),
         (),
         "Equation for divertor heat load upper limit",
-        False,
     )
-    MVA_UPPER_LIMIT = (19, (), ("mvalim",), "Equation for MVA upper limit", False)
+    MVA_UPPER_LIMIT = (19, (), ("mvalim",), "Equation for MVA upper limit")
     NBI_TANGENCY_UPPER_LIMIT = (
         20,
         (3, 13, 31),
         (),
         "Equation for neutral beam tangency radius upper limit",
-        False,
     )
-    AMINOR_LOWER_LIMIT = (21, (), (), "Equation for minor radius lower limit", False)
+    AMINOR_LOWER_LIMIT = (21, (), (), "Equation for minor radius lower limit")
     DIV_COLL_CONN_UPPER_LIMIT = (
         22,
         (34,),
         (),
         "Equation for divertor collision/connection length ratio upper limit",
-        False,
     )
     COND_SHELL_R_RATIO_UPPER_LIMIT = (
         23,
         (1, 74, 104),
         ("cwrmax",),
         "Equation for conducting shell radius / rminor upper limit",
-        False,
     )
-    BETA_UPPER_LIMIT = (24, (1, 2, 3, 4, 6, 18), (), "Beta Upper Limit", False)
+    BETA_UPPER_LIMIT = (24, (1, 2, 3, 4, 6, 18), (), "Beta Upper Limit")
     PEAK_TF_UPPER_LIMIT = (
         25,
         (3, 13, 29),
         ("b_tf_inboard_max",),
         "Peak toroidal field upper limit",
-        False,
     )
     CS_EOF_DENSITY_LIMIT = (
         26,
         (37, 41),
         (),
         "Central solenoid EOF current density upper limit",
-        False,
     )
     CS_BOP_DENSITY_LIMIT = (
         27,
         (37, 41),
         (),
         "Central solenoid bop current density upper limit",
-        False,
     )
     Q_LOWER_LIMIT = (
         28,
         (47,),
         ("big_q_plasma_min",),
         "Equation for fusion gain (big Q) lower limit",
-        False,
     )
     IB_RADIAL_BUILD_CONSISTENCY = (
         29,
         (1, 3, 13, 16, 29, 42, 61),
         (),
         "Equation for minor radius lower limit OR Inboard radial build consistency",
-        True,
     )
     PINJ_UPPER_LIMIT = (
         30,
         (11, 47),
         ("p_hcd_injected_max",),
         "Injection Power Upper Limit",
-        False,
     )
     TF_CASE_STRESS_UPPER_LIMIT = (
         31,
         (56, 57, 58, 59, 60),
         ("sig_tf_case_max",),
         "TF coil case stress upper limit",
-        False,
     )
     TF_JACKET_STRESS_UPPER_LIMIT = (
         32,
         (56, 57, 58, 59, 60),
         ("sig_tf_wp_max",),
         "TF WP steel jacket/conduit stress upper limit",
-        False,
     )
     TF_JCRIT_RATIO_UPPER_LIMIT = (
         33,
         (56, 57, 58, 59, 60),
         (),
         "TF superconductor operating current / critical current density",
-        False,
     )
     TF_DUMP_VOLTAGE_UPPER_LIMIT = (
         34,
         (56, 57, 58, 59, 60),
         ("v_tf_coil_dump_quench_max_kv",),
         "TF dump voltage upper limit",
-        False,
     )
     TF_CURRENT_DENSITY_UPPER_LIMIT = (
         35,
         (56, 57, 58, 59, 60),
         (),
         "TF winding pack current density upper limit",
-        False,
     )
     TF_T_MARGIN_LOWER_LIMIT = (
         36,
         (56, 57, 58, 59, 60),
         ("tftmp",),
         "TF temperature margin upper limit",
-        False,
     )
     CD_GAMMA_UPPER_LIMIT = (
         37,
         (47,),
         ("eta_cd_norm_hcd_primary_max",),
         "Equation for current drive gamma upper limit",
-        False,
     )
     # 38 NOT USED
-    FW_TEMP_UPPER_LIMIT = (39, (), (), "First wall peak temperature upper limit", False)
+    FW_TEMP_UPPER_LIMIT = (39, (), (), "First wall peak temperature upper limit")
     PAUX_LOWER_LIMIT = (
         40,
         (),
         ("p_hcd_injected_min",),
         "Start-up injection power upper limit (PULSE)",
-        False,
     )
     IP_RAMP_LOWER_LIMIT = (
         41,
         (65,),
         ("tohsmn",),
         "Plasma ramp-up time lower limit (PULSE)",
-        False,
     )
     CYCLE_TIME_LOWER_LIMIT = (
         42,
         (17, 65),
         ("t_cycle_min",),
         "Cycle time lower limit (PULSE)",
-        False,
     )
     CENTREPOST_TEMP_AVERAGE = (
         43,
         (13, 20, 69, 70),
         (),
         "Average centrepost temperature (TART) consistency equation",
-        True,
     )
     CENTREPOST_TEMP_UPPER_LIMIT = (
         44,
         (69, 70),
         ("ptempalw",),
         "Peak centrepost temperature upper limit (TART)",
-        False,
     )
     QEDGE_LOWER_LIMIT = (
         45,
         (1, 2, 3, 70),
         (),
         "Edge safety factor lower limit (TART)",
-        False,
     )
     IP_IROD_UPPER_LIMIT = (
         46,
         (2, 60),
         (),
         "Equation for Ip/Irod upper limit (TART)",
-        False,
     )
     # 47 NOT USED (or maybe it is, WTF?!)
     BETAPOL_UPPER_LIMIT = (
@@ -345,7 +305,6 @@ class Constraint(ConstraintSelection, Model):
         (2, 3, 18),
         ("betpmax",),
         "Poloidal beta upper limit",
-        False,
     )
     # 49 NOT USED
     REP_RATE_UPPER_LIMIT = (
@@ -353,42 +312,36 @@ class Constraint(ConstraintSelection, Model):
         (86,),
         (),
         "IFE repetition rate upper limit (IFE)",
-        False,
     )
     CS_FLUX_CONSISTENCY = (
         51,
         (1, 3, 16, 29),
         (),
         "Startup volt-seconds consistency (PULSE)",
-        True,
     )
     TBR_LOWER_LIMIT = (
         52,
         (90, 91),
         ("tbrmin",),
         "Tritium breeding ratio lower limit",
-        False,
     )
     NFLUENCE_TF_UPPER_LIMIT = (
         53,
         (93, 94),
         ("nflutfmax",),
         "Neutron fluence on TF coil upper limit",
-        False,
     )
     PNUCL_TF_UPPER_LIMIT = (
         54,
         (93, 94),
         ("ptfnucmax",),
         "Peak TF coil nuclear heating upper limit",
-        False,
     )
     PSEPR_UPPER_LIMIT = (
         56,
         (1, 3),
         ("pseprmax",),
         "Pseparatrix/Rmajor upper limit",
-        False,
     )
     # 57, 58 NOT USED
     NBI_SHINETHROUGH_UPPER_LIMIT = (
@@ -396,7 +349,6 @@ class Constraint(ConstraintSelection, Model):
         (4, 6, 19),
         ("f_p_beam_shine_through_max",),
         "Neutral beam shinethrough fraction upper limit (NBI)",
-        False,
     )
     CS_T_MARGIN_LOWER_LIMIT = (
         60,
@@ -404,9 +356,8 @@ class Constraint(ConstraintSelection, Model):
         (),
         "Central solenoid temperature margin lower limit (SCTF)[sic.."
         " I guess they mean SCCS]",
-        False,
     )
-    AVAIL_LOWER_LIMIT = (61, (107,), ("avail_min",), "Minimum availability value", False)
+    AVAIL_LOWER_LIMIT = (61, (107,), ("avail_min",), "Minimum availability value")
     CONFINEMENT_RATIO_LOWER_LIMIT = (
         62,
         (),
@@ -415,63 +366,54 @@ class Constraint(ConstraintSelection, Model):
             "t_alpha_confinement/t_energy_confinement "
             "the ratio of particle to energy confinement times"
         ),
-        False,
     )
     NITERPUMP_UPPER_LIMIT = (
         63,
         (),
         (),
         "The number of ITER-like vacuum pumps n_iter_vacuum_pumps < tfno",
-        False,
     )
     ZEFF_UPPER_LIMIT = (
         64,
         (),
         ("zeff_max",),
         "Zeff less than or equal to zeff_max",
-        False,
     )
     DUMP_TIME_LOWER_LIMIT = (
         65,
         (56,),
         ("max_vv_stress",),
         "Dump time set by VV loads",
-        False,
     )
     PF_ENERGY_RATE_UPPER_LIMIT = (
         66,
         (65,),
         ("t_plant_pulse_plasma_current_ramp_up",),
         "Limit on rate of change of energy in poloidal field",
-        False,
     )
     WALL_RADIATION_UPPER_LIMIT = (
         67,
         (4, 6),
         ("f_fw_rad_max", "pflux_fw_rad_max_mw"),
         "Simple radiation wall load limit",
-        False,
     )
     PSEPB_QAR_UPPER_LIMIT = (
         68,
         (),
         ("psepbqarmax",),
         "P_separatrix Bt / q A R upper limit",
-        False,
     )
     PSEP_KALLENBACH_UPPER_LIMIT = (
         69,
         (118,),
         (),
         "ensure the separatrix power = the value from Kallenbach divertor",
-        False,
     )
     TSEP_CONSISTENCY = (
         70,
         (119,),
         (),
         "ensure that temp = separatrix in the pedestal profile",
-        True,
     )
     NSEP_CONSISTENCY = (
         71,
@@ -481,97 +423,84 @@ class Constraint(ConstraintSelection, Model):
             "ensure that neomp "
             "= separatrix density (nd_plasma_separatrix_electron) x neratio"
         ),
-        True,
     )
     CS_STRESS_UPPER_LIMIT = (
         72,
         (),
         (),
         "Central solenoid shear stress limit (Tresca yield criterion)",
-        False,
     )
-    PSEP_LH_AUX_CONSISTENCY = (73, (137,), (), "Psep >= Plh + Paux", False)
+    PSEP_LH_AUX_CONSISTENCY = (73, (137,), (), "Psep >= Plh + Paux")
     TF_CROCO_T_UPPER_LIMIT = (
         74,
         (141,),
         ("temp_croco_quench_max",),
         "TFC quench",
-        False,
     )
     TF_CROCO_CU_AREA_CONSTRAINT = (
         75,
         (143,),
         ("coppera_m2_max",),
         "TFC current / copper area < maximum",
-        False,
     )
-    EICH_SEP_DENSITY_CONSTRAINT = (76, (), (), "Eich critical separatrix density", False)
+    EICH_SEP_DENSITY_CONSTRAINT = (76, (), (), "Eich critical separatrix density")
     TF_TURN_CURRENT_UPPER_LIMIT = (
         77,
         (),
         ("c_tf_turn_max",),
         "TF coil current per turn upper limit",
-        False,
     )
     REINKE_IMP_FRAC_LOWER_LIMIT = (
         78,
         (),
         (),
         "Reinke criterion impurity fraction lower limit",
-        False,
     )
     BMAX_CS_UPPER_LIMIT = (
         79,
         (149,),
         ("b_cs_limit_max",),
         "Peak CS field upper limit",
-        False,
     )
     PDIVT_LOWER_LIMIT = (
         80,
         (153,),
         ("p_plasma_separatrix_min_mw",),
         "Divertor power lower limit",
-        False,
     )
-    DENSITY_PROFILE_CONSISTENCY = (81, (154,), (), "Ne(0) > ne(ped) constraint", False)
-    STELLARATOR_COIL_CONSISTENCY = (82, (171,), ("toroidalgap",), False)
+    DENSITY_PROFILE_CONSISTENCY = (81, (154,), (), "Ne(0) > ne(ped) constraint")
+    STELLARATOR_COIL_CONSISTENCY = (82, (171,), ("toroidalgap",))
     STELLARATOR_RADIAL_BUILD_CONSISTENCY = (
         83,
         (172,),
         (),
         "Radial build consistency for stellarators",
-        False,
     )
-    BETA_LOWER_LIMIT = (84, (173,), (), "Lower limit for beta", False)
+    BETA_LOWER_LIMIT = (84, (173,), (), "Lower limit for beta")
     CP_LIFETIME_LOWER_LIMIT = (
         85,
         (),
         ("nflutfmax",),
         "Constraint for centrepost lifetime",
-        True,
     )
     TURN_SIZE_UPPER_LIMIT = (
         86,
         (),
         ("t_turn_tf_max",),
         "Constraint for TF coil turn dimension",
-        False,
     )
-    CRYOPOWER_UPPER_LIMIT = (87, (), (), "Constraint for cryogenic power", False)
+    CRYOPOWER_UPPER_LIMIT = (87, (), (), "Constraint for cryogenic power")
     TF_STRAIN_UPPER_LIMIT = (
         88,
         (),
         ("str_wp_max",),
         "Constraint for TF coil strain absolute value",
-        False,
     )
     OH_CROCO_CU_AREA_CONSTRAINT = (
         89,
         (166,),
         ("copperaoh_m2_max",),
         "Constraint for CS coil quench protection",
-        False,
     )
     CS_FATIGUE = (
         90,
@@ -592,14 +521,12 @@ class Constraint(ConstraintSelection, Model):
             "fracture_toughness",
         ),
         "CS fatigue constraints",
-        False,
     )
     ECRH_IGNITABILITY = (
         91,
         (),
         (),
         "Checking if the design point is ECRH ignitable",
-        False,
     )
 
 

--- a/bluemira/codes/process/equation_variable_mapping.py
+++ b/bluemira/codes/process/equation_variable_mapping.py
@@ -55,12 +55,15 @@ class ConstraintSelection:
         List of required inputs for the constraint
     description:
         Short description of the model constraint
+    equality:
+        If true, the constraint is an equality
     """
 
     _value_: int
     requires_variables: tuple[int] = field(default_factory=tuple)
     requires_values: tuple[str] = field(default_factory=tuple)
     description: str = ""
+    equality: bool = False
 
 
 class Constraint(ConstraintSelection, Model):
@@ -68,49 +71,56 @@ class Constraint(ConstraintSelection, Model):
     Enum for PROCESS constraints
     """
 
-    BETA_CONSISTENCY = (1, (5,), (), "Beta consistency")
+    BETA_CONSISTENCY = (1, (5,), (), "Beta consistency", True)
     GLOBAL_POWER_CONSISTENCY = (
         2,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "Global Power Balance Consistency",
+        True,
     )
     ION_POWER_CONSISTENCY = (
         3,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "DEPRECATED - Ion Power Balance Consistency",
+        True,
     )
     ELECTRON_POWER_CONSISTENCY = (
         4,
         (1, 2, 3, 4, 6, 10, 11),
         (),
         "DEPRECATED - Electron Power Balance Consistency",
+        True,
     )
     DENSITY_UPPER_LIMIT = (
         5,
         (1, 2, 3, 4, 6),
         (),
         "Density Upper Limit (Greenwald)",
+        False,
     )
     EPS_BETA_POL_UPPER_LIMIT = (
         6,
         (1, 2, 3, 4, 6, 8),
         ("epbetmax",),
         "Equation for epsilon beta-poloidal upper limit",
+        False,
     )
-    HOT_BEAM_ION_DENSITY = (7, (7,), (), "Equation for hot beam ion density")
+    HOT_BEAM_ION_DENSITY = (7, (7,), (), "Equation for hot beam ion density", True)
     NWL_UPPER_LIMIT = (
         8,
         (1, 2, 3, 4, 6),
         ("pflux_fw_neutron_max_mw",),
         "Neutron wall load upper limit",
+        False,
     )
     FUSION_POWER_UPPER_LIMIT = (
         9,
         (1, 2, 3, 4, 6),
         ("p_fusion_total_max_mw",),
         "Equation for fusion power upper limit",
+        False,
     )
     # 10 NOT USED
     RADIAL_BUILD_CONSISTENCY = (
@@ -118,176 +128,216 @@ class Constraint(ConstraintSelection, Model):
         (1, 3, 13, 16, 29, 42, 61),
         (),
         "Radial Build Consistency",
+        True,
     )
     VS_LOWER_LIMIT = (
         12,
         (1, 2, 3),
         (),
         "Equation for volt-second capability lower limit",
+        False,
     )
     BURN_TIME_LOWER_LIMIT = (
         13,
         (1, 2, 3, 6, 16, 17, 19, 29, 42, 44, 61),
         (),
         "Burn time lower limit",
+        False,
     )
     NBI_LAMBDA_CENTRE = (
         14,
         (),
         (),
         "Equation to fix number of NBI decay lengths to plasma centre",
+        True,
     )
-    LH_THRESHHOLD_LIMIT = (15, (), (), "L-H Power ThresHhold Limit")
+    LH_THRESHHOLD_LIMIT = (15, (), (), "L-H Power ThresHhold Limit", False)
     NET_ELEC_LOWER_LIMIT = (
         16,
         (1, 2, 3),
         ("p_plant_electric_net_required_mw",),
         "Net electric power lower limit",
+        False,
     )
-    RAD_POWER_UPPER_LIMIT = (17, (), (), "Equation for radiation power upper limit")
+    RAD_POWER_UPPER_LIMIT = (
+        17,
+        (),
+        (),
+        "Equation for radiation power upper limit",
+        False,
+    )
     DIVERTOR_HEAT_UPPER_LIMIT = (
         18,
         (),
         (),
         "Equation for divertor heat load upper limit",
+        False,
     )
-    MVA_UPPER_LIMIT = (19, (), ("mvalim",), "Equation for MVA upper limit")
+    MVA_UPPER_LIMIT = (19, (), ("mvalim",), "Equation for MVA upper limit", False)
     NBI_TANGENCY_UPPER_LIMIT = (
         20,
         (3, 13, 31),
         (),
         "Equation for neutral beam tangency radius upper limit",
+        False,
     )
-    AMINOR_LOWER_LIMIT = (21, (), (), "Equation for minor radius lower limit")
+    AMINOR_LOWER_LIMIT = (21, (), (), "Equation for minor radius lower limit", False)
     DIV_COLL_CONN_UPPER_LIMIT = (
         22,
         (34,),
         (),
         "Equation for divertor collision/connection length ratio upper limit",
+        False,
     )
     COND_SHELL_R_RATIO_UPPER_LIMIT = (
         23,
         (1, 74, 104),
         ("cwrmax",),
         "Equation for conducting shell radius / rminor upper limit",
+        False,
     )
-    BETA_UPPER_LIMIT = (24, (1, 2, 3, 4, 6, 18), (), "Beta Upper Limit")
+    BETA_UPPER_LIMIT = (24, (1, 2, 3, 4, 6, 18), (), "Beta Upper Limit", False)
     PEAK_TF_UPPER_LIMIT = (
         25,
         (3, 13, 29),
         ("b_tf_inboard_max",),
         "Peak toroidal field upper limit",
+        False,
     )
     CS_EOF_DENSITY_LIMIT = (
         26,
         (37, 41),
         (),
         "Central solenoid EOF current density upper limit",
+        False,
     )
     CS_BOP_DENSITY_LIMIT = (
         27,
         (37, 41),
         (),
         "Central solenoid bop current density upper limit",
+        False,
     )
     Q_LOWER_LIMIT = (
         28,
         (47,),
         ("big_q_plasma_min",),
         "Equation for fusion gain (big Q) lower limit",
+        False,
     )
     IB_RADIAL_BUILD_CONSISTENCY = (
         29,
         (1, 3, 13, 16, 29, 42, 61),
         (),
         "Equation for minor radius lower limit OR Inboard radial build consistency",
+        True,
     )
     PINJ_UPPER_LIMIT = (
         30,
         (11, 47),
         ("p_hcd_injected_max",),
         "Injection Power Upper Limit",
+        False,
     )
     TF_CASE_STRESS_UPPER_LIMIT = (
         31,
         (56, 57, 58, 59, 60),
         ("sig_tf_case_max",),
         "TF coil case stress upper limit",
+        False,
     )
     TF_JACKET_STRESS_UPPER_LIMIT = (
         32,
         (56, 57, 58, 59, 60),
         ("sig_tf_wp_max",),
         "TF WP steel jacket/conduit stress upper limit",
+        False,
     )
     TF_JCRIT_RATIO_UPPER_LIMIT = (
         33,
         (56, 57, 58, 59, 60),
         (),
         "TF superconductor operating current / critical current density",
+        False,
     )
     TF_DUMP_VOLTAGE_UPPER_LIMIT = (
         34,
         (56, 57, 58, 59, 60),
         ("v_tf_coil_dump_quench_max_kv",),
         "TF dump voltage upper limit",
+        False,
     )
     TF_CURRENT_DENSITY_UPPER_LIMIT = (
         35,
         (56, 57, 58, 59, 60),
         (),
         "TF winding pack current density upper limit",
+        False,
     )
     TF_T_MARGIN_LOWER_LIMIT = (
         36,
         (56, 57, 58, 59, 60),
         ("tftmp",),
         "TF temperature margin upper limit",
+        False,
     )
     CD_GAMMA_UPPER_LIMIT = (
         37,
         (47,),
         ("eta_cd_norm_hcd_primary_max",),
         "Equation for current drive gamma upper limit",
+        False,
     )
     # 38 NOT USED
-    FW_TEMP_UPPER_LIMIT = (39, (), (), "First wall peak temperature upper limit")
+    FW_TEMP_UPPER_LIMIT = (39, (), (), "First wall peak temperature upper limit", False)
     PAUX_LOWER_LIMIT = (
         40,
         (),
         ("p_hcd_injected_min",),
         "Start-up injection power upper limit (PULSE)",
+        False,
     )
     IP_RAMP_LOWER_LIMIT = (
         41,
         (65,),
         ("tohsmn",),
         "Plasma ramp-up time lower limit (PULSE)",
+        False,
     )
     CYCLE_TIME_LOWER_LIMIT = (
         42,
         (17, 65),
         ("t_cycle_min",),
         "Cycle time lower limit (PULSE)",
+        False,
     )
     CENTREPOST_TEMP_AVERAGE = (
         43,
         (13, 20, 69, 70),
         (),
         "Average centrepost temperature (TART) consistency equation",
+        True,
     )
     CENTREPOST_TEMP_UPPER_LIMIT = (
         44,
         (69, 70),
         ("ptempalw",),
         "Peak centrepost temperature upper limit (TART)",
+        False,
     )
-    QEDGE_LOWER_LIMIT = (45, (1, 2, 3, 70), (), "Edge safety factor lower limit (TART)")
+    QEDGE_LOWER_LIMIT = (
+        45,
+        (1, 2, 3, 70),
+        (),
+        "Edge safety factor lower limit (TART)",
+        False,
+    )
     IP_IROD_UPPER_LIMIT = (
         46,
         (2, 60),
         (),
         "Equation for Ip/Irod upper limit (TART)",
+        False,
     )
     # 47 NOT USED (or maybe it is, WTF?!)
     BETAPOL_UPPER_LIMIT = (
@@ -295,40 +345,58 @@ class Constraint(ConstraintSelection, Model):
         (2, 3, 18),
         ("betpmax",),
         "Poloidal beta upper limit",
+        False,
     )
     # 49 NOT USED
-    REP_RATE_UPPER_LIMIT = (50, (86,), (), "IFE repetition rate upper limit (IFE)")
+    REP_RATE_UPPER_LIMIT = (
+        50,
+        (86,),
+        (),
+        "IFE repetition rate upper limit (IFE)",
+        False,
+    )
     CS_FLUX_CONSISTENCY = (
         51,
         (1, 3, 16, 29),
         (),
         "Startup volt-seconds consistency (PULSE)",
+        True,
     )
     TBR_LOWER_LIMIT = (
         52,
         (90, 91),
         ("tbrmin",),
         "Tritium breeding ratio lower limit",
+        False,
     )
     NFLUENCE_TF_UPPER_LIMIT = (
         53,
         (93, 94),
         ("nflutfmax",),
         "Neutron fluence on TF coil upper limit",
+        False,
     )
     PNUCL_TF_UPPER_LIMIT = (
         54,
         (93, 94),
         ("ptfnucmax",),
         "Peak TF coil nuclear heating upper limit",
+        False,
     )
-    PSEPR_UPPER_LIMIT = (56, (1, 3), ("pseprmax",), "Pseparatrix/Rmajor upper limit")
+    PSEPR_UPPER_LIMIT = (
+        56,
+        (1, 3),
+        ("pseprmax",),
+        "Pseparatrix/Rmajor upper limit",
+        False,
+    )
     # 57, 58 NOT USED
     NBI_SHINETHROUGH_UPPER_LIMIT = (
         59,
         (4, 6, 19),
         ("f_p_beam_shine_through_max",),
         "Neutral beam shinethrough fraction upper limit (NBI)",
+        False,
     )
     CS_T_MARGIN_LOWER_LIMIT = (
         60,
@@ -336,8 +404,9 @@ class Constraint(ConstraintSelection, Model):
         (),
         "Central solenoid temperature margin lower limit (SCTF)[sic.."
         " I guess they mean SCCS]",
+        False,
     )
-    AVAIL_LOWER_LIMIT = (61, (107,), ("avail_min",), "Minimum availability value")
+    AVAIL_LOWER_LIMIT = (61, (107,), ("avail_min",), "Minimum availability value", False)
     CONFINEMENT_RATIO_LOWER_LIMIT = (
         62,
         (),
@@ -346,49 +415,63 @@ class Constraint(ConstraintSelection, Model):
             "t_alpha_confinement/t_energy_confinement "
             "the ratio of particle to energy confinement times"
         ),
+        False,
     )
     NITERPUMP_UPPER_LIMIT = (
         63,
         (),
         (),
         "The number of ITER-like vacuum pumps n_iter_vacuum_pumps < tfno",
+        False,
     )
-    ZEFF_UPPER_LIMIT = (64, (), ("zeff_max",), "Zeff less than or equal to zeff_max")
+    ZEFF_UPPER_LIMIT = (
+        64,
+        (),
+        ("zeff_max",),
+        "Zeff less than or equal to zeff_max",
+        False,
+    )
     DUMP_TIME_LOWER_LIMIT = (
         65,
         (56,),
         ("max_vv_stress",),
         "Dump time set by VV loads",
+        False,
     )
     PF_ENERGY_RATE_UPPER_LIMIT = (
         66,
         (65,),
         ("t_plant_pulse_plasma_current_ramp_up",),
         "Limit on rate of change of energy in poloidal field",
+        False,
     )
     WALL_RADIATION_UPPER_LIMIT = (
         67,
         (4, 6),
         ("f_fw_rad_max", "pflux_fw_rad_max_mw"),
         "Simple radiation wall load limit",
+        False,
     )
     PSEPB_QAR_UPPER_LIMIT = (
         68,
         (),
         ("psepbqarmax",),
         "P_separatrix Bt / q A R upper limit",
+        False,
     )
     PSEP_KALLENBACH_UPPER_LIMIT = (
         69,
         (118,),
         (),
         "ensure the separatrix power = the value from Kallenbach divertor",
+        False,
     )
     TSEP_CONSISTENCY = (
         70,
         (119,),
         (),
         "ensure that temp = separatrix in the pedestal profile",
+        True,
     )
     NSEP_CONSISTENCY = (
         71,
@@ -398,74 +481,97 @@ class Constraint(ConstraintSelection, Model):
             "ensure that neomp "
             "= separatrix density (nd_plasma_separatrix_electron) x neratio"
         ),
+        True,
     )
     CS_STRESS_UPPER_LIMIT = (
         72,
         (),
         (),
         "Central solenoid shear stress limit (Tresca yield criterion)",
+        False,
     )
-    PSEP_LH_AUX_CONSISTENCY = (73, (137,), (), "Psep >= Plh + Paux")
-    TF_CROCO_T_UPPER_LIMIT = (74, (141,), ("temp_croco_quench_max",), "TFC quench")
+    PSEP_LH_AUX_CONSISTENCY = (73, (137,), (), "Psep >= Plh + Paux", False)
+    TF_CROCO_T_UPPER_LIMIT = (
+        74,
+        (141,),
+        ("temp_croco_quench_max",),
+        "TFC quench",
+        False,
+    )
     TF_CROCO_CU_AREA_CONSTRAINT = (
         75,
         (143,),
         ("coppera_m2_max",),
         "TFC current / copper area < maximum",
+        False,
     )
-    EICH_SEP_DENSITY_CONSTRAINT = (76, (), (), "Eich critical separatrix density")
+    EICH_SEP_DENSITY_CONSTRAINT = (76, (), (), "Eich critical separatrix density", False)
     TF_TURN_CURRENT_UPPER_LIMIT = (
         77,
         (),
         ("c_tf_turn_max",),
         "TF coil current per turn upper limit",
+        False,
     )
     REINKE_IMP_FRAC_LOWER_LIMIT = (
         78,
         (),
         (),
         "Reinke criterion impurity fraction lower limit",
+        False,
     )
-    BMAX_CS_UPPER_LIMIT = (79, (149,), ("b_cs_limit_max",), "Peak CS field upper limit")
+    BMAX_CS_UPPER_LIMIT = (
+        79,
+        (149,),
+        ("b_cs_limit_max",),
+        "Peak CS field upper limit",
+        False,
+    )
     PDIVT_LOWER_LIMIT = (
         80,
         (153,),
         ("p_plasma_separatrix_min_mw",),
         "Divertor power lower limit",
+        False,
     )
-    DENSITY_PROFILE_CONSISTENCY = (81, (154,), (), "Ne(0) > ne(ped) constraint")
-    STELLARATOR_COIL_CONSISTENCY = (82, (171,), ("toroidalgap",))
+    DENSITY_PROFILE_CONSISTENCY = (81, (154,), (), "Ne(0) > ne(ped) constraint", False)
+    STELLARATOR_COIL_CONSISTENCY = (82, (171,), ("toroidalgap",), False)
     STELLARATOR_RADIAL_BUILD_CONSISTENCY = (
         83,
         (172,),
         (),
         "Radial build consistency for stellarators",
+        False,
     )
-    BETA_LOWER_LIMIT = (84, (173,), (), "Lower limit for beta")
+    BETA_LOWER_LIMIT = (84, (173,), (), "Lower limit for beta", False)
     CP_LIFETIME_LOWER_LIMIT = (
         85,
         (),
         ("nflutfmax",),
         "Constraint for centrepost lifetime",
+        True,
     )
     TURN_SIZE_UPPER_LIMIT = (
         86,
         (),
         ("t_turn_tf_max",),
         "Constraint for TF coil turn dimension",
+        False,
     )
-    CRYOPOWER_UPPER_LIMIT = (87, (), (), "Constraint for cryogenic power")
+    CRYOPOWER_UPPER_LIMIT = (87, (), (), "Constraint for cryogenic power", False)
     TF_STRAIN_UPPER_LIMIT = (
         88,
         (),
         ("str_wp_max",),
         "Constraint for TF coil strain absolute value",
+        False,
     )
     OH_CROCO_CU_AREA_CONSTRAINT = (
         89,
         (166,),
         ("copperaoh_m2_max",),
         "Constraint for CS coil quench protection",
+        False,
     )
     CS_FATIGUE = (
         90,
@@ -486,12 +592,14 @@ class Constraint(ConstraintSelection, Model):
             "fracture_toughness",
         ),
         "CS fatigue constraints",
+        False,
     )
     ECRH_IGNITABILITY = (
         91,
         (),
         (),
         "Checking if the design point is ECRH ignitable",
+        False,
     )
 
 

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -123,7 +123,7 @@ class PROCESSTemplateBuilder:
             bluemira_warn(f"Over-writing model choice {model_choice}.")
         self._models[model_choice.switch_name] = model_choice
 
-    def add_constraint(self, constraint: Constraint, *, equality: bool= False):
+    def add_constraint(self, constraint: Constraint, *, equality: bool = False):
         """
         Add a constraint to the PROCESS run
 

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -123,16 +123,19 @@ class PROCESSTemplateBuilder:
             bluemira_warn(f"Over-writing model choice {model_choice}.")
         self._models[model_choice.switch_name] = model_choice
 
-    def add_constraint(self, constraint: Constraint):
+    def add_constraint(self, constraint: Constraint, *, equality: bool):
         """
         Add a constraint to the PROCESS run
+
+        It must be stated whether the constraint is intended as an equality constraint
         """
         if constraint in self._constraints:
             bluemira_warn(
                 f"Constraint {constraint.name} is already in the constraint list."
             )
-        elif constraint.equality:
+        elif equality:
             self._constraints.insert(0, constraint)
+            self.neqns += 1
         else:
             self._constraints.append(constraint)
 
@@ -298,7 +301,6 @@ class PROCESSTemplateBuilder:
 
         self._check_constraint_inputs()
         icc = [con.value for con in self._constraints]
-        neqns = sum(con.equality for con in self._constraints)
         self._check_model_inputs()
         models = {k: v.value for k, v in self._models.items()}
 
@@ -310,7 +312,7 @@ class PROCESSTemplateBuilder:
             ioptimz=self.ioptimiz,
             epsvmc=self.epsvmc,
             maxcal=self.maxcal,
-            neqns=self.neqns or neqns,
+            neqns=self.neqns,
             f_nd_impurity_electrons=self.f_nd_impurity_electrons,
             **self.values,
             **models,

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -123,7 +123,7 @@ class PROCESSTemplateBuilder:
             bluemira_warn(f"Over-writing model choice {model_choice}.")
         self._models[model_choice.switch_name] = model_choice
 
-    def add_constraint(self, constraint: Constraint, *, equality: bool):
+    def add_constraint(self, constraint: Constraint, *, equality: bool= False):
         """
         Add a constraint to the PROCESS run
 

--- a/bluemira/codes/process/template_builder.py
+++ b/bluemira/codes/process/template_builder.py
@@ -131,6 +131,8 @@ class PROCESSTemplateBuilder:
             bluemira_warn(
                 f"Constraint {constraint.name} is already in the constraint list."
             )
+        elif constraint.equality:
+            self._constraints.insert(0, constraint)
         else:
             self._constraints.append(constraint)
 
@@ -296,6 +298,7 @@ class PROCESSTemplateBuilder:
 
         self._check_constraint_inputs()
         icc = [con.value for con in self._constraints]
+        neqns = sum(con.equality for con in self._constraints)
         self._check_model_inputs()
         models = {k: v.value for k, v in self._models.items()}
 
@@ -307,7 +310,7 @@ class PROCESSTemplateBuilder:
             ioptimz=self.ioptimiz,
             epsvmc=self.epsvmc,
             maxcal=self.maxcal,
-            neqns=self.neqns or None,
+            neqns=self.neqns or neqns,
             f_nd_impurity_electrons=self.f_nd_impurity_electrons,
             **self.values,
             **models,

--- a/examples/codes/run_process_example.ex.py
+++ b/examples/codes/run_process_example.ex.py
@@ -106,32 +106,34 @@ print("\n".join(str(o) for o in list(Objective)))
 
 # %% [markdown]
 # Now we will add a series of constraint equations to the PROCESS problem
-# we wish to solve. You can read more about these constraints an what
+# we wish to solve. State True if you wish the constraint to be an equality,
+# or False for an inequality.
+# You can read more about these constraints an what
 # they mean in the PROCESS documentation
 
 # %%
-for constraint in (
-    Constraint.BETA_CONSISTENCY,
-    Constraint.GLOBAL_POWER_CONSISTENCY,
-    Constraint.DENSITY_UPPER_LIMIT,
-    Constraint.RADIAL_BUILD_CONSISTENCY,
-    Constraint.BURN_TIME_LOWER_LIMIT,
-    Constraint.LH_THRESHHOLD_LIMIT,
-    Constraint.NET_ELEC_LOWER_LIMIT,
-    Constraint.TF_CASE_STRESS_UPPER_LIMIT,
-    Constraint.TF_JACKET_STRESS_UPPER_LIMIT,
-    Constraint.TF_JCRIT_RATIO_UPPER_LIMIT,
-    Constraint.TF_DUMP_VOLTAGE_UPPER_LIMIT,
-    Constraint.TF_CURRENT_DENSITY_UPPER_LIMIT,
-    Constraint.TF_T_MARGIN_LOWER_LIMIT,
-    Constraint.CS_T_MARGIN_LOWER_LIMIT,
-    Constraint.CONFINEMENT_RATIO_LOWER_LIMIT,
-    Constraint.DUMP_TIME_LOWER_LIMIT,
-    Constraint.CS_STRESS_UPPER_LIMIT,
-    Constraint.DENSITY_PROFILE_CONSISTENCY,
-    Constraint.PSEPB_QAR_UPPER_LIMIT,
+for constraint, equality in (
+    (Constraint.BETA_CONSISTENCY, True),
+    (Constraint.GLOBAL_POWER_CONSISTENCY, True),
+    (Constraint.DENSITY_UPPER_LIMIT, False),
+    (Constraint.RADIAL_BUILD_CONSISTENCY, True),
+    (Constraint.BURN_TIME_LOWER_LIMIT, False),
+    (Constraint.LH_THRESHHOLD_LIMIT, False),
+    (Constraint.NET_ELEC_LOWER_LIMIT, False),
+    (Constraint.TF_CASE_STRESS_UPPER_LIMIT, False),
+    (Constraint.TF_JACKET_STRESS_UPPER_LIMIT, False),
+    (Constraint.TF_JCRIT_RATIO_UPPER_LIMIT, False),
+    (Constraint.TF_DUMP_VOLTAGE_UPPER_LIMIT, False),
+    (Constraint.TF_CURRENT_DENSITY_UPPER_LIMIT, False),
+    (Constraint.TF_T_MARGIN_LOWER_LIMIT, False),
+    (Constraint.CS_T_MARGIN_LOWER_LIMIT, False),
+    (Constraint.CONFINEMENT_RATIO_LOWER_LIMIT, False),
+    (Constraint.DUMP_TIME_LOWER_LIMIT, False),
+    (Constraint.CS_STRESS_UPPER_LIMIT, False),
+    (Constraint.DENSITY_PROFILE_CONSISTENCY, False),
+    (Constraint.PSEPB_QAR_UPPER_LIMIT, False),
 ):
-    template_builder.add_constraint(constraint)
+    template_builder.add_constraint(constraint, equality=equality)
 
 
 # %% [markdown]


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4240 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

User now needs to state when adding a constraint whether they intend for it to be an equality constraint or not. (i.e. template_builder.add_constraint(constraint, equality=bool))

add_constraint (bluemira/codes/process/template_builder.py) now calculates neqns, and automatically sorts the equalities to be at the top of the list, which PROCESS requires.

This has been tested using examples/codes/run_process_example.ex.py, which finds a feasible solution. 


## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
