### PR TITLE
Modify to allow for to_eqdsk to be used for breakdown class

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -814,7 +814,7 @@ class Breakdown(CoilSetMHDState):
         data_dict["nbdry"] = 2
         data_dict["xbdry"] = np.zeros([2])
         data_dict["zbdry"] = np.zeros([2])
-        data_dict["psibdry"] = np.array([2])
+        data_dict["psibdry"] = 0.0
         data_dict["ffprime"] = np.zeros_like(self.grid.x_1d)
         data_dict["fpol"] = np.zeros_like(self.grid.x_1d)
         data_dict["pprime"] = np.zeros_like(self.grid.x_1d)

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -861,7 +861,7 @@ class Breakdown(CoilSetMHDState):
     def to_eqdsk(
         self,
         filename: Path | str,
-        header: str = "bluemira_breadown",
+        header: str = "bluemira_breakdown",
         directory: str | None = None,
         filetype: str = "json",
         to_cocos: int = BLUEMIRA_DEFAULT_COCOS,

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -796,7 +796,7 @@ class Breakdown(CoilSetMHDState):
             A dictionary for the Breakdown object
         """
         xc, zc, dxc, dzc, currents = self.coilset.to_group_vecs()
-        return {
+        data_dict = {
             "nx": self.grid.nx,
             "nz": self.grid.nz,
             "xdim": self.grid.x_size,
@@ -805,7 +805,6 @@ class Breakdown(CoilSetMHDState):
             "z": self.grid.z_1d,
             "xgrid1": self.grid.x_min,
             "zmid": self.grid.z_mid,
-            "cplasma": 0.0,
             "psi": self.psi(),
             "Bx": self.Bx(),
             "Bz": self.Bz(),
@@ -818,36 +817,27 @@ class Breakdown(CoilSetMHDState):
             "dxc": dxc,
             "dzc": dzc,
             "Ic": currents,
+            "psimag": self.breakdown_psi,
+            "xcentre": self.breakdown_point[0],
+            "xmag": self.breakdown_point[0],
+            "zmag": self.breakdown_point[1],
+            # Data for EQDSK
+            # Plasma current of zero does not work with Sign model in eqdsk
+            # Set to be very small positive value (match BM cocos conventions)
+            "bcentre": 1e-16,
+            # Plasma current of zero does not work with Sign model in eqdsk
+            # Set to be very small positive value (match BM cocos conventions)
+            "cplasma": 1e-16,
+            "nbdry": 2,
+            "xbdry": np.zeros([2]),
+            "zbdry": np.zeros([2]),
+            "psibdry": 0.0,
+            "ffprime": np.zeros_like(self.grid.x_1d),
+            "fpol": np.zeros_like(self.grid.x_1d),
+            "pprime": np.zeros_like(self.grid.x_1d),
+            "pressure": np.zeros_like(self.grid.x_1d),
+            "qpsi": np.zeros_like(self.grid.x_1d),
         }
-
-    def modify_dict_for_eqdsk(self, data_dict):
-        """
-        Takes a dictionary for a Breakdown object, removes any
-        values not used in eqdsk and adds appropriate fill values
-        """
-        # Remove Items can not be saved in eqdsk
-        for key in ["Bx", "By", "Bz", "Bp"]:
-            data_dict.pop(key, None)
-        # Set fill values
-        data_dict["xcentre"] = self.breakdown_point[0]
-        # Plasma current of zero does not work with Sign model in eqdsk
-        # Set to be very small positive value (match BM cocos conventions)
-        data_dict["bcentre"] = 1e-16
-        data_dict["nbdry"] = 2
-        data_dict["xbdry"] = np.zeros([2])
-        data_dict["zbdry"] = np.zeros([2])
-        data_dict["psibdry"] = 0.0
-        data_dict["ffprime"] = np.zeros_like(self.grid.x_1d)
-        data_dict["fpol"] = np.zeros_like(self.grid.x_1d)
-        data_dict["pprime"] = np.zeros_like(self.grid.x_1d)
-        data_dict["pressure"] = np.zeros_like(self.grid.x_1d)
-        data_dict["qpsi"] = np.zeros_like(self.grid.x_1d)
-        # Use breakdown point values
-        data_dict["psimag"] = self.breakdown_psi
-        data_dict["xmag"], data_dict["zmag"] = self.breakdown_point
-        # Plasma current of zero does not work with Sign model in eqdsk
-        # Set to be very small positive value (match BM cocos conventions)
-        data_dict["cplasma"] = 1e-16
         # Also account for limiter
         if self.limiter is None:
             data_dict["nlim"] = 0
@@ -857,6 +847,7 @@ class Breakdown(CoilSetMHDState):
             data_dict["nlim"] = len(self.limiter)
             data_dict["xlim"] = self.limiter.x
             data_dict["zlim"] = self.limiter.z
+        return data_dict
 
     def to_eqdsk(
         self,
@@ -871,7 +862,9 @@ class Breakdown(CoilSetMHDState):
         Writes the Breakdown Object to an eqdsk file
         """
         data = self.to_dict()
-        self.modify_dict_for_eqdsk(data)
+        # Remove Items can not be saved in eqdsk
+        for key in ["Bx", "By", "Bz", "Bp"]:
+            data.pop(key, None)
 
         bluemira_print(
             "Please note that for Breakdown class, chosen to_cocos is used and "

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -20,6 +20,7 @@ import numpy as np
 import numpy.typing as npt
 import tabulate
 from eqdsk import EQDSKInterface
+from eqdsk.cocos import COCOS
 from scipy.optimize import minimize
 
 from bluemira.base.constants import MU_0, raw_uc
@@ -225,6 +226,7 @@ class MHDState:
         directory: str | None = None,
         filetype: str = "json",
         to_cocos: int = BLUEMIRA_DEFAULT_COCOS,
+        breakdown=False,  # noqa: FBT002
         **kwargs,
     ):
         """
@@ -260,7 +262,11 @@ class MHDState:
                 ct if isinstance(ct, str) else ct.name for ct in data["coil_types"]
             ]
         eqdsk = EQDSKInterface(**data)
-        eqdsk.identify(as_cocos=BLUEMIRA_DEFAULT_COCOS, qpsi_positive=False)
+        if breakdown:
+            # Can not use identify method for breakdown, so assume input
+            eqdsk._cocos = COCOS(to_cocos)
+        else:
+            eqdsk.identify(as_cocos=BLUEMIRA_DEFAULT_COCOS, qpsi_positive=False)
         eqdsk = eqdsk.to_cocos(to_cocos)
         eqdsk.write(filename.as_posix(), file_format=filetype, **kwargs)
 
@@ -794,6 +800,41 @@ class Breakdown(CoilSetMHDState):
             "Ic": currents,
         }
 
+    def modify_dict_for_eqdsk(self, data_dict):
+        """
+        Takes a dictionary for a Breakdown object, removes any
+        values not used in eqdsk and adds appropriate fill values
+        """
+        # Remove Items can not be saved in eqdsk
+        for key in ["Bx", "By", "Bz", "Bp"]:
+            data_dict.pop(key, None)
+        # Set fill values
+        data_dict["xcentre"] = 0
+        data_dict["bcentre"] = 0
+        data_dict["nbdry"] = 2
+        data_dict["xbdry"] = np.zeros([2])
+        data_dict["zbdry"] = np.zeros([2])
+        data_dict["psibdry"] = np.array([2])
+        data_dict["ffprime"] = np.zeros_like(self.grid.x_1d)
+        data_dict["fpol"] = np.zeros_like(self.grid.x_1d)
+        data_dict["pprime"] = np.zeros_like(self.grid.x_1d)
+        data_dict["pressure"] = np.zeros_like(self.grid.x_1d)
+        # Use breakdown point values
+        data_dict["psimag"] = self.breakdown_psi
+        data_dict["xmag"], data_dict["zmag"] = self.breakdown_point
+        # # Plasma current of zero does not work with Sign model in eqdsk
+        # # Set to be very small positive value (match BM cocos conventions)
+        # data_dict["cplasma"]= 1e-16
+        # Also account for limiter
+        if self.limiter is None:
+            data_dict["nlim"] = 0
+            data_dict["xlim"] = np.array([])
+            data_dict["zlim"] = np.array([])
+        else:
+            data_dict["nlim"] = len(self.limiter)
+            data_dict["xlim"] = self.limiter.x
+            data_dict["zlim"] = self.limiter.z
+
     def to_eqdsk(
         self,
         filename: Path | str,
@@ -807,10 +848,22 @@ class Breakdown(CoilSetMHDState):
         Writes the Equilibrium Object to an eqdsk file
         """
         data = self.to_dict()
-        data["xcentre"] = 0
-        data["bcentre"] = 0
+        self.modify_dict_for_eqdsk(data)
+
+        bluemira_print(
+            "Please note that for breakdown class, chosen to_cocos is assumed and "
+            "eqdsk.identify() check is not performed."
+        )
+
         super().to_eqdsk(
-            data, filename, header, directory, filetype, to_cocos=to_cocos, **kwargs
+            data,
+            filename,
+            header,
+            directory,
+            filetype,
+            to_cocos=to_cocos,
+            breakdown=True,
+            **kwargs,
         )
 
     def set_breakdown_point(self, x_bd: float, z_bd: float):

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -218,19 +218,21 @@ class MHDState:
                 grid = grid.regrid(*regrid_nx_nz)
         return e, grid, regrid_nx_nz
 
-    def to_eqdsk(
+    def _prepare_eqdsk(
         self,
         data: dict[str, Any],
         filename: Path | str,
         header: str = "bluemira_equilibria",
         directory: str | None = None,
         filetype: str = "json",
-        to_cocos: int = BLUEMIRA_DEFAULT_COCOS,
-        breakdown=False,  # noqa: FBT002
-        **kwargs,
-    ):
+    ) -> EQDSKInterface:
         """
-        Writes the Equilibrium Object to an eqdsk file
+        Prepares the Equilibrium Object eqdsk file
+
+        Returns
+        -------
+        : EQDSKInterface
+            The initial EQDSKInterface data structure
 
         Raises
         ------
@@ -261,14 +263,7 @@ class MHDState:
             data["coil_types"] = [
                 ct if isinstance(ct, str) else ct.name for ct in data["coil_types"]
             ]
-        eqdsk = EQDSKInterface(**data)
-        if breakdown:
-            # Can not use identify method for breakdown, so assume input
-            eqdsk._cocos = COCOS(to_cocos)
-        else:
-            eqdsk.identify(as_cocos=BLUEMIRA_DEFAULT_COCOS, qpsi_positive=False)
-        eqdsk = eqdsk.to_cocos(to_cocos)
-        eqdsk.write(filename.as_posix(), file_format=filetype, **kwargs)
+        return EQDSKInterface(**data)
 
 
 class FixedPlasmaEquilibrium(MHDState):
@@ -369,6 +364,30 @@ class FixedPlasmaEquilibrium(MHDState):
         )
         self._eqdsk = e
         return self
+
+    def to_eqdsk(
+        self,
+        data,
+        filename,
+        header="bluemira_equilibria",
+        directory=None,
+        filetype="json",
+        to_cocos=BLUEMIRA_DEFAULT_COCOS,
+        **kwargs,
+    ):
+        """
+        Writes the FixedPlasmaEquilibrium Object to an eqdsk file
+        """
+        eqdsk = super()._prepare_eqdsk(
+            data,
+            filename,
+            header,
+            directory,
+            filetype,
+        )
+        eqdsk.identify(as_cocos=BLUEMIRA_DEFAULT_COCOS, qpsi_positive=False)
+        eqdsk = eqdsk.to_cocos(to_cocos)
+        eqdsk.write(self.filename.as_posix(), file_format=filetype, **kwargs)
 
     def get_LCFS(self) -> Coordinates:
         """
@@ -751,6 +770,7 @@ class Breakdown(CoilSetMHDState):
             Coilset provided by the user.
             Set current, j_max and b_max to zero in user_coils.
         """  # noqa: DOC201
+        qpsi_positive = False if qpsi_positive is None else qpsi_positive
         eqdsk, grid, _, coilset, limiter = super()._get_eqdsk(
             filename,
             from_cocos,
@@ -809,8 +829,10 @@ class Breakdown(CoilSetMHDState):
         for key in ["Bx", "By", "Bz", "Bp"]:
             data_dict.pop(key, None)
         # Set fill values
-        data_dict["xcentre"] = 0
-        data_dict["bcentre"] = 0
+        data_dict["xcentre"] = self.breakdown_point[0]
+        # Plasma current of zero does not work with Sign model in eqdsk
+        # Set to be very small positive value (match BM cocos conventions)
+        data_dict["bcentre"] = 1e-16
         data_dict["nbdry"] = 2
         data_dict["xbdry"] = np.zeros([2])
         data_dict["zbdry"] = np.zeros([2])
@@ -819,12 +841,13 @@ class Breakdown(CoilSetMHDState):
         data_dict["fpol"] = np.zeros_like(self.grid.x_1d)
         data_dict["pprime"] = np.zeros_like(self.grid.x_1d)
         data_dict["pressure"] = np.zeros_like(self.grid.x_1d)
+        data_dict["qpsi"] = np.zeros_like(self.grid.x_1d)
         # Use breakdown point values
         data_dict["psimag"] = self.breakdown_psi
         data_dict["xmag"], data_dict["zmag"] = self.breakdown_point
-        # # Plasma current of zero does not work with Sign model in eqdsk
-        # # Set to be very small positive value (match BM cocos conventions)
-        # data_dict["cplasma"]= 1e-16
+        # Plasma current of zero does not work with Sign model in eqdsk
+        # Set to be very small positive value (match BM cocos conventions)
+        data_dict["cplasma"] = 1e-16
         # Also account for limiter
         if self.limiter is None:
             data_dict["nlim"] = 0
@@ -838,33 +861,32 @@ class Breakdown(CoilSetMHDState):
     def to_eqdsk(
         self,
         filename: Path | str,
-        header: str = "bluemira_equilibria",
+        header: str = "bluemira_breadown",
         directory: str | None = None,
         filetype: str = "json",
         to_cocos: int = BLUEMIRA_DEFAULT_COCOS,
         **kwargs,
     ):
         """
-        Writes the Equilibrium Object to an eqdsk file
+        Writes the Breakdown Object to an eqdsk file
         """
         data = self.to_dict()
         self.modify_dict_for_eqdsk(data)
 
         bluemira_print(
-            "Please note that for breakdown class, chosen to_cocos is used and "
+            "Please note that for Breakdown class, chosen to_cocos is used and "
             "eqdsk.identify() check is not performed."
         )
-
-        super().to_eqdsk(
+        eqdsk = super()._prepare_eqdsk(
             data,
             filename,
             header,
             directory,
             filetype,
-            to_cocos=to_cocos,
-            breakdown=True,
-            **kwargs,
         )
+        # Can not use identify method for breakdown, so assume input
+        eqdsk._cocos = COCOS(to_cocos)
+        eqdsk.write(self.filename.as_posix(), file_format=filetype, **kwargs)
 
     def set_breakdown_point(self, x_bd: float, z_bd: float):
         """
@@ -1366,15 +1388,16 @@ class Equilibrium(CoilSetMHDState):  # noqa: PLR0904
         if "eqdsk" in filetype and qpsi_calcmode is QpsiCalcMode.NO_CALC:
             qpsi_calcmode = QpsiCalcMode.ZEROS
 
-        super().to_eqdsk(
+        eqdsk = super()._prepare_eqdsk(
             self.to_dict(qpsi_calcmode, to_cocos),
             filename,
             header,
             directory,
             filetype,
-            to_cocos=to_cocos,
-            **kwargs,
         )
+        eqdsk.identify(as_cocos=BLUEMIRA_DEFAULT_COCOS, qpsi_positive=False)
+        eqdsk = eqdsk.to_cocos(to_cocos)
+        eqdsk.write(self.filename.as_posix(), file_format=filetype, **kwargs)
 
     def __getstate__(self):
         """

--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -851,7 +851,7 @@ class Breakdown(CoilSetMHDState):
         self.modify_dict_for_eqdsk(data)
 
         bluemira_print(
-            "Please note that for breakdown class, chosen to_cocos is assumed and "
+            "Please note that for breakdown class, chosen to_cocos is used and "
             "eqdsk.identify() check is not performed."
         )
 

--- a/tests/equilibria/test_breakdown.py
+++ b/tests/equilibria/test_breakdown.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from bluemira.equilibria.constants import BLUEMIRA_DEFAULT_COCOS
 from bluemira.equilibria.equilibrium import Breakdown
 from bluemira.equilibria.grid import Grid
 from bluemira.equilibria.optimisation.constraints import (
@@ -62,8 +63,20 @@ class TestBreakdown:
         bd_flux_vs = self.breakdown.breakdown_psi * 2 * np.pi
         assert bd_flux_vs > 245
 
-    @pytest.mark.parametrize("file_format", ["json", "eqdsk", "imas", None])
-    def test_eqdsk_write(self, file_format, tmp_path):
+    @pytest.mark.parametrize("file_format", ["json", "eqdsk"])
+    def test_eqdsk_write_read(self, file_format, tmp_path):
         new_file_name = f"test_breakdown.{file_format}"
         new_file_path = Path(tmp_path, new_file_name)
-        self.breakdown.to_eqdsk(new_file_name, directory=tmp_path, filetype=file_format)
+        self.breakdown.to_eqdsk(
+            new_file_name,
+            directory=tmp_path,
+            filetype=file_format,
+            to_cocos=BLUEMIRA_DEFAULT_COCOS,
+        )
+        new_bd = Breakdown.from_eqdsk(
+            new_file_path, from_cocos=BLUEMIRA_DEFAULT_COCOS, force_symmetry=False
+        )
+        bd_flux_vs = new_bd.breakdown_psi * 2 * np.pi
+        recalced_flux_vs = new_bd.psi(*new_bd.breakdown_point) * 2 * np.pi
+        assert bd_flux_vs > 245
+        assert recalced_flux_vs > 245

--- a/tests/equilibria/test_breakdown.py
+++ b/tests/equilibria/test_breakdown.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from bluemira.equilibria.equilibrium import Breakdown
+from bluemira.equilibria.grid import Grid
+from bluemira.equilibria.optimisation.constraints import (
+    CoilFieldConstraints,
+    CoilForceConstraints,
+)
+from bluemira.equilibria.optimisation.problem._breakdown import (
+    BreakdownCOP,
+    OutboardBreakdownZoneStrategy,
+)
+from tests.equilibria.setup_methods import _coilset_setup
+
+
+class TestBreakdown:
+    @classmethod
+    def setup_class(cls):
+        _coilset_setup(cls, materials=True)
+        grid = Grid(2, 16.0, -9.0, 9.0, 100, 100)
+        cls.breakdown = Breakdown(cls.coilset, grid)
+
+        # Coil constraints
+        PF_Fz_max = 450e6  # [N]
+        CS_Fz_sum = 300e6  # [N]
+        CS_Fz_sep = 350e6  # [N]
+
+        field_constraints = CoilFieldConstraints(
+            cls.coilset, cls.coilset.b_max, tolerance=1e-6
+        )
+        force_constraints = CoilForceConstraints(
+            cls.coilset, PF_Fz_max, CS_Fz_sum, CS_Fz_sep, tolerance=1e-6
+        )
+
+        R_0 = 8.938
+        A = 3.1
+        max_currents = cls.coilset.get_max_current(0.0)
+        bd_opt_problem = BreakdownCOP(
+            cls.breakdown,
+            OutboardBreakdownZoneStrategy(R_0, A, 0.225),
+            opt_algorithm="COBYLA",
+            opt_conditions={"max_eval": 3000, "ftol_rel": 1e-6},
+            max_currents=max_currents,
+            B_stray_max=1e-3,
+            B_stray_con_tol=1e-6,
+            n_B_stray_points=10,
+            constraints=[field_constraints, force_constraints],
+        )
+
+        cls.coilset = bd_opt_problem.optimise(x0=max_currents).coilset
+
+    def test_breakdown_flux(self):
+        bd_flux_vs = self.breakdown.breakdown_psi * 2 * np.pi
+        assert bd_flux_vs > 245
+
+    @pytest.mark.parametrize("file_format", ["json", "eqdsk", "imas", None])
+    def test_eqdsk_write(self, file_format, tmp_path):
+        new_file_name = f"test_breakdown.{file_format}"
+        new_file_path = Path(tmp_path, new_file_name)
+        self.breakdown.to_eqdsk(new_file_name, directory=tmp_path, filetype=file_format)


### PR DESCRIPTION
## Linked Issues

Closes #4190

## Description

A fix to allow to_eqdsk function to be used for Breakdown class. See comments in issue #4190.
Please note work around on line 265 if you are reviewing. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
