### PR TITLE
Enable caching of greens numba functions

### DIFF
--- a/bluemira/magnetostatics/_ellipe.py
+++ b/bluemira/magnetostatics/_ellipe.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import numba as nb
+import numpy as np
+
+from bluemira.magnetostatics._ellipk import _FloatOrArray, eval_polynomial
+
+_P = (
+    1.53552577301013293365e-4,
+    2.50888492163602239211e-3,
+    8.68786816565889628429e-3,
+    1.07350949056076193403e-2,
+    7.77395492516787092951e-3,
+    7.58395289413514708519e-3,
+    1.15688436810574127319e-2,
+    2.18317996015557253103e-2,
+    5.68051945617860553470e-2,
+    4.43147180560990850618e-1,
+    1.00000000000000000299e0,
+)
+
+_Q = (
+    3.27954898576485872656e-5,
+    1.00962792679356715133e-3,
+    6.50609489976927491433e-3,
+    1.68862163993311317300e-2,
+    2.61769742454493659583e-2,
+    3.34833904888224918614e-2,
+    4.27180926518931511717e-2,
+    5.85936634471101055642e-2,
+    9.37499997205916132169e-2,
+    2.49999999999888314361e-1,
+)
+
+
+@nb.njit([nb.float64(nb.float64)], cache=True)
+def _ellipe(m: float) -> float:
+    """
+    E(m) for m >= 0.
+
+    Parameters
+    ----------
+    m:
+        Positive scalar.
+
+    Returns
+    -------
+    :
+        E(m).
+    """
+    if np.isnan(m):
+        return np.nan
+    # Exact floating point comparisons to match Cephes implementation.
+    if m == 0.0:  # noqa: RUF069
+        return np.pi / 2.0
+    if m == 1.0:  # noqa: RUF069
+        return 1.0
+    if m > 1.0:
+        return np.nan
+
+    x = 1.0 - m
+    return eval_polynomial(x, _P) - np.log(x) * (x * eval_polynomial(x, _Q))
+
+
+@nb.vectorize([nb.float64(nb.float64)], nopython=True, cache=True)
+def ellipe_nb(m: _FloatOrArray) -> _FloatOrArray:
+    """
+    Complete elliptic integral of the second kind, E(m).
+
+    Parameters
+    ----------
+    m:
+        Parameter(s) of the elliptic integral. Values m > 1 return NaN. Can be a float
+        or an NDArray. If an array, the function is executed elementwise.
+
+    Returns
+    -------
+    :
+        E(m)
+
+    Notes
+    -----
+    .. math::
+        E(m) = \\int_{0}^{\\tfrac{\\pi}{2}}{(1 - m \\sin^2(t)})^{\\tfrac{1}{2}} dt
+
+    [ellipe_1]_
+
+    Implementation based on the Cephes [ellipe_2]_ C library (MIT licensed; also used
+    by SciPy) - with help from Claude to translate the C into Python.
+
+    .. [ellipe_1] Abramowitz, M., and I. A. Stegun. Handbook of Mathematical Functions.
+                  Dover Publications, 1965.
+    .. [ellipe_2] Moshier, S. L. (2000). Cephes Math Library Release 2.8.
+                  http://www.netlib.org/cephes
+    """
+    if m < 0.0:
+        # Reflection identity: E(m) = sqrt(1-m) * E(m/(m-1))
+        # See [ellipe_1]_ 17.4.17.
+        return np.sqrt(1.0 - m) * _ellipe(m / (m - 1.0))
+    return _ellipe(m)

--- a/bluemira/magnetostatics/_ellipk.py
+++ b/bluemira/magnetostatics/_ellipk.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from collections.abc import Sequence
+from typing import TypeVar
+
+import numba as nb
+import numpy as np
+import numpy.typing as npt
+
+_FloatOrArray = TypeVar("_FloatOrArray", npt.NDArray, float)
+
+
+_P = (
+    1.37982864606273237150e-4,
+    2.28025724005875567385e-3,
+    7.97404013220415179367e-3,
+    9.85821379021226008714e-3,
+    6.87489687449949877925e-3,
+    6.18901033637687613229e-3,
+    8.79078273952743772254e-3,
+    1.49380448916805252718e-2,
+    3.08851465246711995998e-2,
+    9.65735902811690126535e-2,
+    1.38629436111989062502e0,
+)
+
+_Q = (
+    2.94078955048598507511e-5,
+    9.14184723865917226571e-4,
+    5.94058303753167793257e-3,
+    1.54850516649762399335e-2,
+    2.39089602715924892727e-2,
+    3.01204715227604046988e-2,
+    3.73774314173823228969e-2,
+    4.88280347570998239232e-2,
+    7.03124996963957469739e-2,
+    1.24999999999870820058e-1,
+    4.99999999999999999821e-1,
+)
+
+
+@nb.njit(cache=True)
+def eval_polynomial(x: float, coefs: Sequence[float]) -> float:
+    """
+    Evaluate a polynomial via Horner's method.
+
+    Returns
+    -------
+    :
+        The evaluation of the polynomial.
+    """
+    result = 0.0
+    for c in coefs:
+        result = result * x + c
+    return result
+
+
+@nb.njit([nb.float64(nb.float64)], cache=True)
+def _ellipk(m: float) -> float:
+    """
+    K(m) for m >= 0.
+
+    Parameters
+    ----------
+    m:
+        Positive scalar.
+
+    Returns
+    -------
+    :
+        Evaluation of K(m).
+    """
+    if np.isnan(m):
+        return np.nan
+    # Exact floating point comparison to match Cephes implementation.
+    if m == 1.0:  # noqa: RUF069
+        return np.inf
+    if m > 1.0:
+        return np.nan
+
+    p = 1.0 - m
+    return eval_polynomial(p, _P) - np.log(p) * eval_polynomial(p, _Q)
+
+
+@nb.vectorize([nb.float64(nb.float64)], nopython=True, cache=True)
+def ellipk_nb(m: _FloatOrArray) -> _FloatOrArray:
+    """
+    Complete elliptic integral of the first kind, K(m).
+
+    Parameters
+    ----------
+    m:
+        Parameter(s) of the elliptic integral. Values m > 1 return NaN. Can be a float or
+        an NDArray. If an array, the function is executed elementwise.
+
+    Returns
+    -------
+    :
+        K(m).
+
+    Notes
+    -----
+    .. math::
+        K(m) = \\int_{0}^{\\tfrac{\\pi}{2}}{(1 - m \\sin^2(t)})^{-\\tfrac{1}{2}} dt
+
+    [ellipk_1]_
+
+    Implementation based on the Cephes [ellipk_2]_ C library (MIT licensed; also used
+    by SciPy) - with help from Claude to translate the C into Python.
+
+    .. [ellipk_1] Abramowitz, M., and I. A. Stegun. Handbook of Mathematical Functions.
+                  Dover Publications, 1965.
+    .. [ellipk_2] Moshier, S. L. (2000). Cephes Math Library Release 2.8.
+                  http://www.netlib.org/cephes
+    """
+    if m < 0.0:
+        # Reflection identity: K(m) = K(m/(m-1)) / sqrt(1-m)
+        # See [ellipk_1]_ 17.4.17.
+        return _ellipk(m / (m - 1.0)) / np.sqrt(1.0 - m)
+    return _ellipk(m)

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -10,11 +10,14 @@ Green's functions mappings for psi, Bx, and Bz
 
 import numba as nb
 import numpy as np
-from scipy.special import ellipe, ellipk
 
 from bluemira.base.constants import MU_0, MU_0_2PI, MU_0_4PI
+from bluemira.magnetostatics._ellipe import ellipe_nb
+from bluemira.magnetostatics._ellipk import ellipk_nb
 
 __all__ = [
+    "ellipe_nb",
+    "ellipk_nb",
     "greens_Bx",
     "greens_Bz",
     "greens_all",
@@ -58,57 +61,7 @@ def clip_nb(
     return val
 
 
-@nb.vectorize(nopython=True)
-def ellipe_nb(k: float | np.ndarray) -> float | np.ndarray:
-    """
-    Vectorised scipy ellipe
-
-    Parameters
-    ----------
-    k:
-        parameter of the elliptic integral
-
-    Returns
-    -------
-    :
-        elliptic integral of the second kind
-
-    Notes
-    -----
-    K, E in scipy are set as K(k^2), E(k^2)
-    """
-    return ellipe(k)
-
-
-ellipe_nb.__doc__ += ellipe.__doc__
-
-
-@nb.vectorize(nopython=True)
-def ellipk_nb(k: float | np.ndarray) -> float | np.ndarray:
-    """
-    Vectorised scipy ellipk
-
-    Parameters
-    ----------
-    k:
-        parameter of the elliptic integral
-
-    Returns
-    -------
-    :
-        elliptic integral of the first kind
-
-    Notes
-    -----
-    K, E in scipy are set as K(k^2), E(k^2)
-    """
-    return ellipk(k)
-
-
-ellipk_nb.__doc__ += ellipk.__doc__
-
-
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def _elliptic_derivatives(e, k, k2):
     r"""Get :math:`\frac{dK}{dk}` and :math:`\frac{dE}{dk}` [dimensionless]
 
@@ -133,7 +86,7 @@ def _elliptic_derivatives(e, k, k2):
     return dKdk, dEdk
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def _dkdr(g3, xc, x):
     r"""Get dkdr
 
@@ -163,7 +116,7 @@ def _dkdr(g3, xc, x):
     return term_1 + term_2
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def _g(xc, zc, x, z):
     r"""Get the tuple of (:math:`g_1, g_2, g_3, g_4`)
 
@@ -197,7 +150,7 @@ def _g(xc, zc, x, z):
     return g1, g2, g3, g4
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def _g_r(xc, x):
     r"""Get the tuple of (:math:`g_{1r}, g_{2r}, g_{3r}`)
 
@@ -228,7 +181,7 @@ def _g_r(xc, x):
     return g1r, g2r, g3r
 
 
-@nb.jit(nopython=True)
+@nb.njit(cache=True)
 def circular_coil_inductance_elliptic(
     radius: float | np.ndarray, rc: float | np.ndarray
 ) -> float | np.ndarray:
@@ -325,7 +278,7 @@ def square_coil_inductance_kirchhoff(
     return MU_0 * radius * (np.log(8 * radius / (width + height)) - 0.5)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_psi(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -378,7 +331,7 @@ def greens_psi(
     return MU_0_2PI * np.sqrt(x * xc) * ((2 - k2) * k - 2 * e) / np.sqrt(k2)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_dpsi_dx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -433,7 +386,7 @@ def greens_dpsi_dx(
     return MU_0_2PI * x * ((xc**2 - (z - zc) ** 2 - x**2) * i2 + i1)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_dbz_dx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -498,7 +451,7 @@ def greens_dbz_dx(
     return p1 + p2
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_dpsi_dz(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -553,7 +506,7 @@ def greens_dpsi_dz(
     return MU_0_2PI * ((z - zc) * (i1 - i2 * ((z - zc) ** 2 + x**2 + xc**2)))
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def calc_a_k2(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -588,7 +541,7 @@ def calc_a_k2(
     return a, k2
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def calc_e_k(k2: float | np.ndarray):
     """
     Calculate the elliptic integral of both the first and second kind.
@@ -607,7 +560,7 @@ def calc_e_k(k2: float | np.ndarray):
     return ellipe_nb(k2), ellipk_nb(k2)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def calc_i1_i2(
     a: float | np.ndarray,
     k2: float | np.ndarray,
@@ -643,7 +596,7 @@ def calc_i1_i2(
     return i1, i2
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_Bx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -690,7 +643,7 @@ def greens_Bx(
     return -1 / x * greens_dpsi_dz(xc, zc, x, z, d_xc, d_zc)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_Bz(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -737,7 +690,7 @@ def greens_Bz(
     return 1 / x * greens_dpsi_dx(xc, zc, x, z, d_xc, d_zc)
 
 
-@nb.jit(nopython=True)
+@nb.jit(nopython=True, cache=True)
 def greens_all(
     xc: float | np.ndarray,
     zc: float | np.ndarray,

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -61,7 +61,7 @@ def clip_nb(
     return val
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def _elliptic_derivatives(e, k, k2):
     r"""Get :math:`\frac{dK}{dk}` and :math:`\frac{dE}{dk}` [dimensionless]
 
@@ -86,7 +86,7 @@ def _elliptic_derivatives(e, k, k2):
     return dKdk, dEdk
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def _dkdr(g3, xc, x):
     r"""Get dkdr
 
@@ -116,7 +116,7 @@ def _dkdr(g3, xc, x):
     return term_1 + term_2
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def _g(xc, zc, x, z):
     r"""Get the tuple of (:math:`g_1, g_2, g_3, g_4`)
 
@@ -150,7 +150,7 @@ def _g(xc, zc, x, z):
     return g1, g2, g3, g4
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def _g_r(xc, x):
     r"""Get the tuple of (:math:`g_{1r}, g_{2r}, g_{3r}`)
 
@@ -278,7 +278,7 @@ def square_coil_inductance_kirchhoff(
     return MU_0 * radius * (np.log(8 * radius / (width + height)) - 0.5)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_psi(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -331,7 +331,7 @@ def greens_psi(
     return MU_0_2PI * np.sqrt(x * xc) * ((2 - k2) * k - 2 * e) / np.sqrt(k2)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_dpsi_dx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -386,7 +386,7 @@ def greens_dpsi_dx(
     return MU_0_2PI * x * ((xc**2 - (z - zc) ** 2 - x**2) * i2 + i1)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_dbz_dx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -451,7 +451,7 @@ def greens_dbz_dx(
     return p1 + p2
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_dpsi_dz(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -506,7 +506,7 @@ def greens_dpsi_dz(
     return MU_0_2PI * ((z - zc) * (i1 - i2 * ((z - zc) ** 2 + x**2 + xc**2)))
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def calc_a_k2(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -541,7 +541,7 @@ def calc_a_k2(
     return a, k2
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def calc_e_k(k2: float | np.ndarray):
     """
     Calculate the elliptic integral of both the first and second kind.
@@ -560,7 +560,7 @@ def calc_e_k(k2: float | np.ndarray):
     return ellipe_nb(k2), ellipk_nb(k2)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def calc_i1_i2(
     a: float | np.ndarray,
     k2: float | np.ndarray,
@@ -596,7 +596,7 @@ def calc_i1_i2(
     return i1, i2
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_Bx(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -643,7 +643,7 @@ def greens_Bx(
     return -1 / x * greens_dpsi_dz(xc, zc, x, z, d_xc, d_zc)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_Bz(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -690,7 +690,7 @@ def greens_Bz(
     return 1 / x * greens_dpsi_dx(xc, zc, x, z, d_xc, d_zc)
 
 
-@nb.jit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_all(
     xc: float | np.ndarray,
     zc: float | np.ndarray,

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -327,7 +327,8 @@ def greens_psi(
     \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
     """
     _, k2 = calc_a_k2(xc, zc, x, z)
-    e, k = calc_e_k(k2)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
     return MU_0_2PI * np.sqrt(x * xc) * ((2 - k2) * k - 2 * e) / np.sqrt(k2)
 
 
@@ -418,7 +419,8 @@ def greens_dbz_dx(
         the gradient to the magnetic field
     """
     _, k2 = calc_a_k2(xc, zc, x, z)
-    e, k = calc_e_k(k2)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
     kdk, edk = _elliptic_derivatives(e, k, k2)
     g1, g2, g3, _ = _g(xc, zc, x, z)
     g1r, g2r, g3r = _g_r(x, xc)
@@ -542,25 +544,6 @@ def calc_a_k2(
 
 
 @nb.njit(cache=True)
-def calc_e_k(k2: float | np.ndarray):
-    """
-    Calculate the elliptic integral of both the first and second kind.
-
-    Parameters
-    ----------
-    k2:
-        parameter of the elliptic integral
-
-    Returns
-    -------
-    :
-        elliptic integral of the second kind, elliptic integral of the first kind
-
-    """
-    return ellipe_nb(k2), ellipk_nb(k2)
-
-
-@nb.njit(cache=True)
 def calc_i1_i2(
     a: float | np.ndarray,
     k2: float | np.ndarray,
@@ -590,7 +573,8 @@ def calc_i1_i2(
 
     """
     if (e is None) or (k is None):
-        e, k = calc_e_k(k2)
+        e = ellipe_nb(k2)
+        k = ellipk_nb(k2)
     i1 = k / a
     i2 = e / (a**3 * (1 - k2))
     return i1, i2
@@ -727,7 +711,8 @@ def greens_all(
         if x <= 0
     """
     a, k2 = calc_a_k2(xc, zc, x, z)
-    e, k = calc_e_k(k2)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
     i1, i2 = calc_i1_i2(a, k2, e, k)
     i1 *= 4
     i2 *= 4

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -4,9 +4,12 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+
 import numba as nb
 import numpy as np
 import pytest
+from scipy.special import ellipe as scipy_ellipe
+from scipy.special import ellipk as scipy_ellipk
 
 from bluemira.base.constants import EPS, MU_0_2PI, MU_0_4PI
 from bluemira.magnetostatics.greens import (
@@ -127,6 +130,52 @@ def test_greens_vs_greens_all():
     np.testing.assert_allclose(Bx, Bx2)
     np.testing.assert_allclose(Bz, Bz2)
     np.testing.assert_allclose(psi, psi2)
+
+
+ellip_params = pytest.mark.parametrize(
+    "m",
+    [
+        # nans
+        np.nan,
+        # in valid range [0, 1]
+        0.314,
+        np.linspace(0.05, 0.95, 21),
+        np.full((4, 3, 2), 0.42),
+        # bottom of valid range
+        0.0,
+        np.zeros((3,)),
+        np.zeros((1, 2)),
+        # top of valid range
+        1.0,
+        np.ones((3,)),
+        np.ones((1, 2)),
+        # positive and out of valid range
+        1.5,
+        np.full((3,), 1.5),
+        np.full((2, 3), 2.0),
+        # small negative
+        -0.314,
+        np.full((4, 3, 2), -0.42),
+        # large negative
+        -100.0,
+        np.full((3,), -100.0),
+        # approaching range bounds
+        np.array([1e-9, 1e-22]),
+        np.array([1.0 - 1e-9, 1 - 1e-16]),
+        # non-C-contiguous
+        np.asfortranarray(np.full((4, 3), 0.5)),
+    ],
+)
+
+
+@ellip_params
+def test_ellipe_nb_matches_scipy_implementation(m):
+    np.testing.assert_allclose(ellipe_nb(m), scipy_ellipe(m))
+
+
+@ellip_params
+def test_ellipk_nb_matches_scipy_implementation(m):
+    np.testing.assert_allclose(ellipk_nb(m), scipy_ellipk(m))
 
 
 class TestGreenFieldsRegression:

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -137,9 +137,9 @@ ellip_params = pytest.mark.parametrize(
     [
         # nans
         np.nan,
-        # in valid range [0, 1]
+        # in valid range [0, 1)
         0.314,
-        np.linspace(0.05, 0.95, 21),
+        np.linspace(0.0, np.nextafter(1.0, 0.0, dtype=np.float64), 201),
         np.full((4, 3, 2), 0.42),
         # bottom of valid range
         0.0,
@@ -153,15 +153,17 @@ ellip_params = pytest.mark.parametrize(
         1.5,
         np.full((3,), 1.5),
         np.full((2, 3), 2.0),
-        # small negative
-        -0.314,
+        # in valid negative range
+        np.linspace(-0.0, np.nextafter(-1, 0, dtype=np.float64), 201),
         np.full((4, 3, 2), -0.42),
         # large negative
         -100.0,
-        np.full((3,), -100.0),
+        np.full((3,), -10.0),
         # approaching range bounds
         np.array([1e-9, 1e-22]),
         np.array([1.0 - 1e-9, 1 - 1e-16]),
+        np.array([-1e-9, -1e-22]),
+        np.array([-1.0 + 1e-9, -1 + 1e-16]),
         # non-C-contiguous
         np.asfortranarray(np.full((4, 3), 0.5)),
     ],
@@ -176,6 +178,28 @@ def test_ellipe_nb_matches_scipy_implementation(m):
 @ellip_params
 def test_ellipk_nb_matches_scipy_implementation(m):
     np.testing.assert_allclose(ellipk_nb(m), scipy_ellipk(m))
+
+
+class TestEllipticalFunctionsRegression:
+    rng = np.random.default_rng(846023420)
+    fixtures = []  # noqa: RUF012
+    for _ in range(5):  # Tested with 80000, no failures
+        fixtures.append(  # noqa: PERF401
+            [2.0 * rng.random(rng.integers(1, 10)) - 1.0]
+        )
+
+    @pytest.mark.parametrize("m", fixtures)
+    def test_ellipe_nb(self, m):
+        self.runner(ellipe_nb, scipy_ellipe, m)
+
+    @pytest.mark.parametrize("m", fixtures)
+    def test_ellipk_nb(self, m):
+        self.runner(ellipk_nb, scipy_ellipk, m)
+
+    def runner(self, new_ellip_func, old_ellip_func, m):
+        new = new_ellip_func(m)
+        old = old_ellip_func(m)
+        np.testing.assert_allclose(1e7 * new, 1e7 * old, atol=EPS)
 
 
 class TestGreenFieldsRegression:


### PR DESCRIPTION
## Description

Apologies for the out-of-the-blue PR. Hopefully someone's OK to review this. 

I've been using the `ChargedParticleSolver` a fair bit recently and was curious why 1) `Equilibrium.from_eqdsk()`, and 2) the `ChargedParticleSolver.analyse()` took so long to execute during debugging cycles. 

I profiled a crude benchmark and found that a large part of the time taken was compiling Numba functions.

<details><summary>Benchmark</summary>

```python
from pathlib import Path
from time import time

from bluemira.base.file import get_bluemira_path
from bluemira.equilibria import Equilibrium
from bluemira.geometry.coordinates import Coordinates
from bluemira.radiation_transport.advective_transport import ChargedParticleSolver

read_path = get_bluemira_path("equilibria", subfolder="data")
eq_name = "DN-DEMO_eqref.json"
eq_name = Path(read_path, eq_name)

start = time()
eq = Equilibrium.from_eqdsk(eq_name, from_cocos=3, qpsi_positive=False)
print(f"Equilibrium.from_eqdsk() took {time() - start} s")
# -> Equilibrium.from_eqdsk() took 9.195956468582153 s

params = {
    "P_sep_particle": 150,
    "f_p_sol_near": 0.50,
    "fw_lambda_q_near_omp": 0.01,
    "fw_lambda_q_far_omp": 0.05,
    "f_lfs_lower_target": 0.75,
    "f_hfs_lower_target": 0.25,
    "f_lfs_upper_target": 0,
    "f_hfs_upper_target": 0,
}
read_path = get_bluemira_path("radiation_transport/test_data", subfolder="tests")
fw_name = "DN_fw_shape.json"
fw_name = Path(read_path, fw_name)
fw_shape = Coordinates.from_json(str(fw_name))
solver = ChargedParticleSolver(params, eq, dx_mp=0.001)

start = time()
x, z, hf = solver.analyse(first_wall=fw_shape)  # 
print(f"solver.analyse() took {time() - start} s")
# -> solver.analyse() took 9.254453182220459 s
```

</details>

```
Equilibrium.from_eqdsk() took 9.195956468582153 s
solver.analyse() took 9.254453182220459 s
```

<img width="1203" height="273" alt="image" src="https://github.com/user-attachments/assets/e7fe70a8-1e16-4b73-a85f-1133447ca35f" />

You can see in this profile that the script takes 26.8 seconds, over 16 seconds of which is spent in Numba's compiler lock. You can drill down into the profile and work out that a lot of the compilations are run during functions that are calling Green's functions. 

The Green's functions in the `greens.py` module that are compiled with Numba are not cached. The reason they can't be cached is because they're using `scipy` functions: `ellipk` and `ellipe`. If you try caching, you get a warning like:

```
.../greens.py:328: NumbaWarning: Cannot cache compiled function "greens_psi" as it uses dynamic globals (such as ctypes pointers and large global arrays)
```

I don't know if there's another way around this, but one solution is to just implement the elliptic functions ourself. So that's what I've done here. That allows us to cache the compiled Green's functions.

The first run of the benchmark script will obviously take a similar amount of time as before as it compiles and caches all the functions. But all subsequent runs are significantly faster:

```
Equilibrium.from_eqdsk() took 0.17005300521850586 s
solver.analyse() took 1.0648384094238281 s
```

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

None.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
