### PR TITLE
CadQuery Tests

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -431,6 +431,16 @@ def _check_path_tangent_continuity(path: apiWire, tol: float = 1e-6) -> None:
             )
 
 
+def _get_planar_normal(wire: apiWire) -> tuple[float, float, float] | None:
+    """Returns the normal vector if the wire is planar, otherwise None."""
+    try:
+        face = cq.Face.makeFromWires(wire)  # this succeeds if planar
+        normal = face.normalAt(None)
+        return (normal.x, normal.y, normal.z)
+    except Exception:
+        return None  # wire is non-planar
+
+
 def sweep_shape(
     profiles: Iterable[apiWire],
     path: apiWire,
@@ -462,34 +472,39 @@ def sweep_shape(
 
     _check_path_tangent_continuity(path)
 
-    # bluemira's sweep semantics match FreeCAD's ``Part.Wire.makePipeShell``:
-    # all profiles are section profiles along the path (multi-section sweep),
-    # not an outer+inner wires pair. For a single profile this degenerates to
-    # a plain pipe sweep.
-    try:
-        if len(profiles) == 1:
-            transition_mode = ["transformed", "right", "round"][transition]
-            result = cq.Solid.sweep(
-                profiles[0],
-                [],
-                path,
-                makeSolid=solid,
-                isFrenet=frenet,
-                transitionMode=transition_mode,
-            )
+    planar_normal = _get_planar_normal(path)
+
+    # OCC's Frenet frame calculation relies on local path curvature. For planar paths
+    # with straight segments, this causes the frame to snap when transitioning into
+    # curved arcs, leading to self-intersecting wires that break boolean operations.
+
+    # To bypass this, calculate the normal vector of the plane the path is on. Then,
+    # explicitly pass this normal to the builder to lock the profile for the sweep.
+    # The attempts loop below will fallback to this approach if frenet=True but
+    # the geometry becomes invalid.
+
+    attempts = []
+    if frenet:
+        attempts.append(("Frenet", True, None))
+        if planar_normal:
+            attempts.append(("Planar Binormal Fallback", False, planar_normal))
+    else:
+        if planar_normal:
+            attempts.append(("Planar Binormal", False, planar_normal))
         else:
-            # cq.Solid.sweep_multi doesn't expose ``transitionMode``, so drive
-            # BRepOffsetAPI_MakePipeShell directly — that way ``transition``
-            # is honoured in the multi-profile path too, matching FreeCAD's
-            # ``path.makePipeShell(profiles, solid, frenet, transition)`` which
-            # accepts it unconditionally.
+            attempts.append(("Standard Fixed", False, None))
+
+    result = None
+    last_exc = None
+    for attempt_name, use_frenet, use_binormal in attempts:
+        try:
             builder = BRepOffsetAPI_MakePipeShell(path.wrapped)
-            builder.SetMode(frenet)
-            # Only override the transition mode when the user asked for a
-            # non-default value. Calling ``SetTransitionMode`` at all on a
-            # path without non-tangent transitions confuses OCCT's builder
-            # (Build returns IsDone=False even for the default ``Transformed``
-            # value), so we leave it alone in the common case.
+
+            if use_binormal:
+                builder.SetMode(gp_Dir(*use_binormal))
+            else:
+                builder.SetMode(use_frenet)
+
             if transition != 0:
                 builder.SetTransitionMode(
                     (
@@ -498,31 +513,53 @@ def sweep_shape(
                         BRepBuilderAPI_TransitionMode.BRepBuilderAPI_RoundCorner,
                     )[transition]
                 )
+
             for p in profiles:
                 builder.Add(p.wrapped)
+
             builder.Build()
+
             if not builder.IsDone():
                 raise FreeCADError(  # noqa: TRY301
-                    "BRepOffsetAPI_MakePipeShell failed for multi-profile sweep"
-                )
+                        "BRepOffsetAPI_MakePipeShell failed for multi-profile sweep"
+                    )
+            
             if solid:
                 builder.MakeSolid()
-            result = cq.Shape.cast(builder.Shape())
-    except FreeCADError:
-        raise
-    except Exception as exc:
-        raise FreeCADError(f"CadQuery sweep failed: {exc}") from exc
 
-    # Multi-section sweeps on composite profiles produce shells whose adjacent
-    # faces do not share topological edges — ``isValid()`` still returns True,
-    # but downstream boolean/section operations silently drop individual faces
-    # because there is no shared boundary for them to propagate across. Sewing
-    # stitches the shell back together via vertex/edge merging within
-    # tolerance, restoring a single coherent boundary.
-    if solid and len(profiles) > 1:
-        result = _sewn_solid(result)
-    if solid and not result.isValid():
-        fix_shape(result)
+            temp_result = cq.Shape.cast(builder.Shape())
+
+            # Multi-section sweeps on composite profiles produce shells whose adjacent
+            # faces do not share topological edges — ``isValid()`` still returns True,
+            # but downstream boolean/section operations silently drop individual faces
+            # because there is no shared boundary for them to propagate across. Sewing
+            # stitches the shell back together via vertex/edge merging within
+            # tolerance, restoring a single coherent boundary.
+            if solid and len(profiles) > 1:
+                temp_result = _sewn_solid(temp_result)
+            if solid and not temp_result.isValid():
+                try:
+                    fix_shape(temp_result)
+                except Exception as fix_exc:
+                    raise FreeCADError(
+                        f"{attempt_name} sweep generated an invalid solid that could not be healed."
+                    ) from fix_exc
+                
+            result = temp_result
+            break
+        except Exception as exc:
+            last_exc = exc
+            if attempt_name == "Frenet" and len(attempts) > 1:
+                bluemira_warn(f"Frenet sweep failed. Attempting Planar Binormal fallback...")
+                continue # try the next strategy
+            # If it's the last attempt in the list, we let the loop finish and raise below
+
+    if result is None:
+        raise FreeCADError(
+            "Sweep failed. If the solid was invalid and could not be healed, "
+            "this usually happens when the profile is too large for the path's "
+            "minimum bend radius, causing the sweep to self-intersect."
+        ) from last_exc
 
     if solid:
         return result

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -30,6 +30,7 @@ from OCP.BRepAdaptor import (
 )
 from OCP.BRepAlgoAPI import (
     BRepAlgoAPI_BuilderAlgo,
+    BRepAlgoAPI_Check,
     BRepAlgoAPI_Section,
     BRepAlgoAPI_Splitter,
 )
@@ -47,6 +48,7 @@ from OCP.BRepClass3d import BRepClass3d_SolidClassifier
 from OCP.BRepExtrema import BRepExtrema_DistShapeShape
 from OCP.BRepFilletAPI import BRepFilletAPI_MakeFillet2d
 from OCP.BRepGProp import BRepGProp
+from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.BRepOffsetAPI import BRepOffsetAPI_MakePipeShell, BRepOffsetAPI_ThruSections
 from OCP.BRepPrimAPI import BRepPrimAPI_MakePrism, BRepPrimAPI_MakeRevol
 from OCP.BRepTools import BRepTools_WireExplorer
@@ -549,7 +551,11 @@ def sweep_shape(  # noqa: C901
             # tolerance, restoring a single coherent boundary.
             if solid and len(profiles) > 1:
                 temp_result = _sewn_solid(temp_result)
-            if solid and not temp_result.isValid():
+            # We could check ``is_valid_deep`` here, but it is extremely computationally
+            # expensive and invalid geometry will end up calling it twice.
+            # Instead, it is best to just call ``fix_shape`` regardless, it is much
+            # less expensive and means is_valid_deep only gets called once.
+            if solid:
                 try:
                     fix_shape(temp_result)
                 except Exception as fix_exc:
@@ -557,6 +563,10 @@ def sweep_shape(  # noqa: C901
                         f"{attempt_name} sweep generated an invalid solid "
                         "that could not be healed."
                     ) from fix_exc
+                if not is_valid_deep(temp_result):
+                    raise FreeCADError(  # noqa: TRY301
+                        f"{attempt_name} sweep failed deep validation after healing."
+                    )
 
             result = temp_result
             break
@@ -604,6 +614,7 @@ def _sewn_solid(solid: apiSolid, tolerance: float = 1e-3) -> apiSolid:
         return solid
     new_solid = cq.Solid(maker.Solid())
     if not new_solid.isValid():
+        bluemira_warn("Failed to build valid new solid. Returning original solid.")
         return solid
     return new_solid
 
@@ -822,6 +833,43 @@ def is_closed(obj: apiShape) -> bool:
 def is_valid(obj) -> bool:
     """True if the shape is valid."""
     return obj.isValid()
+
+
+def is_valid_deep(shape: apiShape) -> bool:
+    """Rigorously check shape validity."""
+    bluemira_warn(
+        "This validation can take a long time to run. Only use where necessary."
+    )
+    # topological structure
+    if not shape.isValid():
+        return False
+
+    # inside out check
+    if isinstance(shape, cq.Solid) and shape.Volume() < _OCC_DEFAULT_TOL:
+        return False
+
+    # spatial self-intersections
+    bop_checker = BRepAlgoAPI_Check(shape.wrapped)  # this can take a very long time
+    if not bop_checker.IsValid():
+        return False
+
+    face_explorer = TopExp_Explorer(shape.wrapped, TopAbs_FACE)
+    if face_explorer.More():  # only run surface mesher if the shape contains faces
+        try:
+            # theLinDeflection=0.1 - coarse mesh to test it can build without crashing
+            # isRelative=False - all shapes checked with same tolerances
+            # theAngDeflection=0.5 - coarse curve checking for stability
+            # isInParallel=True
+            # parameters are purposefully coarse to reduce computational load
+            # but this is a good test for mathematical validity
+            mesh = BRepMesh_IncrementalMesh(shape.wrapped, 0.1, False, 0.5, True)
+            mesh.Perform()
+            if not mesh.IsDone():
+                return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    return True
 
 
 def fix_shape(shape: apiShape, precision: float = 1e-6, min_length: float = 1e-8):
@@ -2434,6 +2482,7 @@ __all__ = [
     "is_null",
     "is_same",
     "is_valid",
+    "is_valid_deep",
     "join_connect",
     "length",
     "loft",

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -456,7 +456,7 @@ def _get_planar_normal(wire: apiWire) -> tuple[float, float, float] | None:
         return (normal.x, normal.y, normal.z)
 
 
-def sweep_shape(  # noqa: C901
+def sweep_shape(  # noqa: C901, PLR0912
     profiles: Iterable[apiWire],
     path: apiWire,
     *,
@@ -563,6 +563,10 @@ def sweep_shape(  # noqa: C901
                         f"{attempt_name} sweep generated an invalid solid "
                         "that could not be healed."
                     ) from fix_exc
+                if not temp_result.isValid():
+                    raise FreeCADError(  # noqa: TRY301
+                        f"{attempt_name} sweep failed validation after healing."
+                    )
                 if not is_valid_deep(temp_result):
                     raise FreeCADError(  # noqa: TRY301
                         f"{attempt_name} sweep failed deep validation after healing."
@@ -836,10 +840,10 @@ def is_valid(obj) -> bool:
 
 
 def is_valid_deep(shape: apiShape) -> bool:
-    """Rigorously check shape validity."""
-    bluemira_warn(
-        "This validation can take a long time to run. Only use where necessary."
-    )
+    """
+    Rigorously check shape validity.
+    This can take a very long time to execute.
+    """
     # topological structure
     if not shape.isValid():
         return False

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -409,6 +409,23 @@ def _edge_junction_pairs(wire: apiWire) -> list[tuple[apiEdge, apiEdge]]:
     return pairs
 
 
+def _wire_edges_tangent(wire: apiWire, atol: float = 1e-4) -> bool:
+    """True if all consecutive edges in the wire are tangent at their joins.
+
+    For closed wires also checks the seam (last edge → first edge), matching
+    ``_freecadapi._wire_edges_tangent``. Uses per-edge ``BRepAdaptor_Curve.D1``
+    via :func:`_edge_pair_cos_angle` — wire-level ``tangentAt`` smooths across
+    edge boundaries and would silently miss hard kinks (90° polygon corners).
+    """
+    for e_prev, e_next in _edge_junction_pairs(wire):
+        cos_angle = _edge_pair_cos_angle(e_prev, e_next)
+        if cos_angle is None:
+            continue
+        if cos_angle < 1.0 - atol:
+            return False
+    return True
+
+
 def _check_path_tangent_continuity(path: apiWire, tol: float = 1e-6) -> None:
     """Raise ``FreeCADError`` if the path has a non-tangent-continuous join.
 
@@ -420,15 +437,10 @@ def _check_path_tangent_continuity(path: apiWire, tol: float = 1e-6) -> None:
     producing a self-intersecting / kinked solid. FreeCAD raises on this
     case, so we do too.
     """
-    for e_prev, e_next in _edge_junction_pairs(path):
-        cos_angle = _edge_pair_cos_angle(e_prev, e_next)
-        if cos_angle is None:
-            continue
-        if cos_angle < 1.0 - tol:
-            raise FreeCADError(
-                "sweep_shape: path is not tangent-continuous at an interior "
-                f"vertex (cos(angle)={cos_angle:.6f})."
-            )
+    if not _wire_edges_tangent(path, atol=tol):
+        raise FreeCADError(
+            "sweep_shape: path is not tangent-continuous at an interior vertex."
+        )
 
 
 def _get_planar_normal(wire: apiWire) -> tuple[float, float, float] | None:
@@ -436,12 +448,13 @@ def _get_planar_normal(wire: apiWire) -> tuple[float, float, float] | None:
     try:
         face = cq.Face.makeFromWires(wire)  # this succeeds if planar
         normal = face.normalAt(None)
-        return (normal.x, normal.y, normal.z)
-    except Exception:
+    except ValueError:
         return None  # wire is non-planar
+    else:
+        return (normal.x, normal.y, normal.z)
 
 
-def sweep_shape(
+def sweep_shape(  # noqa: C901
     profiles: Iterable[apiWire],
     path: apiWire,
     *,
@@ -488,11 +501,10 @@ def sweep_shape(
         attempts.append(("Frenet", True, None))
         if planar_normal:
             attempts.append(("Planar Binormal Fallback", False, planar_normal))
+    elif planar_normal:
+        attempts.append(("Planar Binormal", False, planar_normal))
     else:
-        if planar_normal:
-            attempts.append(("Planar Binormal", False, planar_normal))
-        else:
-            attempts.append(("Standard Fixed", False, None))
+        attempts.append(("Standard Fixed", False, None))
 
     result = None
     last_exc = None
@@ -521,9 +533,9 @@ def sweep_shape(
 
             if not builder.IsDone():
                 raise FreeCADError(  # noqa: TRY301
-                        "BRepOffsetAPI_MakePipeShell failed for multi-profile sweep"
-                    )
-            
+                    "BRepOffsetAPI_MakePipeShell failed for multi-profile sweep"
+                )
+
             if solid:
                 builder.MakeSolid()
 
@@ -542,17 +554,20 @@ def sweep_shape(
                     fix_shape(temp_result)
                 except Exception as fix_exc:
                     raise FreeCADError(
-                        f"{attempt_name} sweep generated an invalid solid that could not be healed."
+                        f"{attempt_name} sweep generated an invalid solid "
+                        "that could not be healed."
                     ) from fix_exc
-                
+
             result = temp_result
             break
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             last_exc = exc
             if attempt_name == "Frenet" and len(attempts) > 1:
-                bluemira_warn(f"Frenet sweep failed. Attempting Planar Binormal fallback...")
-                continue # try the next strategy
-            # If it's the last attempt in the list, we let the loop finish and raise below
+                bluemira_warn(
+                    "Frenet sweep failed. Attempting Planar Binormal fallback..."
+                )
+                continue  # try the next strategy
+            # If it's the last attempt in the list, let the loop finish and raise below
 
     if result is None:
         raise FreeCADError(
@@ -587,7 +602,10 @@ def _sewn_solid(solid: apiSolid, tolerance: float = 1e-3) -> apiSolid:
     maker = BRepBuilderAPI_MakeSolid(shells[0].wrapped)
     if not maker.IsDone():
         return solid
-    return cq.Solid(maker.Solid())
+    new_solid = cq.Solid(maker.Solid())
+    if not new_solid.isValid():
+        return solid
+    return new_solid
 
 
 def offset_wire(
@@ -692,23 +710,6 @@ def _wire_is_planar(wire: apiWire) -> bool:
         return face.geomType() == "PLANE"
     except Exception:  # noqa: BLE001
         return False
-
-
-def _wire_edges_tangent(wire: apiWire, atol: float = 1e-4) -> bool:
-    """True if all consecutive edges in the wire are tangent at their joins.
-
-    For closed wires also checks the seam (last edge → first edge), matching
-    ``_freecad.api._wire_edges_tangent``. Uses per-edge ``BRepAdaptor_Curve.D1``
-    via :func:`_edge_pair_cos_angle` — wire-level ``tangentAt`` smooths across
-    edge boundaries and would silently miss hard kinks (90° polygon corners).
-    """
-    for e_prev, e_next in _edge_junction_pairs(wire):
-        cos_angle = _edge_pair_cos_angle(e_prev, e_next)
-        if cos_angle is None:
-            continue
-        if cos_angle < 1.0 - atol:
-            return False
-    return True
 
 
 # ---------------------------------------------------------------------------

--- a/bluemira/codes/cadapi/_freecad/api.py
+++ b/bluemira/codes/cadapi/_freecad/api.py
@@ -867,6 +867,22 @@ def is_valid(obj) -> bool:
     return _get_api_attr(obj, "isValid")()
 
 
+def is_valid_deep(obj) -> bool:
+    """
+    Not implemented.
+
+    Returns
+    -------
+    :
+        A boolean for if the shape is valid.
+    """
+    bluemira_warn(
+        "Deep shape validation is not implemented for FreeCAD. "
+        "Returning regular validation."
+    )
+    return _get_api_attr(obj, "isValid")()
+
+
 def is_same(obj1: apiShape, obj2: apiShape) -> bool:
     """True if obj1 and obj2 have the same shape."""  # noqa: DOC201
     return obj1.isSame(obj2)

--- a/bluemira/geometry/base.py
+++ b/bluemira/geometry/base.py
@@ -255,6 +255,17 @@ class BluemiraGeo(ABC, meshing.Meshable):
         """
         return cadapi.is_valid(self.shape)
 
+    def is_valid_deep(self) -> bool:
+        """
+        Check if the shape is valid more thoroughly than ``is_valid``.
+
+        Returns
+        -------
+        :
+            A boolean for if the shape is valid.
+        """
+        return cadapi.is_valid_deep(self.shape)
+
     def is_same(self, obj: BluemiraGeo) -> bool:
         """
         Check if obj has the same shape as self

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -28,10 +28,16 @@ from scipy.special import ellipe
 from bluemira.base.constants import EPS
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import D_TOLERANCE, EPS_FREECAD
-from bluemira.geometry.wire import BluemiraWire
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import PrincetonDDiscrete
-from bluemira.geometry.tools import boolean_cut, extrude_shape, make_polygon, sweep_shape, offset_wire
+from bluemira.geometry.tools import (
+    boolean_cut,
+    extrude_shape,
+    make_polygon,
+    offset_wire,
+    sweep_shape,
+)
+from bluemira.geometry.wire import BluemiraWire  # noqa: TC001
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -66,13 +72,13 @@ class BackendApiTestsBase:
         return self.cadapi.offset_wire(wire, 0.05, join="intersect", open_wire=False)
 
     def _chain_cad_operations(
-            self,
-            x1: float,
-            x2: float,
-            n_TF: int,
-            tf_wp_depth: float,
-            tf_wp_width: float,
-            d_offset: float,
+        self,
+        x1: float,
+        x2: float,
+        n_TF: int,
+        tf_wp_depth: float,
+        tf_wp_width: float,
+        d_offset: float,
     ) -> tuple[BluemiraWire, BluemiraWire, BluemiraWire, BluemiraWire]:
         """
         Generates a Princeton D coil path, an offset path, and their corresponding
@@ -109,15 +115,37 @@ class BackendApiTestsBase:
         x_min = wire_offset.discretise(10, byedges=True).x.min()
         xs = make_polygon(
             {
-                "x": [-0.5*tf_wp_width, 0.5*tf_wp_width, 0.5*tf_wp_width, -0.5*tf_wp_width],
-                "y": [-0.5*tf_wp_depth, -0.5*tf_wp_depth, 0.5*tf_wp_depth, 0.5*tf_wp_depth],
-            }, closed=True,
+                "x": [
+                    -0.5 * tf_wp_width,
+                    0.5 * tf_wp_width,
+                    0.5 * tf_wp_width,
+                    -0.5 * tf_wp_width,
+                ],
+                "y": [
+                    -0.5 * tf_wp_depth,
+                    -0.5 * tf_wp_depth,
+                    0.5 * tf_wp_depth,
+                    0.5 * tf_wp_depth,
+                ],
+            },
+            closed=True,
         )
         xs2 = make_polygon(
             {
-                "x": [-0.48*tf_wp_width, 0.48*tf_wp_width, 0.48*tf_wp_width, -0.48*tf_wp_width],
-                "y": [-0.48*tf_wp_depth, -0.48*tf_wp_depth, 0.48*tf_wp_depth, 0.48*tf_wp_depth],
-            }, closed=True,
+                "x": [
+                    -0.48 * tf_wp_width,
+                    0.48 * tf_wp_width,
+                    0.48 * tf_wp_width,
+                    -0.48 * tf_wp_width,
+                ],
+                "y": [
+                    -0.48 * tf_wp_depth,
+                    -0.48 * tf_wp_depth,
+                    0.48 * tf_wp_depth,
+                    0.48 * tf_wp_depth,
+                ],
+            },
+            closed=True,
         )
         xs.translate((wire.discretise(10, byedges=True).x.min(), 0, 0))
         xs2.translate((x_min, 0, 0))
@@ -489,14 +517,14 @@ class BackendApiTestsBase:
         sweep = sweep_shape(xs2, wire_offset, frenet=frenet)
         assert sweep.is_valid()
         if frenet:
-            assert ("Attempting Planar Binormal fallback." in caplog.messages[0])
+            assert "Attempting Planar Binormal fallback." in caplog.messages[0]
 
     def test_invalid_offset(self):
         """Inward offset too great - causing self-intersecting wires."""
+        _, wire_offset, _, xs2 = self._chain_cad_operations(
+            x1=3, x2=10, n_TF=10, tf_wp_depth=0.5, tf_wp_width=0.5, d_offset=1.0
+        )
         with pytest.raises(FreeCADError):
-            _, wire_offset, _, xs2 = self._chain_cad_operations(
-                x1=3, x2=10, n_TF=10, tf_wp_depth=0.5, tf_wp_width=0.5, d_offset=1.0
-            )
             _ = sweep_shape(xs2, wire_offset, frenet=False)
 
     @pytest.mark.parametrize("frenet", [True, False])
@@ -520,8 +548,7 @@ class BackendApiTestsBase:
         xs2.scale(0.95)
         sweep_inner = sweep_shape(xs2, wire, frenet=False)
 
-        result_hollow = boolean_cut(sweep_outer, sweep_inner)[0]
-        return result_hollow
+        return boolean_cut(sweep_outer, sweep_inner)[0]
 
     def test_boolean_cut_hollow_coil(self, boolean_cut_princeton):
         assert boolean_cut_princeton.is_valid()
@@ -531,7 +558,8 @@ class BackendApiTestsBase:
         cut_tool = extrude_shape(
             BluemiraFace(
                 make_polygon({"x": [0, 20, 20, 0], "z": [-20, -20, 20, 20]}, closed=True)
-            ), (0, -10, 0)
+            ),
+            (0, -10, 0),
         )
         sliced_coil = boolean_cut(boolean_cut_princeton, cut_tool)[0]
         assert sliced_coil.is_valid()

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -508,6 +508,7 @@ class BackendApiTestsBase:
         )
         self._assert_arc_endpoints_match(ellipse_arc, reconstructed, reverse=reverse)
 
+    @pytest.mark.longrun
     @pytest.mark.parametrize("frenet", [True, False])
     def test_valid_offset(self, frenet, caplog):
         """Offset the Princeton D by a valid amount."""

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -515,6 +515,9 @@ class BackendApiTestsBase:
             x1=3, x2=16, n_TF=16, tf_wp_depth=0.5, tf_wp_width=0.5, d_offset=0.1
         )
         sweep = sweep_shape(xs2, wire_offset, frenet=frenet)
+        # It is enough to simply check that sweep exists since, for solids,
+        # sweep_shape now only returns geometry for which ``is_valid_deep``
+        # evaluates to true, otherwise it raises.
         assert sweep.is_valid()
         if frenet:
             assert "Attempting Planar Binormal fallback." in caplog.messages[0]
@@ -534,6 +537,9 @@ class BackendApiTestsBase:
             x1=3, x2=10, n_TF=18, tf_wp_depth=0.5, tf_wp_width=0.6, d_offset=0.2
         )
         sweep_frenet = sweep_shape(xs, wire, frenet=frenet)
+        # For the same reason as ``test_valid_offset``, we only need check
+        # sweep_frenet exists to know it is valid. This avoids calling the
+        # expensive ``is_valid_deep`` again.
         assert sweep_frenet.is_valid()
 
     @pytest.fixture
@@ -551,7 +557,9 @@ class BackendApiTestsBase:
         return boolean_cut(sweep_outer, sweep_inner)[0]
 
     def test_boolean_cut_hollow_coil(self, boolean_cut_princeton):
-        assert boolean_cut_princeton.is_valid()
+        # We must call ``is_valid_deep`` here because boolean cut does not currently
+        # guarantee returned geometry is truly valid
+        assert boolean_cut_princeton.is_valid_deep()
 
     def test_boolean_cut_cross_section(self, boolean_cut_princeton):
         """Cut complex swept solid with extruded block."""
@@ -562,4 +570,4 @@ class BackendApiTestsBase:
             (0, -10, 0),
         )
         sliced_coil = boolean_cut(boolean_cut_princeton, cut_tool)[0]
-        assert sliced_coil.is_valid()
+        assert sliced_coil.is_valid_deep()  # similar to ``test_boolean_cut_hollow_coil``

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -28,6 +28,10 @@ from scipy.special import ellipe
 from bluemira.base.constants import EPS
 from bluemira.codes.error import FreeCADError
 from bluemira.geometry.constants import D_TOLERANCE, EPS_FREECAD
+from bluemira.geometry.wire import BluemiraWire
+from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.parameterisations import PrincetonDDiscrete
+from bluemira.geometry.tools import boolean_cut, extrude_shape, make_polygon, sweep_shape, offset_wire
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -60,6 +64,64 @@ class BackendApiTestsBase:
 
     def _offsetter(self, wire):
         return self.cadapi.offset_wire(wire, 0.05, join="intersect", open_wire=False)
+
+    def _chain_cad_operations(
+            self,
+            x1: float,
+            x2: float,
+            n_TF: int,
+            tf_wp_depth: float,
+            tf_wp_width: float,
+            d_offset: float,
+    ) -> tuple[BluemiraWire, BluemiraWire, BluemiraWire, BluemiraWire]:
+        """
+        Generates a Princeton D coil path, an offset path, and their corresponding
+        sweep profiles for testing CAD sweep and boolean operations chained.
+
+        Parameters
+        ----------
+        x1:
+            The inner radial coorindate of the D.
+        x2:
+            The outer radial coordinate of the D.
+        n_TF:
+            Number of toroidal field coils.
+        tf_wp_depth:
+            The thickness of the winding pack cross section.
+        tf_wp_width:
+            The width of the winding pack cross section.
+        d_offset:
+            The distance to offset the D.
+
+        Returns
+        -------
+        A tuple consisting of the original Princeton D path, the offset path,
+        a rectangular cross section profile, and a scaled down cross section profile.
+        """
+        p = PrincetonDDiscrete(
+            {"x1": {"value": x1}, "x2": {"value": x2}},
+            n_TF=n_TF,
+            tf_wp_depth=tf_wp_depth,
+            tf_wp_width=tf_wp_width,
+        )
+        wire = p.create_shape()
+        wire_offset = offset_wire(wire, d_offset, fallback_method="round", join="arc")
+        x_min = wire_offset.discretise(10, byedges=True).x.min()
+        xs = make_polygon(
+            {
+                "x": [-0.5*tf_wp_width, 0.5*tf_wp_width, 0.5*tf_wp_width, -0.5*tf_wp_width],
+                "y": [-0.5*tf_wp_depth, -0.5*tf_wp_depth, 0.5*tf_wp_depth, 0.5*tf_wp_depth],
+            }, closed=True,
+        )
+        xs2 = make_polygon(
+            {
+                "x": [-0.48*tf_wp_width, 0.48*tf_wp_width, 0.48*tf_wp_width, -0.48*tf_wp_width],
+                "y": [-0.48*tf_wp_depth, -0.48*tf_wp_depth, 0.48*tf_wp_depth, 0.48*tf_wp_depth],
+            }, closed=True,
+        )
+        xs.translate((wire.discretise(10, byedges=True).x.min(), 0, 0))
+        xs2.translate((x_min, 0, 0))
+        return wire, wire_offset, xs, xs2
 
     def test_multi_offset_wire(self):
         circ = self.cadapi.make_circle(10)
@@ -417,3 +479,59 @@ class BackendApiTestsBase:
             self.cadapi.serialise_shape(ellipse_arc)
         )
         self._assert_arc_endpoints_match(ellipse_arc, reconstructed, reverse=reverse)
+
+    @pytest.mark.parametrize("frenet", [True, False])
+    def test_valid_offset(self, frenet, caplog):
+        """Offset the Princeton D by a valid amount."""
+        _, wire_offset, _, xs2 = self._chain_cad_operations(
+            x1=3, x2=16, n_TF=16, tf_wp_depth=0.5, tf_wp_width=0.5, d_offset=0.1
+        )
+        sweep = sweep_shape(xs2, wire_offset, frenet=frenet)
+        assert sweep.is_valid()
+        if frenet:
+            assert ("Attempting Planar Binormal fallback." in caplog.messages[0])
+
+    def test_invalid_offset(self):
+        """Inward offset too great - causing self-intersecting wires."""
+        with pytest.raises(FreeCADError):
+            _, wire_offset, _, xs2 = self._chain_cad_operations(
+                x1=3, x2=10, n_TF=10, tf_wp_depth=0.5, tf_wp_width=0.5, d_offset=1.0
+            )
+            _ = sweep_shape(xs2, wire_offset, frenet=False)
+
+    @pytest.mark.parametrize("frenet", [True, False])
+    def test_sweep_no_offset(self, frenet):
+        """Sweep the original Princeton D."""
+        wire, wire_offset, xs, xs2 = self._chain_cad_operations(
+            x1=3, x2=10, n_TF=18, tf_wp_depth=0.5, tf_wp_width=0.6, d_offset=0.2
+        )
+        sweep_frenet = sweep_shape(xs, wire, frenet=frenet)
+        assert sweep_frenet.is_valid()
+
+    @pytest.fixture
+    def boolean_cut_princeton(self):
+        """Boolean cut using two sweeps."""
+        wire, _, xs, _ = self._chain_cad_operations(
+            x1=3, x2=10, n_TF=18, tf_wp_depth=0.5, tf_wp_width=0.6, d_offset=0.2
+        )
+        sweep_outer = sweep_shape(xs, wire, frenet=False)
+
+        xs2 = xs.deepcopy()
+        xs2.scale(0.95)
+        sweep_inner = sweep_shape(xs2, wire, frenet=False)
+
+        result_hollow = boolean_cut(sweep_outer, sweep_inner)[0]
+        return result_hollow
+
+    def test_boolean_cut_hollow_coil(self, boolean_cut_princeton):
+        assert boolean_cut_princeton.is_valid()
+
+    def test_boolean_cut_cross_section(self, boolean_cut_princeton):
+        """Cut complex swept solid with extruded block."""
+        cut_tool = extrude_shape(
+            BluemiraFace(
+                make_polygon({"x": [0, 20, 20, 0], "z": [-20, -20, 20, 20]}, closed=True)
+            ), (0, -10, 0)
+        )
+        sliced_coil = boolean_cut(boolean_cut_princeton, cut_tool)[0]
+        assert sliced_coil.is_valid()

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -21,6 +21,10 @@ pytestmark = pytest.mark.skipif(
 cadapi = pytest.importorskip("bluemira.codes.cadapi._cadquery")
 cq = pytest.importorskip("cadquery")
 
+import numpy as np
+import cadquery as cq
+
+from bluemira.geometry.error import GeometryError
 from bluemira.codes.error import FreeCADError  # noqa: E402
 from bluemira.geometry.error import GeometryError  # noqa: E402
 from tests.codes._shared.backend_api_tests import BackendApiTestsBase  # noqa: E402
@@ -43,6 +47,191 @@ def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
 
 class TestCadqueryapi(BackendApiTestsBase):
     cadapi = cadapi
+
+    def test_face_from_wires_tolerant_non_planar_path(self):
+        """
+        Test non-planar path.
+        Create a rectangle on the surface of a cylinder and attempt to create a face from the wire.
+        """
+        radius = 1.0
+        height = 2.0
+
+        vertical_line = cadapi.make_polygon([(radius, 0, 0), (radius, 0, height)])
+        cylinder_surface = cadapi.revolve_shape(  # revolve vertical line to create cylinder
+            vertical_line,
+            base=(0, 0, 0),
+            direction=(0, 0, 1),
+            degree=360,
+        )
+
+        rect_points = [
+            (0, -2, 0),
+            (radius, -2, 0),
+            (radius, -2, height),
+            (0, -2, height),
+            (0, -2, 0),
+        ]
+        rect_wire = cadapi.make_polygon(rect_points)
+        rect_face = cadapi.make_face(rect_wire)  # create a 2D rectangle in the XZ plane
+
+        cutting_block = cadapi.extrude_shape(rect_face, (0, 4, 0))  # extrude in Y
+
+        intersection_result = cylinder_surface.intersect(cutting_block)
+        curved_faces = cadapi.faces(intersection_result)  # intersect to yield curved cylinder face
+
+        if curved_faces:
+            target_face = curved_faces[0]
+            wrapped_wire = target_face.outerWire()
+
+        face = cadapi._face_from_wires_tolerant(wrapped_wire, [])  # should succeed via non-planar path
+
+        assert isinstance(face, cq.Face)  # verify face
+        assert cadapi.area(face) > 0
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(wrapped_wire)  # expected error
+
+    def test_face_from_wires_tolerant_strict_planar_path(self):
+        """
+        Test the strict planar path.
+        Create a square in the XY plane and attempt to create a face from the wire.
+        """
+        points = [
+            (0, 0, 0),
+            (1, 0, 0),
+            (1, 1, 0),
+            (0, 1, 0),
+            (0, 0, 0),
+        ]
+
+        wire = cadapi.make_polygon(points)  # planar square wire
+
+        face = cadapi._face_from_wires_tolerant(wire, [])  # this should fail the first path but succeed with makeFromWires
+
+        assert isinstance(face, cq.Face)  # verify face and area
+        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
+
+        direct_face = cq.Face.makeFromWires(wire)  # should work directly with makeFromWires
+        assert cadapi.area(direct_face) == pytest.approx(1.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_tolerant_planar_path(self):
+        """
+        Test the tolerant planar path.
+        Create a planar square but add small noise to the points that exceeds the default confusion tolerance.
+        Attempt to create a face from the wire, should fallback to SVD.
+        """
+        # corners of a square with out-of-plane noise in z
+        p0 = (0.0, 0.0,  1.5e-5)
+        p1 = (1.0, 0.0, -1.2e-5)
+        p2 = (1.0, 1.0,  2.1e-5)
+        p3 = (0.0, 1.0, -1.8e-5)
+
+        # guarantee closed wire
+        noisy_points = [p0, p1, p2, p3, p0]
+
+        wire = cadapi.make_polygon(noisy_points)
+
+        assert wire.IsClosed()
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(wire)
+
+        face = cadapi._face_from_wires_tolerant(wire, [])  # should succeed via SVD fallback
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_with_holes(self):
+        """Test planar path with inner hole wires."""
+
+        outer_points = [  # 2x2 flat square
+            (-1.0, -1.0, 0.0), 
+            ( 1.0, -1.0, 0.0), 
+            ( 1.0,  1.0, 0.0), 
+            (-1.0,  1.0, 0.0), 
+            (-1.0, -1.0, 0.0)
+        ]
+        outer_wire = cadapi.make_polygon(outer_points)
+
+        inner_points = [  # inner 1x1 square hole
+            (-0.5, -0.5, 0.0), 
+            ( 0.5, -0.5, 0.0), 
+            ( 0.5,  0.5, 0.0), 
+            (-0.5,  0.5, 0.0), 
+            (-0.5, -0.5, 0.0)
+        ]
+        inner_wire = cadapi.make_polygon(inner_points)
+
+        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+
+        assert len(face.innerWires()) == 1
+
+        # area = 4.0 (outer) - 1.0 (inner)
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_planar_with_noisy_hole(self):
+        """Test planar path with a noisy inner hole that exceeds tolerance."""
+        outer_points = [  # noisy 2x2 square
+            (0.0, 0.0,  1.5e-5), 
+            (2.0, 0.0, -1.2e-5), 
+            (2.0, 2.0,  2.1e-5), 
+            (0.0, 2.0, -1.8e-5), 
+            (0.0, 0.0,  1.5e-5),
+        ]
+        outer_wire = cadapi.make_polygon(outer_points)
+
+        inner_points = [  # noisy 1x1 square hole
+            (0.5, 0.5,  1.1e-5), 
+            (1.5, 0.5, -1.3e-5), 
+            (1.5, 1.5,  2.0e-5), 
+            (0.5, 1.5, -1.6e-5), 
+            (0.5, 0.5,  1.1e-5),
+        ]
+        inner_wire = cadapi.make_polygon(inner_points)
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(outer_wire, [inner_wire])
+
+        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+        assert len(face.innerWires()) == 1
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_inner_same_winding(self):
+        """Test that inner wires with the same winding as the outer wire are handled correctly."""
+        outer = cadapi.make_polygon(  # out square
+            [(0, 0, 0), (2, 0, 0), (2, 2, 0), (0, 2, 0), (0, 0, 0)]
+        )
+
+        inner = cadapi.make_polygon(  # inner square hole with same anticlockwise winding
+            [(0.5, 0.5, 0), (1.5, 0.5, 0), (1.5, 1.5, 0), (0.5, 1.5, 0), (0.5, 0.5, 0)]
+        )
+
+        face = cadapi._face_from_wires_tolerant(outer, [inner])
+
+        assert face.isValid()
+        assert len(face.innerWires()) == 1
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_hole_outside_outer(self):
+        """Test that an inner hole completely outside the outer wire is rejected."""
+        outer = cadapi.make_polygon(
+            [(0,0,0), (2,0,0), (2,2,0), (0,2,0), (0,0,0)]
+        )
+
+        inner_outside = cadapi.make_polygon(  # hole is located completely outside of the outer wire
+            [(5,5,0), (6,5,0), (6,6,0), (5,6,0), (5,5,0)]
+        )
+ 
+        with pytest.raises(GeometryError):
+            face = cadapi._face_from_wires_tolerant(outer, [inner_outside])
+            assert not face.isValid()
 
 
 class TestSaveCadMeshFormats:

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -25,6 +25,8 @@ from unittest.mock import MagicMock, patch  # noqa: E402
 
 import cadquery as cq  # noqa: E402
 import numpy as np  # noqa: E402
+from OCP.BRep import BRep_Builder  # noqa: E402
+from OCP.TopoDS import TopoDS_Wire  # noqa: E402
 
 from bluemira.codes.error import FreeCADError  # noqa: E402
 from bluemira.geometry.error import GeometryError  # noqa: E402
@@ -32,6 +34,7 @@ from bluemira.geometry.tools import convert  # noqa: E402
 from tests.codes._shared.backend_api_tests import BackendApiTestsBase  # noqa: E402
 
 E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
+CORE = "bluemira.codes._cadqueryapi._core"
 
 E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
 
@@ -54,17 +57,17 @@ def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
 class TestCadqueryapi(BackendApiTestsBase):
     cadapi = cadapi
 
-    def _make_box(self):
+    def _make_box(self, s=1):
         return cadapi.extrude_shape(
             cadapi.make_face(
                 cadapi.make_polygon([
                     (0, 0, 0),
-                    (1, 0, 0),
-                    (1, 1, 0),
-                    (0, 1, 0),
+                    (s, 0, 0),
+                    (s, s, 0),
+                    (0, s, 0),
                 ]).close()
             ),
-            (0, 0, 1),
+            (0, 0, s),
         )
 
     def test_face_from_wires_tolerant_non_planar_path(self):
@@ -323,8 +326,8 @@ class TestCadqueryapi(BackendApiTestsBase):
             ([], True, []),
         ],
     )
-    @patch("bluemira.codes._cadqueryapi._core.is_closed")
-    @patch("bluemira.codes._cadqueryapi._core.ordered_edges")
+    @patch(f"{CORE}.is_closed")
+    @patch(f"{CORE}.ordered_edges")
     def test_edge_junction_pairs_mocked(
         self,
         mock_ordered_edges,
@@ -492,10 +495,355 @@ class TestCadqueryapi(BackendApiTestsBase):
             4.0 - (np.pi * 0.25)
         )
 
+    def test_unify_same_domain_coplanar_faces(self):
+        """Coplanar faces and collinear edges are unified."""
+        box1 = self._make_box()
+        box2 = cadapi.translate_shape(self._make_box(), (1, 0, 0))
+
+        bad_shape = box1.fuse(box2)
+        assert len(bad_shape.Faces()) > 6
+
+        unified = cadapi._unify_same_domain(bad_shape)
+        assert len(unified.Faces()) == 6
+        assert isinstance(unified, cq.Shape)
+
+    def test_unify_same_domain_clean_shape(self):
+        """Passing clean shape is idempotent."""
+        clean = self._make_box()
+        unified = cadapi._unify_same_domain(clean)
+        assert len(unified.Faces()) == len(clean.Faces())
+        assert len(unified.Edges()) == len(clean.Edges())
+
+    @patch(f"{CORE}.bluemira_warn")
+    @patch(f"{CORE}.ShapeUpgrade_UnifySameDomain")
+    def test_unify_same_domain_exception(self, mock_unify, mock_warn):
+        """Exceptions are caught."""
+        unifier = MagicMock()
+        unifier.Build.side_effect = RuntimeError("Fake Error")
+        mock_unify.return_value = unifier
+
+        box = self._make_box()
+        result = cadapi._unify_same_domain(box)
+
+        mock_warn.assert_called_once()
+        assert "UnifySameDomain failed" in mock_warn.call_args[0][0]
+        assert result is box
+
+    def test_assemble_wires_from_edges_empty(self):
+        """Empty list of edges returns empty list."""
+        assert cadapi._assemble_wires_from_edges([]) == []
+
+    def test_assemble_wires_from_edges_connected(self):
+        """Sequentially connected wires are merged into a single wire."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
+        e2 = cadapi.make_polygon([(1, 0, 0), (1, 1, 0)]).Edges()
+        e3 = cadapi.make_polygon([(1, 1, 0), (0, 1, 0)]).Edges()
+
+        wires = cadapi._assemble_wires_from_edges(e1 + e2 + e3)
+
+        assert len(wires) == 1
+        assert len(wires[0].Edges()) == 3
+        assert isinstance(wires[0], cq.Wire)
+
+    def test_assemble_wires_from_edges_disconnected(self):
+        """Disconnected edges return separate wires."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
+        e2 = cadapi.make_polygon([(1, 1, 0), (2, 1, 0)]).Edges()
+
+        wires = cadapi._assemble_wires_from_edges(e1 + e2)
+
+        assert len(wires) == 2
+        assert len(wires[0].Edges()) == 1
+        assert len(wires[1].Edges()) == 1
+
+    def test_split_wire_by_closed_tools_intersection(self):
+        """Split wire using closed tool that perfectly crosses it."""
+        wire = cadapi.make_polygon([(0, 0, 0), (10, 0, 0)])
+        tool = cadapi.make_polygon([
+            (3, -2, 0),
+            (7, -2, 0),
+            (7, 2, 0),
+            (3, 2, 0),
+        ]).close()
+
+        result = cadapi._split_wire_by_closed_tools(wire, [tool])
+
+        assert len(result) == 3
+        assert sorted([w.Length() for w in result]) == [3.0, 3.0, 4.0]
+
+    def test_split_wire_by_closed_tools_no_intersection(self):
+        """Unchanged wire if the tool doesn't overlap."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        tool = cadapi.make_polygon([
+            (2, 0, 0),
+            (4, 0, 0),
+            (4, 2, 0),
+            (2, 2, 0),
+        ]).close()
+
+        result = cadapi._split_wire_by_closed_tools(wire, [tool])
+
+        assert len(result) == 1
+        assert result[0].Length() == 1
+
+    def test_split_wire_at_tool_crossings_single_cut(self):
+        """Split wire with open tool."""
+        wire = cadapi.make_polygon([(0, 0, 0), (5, 0, 0)])
+        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
+
+        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
+
+        assert len(result) == 2
+        assert [w.Length() for w in result] == [3, 2]  # must be sorted
+
+    def test_split_wire_at_tool_crossings_no_cut(self):
+        """Split wire with open tool that doesn't intersect."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
+
+        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
+
+        assert len(result) == 1
+        assert result[0].Length() == 1
+
+    def test_collect_subshapes_direct_children(self):
+        """Extract immediate children."""
+        box = self._make_box()
+        faces = cadapi._collect_subshapes(box, cq.Face)
+        assert len(faces) == 6
+        assert all(isinstance(f, cq.Face) for f in faces)
+
+    def test_collect_subshapes_nested_compounds(self):
+        """Compound inside a compounds."""
+        box = self._make_box()
+        inner_compound = cadapi.make_compound([box])
+        outer_compound = cadapi.make_compound([inner_compound])
+
+        solids = cadapi._collect_subshapes(outer_compound, cq.Solid)
+        assert len(solids) == 1
+        assert isinstance(solids[0], cq.Solid)
+
+    def test_collect_subshapes_not_found(self):
+        """Return an empty list if kind doesn't exist."""
+        face = cadapi.make_face(
+            cadapi.make_polygon([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]).close()
+        )
+
+        solids = cadapi._collect_subshapes(face, cq.Solid)
+
+        assert isinstance(solids, list)
+        assert len(solids) == 0
+
+    def test_collect_subshapes_shell_promotion_valid(self):
+        """Request solid from closed shell promotes shell to solid."""
+        box = self._make_box()
+        shell = box.Shells()[0]
+        compound = cadapi.make_compound([shell])
+
+        solids = cadapi._collect_subshapes(compound, cq.Solid)
+
+        assert len(solids) == 1
+        assert isinstance(solids[0], cq.Solid)
+        assert solids[0].isValid()
+
+    @patch(f"{CORE}.fix_shape")
+    @patch.object(cq.Solid, "isValid", return_value=False)
+    def test_collect_subshapes_shell_promotion_invalid_repair(self, mock_fix_shape):
+        """fix_shape called to repair invalid promoted solid."""
+        box = self._make_box()
+        shell = box.Shells()[0]
+        compound = cadapi.make_compound([shell])
+
+        solids = cadapi._collect_subshapes(compound, cq.Solid)
+
+        assert len(solids) == 1
+        assert isinstance(solids[0], cq.Solid)
+        mock_fix_shape.assert_called_once_with(solids[0])
+
+    def test_repair_closed_wire_closed(self):
+        """Repair already closed wire is idempotent."""
+        wire = cadapi.make_circle()
+        assert wire.IsClosed()
+
+        with patch(f"{CORE}.ShapeFix_Wire") as mock_fixer:
+            result = cadapi._repair_closed_wire(wire)
+            assert result is wire
+            mock_fixer.assert_not_called()
+
+    def test_repair_closed_wire_unflagged(self):
+        """Wire is closed but topods close is false."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
+        e2 = cadapi.make_polygon([(1, 0, 0), (0, 0, 0)]).Edges()[0]
+
+        raw_wire = TopoDS_Wire()
+        builder = BRep_Builder()
+        builder.MakeWire(raw_wire)
+        builder.Add(raw_wire, e1.wrapped)
+        builder.Add(raw_wire, e2.wrapped)
+
+        wire = cq.Wire(raw_wire)
+        assert not wire.IsClosed()
+
+        repaired = cadapi._repair_closed_wire(wire)
+        assert repaired.IsClosed()
+        assert isinstance(repaired, cq.Wire)
+
+    def test_repair_closed_wire_open_wire(self):
+        """Open wire remains open."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        assert not wire.IsClosed()
+
+        repaired = cadapi._repair_closed_wire(wire)
+        assert not repaired.IsClosed()
+
+    @patch(f"{CORE}.ShapeFix_Wire")
+    def test_repair_closed_wire_null_fallback(self, mock_shape_fix):
+        """Return original wire if ShapeFix_Wire fails."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+
+        mock_fixer = MagicMock()
+        mock_null = MagicMock()
+        mock_null.IsNull.return_value = True
+        mock_fixer.Wire.return_value = mock_null
+        mock_shape_fix.return_value = mock_fixer
+
+        repaired = cadapi._repair_closed_wire(wire)
+
+        assert repaired is wire
+
+    def test_force_close_wire_already_closed(self):
+        """Force close already closed wire returns."""
+        wire = cadapi.make_circle()
+        assert wire.IsClosed()
+
+        result = cadapi._force_close_wire(wire)
+        assert result is wire
+
+    @patch(f"{CORE}._repair_closed_wire")
+    def test_force_close_coincident_endpoints(self, mock_repair):
+        """Open wire with coincident endpoints calls _repair_closed_wire."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        assert not wire.IsClosed()
+
+        mock_repair.return_value = "fake_repaired_wire"
+
+        with (
+            patch.object(wire, "startPoint", return_value=cq.Vector(0, 0, 0)),
+            patch.object(wire, "endPoint", return_value=cq.Vector(0, 0, 0)),
+        ):
+            result = cadapi._force_close_wire(wire)
+
+        mock_repair.assert_called_once_with(wire)
+        assert result == "fake_repaired_wire"
+
+    def test_force_close_open_wire(self):
+        """Bridge open wire to close it."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
+        e2 = cadapi.make_polygon([(1, 0, 0), (1, 1, 0)]).Edges()[0]
+        wire = cadapi.wire_from_edges([e1, e2])
+
+        assert not wire.IsClosed()
+        assert len(wire.Edges()) == 2
+
+        closed = cadapi._force_close_wire(wire)
+        assert len(closed.Edges()) == 3
+        assert closed.IsClosed()
+        assert isinstance(closed, cq.Wire)
+
+    def test_piece_mass_solid(self):
+        """Solid's mass evaluates to its volume."""
+        box = self._make_box()
+        mass = cadapi._piece_mass(box)
+        assert mass == pytest.approx(1.0)
+
+    def test_piece_mass_face(self):
+        """Face's mass evaluates to its area."""
+        face = cadapi.make_face(cadapi.make_circle())
+        mass = cadapi._piece_mass(face)
+        assert mass == pytest.approx(np.pi)
+
+    def test_piece_mass_edge(self):
+        """Edge's mass evaluates to its area."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
+        mass = cadapi._piece_mass(e1)
+        assert mass == pytest.approx(1.0)
+
+    def test_pick_dominant_dangler_success(self):
+        """Largest mass piece is selected."""
+        small = self._make_box()
+        large = self._make_box(s=2)
+
+        dominant = cadapi._pick_dominant_dangler([small, large], source_idx=0)
+        assert dominant is large
+
+    def test_pick_dominant_dangler_tie(self):
+        """Raise when equal largest pieces."""
+        box1 = self._make_box()
+        box2 = self._make_box()
+
+        with pytest.raises(GeometryError, match="equally-sized dangling pieces"):
+            cadapi._pick_dominant_dangler([box1, box2], source_idx=1)
+
+    def test_piece_source_map(self):
+        """Fragment maps correctly group identical shapes."""
+        s1 = self._make_box()
+        s2 = self._make_box()
+        s3 = self._make_box()
+
+        fragment_map = [[s1, s2], [s1, s3]]
+        unique_map = cadapi._piece_source_map(fragment_map)
+        assert len(unique_map) == 3
+
+        s1_entry = next((i for i in unique_map if i[0] is s1), None)
+        s2_entry = next((i for i in unique_map if i[0] is s2), None)
+        s3_entry = next((i for i in unique_map if i[0] is s3), None)
+
+        assert s1_entry is not None
+        assert s1_entry[1] == {0, 1}
+        assert s2_entry is not None
+        assert s2_entry[1] == {0}
+        assert s3_entry is not None
+        assert s3_entry[1] == {1}
+
+    def test_grow_keepers_by_overlap(self):
+        """Add pieces if they touch a kept piece, from 2 sources to max overlap."""
+        k1 = self._make_box()
+        p_layer_2 = self._make_box(s=2)
+        p_layer_3 = self._make_box(s=3)
+        p_isolated_2 = cadapi.translate_shape(self._make_box(s=4), (10, 10, 10))
+
+        keepers = [k1]
+        unique_pieces = [
+            (k1, {0}),
+            (p_layer_2, {0, 1}),  # 2 sources, touches k1
+            (p_isolated_2, {1, 2}),  # 2 sources, touches nothing
+            (p_layer_3, {0, 1, 2}),  # 2 sources, touches p_layer_2
+        ]
+
+        cadapi._grow_keepers_by_overlap(keepers, unique_pieces)
+
+        assert len(keepers) == 3
+        assert k1 in keepers
+        assert p_layer_2 in keepers
+        assert p_layer_3 in keepers
+        assert p_isolated_2 not in keepers
+
+    def test_shapes_touch_true(self):
+        """Touching shapes return true."""
+        box1 = self._make_box()
+        box2 = cadapi.translate_shape(self._make_box(), (1, 0, 0))
+        assert cadapi._shapes_touch(box1, box2)
+
+    def test_shapes_touch_false(self):
+        """Separated shapes return false."""
+        box1 = self._make_box()
+        box2 = cadapi.translate_shape(self._make_box(), (2, 0, 0))
+        assert not cadapi._shapes_touch(box1, box2)
+
 
 @patch("bluemira.codes.error.FreeCADError", FreeCADError)
-@patch("bluemira.codes._cadqueryapi._core._edge_pair_cos_angle")
-@patch("bluemira.codes._cadqueryapi._core._edge_junction_pairs")
+@patch(f"{CORE}._edge_pair_cos_angle")
+@patch(f"{CORE}._edge_junction_pairs")
 class TestCheckPathTangentContinuity:
     def test_smooth_path(self, mock_pairs, mock_cos_angle):
         """Smooth path should pass without error."""

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -24,8 +24,6 @@ cq = pytest.importorskip("cadquery")
 from dataclasses import dataclass  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
-import cadquery as cq  # noqa: E402
-import numpy as np  # noqa: E402
 from OCP.BRep import BRep_Builder  # noqa: E402
 from OCP.TopoDS import TopoDS_Wire  # noqa: E402
 from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt, gp_Trsf  # noqa: E402
@@ -36,9 +34,7 @@ from bluemira.geometry.tools import convert  # noqa: E402
 from tests.codes._shared.backend_api_tests import BackendApiTestsBase  # noqa: E402
 
 E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
-CORE = "bluemira.codes._cadqueryapi._core"
-
-E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
+CORE = "bluemira.codes.cadapi._cadquery.core"
 
 
 def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
@@ -54,6 +50,20 @@ def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
         [ox, oy + side, oz],
         [ox, oy, oz],
     ])
+
+
+def _make_box(s=1):
+    return cadapi.extrude_shape(
+        cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (s, 0, 0),
+                (s, s, 0),
+                (0, s, 0),
+            ]).close()
+        ),
+        (0, 0, s),
+    )
 
 
 def _pnt_dir_to_array(obj: gp_Pnt | gp_Dir) -> np.ndarray:
@@ -78,1091 +88,6 @@ class DummyPart:
 
 class TestCadqueryapi(BackendApiTestsBase):
     cadapi = cadapi
-
-    def _make_box(self, s=1):
-        return cadapi.extrude_shape(
-            cadapi.make_face(
-                cadapi.make_polygon([
-                    (0, 0, 0),
-                    (s, 0, 0),
-                    (s, s, 0),
-                    (0, s, 0),
-                ]).close()
-            ),
-            (0, 0, s),
-        )
-
-    def test_face_from_wires_tolerant_non_planar_path(self):
-        """
-        Test non-planar path.
-        Create a rectangle on the surface of a cylinder and attempt to
-        create a face from the wire.
-        """
-        radius = 1.0
-        height = 2.0
-
-        vertical_line = cadapi.make_polygon([(radius, 0, 0), (radius, 0, height)])
-        cylinder_surface = (
-            cadapi.revolve_shape(  # revolve vertical line to create cylinder
-                vertical_line,
-                base=(0, 0, 0),
-                direction=(0, 0, 1),
-                degree=360,
-            )
-        )
-
-        rect_points = [
-            (0, -2, 0),
-            (radius, -2, 0),
-            (radius, -2, height),
-            (0, -2, height),
-            (0, -2, 0),
-        ]
-        rect_wire = cadapi.make_polygon(rect_points)
-        rect_face = cadapi.make_face(rect_wire)  # create a 2D rectangle in the XZ plane
-
-        cutting_block = cadapi.extrude_shape(rect_face, (0, 4, 0))  # extrude in Y
-
-        intersection_result = cylinder_surface.intersect(cutting_block)
-        curved_faces = cadapi.faces(
-            intersection_result
-        )  # intersect to yield curved cylinder face
-
-        if curved_faces:
-            target_face = curved_faces[0]
-            wrapped_wire = target_face.outerWire()
-
-        face = cadapi._face_from_wires_tolerant(
-            wrapped_wire, []
-        )  # should succeed via non-planar path
-
-        assert isinstance(face, cq.Face)  # verify face
-        assert cadapi.area(face) > 0
-
-        with pytest.raises(ValueError, match="not planar"):
-            cq.Face.makeFromWires(wrapped_wire)  # expected error
-
-    def test_face_from_wires_tolerant_strict_planar_path(self):
-        """
-        Test the strict planar path.
-        Create a square in the XY plane and attempt to create a face from the wire.
-        """
-        points = [
-            (0, 0, 0),
-            (1, 0, 0),
-            (1, 1, 0),
-            (0, 1, 0),
-            (0, 0, 0),
-        ]
-
-        wire = cadapi.make_polygon(points)  # planar square wire
-
-        face = cadapi._face_from_wires_tolerant(
-            wire, []
-        )  # this should fail the first path but succeed with makeFromWires
-
-        assert isinstance(face, cq.Face)  # verify face and area
-        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
-
-        direct_face = cq.Face.makeFromWires(
-            wire
-        )  # should work directly with makeFromWires
-        assert cadapi.area(direct_face) == pytest.approx(1.0, abs=1e-6)
-
-    def test_face_from_wires_tolerant_tolerant_planar_path(self):
-        """
-        Test the tolerant planar path.
-        Create a planar square but add small noise to the points that exceeds
-        the default confusion tolerance.
-        Attempt to create a face from the wire, should fallback to SVD.
-        """
-        # corners of a square with out-of-plane noise in z
-        p0 = (0.0, 0.0, 1.5e-5)
-        p1 = (1.0, 0.0, -1.2e-5)
-        p2 = (1.0, 1.0, 2.1e-5)
-        p3 = (0.0, 1.0, -1.8e-5)
-
-        # guarantee closed wire
-        noisy_points = [p0, p1, p2, p3, p0]
-
-        wire = cadapi.make_polygon(noisy_points)
-
-        assert wire.IsClosed()
-
-        with pytest.raises(ValueError, match="not planar"):
-            cq.Face.makeFromWires(wire)
-
-        face = cadapi._face_from_wires_tolerant(
-            wire, []
-        )  # should succeed via SVD fallback
-
-        assert isinstance(face, cq.Face)
-        assert face.isValid()
-        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
-
-    def test_face_from_wires_tolerant_with_holes(self):
-        """Test planar path with inner hole wires."""
-
-        outer_points = [  # 2x2 flat square
-            (-1.0, -1.0, 0.0),
-            (1.0, -1.0, 0.0),
-            (1.0, 1.0, 0.0),
-            (-1.0, 1.0, 0.0),
-            (-1.0, -1.0, 0.0),
-        ]
-        outer_wire = cadapi.make_polygon(outer_points)
-
-        inner_points = [  # inner 1x1 square hole
-            (-0.5, -0.5, 0.0),
-            (0.5, -0.5, 0.0),
-            (0.5, 0.5, 0.0),
-            (-0.5, 0.5, 0.0),
-            (-0.5, -0.5, 0.0),
-        ]
-        inner_wire = cadapi.make_polygon(inner_points)
-
-        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
-
-        assert isinstance(face, cq.Face)
-        assert face.isValid()
-
-        assert len(face.innerWires()) == 1
-
-        # area = 4.0 (outer) - 1.0 (inner)
-        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
-
-    def test_face_from_wires_tolerant_planar_with_noisy_hole(self):
-        """Test planar path with a noisy inner hole that exceeds tolerance."""
-        outer_points = [  # noisy 2x2 square
-            (0.0, 0.0, 1.5e-5),
-            (2.0, 0.0, -1.2e-5),
-            (2.0, 2.0, 2.1e-5),
-            (0.0, 2.0, -1.8e-5),
-            (0.0, 0.0, 1.5e-5),
-        ]
-        outer_wire = cadapi.make_polygon(outer_points)
-
-        inner_points = [  # noisy 1x1 square hole
-            (0.5, 0.5, 1.1e-5),
-            (1.5, 0.5, -1.3e-5),
-            (1.5, 1.5, 2.0e-5),
-            (0.5, 1.5, -1.6e-5),
-            (0.5, 0.5, 1.1e-5),
-        ]
-        inner_wire = cadapi.make_polygon(inner_points)
-
-        with pytest.raises(ValueError, match="not planar"):
-            cq.Face.makeFromWires(outer_wire, [inner_wire])
-
-        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
-
-        assert isinstance(face, cq.Face)
-        assert face.isValid()
-        assert len(face.innerWires()) == 1
-        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
-
-    def test_face_from_wires_tolerant_inner_same_winding(self):
-        """Test that inner wires with the same winding as the outer wire
-        are handled correctly.
-        """
-        outer = cadapi.make_polygon(  # out square
-            [(0, 0, 0), (2, 0, 0), (2, 2, 0), (0, 2, 0), (0, 0, 0)]
-        )
-
-        inner = cadapi.make_polygon(  # inner square hole with same anticlockwise winding
-            [(0.5, 0.5, 0), (1.5, 0.5, 0), (1.5, 1.5, 0), (0.5, 1.5, 0), (0.5, 0.5, 0)]
-        )
-
-        face = cadapi._face_from_wires_tolerant(outer, [inner])
-
-        assert face.isValid()
-        assert len(face.innerWires()) == 1
-        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
-
-    def test_face_from_wires_tolerant_hole_outside_outer(self):
-        """Test that an inner hole completely outside the outer wire is rejected."""
-        outer = cadapi.make_polygon([
-            (0, 0, 0),
-            (2, 0, 0),
-            (2, 2, 0),
-            (0, 2, 0),
-            (0, 0, 0),
-        ])
-
-        inner_outside = (
-            cadapi.make_polygon(  # hole is located completely outside of the outer wire
-                [(5, 5, 0), (6, 5, 0), (6, 6, 0), (5, 6, 0), (5, 5, 0)]
-            )
-        )
-
-        with pytest.raises(GeometryError):
-            _ = cadapi._face_from_wires_tolerant(outer, [inner_outside])
-
-    def test_edge_pair_cos_angle_straight(self):
-        """Perfectly collinear."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
-        e2 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
-
-        result = cadapi._edge_pair_cos_angle(e1, e2)
-        assert result == pytest.approx(1.0)
-
-    def test_edge_pair_cos_angle_orthogonal(self):
-        """Orthogonal edges."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
-        e2 = cadapi.make_polygon([(0, 0, 0), (0, 1, 0)]).edges()
-
-        result = cadapi._edge_pair_cos_angle(e1, e2)
-        assert result == pytest.approx(0.0)
-
-    def test_edge_pair_cos_angle_u_turn(self):
-        """Opposite directions."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
-        e2 = cadapi.make_polygon([(0, 0, 0), (-1, 0, 0)]).edges()
-
-        result = cadapi._edge_pair_cos_angle(e1, e2)
-        assert result == pytest.approx(-1.0)
-
-    def test_edge_junction_pairs(self):
-        """Test pairwise list of edges"""
-        wire = cadapi.make_polygon([
-            (0, 0, 0),
-            (1, 0, 0),
-            (1, 1, 0),
-            (0, 1, 0),
-        ]).close()
-
-        pairs = cadapi._edge_junction_pairs(wire)
-
-        assert len(pairs) == 4
-
-    @pytest.mark.parametrize(
-        ("edges", "is_closed", "expected_pairs"),
-        [
-            ([E1, E2, E3, E4], False, [(E1, E2), (E2, E3), (E3, E4)]),
-            ([E1, E2], False, [(E1, E2)]),
-            ([E1], False, []),
-            ([], False, []),
-            ([E1, E2, E3], True, [(E1, E2), (E2, E3), (E3, E1)]),
-            ([E1, E2], True, [(E1, E2), (E2, E1)]),
-            ([E1], True, []),
-            ([], True, []),
-        ],
-    )
-    @patch(f"{CORE}.is_closed")
-    @patch(f"{CORE}.ordered_edges")
-    def test_edge_junction_pairs_mocked(
-        self,
-        mock_ordered_edges,
-        mock_is_closed,
-        edges,
-        is_closed,
-        expected_pairs,
-    ):
-        mock_ordered_edges.return_value = edges
-        mock_is_closed.return_value = is_closed
-
-        result = cadapi._edge_junction_pairs("dummy_wire")
-
-        assert result == expected_pairs
-
-    def test_planar_wire_returns_normal(self):
-        """_get_planar_normal returns correct normal for valid planar wire."""
-        result = cadapi._get_planar_normal(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 0),
-                (0, 1, 0),
-            ])
-        )
-        assert result == (0, 0, 1)
-
-    def test_non_planar_wire_returns_none(self):
-        """_get_planar_normal returns none for a non-planar wire."""
-        result = cadapi._get_planar_normal(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 1),
-                (0, 1, 0),
-            ])
-        )
-        assert result is None
-
-    def test_sewn_solid_successful_rebuild(self):
-        """Sew disconnected faces into a valid solid."""
-        box = self._make_box()
-        faces = box.faces()
-        assert not isinstance(faces, cq.Solid)
-        solid = cadapi._sewn_solid(faces)
-        assert isinstance(solid, cq.Solid)
-        assert solid.isValid()
-        assert len(solid.Faces()) == 6
-        assert solid.Volume() == pytest.approx(1.0)
-
-    def test_sewn_solid_missing_face(self):
-        """Sew open shell fails to make closed solid."""
-        box = self._make_box()
-        faces = box.Faces()[:-1]
-        open_shell = cadapi.make_compound(faces)
-        open_solid = cadapi._sewn_solid(open_shell)
-        assert open_solid is open_shell
-
-    def test_sewn_solid_multiple_shells(self):
-        """Sew disconnected regions gives >1 shell."""
-        box1 = self._make_box()
-        box2 = box = cadapi.translate_shape(self._make_box(), (5, 0, 0))
-
-        all_faces = box1.Faces() + box2.Faces()
-        split_compound = cadapi.make_compound(all_faces)
-
-        multi_shell = cadapi._sewn_solid(split_compound)
-        assert multi_shell is split_compound
-
-    def test_sewn_solid_already_valid(self):
-        """Valid solid should rebuild safely."""
-        box = self._make_box()
-        solid = cadapi._sewn_solid(box)
-        assert isinstance(solid, cq.Solid)
-        assert solid.isValid()
-        assert solid.Volume() == pytest.approx(1.0)
-
-    def test_wire_is_straight_single_straight(self):
-        """True for single straight line."""
-        assert cadapi._wire_is_straight(cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]))
-
-    def test_wire_is_straight_multi_straight(self):
-        """False for multiple straight lines."""
-        assert not cadapi._wire_is_straight(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (2, 0, 0),
-            ])
-        )
-
-    def test_wire_is_straight_curved(self):
-        """False for curved line."""
-        assert not cadapi._wire_is_straight(
-            cadapi.make_circle_arc_3P(
-                (0, 0, 0),
-                (5, 5, 0),
-                (10, 0, 0),
-            )
-        )
-
-    def test_wire_is_planar_closed(self):
-        """True for 2D flat shape."""
-        assert cadapi._wire_is_planar(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 0),
-                (0, 1, 0),
-            ]).close()
-        )
-
-    def test_wire_is_planar_non_planar(self):
-        """False for non-planar shape."""
-        assert not cadapi._wire_is_planar(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 1),
-                (0, 1, 0),
-            ]).close()
-        )
-
-    def test_occ_face_area_square(self):
-        """Simple area calculation on square."""
-        square = cadapi.make_face(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 0),
-                (0, 1, 0),
-            ]).close()
-        )
-        assert cadapi._occ_face_area(square.wrapped) == pytest.approx(1.0)
-
-    def test_occ_face_area_circle(self):
-        """Simple area calculation on circle."""
-        circle = cadapi.make_face(cadapi.make_circle())
-        assert cadapi._occ_face_area(circle.wrapped) == pytest.approx(np.pi)
-
-    def test_cq_area_prop_face(self):
-        """Area property on standard face."""
-        square = cadapi.make_face(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (1, 0, 0),
-                (1, 1, 0),
-                (0, 1, 0),
-            ]).close()
-        )
-        assert convert(square).area == pytest.approx(1.0)
-
-    def test_cq_area_prop_face_with_holes(self):
-        """Area property on face with holes."""
-        square = cadapi.make_face(
-            cadapi.make_polygon([
-                (0, 0, 0),
-                (2, 0, 0),
-                (2, 2, 0),
-                (0, 2, 0),
-            ]).close()
-        )
-        circle = cadapi.make_face(cadapi.make_circle(radius=0.5, center=(1, 1, 0)))
-        assert convert(cadapi.boolean_cut(square, circle)[0]).area == pytest.approx(
-            4.0 - (np.pi * 0.25)
-        )
-
-    def test_unify_same_domain_coplanar_faces(self):
-        """Coplanar faces and collinear edges are unified."""
-        box1 = self._make_box()
-        box2 = cadapi.translate_shape(self._make_box(), (1, 0, 0))
-
-        bad_shape = box1.fuse(box2)
-        assert len(bad_shape.Faces()) > 6
-
-        unified = cadapi._unify_same_domain(bad_shape)
-        assert len(unified.Faces()) == 6
-        assert isinstance(unified, cq.Shape)
-
-    def test_unify_same_domain_clean_shape(self):
-        """Passing clean shape is idempotent."""
-        clean = self._make_box()
-        unified = cadapi._unify_same_domain(clean)
-        assert len(unified.Faces()) == len(clean.Faces())
-        assert len(unified.Edges()) == len(clean.Edges())
-
-    @patch(f"{CORE}.bluemira_warn")
-    @patch(f"{CORE}.ShapeUpgrade_UnifySameDomain")
-    def test_unify_same_domain_exception(self, mock_unify, mock_warn):
-        """Exceptions are caught."""
-        unifier = MagicMock()
-        unifier.Build.side_effect = RuntimeError("Fake Error")
-        mock_unify.return_value = unifier
-
-        box = self._make_box()
-        result = cadapi._unify_same_domain(box)
-
-        mock_warn.assert_called_once()
-        assert "UnifySameDomain failed" in mock_warn.call_args[0][0]
-        assert result is box
-
-    def test_assemble_wires_from_edges_empty(self):
-        """Empty list of edges returns empty list."""
-        assert cadapi._assemble_wires_from_edges([]) == []
-
-    def test_assemble_wires_from_edges_connected(self):
-        """Sequentially connected wires are merged into a single wire."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
-        e2 = cadapi.make_polygon([(1, 0, 0), (1, 1, 0)]).Edges()
-        e3 = cadapi.make_polygon([(1, 1, 0), (0, 1, 0)]).Edges()
-
-        wires = cadapi._assemble_wires_from_edges(e1 + e2 + e3)
-
-        assert len(wires) == 1
-        assert len(wires[0].Edges()) == 3
-        assert isinstance(wires[0], cq.Wire)
-
-    def test_assemble_wires_from_edges_disconnected(self):
-        """Disconnected edges return separate wires."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
-        e2 = cadapi.make_polygon([(1, 1, 0), (2, 1, 0)]).Edges()
-
-        wires = cadapi._assemble_wires_from_edges(e1 + e2)
-
-        assert len(wires) == 2
-        assert len(wires[0].Edges()) == 1
-        assert len(wires[1].Edges()) == 1
-
-    def test_split_wire_by_closed_tools_intersection(self):
-        """Split wire using closed tool that perfectly crosses it."""
-        wire = cadapi.make_polygon([(0, 0, 0), (10, 0, 0)])
-        tool = cadapi.make_polygon([
-            (3, -2, 0),
-            (7, -2, 0),
-            (7, 2, 0),
-            (3, 2, 0),
-        ]).close()
-
-        result = cadapi._split_wire_by_closed_tools(wire, [tool])
-
-        assert len(result) == 3
-        assert sorted([w.Length() for w in result]) == [3.0, 3.0, 4.0]
-
-    def test_split_wire_by_closed_tools_no_intersection(self):
-        """Unchanged wire if the tool doesn't overlap."""
-        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
-        tool = cadapi.make_polygon([
-            (2, 0, 0),
-            (4, 0, 0),
-            (4, 2, 0),
-            (2, 2, 0),
-        ]).close()
-
-        result = cadapi._split_wire_by_closed_tools(wire, [tool])
-
-        assert len(result) == 1
-        assert result[0].Length() == 1
-
-    def test_split_wire_at_tool_crossings_single_cut(self):
-        """Split wire with open tool."""
-        wire = cadapi.make_polygon([(0, 0, 0), (5, 0, 0)])
-        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
-
-        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
-
-        assert len(result) == 2
-        assert [w.Length() for w in result] == [3, 2]  # must be sorted
-
-    def test_split_wire_at_tool_crossings_no_cut(self):
-        """Split wire with open tool that doesn't intersect."""
-        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
-        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
-
-        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
-
-        assert len(result) == 1
-        assert result[0].Length() == 1
-
-    def test_collect_subshapes_direct_children(self):
-        """Extract immediate children."""
-        box = self._make_box()
-        faces = cadapi._collect_subshapes(box, cq.Face)
-        assert len(faces) == 6
-        assert all(isinstance(f, cq.Face) for f in faces)
-
-    def test_collect_subshapes_nested_compounds(self):
-        """Compound inside a compounds."""
-        box = self._make_box()
-        inner_compound = cadapi.make_compound([box])
-        outer_compound = cadapi.make_compound([inner_compound])
-
-        solids = cadapi._collect_subshapes(outer_compound, cq.Solid)
-        assert len(solids) == 1
-        assert isinstance(solids[0], cq.Solid)
-
-    def test_collect_subshapes_not_found(self):
-        """Return an empty list if kind doesn't exist."""
-        face = cadapi.make_face(
-            cadapi.make_polygon([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]).close()
-        )
-
-        solids = cadapi._collect_subshapes(face, cq.Solid)
-
-        assert isinstance(solids, list)
-        assert len(solids) == 0
-
-    def test_collect_subshapes_shell_promotion_valid(self):
-        """Request solid from closed shell promotes shell to solid."""
-        box = self._make_box()
-        shell = box.Shells()[0]
-        compound = cadapi.make_compound([shell])
-
-        solids = cadapi._collect_subshapes(compound, cq.Solid)
-
-        assert len(solids) == 1
-        assert isinstance(solids[0], cq.Solid)
-        assert solids[0].isValid()
-
-    @patch(f"{CORE}.fix_shape")
-    @patch.object(cq.Solid, "isValid", return_value=False)
-    def test_collect_subshapes_shell_promotion_invalid_repair(
-        self,
-        mock_valid,  # noqa: ARG002
-        mock_fix_shape,
-    ):
-        """fix_shape called to repair invalid promoted solid."""
-        box = self._make_box()
-        shell = box.Shells()[0]
-        compound = cadapi.make_compound([shell])
-
-        solids = cadapi._collect_subshapes(compound, cq.Solid)
-
-        assert len(solids) == 1
-        assert isinstance(solids[0], cq.Solid)
-        mock_fix_shape.assert_called_once_with(solids[0])
-
-    def test_repair_closed_wire_closed(self):
-        """Repair already closed wire is idempotent."""
-        wire = cadapi.make_circle()
-        assert wire.IsClosed()
-
-        with patch(f"{CORE}.ShapeFix_Wire") as mock_fixer:
-            result = cadapi._repair_closed_wire(wire)
-            assert result is wire
-            mock_fixer.assert_not_called()
-
-    def test_repair_closed_wire_unflagged(self):
-        """Wire is closed but topods close is false."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
-        e2 = cadapi.make_polygon([(1, 0, 0), (0, 0, 0)]).Edges()[0]
-
-        raw_wire = TopoDS_Wire()
-        builder = BRep_Builder()
-        builder.MakeWire(raw_wire)
-        builder.Add(raw_wire, e1.wrapped)
-        builder.Add(raw_wire, e2.wrapped)
-
-        wire = cq.Wire(raw_wire)
-        assert not wire.IsClosed()
-
-        repaired = cadapi._repair_closed_wire(wire)
-        assert repaired.IsClosed()
-        assert isinstance(repaired, cq.Wire)
-
-    def test_repair_closed_wire_open_wire(self):
-        """Open wire remains open."""
-        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
-        assert not wire.IsClosed()
-
-        repaired = cadapi._repair_closed_wire(wire)
-        assert not repaired.IsClosed()
-
-    @patch(f"{CORE}.ShapeFix_Wire")
-    def test_repair_closed_wire_null_fallback(self, mock_shape_fix):
-        """Return original wire if ShapeFix_Wire fails."""
-        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
-
-        mock_fixer = MagicMock()
-        mock_null = MagicMock()
-        mock_null.IsNull.return_value = True
-        mock_fixer.Wire.return_value = mock_null
-        mock_shape_fix.return_value = mock_fixer
-
-        repaired = cadapi._repair_closed_wire(wire)
-
-        assert repaired is wire
-
-    def test_force_close_wire_already_closed(self):
-        """Force close already closed wire returns."""
-        wire = cadapi.make_circle()
-        assert wire.IsClosed()
-
-        result = cadapi._force_close_wire(wire)
-        assert result is wire
-
-    @patch(f"{CORE}._repair_closed_wire")
-    def test_force_close_coincident_endpoints(self, mock_repair):
-        """Open wire with coincident endpoints calls _repair_closed_wire."""
-        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
-        assert not wire.IsClosed()
-
-        mock_repair.return_value = "fake_repaired_wire"
-
-        with (
-            patch.object(wire, "startPoint", return_value=cq.Vector(0, 0, 0)),
-            patch.object(wire, "endPoint", return_value=cq.Vector(0, 0, 0)),
-        ):
-            result = cadapi._force_close_wire(wire)
-
-        mock_repair.assert_called_once_with(wire)
-        assert result == "fake_repaired_wire"
-
-    def test_force_close_open_wire(self):
-        """Bridge open wire to close it."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
-        e2 = cadapi.make_polygon([(1, 0, 0), (1, 1, 0)]).Edges()[0]
-        wire = cadapi.wire_from_edges([e1, e2])
-
-        assert not wire.IsClosed()
-        assert len(wire.Edges()) == 2
-
-        closed = cadapi._force_close_wire(wire)
-        assert len(closed.Edges()) == 3
-        assert closed.IsClosed()
-        assert isinstance(closed, cq.Wire)
-
-    def test_piece_mass_solid(self):
-        """Solid's mass evaluates to its volume."""
-        box = self._make_box()
-        mass = cadapi._piece_mass(box)
-        assert mass == pytest.approx(1.0)
-
-    def test_piece_mass_face(self):
-        """Face's mass evaluates to its area."""
-        face = cadapi.make_face(cadapi.make_circle())
-        mass = cadapi._piece_mass(face)
-        assert mass == pytest.approx(np.pi)
-
-    def test_piece_mass_edge(self):
-        """Edge's mass evaluates to its area."""
-        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
-        mass = cadapi._piece_mass(e1)
-        assert mass == pytest.approx(1.0)
-
-    def test_pick_dominant_dangler_success(self):
-        """Largest mass piece is selected."""
-        small = self._make_box()
-        large = self._make_box(s=2)
-
-        dominant = cadapi._pick_dominant_dangler([small, large], source_idx=0)
-        assert dominant is large
-
-    def test_pick_dominant_dangler_tie(self):
-        """Raise when equal largest pieces."""
-        box1 = self._make_box()
-        box2 = self._make_box()
-
-        with pytest.raises(GeometryError, match="equally-sized dangling pieces"):
-            cadapi._pick_dominant_dangler([box1, box2], source_idx=1)
-
-    def test_piece_source_map(self):
-        """Fragment maps correctly group identical shapes."""
-        s1 = self._make_box()
-        s2 = self._make_box()
-        s3 = self._make_box()
-
-        fragment_map = [[s1, s2], [s1, s3]]
-        unique_map = cadapi._piece_source_map(fragment_map)
-        assert len(unique_map) == 3
-
-        s1_entry = next((i for i in unique_map if i[0] is s1), None)
-        s2_entry = next((i for i in unique_map if i[0] is s2), None)
-        s3_entry = next((i for i in unique_map if i[0] is s3), None)
-
-        assert s1_entry is not None
-        assert s1_entry[1] == {0, 1}
-        assert s2_entry is not None
-        assert s2_entry[1] == {0}
-        assert s3_entry is not None
-        assert s3_entry[1] == {1}
-
-    def test_grow_keepers_by_overlap(self):
-        """Add pieces if they touch a kept piece, from 2 sources to max overlap."""
-        k1 = self._make_box()
-        p_layer_2 = self._make_box(s=2)
-        p_layer_3 = self._make_box(s=3)
-        p_isolated_2 = cadapi.translate_shape(self._make_box(s=4), (10, 10, 10))
-
-        keepers = [k1]
-        unique_pieces = [
-            (k1, {0}),
-            (p_layer_2, {0, 1}),  # 2 sources, touches k1
-            (p_isolated_2, {1, 2}),  # 2 sources, touches nothing
-            (p_layer_3, {0, 1, 2}),  # 2 sources, touches p_layer_2
-        ]
-
-        cadapi._grow_keepers_by_overlap(keepers, unique_pieces)
-
-        assert len(keepers) == 3
-        assert k1 in keepers
-        assert p_layer_2 in keepers
-        assert p_layer_3 in keepers
-        assert p_isolated_2 not in keepers
-
-    def test_shapes_touch_true(self):
-        """Touching shapes return true."""
-        box1 = self._make_box()
-        box2 = cadapi.translate_shape(self._make_box(), (1, 0, 0))
-        assert cadapi._shapes_touch(box1, box2)
-
-    def test_shapes_touch_false(self):
-        """Separated shapes return false."""
-        box1 = self._make_box()
-        box2 = cadapi.translate_shape(self._make_box(), (2, 0, 0))
-        assert not cadapi._shapes_touch(box1, box2)
-
-    def test_freecad_ax2_standard_projection(self):
-        """Global x (1, 0, 0) is projected to (1, 0, 0)."""
-        center = [1.0, 2.0, 3.0]
-        axis = [0.0, 0.0, 1.0]
-
-        ax2 = cadapi._freecad_ax2(center, axis)
-
-        assert isinstance(ax2, gp_Ax2)
-        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Location()), center, atol=1e-12)
-        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Direction()), axis, atol=1e-12)
-        np.testing.assert_allclose(
-            _pnt_dir_to_array(ax2.XDirection()), [1.0, 0.0, 0.0], atol=1e-12
-        )
-
-    @pytest.mark.parametrize(
-        "axis",
-        [
-            ([1.0, 0.0, 0.0]),
-            ([-1.0, 0.0, 0.0]),
-            ([2.0, 0.0, 0.0]),
-        ],
-    )
-    def test_freecad_ax2_fallback_projection(self, axis):
-        """Axis parallel to global x, fallback to project global y."""
-        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], axis)
-
-        # expected normal is normalised input axis
-        expected_n = np.array(axis, dtype=float)
-        expected_n /= np.linalg.norm(expected_n)
-
-        np.testing.assert_allclose(
-            _pnt_dir_to_array(ax2.Direction()), expected_n, atol=1e-12
-        )
-        np.testing.assert_allclose(
-            _pnt_dir_to_array(ax2.XDirection()), [0.0, 1.0, 0.0], atol=1e-12
-        )
-
-    def test_freecad_ax2_explicit_override(self):
-        """Providing x_direction bypasses projection logic."""
-        x_direction = [1.0, 1.0, 0.0]
-
-        ax2 = cadapi._freecad_ax2(
-            [0.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0],
-            x_direction=x_direction,
-        )
-
-        expected_x = np.array(x_direction)
-        expected_x /= np.linalg.norm(expected_x)
-
-        np.testing.assert_allclose(
-            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
-        )
-
-    def test_freecad_ax2_arbitrary_axis(self):
-        """Projection correctly applise to diagonal normal."""
-        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])
-
-        # n = (1, 1, 1) / sqrt(3)
-        # ref = (1, 0, 0)
-        # x = ref - dot(ref, n) * n
-        # x = (1, 0, 0) - (1/3, 1/3, 1/3) = (2/3, -1/3, -1/3)
-        # normalised x = (2, -1, -1) / sqrt(6)
-        expected_x = np.array([2.0, -1.0, -1.0]) / np.sqrt(6.0)
-
-        np.testing.assert_allclose(
-            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
-        )
-        assert (
-            abs(
-                np.dot(  # veryify orthogonal
-                    _pnt_dir_to_array(ax2.Direction()),
-                    _pnt_dir_to_array(ax2.XDirection()),
-                )
-            )
-            < 1e-12
-        )
-
-    @pytest.mark.parametrize(
-        ("bbox", "expected_cam", "expected_target"),
-        [
-            # flat in xz plane: looks from -y
-            (
-                (0.0, 0.0, 0.0, 10.0, 0.0, 10.0),
-                (5.0, -15.0, 5.0),
-                (5.0, 0.0, 5.0),
-            ),
-            # flat in yz plane: looks from +x
-            (
-                (0.0, 0.0, 0.0, 0.0, 10.0, 10.0),
-                (15.0, 5.0, 5.0),
-                (0.0, 5.0, 5.0),
-            ),
-            # flat in xy plane: looks from +z
-            (
-                (0.0, 0.0, 0.0, 10.0, 10.0, 0.0),
-                (5.0, 5.0, 15.0),
-                (5.0, 5.0, 0.0),
-            ),
-            # 3D object: falls back to xz side view (-y)
-            (
-                (0.0, 0.0, 0.0, 10.0, 10.0, 10.0),
-                (5.0, -10.0, 5.0),
-                (5.0, 5.0, 5.0),
-            ),
-            # single point: acts like flat in y
-            (
-                (2.0, 2.0, 2.0, 2.0, 2.0, 2.0),
-                (2.0, 0.5, 2.0),
-                (2.0, 2.0, 2.0),
-            ),
-            # near flat geometry: triggers flat in y.
-            (
-                (0.0, 0.0, 0.0, 100.0, 0.5, 100.0),
-                (50.0, 0.25 - 150.0, 50.0),
-                (50.0, 0.25, 50.0),
-            ),
-        ],
-    )
-    @patch(f"{CORE}.bounding_box")
-    def test_compute_default_camera_orientations(
-        self, mock_bb, bbox, expected_cam, expected_target
-    ):
-        """Different camera placements and orientation thresholds."""
-        mock_bb.side_effect = lambda p: p.bb
-
-        cam, target = cadapi._compute_default_camera([DummyPart(bbox)])
-
-        assert cam == pytest.approx(expected_cam)
-        assert target == pytest.approx(expected_target)
-
-    @patch(f"{CORE}.bounding_box")
-    def test_compute_default_camera_multipart_bounding_box(self, mock_bb):
-        """Multiple parts merge into a single global bounding box."""
-        mock_bb.side_effect = lambda p: p.bb
-
-        # part 1 (0, 0, 0) to (2, 2, 2)
-        part1 = DummyPart((0.0, 0.0, 0.0, 2.0, 2.0, 2.0))
-        # part 2 (8, 8, 8) to (10, 10, 10)
-        part2 = DummyPart((8.0, 8.0, 8.0, 10.0, 10.0, 10.0))
-
-        # global bounding box (0, 0, 0) to (10, 10, 10).
-        cam, target = cadapi._compute_default_camera([part1, part2])
-
-        # global center (5, 5, 5)
-        assert target == pytest.approx((5.0, 5.0, 5.0))
-
-        # expected camera is 3D XZ fallback
-        assert cam == pytest.approx((5.0, -10.0, 5.0))
-
-    def test_placement_to_trsf_pure_translation(self):
-        """Placement with 0 angle only applies translation."""
-        placement = cadapi._CQPlacement(base=(10.0, -5.0, 3.0))
-
-        trsf = cadapi._placement_to_trsf(placement)
-
-        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
-            10.0,
-            -5.0,
-            3.0,
-        ))
-        assert apply_transformation(trsf, 1.0, 1.0, 1.0) == pytest.approx((
-            11.0,
-            -4.0,
-            4.0,
-        ))
-
-    def test_placement_to_trsf_pure_rotation(self):
-        """Placement with 0 translation only applies rotation."""
-        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=np.pi / 2)
-
-        trsf = cadapi._placement_to_trsf(placement)
-
-        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
-            0.0,
-            0.0,
-            0.0,
-        ))
-        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
-            0.0,
-            1.0,
-            0.0,
-        ))
-
-    def test_placement_to_trsf_combined(self):
-        """Rotation and translation."""
-        placement = cadapi._CQPlacement(
-            base=(5.0, 10.0, 15.0), axis=(0, 1, 0), angle_rad=np.pi / 2
-        )
-
-        trsf = cadapi._placement_to_trsf(placement)
-
-        # (1, 0, 0) rotated 90 deg anti-clockwise about y = (0, 0, -1)
-        # (0, 0, -1) translated by (5, 10, 15) = (5, 10, 14)
-        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
-            5.0,
-            10.0,
-            14.0,
-        ))
-
-    def test_placement_to_trsf_angle_tolerance(self):
-        """Skip rotation when angle is below tolerance."""
-        angle = cadapi._ANGLE_PARALLEL_TOL * 0.5
-        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=angle)
-
-        trsf = cadapi._placement_to_trsf(placement)
-
-        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == (1.0, 0.0, 0.0)  # exactly
-
-    @pytest.mark.parametrize(
-        ("src", "dst", "expected_axis", "expected_angle"),
-        [
-            # 90 deg rotation: revolves around +z
-            (
-                [1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [0.0, 0.0, 1.0],
-                np.pi / 2,
-            ),
-            # 90 deg rotation: revolves around -z
-            (
-                [0.0, 1.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [0.0, 0.0, -1.0],
-                np.pi / 2,
-            ),
-            # 45 deg rotation in xy plane
-            (
-                [1.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [0.0, 0.0, 1.0],
-                np.pi / 4,
-            ),
-            # 90 deg rotation: revolves around -y
-            (
-                [1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0],
-                [0.0, -1.0, 0.0],
-                np.pi / 2,
-            ),
-        ],
-    )
-    def test_rotation_to_align_standard(self, src, dst, expected_axis, expected_angle):
-        """Standard rotations."""
-        axis, angle = cadapi._rotation_to_align(
-            np.array(src, dtype=float),
-            np.array(dst, dtype=float),
-        )
-
-        assert angle == pytest.approx(expected_angle, abs=1e-9)
-        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
-
-    def test_rotation_to_align_parallel(self):
-        """Parallel vectors return default axis and angle."""
-        axis, angle = cadapi._rotation_to_align(
-            np.array([1.0, 2.0, 3.0]),
-            np.array([1.0, 2.0, 3.0]),
-        )
-
-        assert angle == pytest.approx(0.0)
-        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
-
-    def test_rotation_to_align_anti_parallel_x_dominant(self):
-        """180 deg flip - source vec in dominant in x."""
-        axis, angle = cadapi._rotation_to_align(
-            np.array([1.0, 0.0, 0.0]),
-            np.array([-1.0, 0.0, 0.0]),
-        )
-
-        assert angle == pytest.approx(np.pi)
-
-        # cross([1, 0, 0], [0, 1, 0]) = [0, 0, 1]
-        expected_axis = [0.0, 0.0, 1.0]
-        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
-
-    def test_rotation_to_align_anti_parallel_y_dominant(self):
-        """180 deg flip - source vec not dominant in x."""
-        axis, angle = cadapi._rotation_to_align(
-            np.array([0.0, 1.0, 0.0]),
-            np.array([0.0, -1.0, 0.0]),
-        )
-
-        assert angle == pytest.approx(np.pi)
-
-        # cross([0, 1, 0], [1, 0, 0]) = [0, 0, -1]
-        expected_axis = [0.0, 0.0, -1.0]
-        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
-
-    def test_rotation_to_align_unnormalized_inputs(self):
-        """Non-unit vectors yield same alignment."""
-        axis, angle = cadapi._rotation_to_align(
-            np.array([2.0, 0.0, 0.0]),
-            np.array([0.0, 5.0, 0.0]),
-        )
-
-        assert angle == pytest.approx(np.pi / 2, abs=1e-9)
-        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
 
 
 @patch("bluemira.codes.error.FreeCADError", FreeCADError)
@@ -1437,6 +362,193 @@ class TestInternalHelpers:
         with pytest.raises(GeometryError, match="outside the bounds"):
             cadapi.apiFace([outer, bad_inner])
 
+    def test_face_from_wires_tolerant_non_planar_path(self):
+        """
+        Test non-planar path.
+        Create a rectangle on the surface of a cylinder and attempt to
+        create a face from the wire.
+        """
+        radius = 1.0
+        height = 2.0
+
+        vertical_line = cadapi.make_polygon([(radius, 0, 0), (radius, 0, height)])
+        cylinder_surface = (
+            cadapi.revolve_shape(  # revolve vertical line to create cylinder
+                vertical_line,
+                base=(0, 0, 0),
+                direction=(0, 0, 1),
+                degree=360,
+            )
+        )
+
+        rect_points = [
+            (0, -2, 0),
+            (radius, -2, 0),
+            (radius, -2, height),
+            (0, -2, height),
+            (0, -2, 0),
+        ]
+        rect_wire = cadapi.make_polygon(rect_points)
+        rect_face = cadapi.make_face(rect_wire)  # create a 2D rectangle in the XZ plane
+
+        cutting_block = cadapi.extrude_shape(rect_face, (0, 4, 0))  # extrude in Y
+
+        intersection_result = cylinder_surface.intersect(cutting_block)
+        curved_faces = cadapi.faces(
+            intersection_result
+        )  # intersect to yield curved cylinder face
+
+        if curved_faces:
+            target_face = curved_faces[0]
+            wrapped_wire = target_face.outerWire()
+
+        face = cadapi._face_from_wires_tolerant(
+            wrapped_wire, []
+        )  # should succeed via non-planar path
+
+        assert isinstance(face, cq.Face)  # verify face
+        assert cadapi.area(face) > 0
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(wrapped_wire)  # expected error
+
+    def test_face_from_wires_tolerant_strict_planar_path(self):
+        """
+        Test the strict planar path.
+        Create a square in the XY plane and attempt to create a face from the wire.
+        """
+        points = [
+            (0, 0, 0),
+            (1, 0, 0),
+            (1, 1, 0),
+            (0, 1, 0),
+            (0, 0, 0),
+        ]
+
+        wire = cadapi.make_polygon(points)  # planar square wire
+
+        face = cadapi._face_from_wires_tolerant(
+            wire, []
+        )  # this should fail the first path but succeed with makeFromWires
+
+        assert isinstance(face, cq.Face)  # verify face and area
+        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
+
+        direct_face = cq.Face.makeFromWires(
+            wire
+        )  # should work directly with makeFromWires
+        assert cadapi.area(direct_face) == pytest.approx(1.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_tolerant_planar_path(self):
+        """
+        Test the tolerant planar path.
+        Create a planar square but add small noise to the points that exceeds
+        the default confusion tolerance.
+        Attempt to create a face from the wire, should fallback to SVD.
+        """
+        # corners of a square with out-of-plane noise in z
+        p0 = (0.0, 0.0, 1.5e-5)
+        p1 = (1.0, 0.0, -1.2e-5)
+        p2 = (1.0, 1.0, 2.1e-5)
+        p3 = (0.0, 1.0, -1.8e-5)
+
+        # guarantee closed wire
+        noisy_points = [p0, p1, p2, p3, p0]
+
+        wire = cadapi.make_polygon(noisy_points)
+
+        assert wire.IsClosed()
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(wire)
+
+        face = cadapi._face_from_wires_tolerant(
+            wire, []
+        )  # should succeed via SVD fallback
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+        assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_with_holes(self):
+        """Test planar path with inner hole wires."""
+
+        outer_points = [  # 2x2 flat square
+            (-1.0, -1.0, 0.0),
+            (1.0, -1.0, 0.0),
+            (1.0, 1.0, 0.0),
+            (-1.0, 1.0, 0.0),
+            (-1.0, -1.0, 0.0),
+        ]
+        outer_wire = cadapi.make_polygon(outer_points)
+
+        inner_points = [  # inner 1x1 square hole
+            (-0.5, -0.5, 0.0),
+            (0.5, -0.5, 0.0),
+            (0.5, 0.5, 0.0),
+            (-0.5, 0.5, 0.0),
+            (-0.5, -0.5, 0.0),
+        ]
+        inner_wire = cadapi.make_polygon(inner_points)
+
+        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+
+        assert len(face.innerWires()) == 1
+
+        # area = 4.0 (outer) - 1.0 (inner)
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_planar_with_noisy_hole(self):
+        """Test planar path with a noisy inner hole that exceeds tolerance."""
+        outer_points = [  # noisy 2x2 square
+            (0.0, 0.0, 1.5e-5),
+            (2.0, 0.0, -1.2e-5),
+            (2.0, 2.0, 2.1e-5),
+            (0.0, 2.0, -1.8e-5),
+            (0.0, 0.0, 1.5e-5),
+        ]
+        outer_wire = cadapi.make_polygon(outer_points)
+
+        inner_points = [  # noisy 1x1 square hole
+            (0.5, 0.5, 1.1e-5),
+            (1.5, 0.5, -1.3e-5),
+            (1.5, 1.5, 2.0e-5),
+            (0.5, 1.5, -1.6e-5),
+            (0.5, 0.5, 1.1e-5),
+        ]
+        inner_wire = cadapi.make_polygon(inner_points)
+
+        with pytest.raises(ValueError, match="not planar"):
+            cq.Face.makeFromWires(outer_wire, [inner_wire])
+
+        face = cadapi._face_from_wires_tolerant(outer_wire, [inner_wire])
+
+        assert isinstance(face, cq.Face)
+        assert face.isValid()
+        assert len(face.innerWires()) == 1
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
+    def test_face_from_wires_tolerant_inner_same_winding(self):
+        """Test that inner wires with the same winding as the outer wire
+        are handled correctly.
+        """
+        outer = cadapi.make_polygon(  # out square
+            [(0, 0, 0), (2, 0, 0), (2, 2, 0), (0, 2, 0), (0, 0, 0)]
+        )
+
+        inner = cadapi.make_polygon(  # inner square hole with same anticlockwise winding
+            [(0.5, 0.5, 0), (1.5, 0.5, 0), (1.5, 1.5, 0), (0.5, 1.5, 0), (0.5, 0.5, 0)]
+        )
+
+        face = cadapi._face_from_wires_tolerant(outer, [inner])
+
+        assert face.isValid()
+        assert len(face.innerWires()) == 1
+        assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
+
     def test_apiface_with_none_returns_empty_face(self):
         face = cadapi.apiFace(None)
         # The ``None`` branch returns ``cq.Face.__new__(cq.Face)`` — uninitialised
@@ -1487,6 +599,23 @@ class TestInternalHelpers:
         # Short-circuit branch: returns the same instance unchanged.
         assert cadapi._force_close_wire(closed) is closed
 
+    @patch(f"{CORE}._repair_closed_wire")
+    def test_force_close_coincident_endpoints(self, mock_repair):
+        """Open wire with coincident endpoints calls _repair_closed_wire."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        assert not wire.IsClosed()
+
+        mock_repair.return_value = "fake_repaired_wire"
+
+        with (
+            patch.object(wire, "startPoint", return_value=cq.Vector(0, 0, 0)),
+            patch.object(wire, "endPoint", return_value=cq.Vector(0, 0, 0)),
+        ):
+            result = cadapi._force_close_wire(wire)
+
+        mock_repair.assert_called_once_with(wire)
+        assert result == "fake_repaired_wire"
+
     def test_force_close_wire_bridges_open_wire(self):
         # Open polygon (last point != first) — the bridge edge gets appended.
         open_wire = cadapi.make_polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]])
@@ -1515,6 +644,841 @@ class TestInternalHelpers:
         # recursive explorer.
         faces = cadapi._collect_subshapes(compound, cq.Face)
         assert len(faces) == 12
+
+    def test_collect_subshapes_direct_children(self):
+        """Extract immediate children."""
+        box = _make_box()
+        faces = cadapi._collect_subshapes(box, cq.Face)
+        assert len(faces) == 6
+        assert all(isinstance(f, cq.Face) for f in faces)
+
+    def test_collect_subshapes_not_found(self):
+        """Return an empty list if kind doesn't exist."""
+        face = cadapi.make_face(
+            cadapi.make_polygon([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)]).close()
+        )
+
+        solids = cadapi._collect_subshapes(face, cq.Solid)
+
+        assert isinstance(solids, list)
+        assert len(solids) == 0
+
+    def test_collect_subshapes_shell_promotion_valid(self):
+        """Request solid from closed shell promotes shell to solid."""
+        box = _make_box()
+        shell = box.Shells()[0]
+        compound = cadapi.make_compound([shell])
+
+        solids = cadapi._collect_subshapes(compound, cq.Solid)
+
+        assert len(solids) == 1
+        assert isinstance(solids[0], cq.Solid)
+        assert solids[0].isValid()
+
+    @patch(f"{CORE}.fix_shape")
+    @patch.object(cq.Solid, "isValid", return_value=False)
+    def test_collect_subshapes_shell_promotion_invalid_repair(
+        self,
+        mock_valid,  # noqa: ARG002
+        mock_fix_shape,
+    ):
+        """fix_shape called to repair invalid promoted solid."""
+        box = _make_box()
+        shell = box.Shells()[0]
+        compound = cadapi.make_compound([shell])
+
+        solids = cadapi._collect_subshapes(compound, cq.Solid)
+
+        assert len(solids) == 1
+        assert isinstance(solids[0], cq.Solid)
+        mock_fix_shape.assert_called_once_with(solids[0])
+
+    # ---- _edge_pair_cos_angle -----------------------------------------------
+
+    def test_edge_pair_cos_angle_straight(self):
+        """Perfectly collinear."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(1.0)
+
+    def test_edge_pair_cos_angle_orthogonal(self):
+        """Orthogonal edges."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (0, 1, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(0.0)
+
+    def test_edge_pair_cos_angle_u_turn(self):
+        """Opposite directions."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (-1, 0, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(-1.0)
+
+    # ---- _edge_junction_pairs -----------------------------------------------
+
+    def test_edge_junction_pairs(self):
+        """Test pairwise list of edges"""
+        wire = cadapi.make_polygon([
+            (0, 0, 0),
+            (1, 0, 0),
+            (1, 1, 0),
+            (0, 1, 0),
+        ]).close()
+
+        pairs = cadapi._edge_junction_pairs(wire)
+
+        assert len(pairs) == 4
+
+    @pytest.mark.parametrize(
+        ("edges", "is_closed", "expected_pairs"),
+        [
+            ([E1, E2, E3, E4], False, [(E1, E2), (E2, E3), (E3, E4)]),
+            ([E1, E2], False, [(E1, E2)]),
+            ([E1], False, []),
+            ([], False, []),
+            ([E1, E2, E3], True, [(E1, E2), (E2, E3), (E3, E1)]),
+            ([E1, E2], True, [(E1, E2), (E2, E1)]),
+            ([E1], True, []),
+            ([], True, []),
+        ],
+    )
+    @patch(f"{CORE}.is_closed")
+    @patch(f"{CORE}.ordered_edges")
+    def test_edge_junction_pairs_mocked(
+        self,
+        mock_ordered_edges,
+        mock_is_closed,
+        edges,
+        is_closed,
+        expected_pairs,
+    ):
+        mock_ordered_edges.return_value = edges
+        mock_is_closed.return_value = is_closed
+
+        result = cadapi._edge_junction_pairs("dummy_wire")
+
+        assert result == expected_pairs
+
+    # ---- _planar_wire -----------------------------------------------
+
+    def test_planar_wire_returns_normal(self):
+        """_get_planar_normal returns correct normal for valid planar wire."""
+        result = cadapi._get_planar_normal(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ])
+        )
+        assert result == (0, 0, 1)
+
+    def test_non_planar_wire_returns_none(self):
+        """_get_planar_normal returns none for a non-planar wire."""
+        result = cadapi._get_planar_normal(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 1),
+                (0, 1, 0),
+            ])
+        )
+        assert result is None
+
+    # ---- _sewn_solid -----------------------------------------------
+
+    def test_sewn_solid_successful_rebuild(self):
+        """Sew disconnected faces into a valid solid."""
+        box = _make_box()
+        faces = box.faces()
+        assert not isinstance(faces, cq.Solid)
+        solid = cadapi._sewn_solid(faces)
+        assert isinstance(solid, cq.Solid)
+        assert solid.isValid()
+        assert len(solid.Faces()) == 6
+        assert solid.Volume() == pytest.approx(1.0)
+
+    def test_sewn_solid_missing_face(self):
+        """Sew open shell fails to make closed solid."""
+        box = _make_box()
+        faces = box.Faces()[:-1]
+        open_shell = cadapi.make_compound(faces)
+        open_solid = cadapi._sewn_solid(open_shell)
+        assert open_solid is open_shell
+
+    def test_sewn_solid_multiple_shells(self):
+        """Sew disconnected regions gives >1 shell."""
+        box1 = _make_box()
+        box2 = box = cadapi.translate_shape(_make_box(), (5, 0, 0))
+
+        all_faces = box1.Faces() + box2.Faces()
+        split_compound = cadapi.make_compound(all_faces)
+
+        multi_shell = cadapi._sewn_solid(split_compound)
+        assert multi_shell is split_compound
+
+    def test_sewn_solid_already_valid(self):
+        """Valid solid should rebuild safely."""
+        box = _make_box()
+        solid = cadapi._sewn_solid(box)
+        assert isinstance(solid, cq.Solid)
+        assert solid.isValid()
+        assert solid.Volume() == pytest.approx(1.0)
+
+    # ---- _wire_is_straight -----------------------------------------------
+
+    def test_wire_is_straight_single_straight(self):
+        """True for single straight line."""
+        assert cadapi._wire_is_straight(cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]))
+
+    def test_wire_is_straight_multi_straight(self):
+        """False for multiple straight lines."""
+        assert not cadapi._wire_is_straight(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (2, 0, 0),
+            ])
+        )
+
+    def test_wire_is_straight_curved(self):
+        """False for curved line."""
+        assert not cadapi._wire_is_straight(
+            cadapi.make_circle_arc_3P(
+                (0, 0, 0),
+                (5, 5, 0),
+                (10, 0, 0),
+            )
+        )
+
+    # ---- _wire_is_planar -----------------------------------------------
+
+    def test_wire_is_planar_closed(self):
+        """True for 2D flat shape."""
+        assert cadapi._wire_is_planar(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+
+    def test_wire_is_planar_non_planar(self):
+        """False for non-planar shape."""
+        assert not cadapi._wire_is_planar(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 1),
+                (0, 1, 0),
+            ]).close()
+        )
+
+    # ---- _occ_face_area -----------------------------------------------
+
+    def test_occ_face_area_square(self):
+        """Simple area calculation on square."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+        assert cadapi._occ_face_area(square.wrapped) == pytest.approx(1.0)
+
+    def test_occ_face_area_circle(self):
+        """Simple area calculation on circle."""
+        circle = cadapi.make_face(cadapi.make_circle())
+        assert cadapi._occ_face_area(circle.wrapped) == pytest.approx(np.pi)
+
+    def test_cq_area_prop_face(self):
+        """Area property on standard face."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+        assert convert(square).area == pytest.approx(1.0)
+
+    def test_cq_area_prop_face_with_holes(self):
+        """Area property on face with holes."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (2, 0, 0),
+                (2, 2, 0),
+                (0, 2, 0),
+            ]).close()
+        )
+        circle = cadapi.make_face(cadapi.make_circle(radius=0.5, center=(1, 1, 0)))
+        assert convert(cadapi.boolean_cut(square, circle)[0]).area == pytest.approx(
+            4.0 - (np.pi * 0.25)
+        )
+
+    # ---- _unify_same_domain -----------------------------------------------
+
+    def test_unify_same_domain_coplanar_faces(self):
+        """Coplanar faces and collinear edges are unified."""
+        box1 = _make_box()
+        box2 = cadapi.translate_shape(_make_box(), (1, 0, 0))
+
+        bad_shape = box1.fuse(box2)
+        assert len(bad_shape.Faces()) > 6
+
+        unified = cadapi._unify_same_domain(bad_shape)
+        assert len(unified.Faces()) == 6
+        assert isinstance(unified, cq.Shape)
+
+    def test_unify_same_domain_clean_shape(self):
+        """Passing clean shape is idempotent."""
+        clean = _make_box()
+        unified = cadapi._unify_same_domain(clean)
+        assert len(unified.Faces()) == len(clean.Faces())
+        assert len(unified.Edges()) == len(clean.Edges())
+
+    @patch(f"{CORE}.bluemira_warn")
+    @patch(f"{CORE}.ShapeUpgrade_UnifySameDomain")
+    def test_unify_same_domain_exception(self, mock_unify, mock_warn):
+        """Exceptions are caught."""
+        unifier = MagicMock()
+        unifier.Build.side_effect = RuntimeError("Fake Error")
+        mock_unify.return_value = unifier
+
+        box = _make_box()
+        result = cadapi._unify_same_domain(box)
+
+        mock_warn.assert_called_once()
+        assert "UnifySameDomain failed" in mock_warn.call_args[0][0]
+        assert result is box
+
+    # ---- _assemble_wires_from_edges -----------------------------------------------
+
+    def test_assemble_wires_from_edges_empty(self):
+        """Empty list of edges returns empty list."""
+        assert cadapi._assemble_wires_from_edges([]) == []
+
+    def test_assemble_wires_from_edges_connected(self):
+        """Sequentially connected wires are merged into a single wire."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
+        e2 = cadapi.make_polygon([(1, 0, 0), (1, 1, 0)]).Edges()
+        e3 = cadapi.make_polygon([(1, 1, 0), (0, 1, 0)]).Edges()
+
+        wires = cadapi._assemble_wires_from_edges(e1 + e2 + e3)
+
+        assert len(wires) == 1
+        assert len(wires[0].Edges()) == 3
+        assert isinstance(wires[0], cq.Wire)
+
+    def test_assemble_wires_from_edges_disconnected(self):
+        """Disconnected edges return separate wires."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()
+        e2 = cadapi.make_polygon([(1, 1, 0), (2, 1, 0)]).Edges()
+
+        wires = cadapi._assemble_wires_from_edges(e1 + e2)
+
+        assert len(wires) == 2
+        assert len(wires[0].Edges()) == 1
+        assert len(wires[1].Edges()) == 1
+
+    # ---- _split_wire -----------------------------------------------
+
+    def test_split_wire_by_closed_tools_intersection(self):
+        """Split wire using closed tool that perfectly crosses it."""
+        wire = cadapi.make_polygon([(0, 0, 0), (10, 0, 0)])
+        tool = cadapi.make_polygon([
+            (3, -2, 0),
+            (7, -2, 0),
+            (7, 2, 0),
+            (3, 2, 0),
+        ]).close()
+
+        result = cadapi._split_wire_by_closed_tools(wire, [tool])
+
+        assert len(result) == 3
+        assert sorted([w.Length() for w in result]) == [3.0, 3.0, 4.0]
+
+    def test_split_wire_by_closed_tools_no_intersection(self):
+        """Unchanged wire if the tool doesn't overlap."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        tool = cadapi.make_polygon([
+            (2, 0, 0),
+            (4, 0, 0),
+            (4, 2, 0),
+            (2, 2, 0),
+        ]).close()
+
+        result = cadapi._split_wire_by_closed_tools(wire, [tool])
+
+        assert len(result) == 1
+        assert result[0].Length() == 1
+
+    def test_split_wire_at_tool_crossings_single_cut(self):
+        """Split wire with open tool."""
+        wire = cadapi.make_polygon([(0, 0, 0), (5, 0, 0)])
+        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
+
+        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
+
+        assert len(result) == 2
+        assert [w.Length() for w in result] == [3, 2]  # must be sorted
+
+    def test_split_wire_at_tool_crossings_no_cut(self):
+        """Split wire with open tool that doesn't intersect."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        tool = cadapi.make_polygon([(2, -2, 0), (2, 2, 0)])
+
+        result = cadapi._split_wire_at_tool_crossings(wire, [tool])
+
+        assert len(result) == 1
+        assert result[0].Length() == 1
+
+    # ---- _repair_closed_wire -----------------------------------------------
+
+    def test_repair_closed_wire_closed(self):
+        """Repair already closed wire is idempotent."""
+        wire = cadapi.make_circle()
+        assert wire.IsClosed()
+
+        with patch(f"{CORE}.ShapeFix_Wire") as mock_fixer:
+            result = cadapi._repair_closed_wire(wire)
+            assert result is wire
+            mock_fixer.assert_not_called()
+
+    def test_repair_closed_wire_unflagged(self):
+        """Wire is closed but topods close is false."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
+        e2 = cadapi.make_polygon([(1, 0, 0), (0, 0, 0)]).Edges()[0]
+
+        raw_wire = TopoDS_Wire()
+        builder = BRep_Builder()
+        builder.MakeWire(raw_wire)
+        builder.Add(raw_wire, e1.wrapped)
+        builder.Add(raw_wire, e2.wrapped)
+
+        wire = cq.Wire(raw_wire)
+        assert not wire.IsClosed()
+
+        repaired = cadapi._repair_closed_wire(wire)
+        assert repaired.IsClosed()
+        assert isinstance(repaired, cq.Wire)
+
+    def test_repair_closed_wire_open_wire(self):
+        """Open wire remains open."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+        assert not wire.IsClosed()
+
+        repaired = cadapi._repair_closed_wire(wire)
+        assert not repaired.IsClosed()
+
+    @patch(f"{CORE}.ShapeFix_Wire")
+    def test_repair_closed_wire_null_fallback(self, mock_shape_fix):
+        """Return original wire if ShapeFix_Wire fails."""
+        wire = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)])
+
+        mock_fixer = MagicMock()
+        mock_null = MagicMock()
+        mock_null.IsNull.return_value = True
+        mock_fixer.Wire.return_value = mock_null
+        mock_shape_fix.return_value = mock_fixer
+
+        repaired = cadapi._repair_closed_wire(wire)
+
+        assert repaired is wire
+
+    # ---- _piece_mass -----------------------------------------------
+
+    def test_piece_mass_solid(self):
+        """Solid's mass evaluates to its volume."""
+        box = _make_box()
+        mass = cadapi._piece_mass(box)
+        assert mass == pytest.approx(1.0)
+
+    def test_piece_mass_face(self):
+        """Face's mass evaluates to its area."""
+        face = cadapi.make_face(cadapi.make_circle())
+        mass = cadapi._piece_mass(face)
+        assert mass == pytest.approx(np.pi)
+
+    def test_piece_mass_edge(self):
+        """Edge's mass evaluates to its area."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).Edges()[0]
+        mass = cadapi._piece_mass(e1)
+        assert mass == pytest.approx(1.0)
+
+    def test_piece_source_map(self):
+        """Fragment maps correctly group identical shapes."""
+        s1 = _make_box()
+        s2 = _make_box()
+        s3 = _make_box()
+
+        fragment_map = [[s1, s2], [s1, s3]]
+        unique_map = cadapi._piece_source_map(fragment_map)
+        assert len(unique_map) == 3
+
+        s1_entry = next((i for i in unique_map if i[0] is s1), None)
+        s2_entry = next((i for i in unique_map if i[0] is s2), None)
+        s3_entry = next((i for i in unique_map if i[0] is s3), None)
+
+        assert s1_entry is not None
+        assert s1_entry[1] == {0, 1}
+        assert s2_entry is not None
+        assert s2_entry[1] == {0}
+        assert s3_entry is not None
+        assert s3_entry[1] == {1}
+
+    # ---- _shapes_touch -----------------------------------------------
+
+    def test_grow_keepers_by_overlap(self):
+        """Add pieces if they touch a kept piece, from 2 sources to max overlap."""
+        k1 = _make_box()
+        p_layer_2 = _make_box(s=2)
+        p_layer_3 = _make_box(s=3)
+        p_isolated_2 = cadapi.translate_shape(_make_box(s=4), (10, 10, 10))
+
+        keepers = [k1]
+        unique_pieces = [
+            (k1, {0}),
+            (p_layer_2, {0, 1}),  # 2 sources, touches k1
+            (p_isolated_2, {1, 2}),  # 2 sources, touches nothing
+            (p_layer_3, {0, 1, 2}),  # 2 sources, touches p_layer_2
+        ]
+
+        cadapi._grow_keepers_by_overlap(keepers, unique_pieces)
+
+        assert len(keepers) == 3
+        assert k1 in keepers
+        assert p_layer_2 in keepers
+        assert p_layer_3 in keepers
+        assert p_isolated_2 not in keepers
+
+    def test_shapes_touch_true(self):
+        """Touching shapes return true."""
+        box1 = _make_box()
+        box2 = cadapi.translate_shape(_make_box(), (1, 0, 0))
+        assert cadapi._shapes_touch(box1, box2)
+
+    def test_shapes_touch_false(self):
+        """Separated shapes return false."""
+        box1 = _make_box()
+        box2 = cadapi.translate_shape(_make_box(), (2, 0, 0))
+        assert not cadapi._shapes_touch(box1, box2)
+
+    # ---- _freecad_ax2 -----------------------------------------------
+
+    def test_freecad_ax2_standard_projection(self):
+        """Global x (1, 0, 0) is projected to (1, 0, 0)."""
+        center = [1.0, 2.0, 3.0]
+        axis = [0.0, 0.0, 1.0]
+
+        ax2 = cadapi._freecad_ax2(center, axis)
+
+        assert isinstance(ax2, gp_Ax2)
+        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Location()), center, atol=1e-12)
+        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Direction()), axis, atol=1e-12)
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), [1.0, 0.0, 0.0], atol=1e-12
+        )
+
+    @pytest.mark.parametrize(
+        "axis",
+        [
+            ([1.0, 0.0, 0.0]),
+            ([-1.0, 0.0, 0.0]),
+            ([2.0, 0.0, 0.0]),
+        ],
+    )
+    def test_freecad_ax2_fallback_projection(self, axis):
+        """Axis parallel to global x, fallback to project global y."""
+        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], axis)
+
+        # expected normal is normalised input axis
+        expected_n = np.array(axis, dtype=float)
+        expected_n /= np.linalg.norm(expected_n)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.Direction()), expected_n, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), [0.0, 1.0, 0.0], atol=1e-12
+        )
+
+    def test_freecad_ax2_explicit_override(self):
+        """Providing x_direction bypasses projection logic."""
+        x_direction = [1.0, 1.0, 0.0]
+
+        ax2 = cadapi._freecad_ax2(
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+            x_direction=x_direction,
+        )
+
+        expected_x = np.array(x_direction)
+        expected_x /= np.linalg.norm(expected_x)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
+        )
+
+    def test_freecad_ax2_arbitrary_axis(self):
+        """Projection correctly applise to diagonal normal."""
+        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])
+
+        # n = (1, 1, 1) / sqrt(3)
+        # ref = (1, 0, 0)
+        # x = ref - dot(ref, n) * n
+        # x = (1, 0, 0) - (1/3, 1/3, 1/3) = (2/3, -1/3, -1/3)
+        # normalised x = (2, -1, -1) / sqrt(6)
+        expected_x = np.array([2.0, -1.0, -1.0]) / np.sqrt(6.0)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
+        )
+        assert (
+            abs(
+                np.dot(  # veryify orthogonal
+                    _pnt_dir_to_array(ax2.Direction()),
+                    _pnt_dir_to_array(ax2.XDirection()),
+                )
+            )
+            < 1e-12
+        )
+
+    # ---- _compute_default_camera -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("bbox", "expected_cam", "expected_target"),
+        [
+            # flat in xz plane: looks from -y
+            (
+                (0.0, 0.0, 0.0, 10.0, 0.0, 10.0),
+                (5.0, -15.0, 5.0),
+                (5.0, 0.0, 5.0),
+            ),
+            # flat in yz plane: looks from +x
+            (
+                (0.0, 0.0, 0.0, 0.0, 10.0, 10.0),
+                (15.0, 5.0, 5.0),
+                (0.0, 5.0, 5.0),
+            ),
+            # flat in xy plane: looks from +z
+            (
+                (0.0, 0.0, 0.0, 10.0, 10.0, 0.0),
+                (5.0, 5.0, 15.0),
+                (5.0, 5.0, 0.0),
+            ),
+            # 3D object: falls back to xz side view (-y)
+            (
+                (0.0, 0.0, 0.0, 10.0, 10.0, 10.0),
+                (5.0, -10.0, 5.0),
+                (5.0, 5.0, 5.0),
+            ),
+            # single point: acts like flat in y
+            (
+                (2.0, 2.0, 2.0, 2.0, 2.0, 2.0),
+                (2.0, 0.5, 2.0),
+                (2.0, 2.0, 2.0),
+            ),
+            # near flat geometry: triggers flat in y.
+            (
+                (0.0, 0.0, 0.0, 100.0, 0.5, 100.0),
+                (50.0, 0.25 - 150.0, 50.0),
+                (50.0, 0.25, 50.0),
+            ),
+        ],
+    )
+    @patch(f"{CORE}.bounding_box")
+    def test_compute_default_camera_orientations(
+        self, mock_bb, bbox, expected_cam, expected_target
+    ):
+        """Different camera placements and orientation thresholds."""
+        mock_bb.side_effect = lambda p: p.bb
+
+        cam, target = cadapi._compute_default_camera([DummyPart(bbox)])
+
+        assert cam == pytest.approx(expected_cam)
+        assert target == pytest.approx(expected_target)
+
+    @patch(f"{CORE}.bounding_box")
+    def test_compute_default_camera_multipart_bounding_box(self, mock_bb):
+        """Multiple parts merge into a single global bounding box."""
+        mock_bb.side_effect = lambda p: p.bb
+
+        # part 1 (0, 0, 0) to (2, 2, 2)
+        part1 = DummyPart((0.0, 0.0, 0.0, 2.0, 2.0, 2.0))
+        # part 2 (8, 8, 8) to (10, 10, 10)
+        part2 = DummyPart((8.0, 8.0, 8.0, 10.0, 10.0, 10.0))
+
+        # global bounding box (0, 0, 0) to (10, 10, 10).
+        cam, target = cadapi._compute_default_camera([part1, part2])
+
+        # global center (5, 5, 5)
+        assert target == pytest.approx((5.0, 5.0, 5.0))
+
+        # expected camera is 3D XZ fallback
+        assert cam == pytest.approx((5.0, -10.0, 5.0))
+
+    # ---- _placement_to_trsf -----------------------------------------------
+
+    def test_placement_to_trsf_pure_translation(self):
+        """Placement with 0 angle only applies translation."""
+        placement = cadapi._CQPlacement(base=(10.0, -5.0, 3.0))
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
+            10.0,
+            -5.0,
+            3.0,
+        ))
+        assert apply_transformation(trsf, 1.0, 1.0, 1.0) == pytest.approx((
+            11.0,
+            -4.0,
+            4.0,
+        ))
+
+    def test_placement_to_trsf_pure_rotation(self):
+        """Placement with 0 translation only applies rotation."""
+        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=np.pi / 2)
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
+            0.0,
+            0.0,
+            0.0,
+        ))
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
+            0.0,
+            1.0,
+            0.0,
+        ))
+
+    def test_placement_to_trsf_combined(self):
+        """Rotation and translation."""
+        placement = cadapi._CQPlacement(
+            base=(5.0, 10.0, 15.0), axis=(0, 1, 0), angle_rad=np.pi / 2
+        )
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        # (1, 0, 0) rotated 90 deg anti-clockwise about y = (0, 0, -1)
+        # (0, 0, -1) translated by (5, 10, 15) = (5, 10, 14)
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
+            5.0,
+            10.0,
+            14.0,
+        ))
+
+    def test_placement_to_trsf_angle_tolerance(self):
+        """Skip rotation when angle is below tolerance."""
+        angle = cadapi._ANGLE_PARALLEL_TOL * 0.5
+        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=angle)
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == (1.0, 0.0, 0.0)  # exactly
+
+    # ---- _rotation_to_align -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("src", "dst", "expected_axis", "expected_angle"),
+        [
+            # 90 deg rotation: revolves around +z
+            (
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                np.pi / 2,
+            ),
+            # 90 deg rotation: revolves around -z
+            (
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+                np.pi / 2,
+            ),
+            # 45 deg rotation in xy plane
+            (
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                np.pi / 4,
+            ),
+            # 90 deg rotation: revolves around -y
+            (
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, -1.0, 0.0],
+                np.pi / 2,
+            ),
+        ],
+    )
+    def test_rotation_to_align_standard(self, src, dst, expected_axis, expected_angle):
+        """Standard rotations."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array(src, dtype=float),
+            np.array(dst, dtype=float),
+        )
+
+        assert angle == pytest.approx(expected_angle, abs=1e-9)
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_parallel(self):
+        """Parallel vectors return default axis and angle."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+        )
+
+        assert angle == pytest.approx(0.0)
+        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
+
+    def test_rotation_to_align_anti_parallel_x_dominant(self):
+        """180 deg flip - source vec in dominant in x."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([1.0, 0.0, 0.0]),
+            np.array([-1.0, 0.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi)
+
+        # cross([1, 0, 0], [0, 1, 0]) = [0, 0, 1]
+        expected_axis = [0.0, 0.0, 1.0]
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_anti_parallel_y_dominant(self):
+        """180 deg flip - source vec not dominant in x."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([0.0, 1.0, 0.0]),
+            np.array([0.0, -1.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi)
+
+        # cross([0, 1, 0], [1, 0, 0]) = [0, 0, -1]
+        expected_axis = [0.0, 0.0, -1.0]
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_unnormalized_inputs(self):
+        """Non-unit vectors yield same alignment."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([2.0, 0.0, 0.0]),
+            np.array([0.0, 5.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi / 2, abs=1e-9)
+        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
 
 
 class TestCurves:

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -21,12 +21,14 @@ pytestmark = pytest.mark.skipif(
 cadapi = pytest.importorskip("bluemira.codes.cadapi._cadquery")
 cq = pytest.importorskip("cadquery")
 
+from dataclasses import dataclass  # noqa: E402
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import cadquery as cq  # noqa: E402
 import numpy as np  # noqa: E402
 from OCP.BRep import BRep_Builder  # noqa: E402
 from OCP.TopoDS import TopoDS_Wire  # noqa: E402
+from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt, gp_Trsf  # noqa: E402
 
 from bluemira.codes.error import FreeCADError  # noqa: E402
 from bluemira.geometry.error import GeometryError  # noqa: E402
@@ -52,6 +54,26 @@ def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
         [ox, oy + side, oz],
         [ox, oy, oz],
     ])
+
+
+def _pnt_dir_to_array(obj: gp_Pnt | gp_Dir) -> np.ndarray:
+    return np.array([obj.X(), obj.Y(), obj.Z()])
+
+
+def apply_transformation(
+    trsf: gp_Trsf, x: float, y: float, z: float
+) -> tuple[float, float, float]:
+    """Applies a gp_Trsf to a 3D point and returns the new coordinates."""
+    pnt = gp_Pnt(x, y, z)
+    pnt.Transform(trsf)
+    return pnt.X(), pnt.Y(), pnt.Z()
+
+
+@dataclass
+class DummyPart:
+    """A lightweight mock object to carry a predetermined bounding box."""
+
+    bb: tuple[float, float, float, float, float, float]
 
 
 class TestCadqueryapi(BackendApiTestsBase):
@@ -648,7 +670,11 @@ class TestCadqueryapi(BackendApiTestsBase):
 
     @patch(f"{CORE}.fix_shape")
     @patch.object(cq.Solid, "isValid", return_value=False)
-    def test_collect_subshapes_shell_promotion_invalid_repair(self, mock_fix_shape):
+    def test_collect_subshapes_shell_promotion_invalid_repair(
+        self,
+        mock_valid,  # noqa: ARG002
+        mock_fix_shape,
+    ):
         """fix_shape called to repair invalid promoted solid."""
         box = self._make_box()
         shell = box.Shells()[0]
@@ -839,6 +865,304 @@ class TestCadqueryapi(BackendApiTestsBase):
         box1 = self._make_box()
         box2 = cadapi.translate_shape(self._make_box(), (2, 0, 0))
         assert not cadapi._shapes_touch(box1, box2)
+
+    def test_freecad_ax2_standard_projection(self):
+        """Global x (1, 0, 0) is projected to (1, 0, 0)."""
+        center = [1.0, 2.0, 3.0]
+        axis = [0.0, 0.0, 1.0]
+
+        ax2 = cadapi._freecad_ax2(center, axis)
+
+        assert isinstance(ax2, gp_Ax2)
+        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Location()), center, atol=1e-12)
+        np.testing.assert_allclose(_pnt_dir_to_array(ax2.Direction()), axis, atol=1e-12)
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), [1.0, 0.0, 0.0], atol=1e-12
+        )
+
+    @pytest.mark.parametrize(
+        "axis",
+        [
+            ([1.0, 0.0, 0.0]),
+            ([-1.0, 0.0, 0.0]),
+            ([2.0, 0.0, 0.0]),
+        ],
+    )
+    def test_freecad_ax2_fallback_projection(self, axis):
+        """Axis parallel to global x, fallback to project global y."""
+        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], axis)
+
+        # expected normal is normalised input axis
+        expected_n = np.array(axis, dtype=float)
+        expected_n /= np.linalg.norm(expected_n)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.Direction()), expected_n, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), [0.0, 1.0, 0.0], atol=1e-12
+        )
+
+    def test_freecad_ax2_explicit_override(self):
+        """Providing x_direction bypasses projection logic."""
+        x_direction = [1.0, 1.0, 0.0]
+
+        ax2 = cadapi._freecad_ax2(
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+            x_direction=x_direction,
+        )
+
+        expected_x = np.array(x_direction)
+        expected_x /= np.linalg.norm(expected_x)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
+        )
+
+    def test_freecad_ax2_arbitrary_axis(self):
+        """Projection correctly applise to diagonal normal."""
+        ax2 = cadapi._freecad_ax2([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])
+
+        # n = (1, 1, 1) / sqrt(3)
+        # ref = (1, 0, 0)
+        # x = ref - dot(ref, n) * n
+        # x = (1, 0, 0) - (1/3, 1/3, 1/3) = (2/3, -1/3, -1/3)
+        # normalised x = (2, -1, -1) / sqrt(6)
+        expected_x = np.array([2.0, -1.0, -1.0]) / np.sqrt(6.0)
+
+        np.testing.assert_allclose(
+            _pnt_dir_to_array(ax2.XDirection()), expected_x, atol=1e-12
+        )
+        assert (
+            abs(
+                np.dot(  # veryify orthogonal
+                    _pnt_dir_to_array(ax2.Direction()),
+                    _pnt_dir_to_array(ax2.XDirection()),
+                )
+            )
+            < 1e-12
+        )
+
+    @pytest.mark.parametrize(
+        ("bbox", "expected_cam", "expected_target"),
+        [
+            # flat in xz plane: looks from -y
+            (
+                (0.0, 0.0, 0.0, 10.0, 0.0, 10.0),
+                (5.0, -15.0, 5.0),
+                (5.0, 0.0, 5.0),
+            ),
+            # flat in yz plane: looks from +x
+            (
+                (0.0, 0.0, 0.0, 0.0, 10.0, 10.0),
+                (15.0, 5.0, 5.0),
+                (0.0, 5.0, 5.0),
+            ),
+            # flat in xy plane: looks from +z
+            (
+                (0.0, 0.0, 0.0, 10.0, 10.0, 0.0),
+                (5.0, 5.0, 15.0),
+                (5.0, 5.0, 0.0),
+            ),
+            # 3D object: falls back to xz side view (-y)
+            (
+                (0.0, 0.0, 0.0, 10.0, 10.0, 10.0),
+                (5.0, -10.0, 5.0),
+                (5.0, 5.0, 5.0),
+            ),
+            # single point: acts like flat in y
+            (
+                (2.0, 2.0, 2.0, 2.0, 2.0, 2.0),
+                (2.0, 0.5, 2.0),
+                (2.0, 2.0, 2.0),
+            ),
+            # near flat geometry: triggers flat in y.
+            (
+                (0.0, 0.0, 0.0, 100.0, 0.5, 100.0),
+                (50.0, 0.25 - 150.0, 50.0),
+                (50.0, 0.25, 50.0),
+            ),
+        ],
+    )
+    @patch(f"{CORE}.bounding_box")
+    def test_compute_default_camera_orientations(
+        self, mock_bb, bbox, expected_cam, expected_target
+    ):
+        """Different camera placements and orientation thresholds."""
+        mock_bb.side_effect = lambda p: p.bb
+
+        cam, target = cadapi._compute_default_camera([DummyPart(bbox)])
+
+        assert cam == pytest.approx(expected_cam)
+        assert target == pytest.approx(expected_target)
+
+    @patch(f"{CORE}.bounding_box")
+    def test_compute_default_camera_multipart_bounding_box(self, mock_bb):
+        """Multiple parts merge into a single global bounding box."""
+        mock_bb.side_effect = lambda p: p.bb
+
+        # part 1 (0, 0, 0) to (2, 2, 2)
+        part1 = DummyPart((0.0, 0.0, 0.0, 2.0, 2.0, 2.0))
+        # part 2 (8, 8, 8) to (10, 10, 10)
+        part2 = DummyPart((8.0, 8.0, 8.0, 10.0, 10.0, 10.0))
+
+        # global bounding box (0, 0, 0) to (10, 10, 10).
+        cam, target = cadapi._compute_default_camera([part1, part2])
+
+        # global center (5, 5, 5)
+        assert target == pytest.approx((5.0, 5.0, 5.0))
+
+        # expected camera is 3D XZ fallback
+        assert cam == pytest.approx((5.0, -10.0, 5.0))
+
+    def test_placement_to_trsf_pure_translation(self):
+        """Placement with 0 angle only applies translation."""
+        placement = cadapi._CQPlacement(base=(10.0, -5.0, 3.0))
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
+            10.0,
+            -5.0,
+            3.0,
+        ))
+        assert apply_transformation(trsf, 1.0, 1.0, 1.0) == pytest.approx((
+            11.0,
+            -4.0,
+            4.0,
+        ))
+
+    def test_placement_to_trsf_pure_rotation(self):
+        """Placement with 0 translation only applies rotation."""
+        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=np.pi / 2)
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 0.0, 0.0, 0.0) == pytest.approx((
+            0.0,
+            0.0,
+            0.0,
+        ))
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
+            0.0,
+            1.0,
+            0.0,
+        ))
+
+    def test_placement_to_trsf_combined(self):
+        """Rotation and translation."""
+        placement = cadapi._CQPlacement(
+            base=(5.0, 10.0, 15.0), axis=(0, 1, 0), angle_rad=np.pi / 2
+        )
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        # (1, 0, 0) rotated 90 deg anti-clockwise about y = (0, 0, -1)
+        # (0, 0, -1) translated by (5, 10, 15) = (5, 10, 14)
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == pytest.approx((
+            5.0,
+            10.0,
+            14.0,
+        ))
+
+    def test_placement_to_trsf_angle_tolerance(self):
+        """Skip rotation when angle is below tolerance."""
+        angle = cadapi._ANGLE_PARALLEL_TOL * 0.5
+        placement = cadapi._CQPlacement(base=(0.0, 0.0, 0.0), angle_rad=angle)
+
+        trsf = cadapi._placement_to_trsf(placement)
+
+        assert apply_transformation(trsf, 1.0, 0.0, 0.0) == (1.0, 0.0, 0.0)  # exactly
+
+    @pytest.mark.parametrize(
+        ("src", "dst", "expected_axis", "expected_angle"),
+        [
+            # 90 deg rotation: revolves around +z
+            (
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                np.pi / 2,
+            ),
+            # 90 deg rotation: revolves around -z
+            (
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+                np.pi / 2,
+            ),
+            # 45 deg rotation in xy plane
+            (
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                np.pi / 4,
+            ),
+            # 90 deg rotation: revolves around -y
+            (
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, -1.0, 0.0],
+                np.pi / 2,
+            ),
+        ],
+    )
+    def test_rotation_to_align_standard(self, src, dst, expected_axis, expected_angle):
+        """Standard rotations."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array(src, dtype=float),
+            np.array(dst, dtype=float),
+        )
+
+        assert angle == pytest.approx(expected_angle, abs=1e-9)
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_parallel(self):
+        """Parallel vectors return default axis and angle."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+        )
+
+        assert angle == pytest.approx(0.0)
+        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
+
+    def test_rotation_to_align_anti_parallel_x_dominant(self):
+        """180 deg flip - source vec in dominant in x."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([1.0, 0.0, 0.0]),
+            np.array([-1.0, 0.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi)
+
+        # cross([1, 0, 0], [0, 1, 0]) = [0, 0, 1]
+        expected_axis = [0.0, 0.0, 1.0]
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_anti_parallel_y_dominant(self):
+        """180 deg flip - source vec not dominant in x."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([0.0, 1.0, 0.0]),
+            np.array([0.0, -1.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi)
+
+        # cross([0, 1, 0], [1, 0, 0]) = [0, 0, -1]
+        expected_axis = [0.0, 0.0, -1.0]
+        np.testing.assert_allclose(axis, expected_axis, atol=1e-9)
+
+    def test_rotation_to_align_unnormalized_inputs(self):
+        """Non-unit vectors yield same alignment."""
+        axis, angle = cadapi._rotation_to_align(
+            np.array([2.0, 0.0, 0.0]),
+            np.array([0.0, 5.0, 0.0]),
+        )
+
+        assert angle == pytest.approx(np.pi / 2, abs=1e-9)
+        np.testing.assert_allclose(axis, [0.0, 0.0, 1.0], atol=1e-9)
 
 
 @patch("bluemira.codes.error.FreeCADError", FreeCADError)

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -21,13 +21,19 @@ pytestmark = pytest.mark.skipif(
 cadapi = pytest.importorskip("bluemira.codes.cadapi._cadquery")
 cq = pytest.importorskip("cadquery")
 
-import numpy as np
-import cadquery as cq
+from unittest.mock import MagicMock, patch  # noqa: E402
 
-from bluemira.geometry.error import GeometryError
+import cadquery as cq  # noqa: E402
+import numpy as np  # noqa: E402
+
 from bluemira.codes.error import FreeCADError  # noqa: E402
 from bluemira.geometry.error import GeometryError  # noqa: E402
+from bluemira.geometry.tools import convert  # noqa: E402
 from tests.codes._shared.backend_api_tests import BackendApiTestsBase  # noqa: E402
+
+E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
+
+E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
 
 
 def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
@@ -48,20 +54,36 @@ def _closed_square(side: float = 1.0, origin=(0.0, 0.0, 0.0)):
 class TestCadqueryapi(BackendApiTestsBase):
     cadapi = cadapi
 
+    def _make_box(self):
+        return cadapi.extrude_shape(
+            cadapi.make_face(
+                cadapi.make_polygon([
+                    (0, 0, 0),
+                    (1, 0, 0),
+                    (1, 1, 0),
+                    (0, 1, 0),
+                ]).close()
+            ),
+            (0, 0, 1),
+        )
+
     def test_face_from_wires_tolerant_non_planar_path(self):
         """
         Test non-planar path.
-        Create a rectangle on the surface of a cylinder and attempt to create a face from the wire.
+        Create a rectangle on the surface of a cylinder and attempt to
+        create a face from the wire.
         """
         radius = 1.0
         height = 2.0
 
         vertical_line = cadapi.make_polygon([(radius, 0, 0), (radius, 0, height)])
-        cylinder_surface = cadapi.revolve_shape(  # revolve vertical line to create cylinder
-            vertical_line,
-            base=(0, 0, 0),
-            direction=(0, 0, 1),
-            degree=360,
+        cylinder_surface = (
+            cadapi.revolve_shape(  # revolve vertical line to create cylinder
+                vertical_line,
+                base=(0, 0, 0),
+                direction=(0, 0, 1),
+                degree=360,
+            )
         )
 
         rect_points = [
@@ -77,13 +99,17 @@ class TestCadqueryapi(BackendApiTestsBase):
         cutting_block = cadapi.extrude_shape(rect_face, (0, 4, 0))  # extrude in Y
 
         intersection_result = cylinder_surface.intersect(cutting_block)
-        curved_faces = cadapi.faces(intersection_result)  # intersect to yield curved cylinder face
+        curved_faces = cadapi.faces(
+            intersection_result
+        )  # intersect to yield curved cylinder face
 
         if curved_faces:
             target_face = curved_faces[0]
             wrapped_wire = target_face.outerWire()
 
-        face = cadapi._face_from_wires_tolerant(wrapped_wire, [])  # should succeed via non-planar path
+        face = cadapi._face_from_wires_tolerant(
+            wrapped_wire, []
+        )  # should succeed via non-planar path
 
         assert isinstance(face, cq.Face)  # verify face
         assert cadapi.area(face) > 0
@@ -106,24 +132,29 @@ class TestCadqueryapi(BackendApiTestsBase):
 
         wire = cadapi.make_polygon(points)  # planar square wire
 
-        face = cadapi._face_from_wires_tolerant(wire, [])  # this should fail the first path but succeed with makeFromWires
+        face = cadapi._face_from_wires_tolerant(
+            wire, []
+        )  # this should fail the first path but succeed with makeFromWires
 
         assert isinstance(face, cq.Face)  # verify face and area
         assert cadapi.area(face) == pytest.approx(1.0, abs=1e-6)
 
-        direct_face = cq.Face.makeFromWires(wire)  # should work directly with makeFromWires
+        direct_face = cq.Face.makeFromWires(
+            wire
+        )  # should work directly with makeFromWires
         assert cadapi.area(direct_face) == pytest.approx(1.0, abs=1e-6)
 
     def test_face_from_wires_tolerant_tolerant_planar_path(self):
         """
         Test the tolerant planar path.
-        Create a planar square but add small noise to the points that exceeds the default confusion tolerance.
+        Create a planar square but add small noise to the points that exceeds
+        the default confusion tolerance.
         Attempt to create a face from the wire, should fallback to SVD.
         """
         # corners of a square with out-of-plane noise in z
-        p0 = (0.0, 0.0,  1.5e-5)
+        p0 = (0.0, 0.0, 1.5e-5)
         p1 = (1.0, 0.0, -1.2e-5)
-        p2 = (1.0, 1.0,  2.1e-5)
+        p2 = (1.0, 1.0, 2.1e-5)
         p3 = (0.0, 1.0, -1.8e-5)
 
         # guarantee closed wire
@@ -136,7 +167,9 @@ class TestCadqueryapi(BackendApiTestsBase):
         with pytest.raises(ValueError, match="not planar"):
             cq.Face.makeFromWires(wire)
 
-        face = cadapi._face_from_wires_tolerant(wire, [])  # should succeed via SVD fallback
+        face = cadapi._face_from_wires_tolerant(
+            wire, []
+        )  # should succeed via SVD fallback
 
         assert isinstance(face, cq.Face)
         assert face.isValid()
@@ -146,20 +179,20 @@ class TestCadqueryapi(BackendApiTestsBase):
         """Test planar path with inner hole wires."""
 
         outer_points = [  # 2x2 flat square
-            (-1.0, -1.0, 0.0), 
-            ( 1.0, -1.0, 0.0), 
-            ( 1.0,  1.0, 0.0), 
-            (-1.0,  1.0, 0.0), 
-            (-1.0, -1.0, 0.0)
+            (-1.0, -1.0, 0.0),
+            (1.0, -1.0, 0.0),
+            (1.0, 1.0, 0.0),
+            (-1.0, 1.0, 0.0),
+            (-1.0, -1.0, 0.0),
         ]
         outer_wire = cadapi.make_polygon(outer_points)
 
         inner_points = [  # inner 1x1 square hole
-            (-0.5, -0.5, 0.0), 
-            ( 0.5, -0.5, 0.0), 
-            ( 0.5,  0.5, 0.0), 
-            (-0.5,  0.5, 0.0), 
-            (-0.5, -0.5, 0.0)
+            (-0.5, -0.5, 0.0),
+            (0.5, -0.5, 0.0),
+            (0.5, 0.5, 0.0),
+            (-0.5, 0.5, 0.0),
+            (-0.5, -0.5, 0.0),
         ]
         inner_wire = cadapi.make_polygon(inner_points)
 
@@ -176,20 +209,20 @@ class TestCadqueryapi(BackendApiTestsBase):
     def test_face_from_wires_tolerant_planar_with_noisy_hole(self):
         """Test planar path with a noisy inner hole that exceeds tolerance."""
         outer_points = [  # noisy 2x2 square
-            (0.0, 0.0,  1.5e-5), 
-            (2.0, 0.0, -1.2e-5), 
-            (2.0, 2.0,  2.1e-5), 
-            (0.0, 2.0, -1.8e-5), 
-            (0.0, 0.0,  1.5e-5),
+            (0.0, 0.0, 1.5e-5),
+            (2.0, 0.0, -1.2e-5),
+            (2.0, 2.0, 2.1e-5),
+            (0.0, 2.0, -1.8e-5),
+            (0.0, 0.0, 1.5e-5),
         ]
         outer_wire = cadapi.make_polygon(outer_points)
 
         inner_points = [  # noisy 1x1 square hole
-            (0.5, 0.5,  1.1e-5), 
-            (1.5, 0.5, -1.3e-5), 
-            (1.5, 1.5,  2.0e-5), 
-            (0.5, 1.5, -1.6e-5), 
-            (0.5, 0.5,  1.1e-5),
+            (0.5, 0.5, 1.1e-5),
+            (1.5, 0.5, -1.3e-5),
+            (1.5, 1.5, 2.0e-5),
+            (0.5, 1.5, -1.6e-5),
+            (0.5, 0.5, 1.1e-5),
         ]
         inner_wire = cadapi.make_polygon(inner_points)
 
@@ -204,7 +237,9 @@ class TestCadqueryapi(BackendApiTestsBase):
         assert cadapi.area(face) == pytest.approx(3.0, abs=1e-6)
 
     def test_face_from_wires_tolerant_inner_same_winding(self):
-        """Test that inner wires with the same winding as the outer wire are handled correctly."""
+        """Test that inner wires with the same winding as the outer wire
+        are handled correctly.
+        """
         outer = cadapi.make_polygon(  # out square
             [(0, 0, 0), (2, 0, 0), (2, 2, 0), (0, 2, 0), (0, 0, 0)]
         )
@@ -221,17 +256,303 @@ class TestCadqueryapi(BackendApiTestsBase):
 
     def test_face_from_wires_tolerant_hole_outside_outer(self):
         """Test that an inner hole completely outside the outer wire is rejected."""
-        outer = cadapi.make_polygon(
-            [(0,0,0), (2,0,0), (2,2,0), (0,2,0), (0,0,0)]
+        outer = cadapi.make_polygon([
+            (0, 0, 0),
+            (2, 0, 0),
+            (2, 2, 0),
+            (0, 2, 0),
+            (0, 0, 0),
+        ])
+
+        inner_outside = (
+            cadapi.make_polygon(  # hole is located completely outside of the outer wire
+                [(5, 5, 0), (6, 5, 0), (6, 6, 0), (5, 6, 0), (5, 5, 0)]
+            )
         )
 
-        inner_outside = cadapi.make_polygon(  # hole is located completely outside of the outer wire
-            [(5,5,0), (6,5,0), (6,6,0), (5,6,0), (5,5,0)]
-        )
- 
         with pytest.raises(GeometryError):
-            face = cadapi._face_from_wires_tolerant(outer, [inner_outside])
-            assert not face.isValid()
+            _ = cadapi._face_from_wires_tolerant(outer, [inner_outside])
+
+    def test_edge_pair_cos_angle_straight(self):
+        """Perfectly collinear."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(1.0)
+
+    def test_edge_pair_cos_angle_orthogonal(self):
+        """Orthogonal edges."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (0, 1, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(0.0)
+
+    def test_edge_pair_cos_angle_u_turn(self):
+        """Opposite directions."""
+        e1 = cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]).edges()
+        e2 = cadapi.make_polygon([(0, 0, 0), (-1, 0, 0)]).edges()
+
+        result = cadapi._edge_pair_cos_angle(e1, e2)
+        assert result == pytest.approx(-1.0)
+
+    def test_edge_junction_pairs(self):
+        """Test pairwise list of edges"""
+        wire = cadapi.make_polygon([
+            (0, 0, 0),
+            (1, 0, 0),
+            (1, 1, 0),
+            (0, 1, 0),
+        ]).close()
+
+        pairs = cadapi._edge_junction_pairs(wire)
+
+        assert len(pairs) == 4
+
+    @pytest.mark.parametrize(
+        ("edges", "is_closed", "expected_pairs"),
+        [
+            ([E1, E2, E3, E4], False, [(E1, E2), (E2, E3), (E3, E4)]),
+            ([E1, E2], False, [(E1, E2)]),
+            ([E1], False, []),
+            ([], False, []),
+            ([E1, E2, E3], True, [(E1, E2), (E2, E3), (E3, E1)]),
+            ([E1, E2], True, [(E1, E2), (E2, E1)]),
+            ([E1], True, []),
+            ([], True, []),
+        ],
+    )
+    @patch("bluemira.codes._cadqueryapi._core.is_closed")
+    @patch("bluemira.codes._cadqueryapi._core.ordered_edges")
+    def test_edge_junction_pairs_mocked(
+        self,
+        mock_ordered_edges,
+        mock_is_closed,
+        edges,
+        is_closed,
+        expected_pairs,
+    ):
+        mock_ordered_edges.return_value = edges
+        mock_is_closed.return_value = is_closed
+
+        result = cadapi._edge_junction_pairs("dummy_wire")
+
+        assert result == expected_pairs
+
+    def test_planar_wire_returns_normal(self):
+        """_get_planar_normal returns correct normal for valid planar wire."""
+        result = cadapi._get_planar_normal(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ])
+        )
+        assert result == (0, 0, 1)
+
+    def test_non_planar_wire_returns_none(self):
+        """_get_planar_normal returns none for a non-planar wire."""
+        result = cadapi._get_planar_normal(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 1),
+                (0, 1, 0),
+            ])
+        )
+        assert result is None
+
+    def test_sewn_solid_successful_rebuild(self):
+        """Sew disconnected faces into a valid solid."""
+        box = self._make_box()
+        faces = box.faces()
+        assert not isinstance(faces, cq.Solid)
+        solid = cadapi._sewn_solid(faces)
+        assert isinstance(solid, cq.Solid)
+        assert solid.isValid()
+        assert len(solid.Faces()) == 6
+        assert solid.Volume() == pytest.approx(1.0)
+
+    def test_sewn_solid_missing_face(self):
+        """Sew open shell fails to make closed solid."""
+        box = self._make_box()
+        faces = box.Faces()[:-1]
+        open_shell = cadapi.make_compound(faces)
+        open_solid = cadapi._sewn_solid(open_shell)
+        assert open_solid is open_shell
+
+    def test_sewn_solid_multiple_shells(self):
+        """Sew disconnected regions gives >1 shell."""
+        box1 = self._make_box()
+        box2 = box = cadapi.translate_shape(self._make_box(), (5, 0, 0))
+
+        all_faces = box1.Faces() + box2.Faces()
+        split_compound = cadapi.make_compound(all_faces)
+
+        multi_shell = cadapi._sewn_solid(split_compound)
+        assert multi_shell is split_compound
+
+    def test_sewn_solid_already_valid(self):
+        """Valid solid should rebuild safely."""
+        box = self._make_box()
+        solid = cadapi._sewn_solid(box)
+        assert isinstance(solid, cq.Solid)
+        assert solid.isValid()
+        assert solid.Volume() == pytest.approx(1.0)
+
+    def test_wire_is_straight_single_straight(self):
+        """True for single straight line."""
+        assert cadapi._wire_is_straight(cadapi.make_polygon([(0, 0, 0), (1, 0, 0)]))
+
+    def test_wire_is_straight_multi_straight(self):
+        """False for multiple straight lines."""
+        assert not cadapi._wire_is_straight(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (2, 0, 0),
+            ])
+        )
+
+    def test_wire_is_straight_curved(self):
+        """False for curved line."""
+        assert not cadapi._wire_is_straight(
+            cadapi.make_circle_arc_3P(
+                (0, 0, 0),
+                (5, 5, 0),
+                (10, 0, 0),
+            )
+        )
+
+    def test_wire_is_planar_closed(self):
+        """True for 2D flat shape."""
+        assert cadapi._wire_is_planar(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+
+    def test_wire_is_planar_non_planar(self):
+        """False for non-planar shape."""
+        assert not cadapi._wire_is_planar(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 1),
+                (0, 1, 0),
+            ]).close()
+        )
+
+    def test_occ_face_area_square(self):
+        """Simple area calculation on square."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+        assert cadapi._occ_face_area(square.wrapped) == pytest.approx(1.0)
+
+    def test_occ_face_area_circle(self):
+        """Simple area calculation on circle."""
+        circle = cadapi.make_face(cadapi.make_circle())
+        assert cadapi._occ_face_area(circle.wrapped) == pytest.approx(np.pi)
+
+    def test_cq_area_prop_face(self):
+        """Area property on standard face."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (1, 0, 0),
+                (1, 1, 0),
+                (0, 1, 0),
+            ]).close()
+        )
+        assert convert(square).area == pytest.approx(1.0)
+
+    def test_cq_area_prop_face_with_holes(self):
+        """Area property on face with holes."""
+        square = cadapi.make_face(
+            cadapi.make_polygon([
+                (0, 0, 0),
+                (2, 0, 0),
+                (2, 2, 0),
+                (0, 2, 0),
+            ]).close()
+        )
+        circle = cadapi.make_face(cadapi.make_circle(radius=0.5, center=(1, 1, 0)))
+        assert convert(cadapi.boolean_cut(square, circle)[0]).area == pytest.approx(
+            4.0 - (np.pi * 0.25)
+        )
+
+
+@patch("bluemira.codes.error.FreeCADError", FreeCADError)
+@patch("bluemira.codes._cadqueryapi._core._edge_pair_cos_angle")
+@patch("bluemira.codes._cadqueryapi._core._edge_junction_pairs")
+class TestCheckPathTangentContinuity:
+    def test_smooth_path(self, mock_pairs, mock_cos_angle):
+        """Smooth path should pass without error."""
+        mock_pairs.return_value = [(E1, E2), (E2, E3)]
+        mock_cos_angle.side_effect = [1.0, 1.0]  # covers all calls in for loop
+
+        cadapi._check_path_tangent_continuity(MagicMock())
+
+        assert mock_cos_angle.call_count == 2
+
+    def test_kinked_path_raises_error(self, mock_pairs, mock_cos_angle):
+        """Path with kink should raise FreeCADError."""
+        mock_pairs.return_value = [(E1, E2)]
+        mock_cos_angle.side_effect = [0.5]
+
+        with pytest.raises(FreeCADError) as e:
+            cadapi._check_path_tangent_continuity(MagicMock())
+
+        assert "path is not tangent-continuous" in str(e.value)
+
+    def test_degenerate_edge_skipped(self, mock_pairs, mock_cos_angle):
+        """Continue without failing if _edge_pair_cos_angle returns None."""
+        mock_pairs.return_value = [(E1, E2), (E2, E3)]
+        mock_cos_angle.side_effect = [None, 1.0]
+
+        cadapi._check_path_tangent_continuity(MagicMock())
+
+        assert mock_cos_angle.call_count == 2
+
+    def test_within_tolerance(self, mock_pairs, mock_cos_angle):
+        """Values inside tolerance limit pass without error."""
+        mock_pairs.return_value = [(E1, E2)]
+        tol = 1e-6
+        mock_cos_angle.side_effect = [1.0 - (1e-6 / 10)]
+
+        cadapi._check_path_tangent_continuity(MagicMock(), tol=tol)
+
+        assert mock_cos_angle.call_count == 1
+
+    def test_outside_tolerance(self, mock_pairs, mock_cos_angle):
+        """Values outside tolerance limit should raise FreeCADError."""
+        mock_pairs.return_value = [(E1, E2)]
+        tol = 1e-6
+        mock_cos_angle.side_effect = [1.0 - (tol * 10)]
+
+        with pytest.raises(FreeCADError):
+            cadapi._check_path_tangent_continuity(MagicMock(), tol=tol)
+
+    def test_raises_on_first_failure(self, mock_pairs, mock_cos_angle):
+        """Raise FreeCADError on first kink found."""
+        mock_pairs.return_value = [(E1, E2), (E2, E3), (E3, E4)]
+        mock_cos_angle.side_effect = [1.0, 0.0, 1.0]
+
+        with pytest.raises(FreeCADError):
+            cadapi._check_path_tangent_continuity(MagicMock())
+
+        assert mock_cos_angle.call_count == 2
 
 
 class TestSaveCadMeshFormats:

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -310,9 +310,12 @@ class TestFreecadapi(BackendApiTestsBase):
     def test_invalid_offset(self):
         super().test_invalid_offset()
 
-    @pytest.mark.xfail(reason="FreeCAD will \"pass\" this test but it produces garbage geometry.")
+    @pytest.mark.xfail(
+        reason='FreeCAD will "pass" this test but it produces garbage geometry.'
+    )
     def test_boolean_cut_hollow_coil(self, boolean_cut_princeton):
         super().test_boolean_cut_hollow_coil(boolean_cut_princeton)
+
 
 # Commented out CADFileTypes dont work with basic shapes tested or needed more
 # FreeCAD imported, should be reviewed in future

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -302,6 +302,17 @@ class TestFreecadapi(BackendApiTestsBase):
                 atol=EPS_FREECAD,
             )
 
+    @pytest.mark.xfail(reason="It is known that FreeCAD will fail this test.")
+    def test_valid_offset(self, frenet, caplog):
+        super().test_valid_offset(frenet, caplog)
+
+    @pytest.mark.xfail(reason="It is known that FreeCAD will fail this test.")
+    def test_invalid_offset(self):
+        super().test_invalid_offset()
+
+    @pytest.mark.xfail(reason="FreeCAD will \"pass\" this test but it produces garbage geometry.")
+    def test_boolean_cut_hollow_coil(self, boolean_cut_princeton):
+        super().test_boolean_cut_hollow_coil(boolean_cut_princeton)
 
 # Commented out CADFileTypes dont work with basic shapes tested or needed more
 # FreeCAD imported, should be reviewed in future


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Implements a complex spline, offset, sweep, cut operation chain to test the limits of each CAD backend. Includes a fix that makes CadQuery's sweep operation more robust.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
