### PR TITLE
Boundary handling for global optimisation algorithms

### DIFF
--- a/bluemira/optimisation/_nlopt/optimiser.py
+++ b/bluemira/optimisation/_nlopt/optimiser.py
@@ -20,7 +20,7 @@ from bluemira.optimisation._nlopt.functions import (
     ObjectiveFunction,
 )
 from bluemira.optimisation._optimiser import Optimiser, OptimiserResult
-from bluemira.optimisation._tools import _check_bounds, _initial_guess_from_bounds
+from bluemira.optimisation._tools import _check_bounds_dims, _initial_guess_from_bounds
 from bluemira.optimisation.error import OptimisationError, OptimisationParametersError
 from bluemira.utilities.error import OptVariablesError
 
@@ -29,17 +29,22 @@ if TYPE_CHECKING:
 
     from bluemira.optimisation.typed import ObjectiveCallable, OptimiserCallable
 
-NLOPT_ALG_MAPPING = {
+NLOPT_LOCAL = {
     Algorithm.SLSQP: nlopt.LD_SLSQP,
     Algorithm.COBYLA: nlopt.LN_COBYLA,
     Algorithm.SBPLX: nlopt.LN_SBPLX,
     Algorithm.MMA: nlopt.LD_MMA,
     Algorithm.BFGS: nlopt.LD_LBFGS,
+}
+
+NLOPT_GLOBAL = {
     Algorithm.DIRECT: nlopt.GN_DIRECT,
     Algorithm.DIRECT_L: nlopt.GN_DIRECT_L,
     Algorithm.CRS: nlopt.GN_CRS2_LM,
     Algorithm.ISRES: nlopt.GN_ISRES,
 }
+
+NLOPT_ALG_MAPPING = {**NLOPT_LOCAL, **NLOPT_GLOBAL}
 
 
 class NloptOptimiser(Optimiser):
@@ -310,7 +315,8 @@ class NloptOptimiser(Optimiser):
         See :meth:`~bluemira.optimisation._optimiser.Optimiser.set_lower_bounds`.
         """
         bounds = np.array(bounds)
-        _check_bounds(self._opt.get_dimension(), bounds)
+        _check_bounds_dims(self._opt.get_dimension(), bounds)
+        _check_bounds_vals(self.algorithm, bounds)
         self._opt.set_lower_bounds(bounds)
         # As we use the optimisation variable bounds when calculating an
         # approximate derivative, we must set the new bounds on the
@@ -326,7 +332,8 @@ class NloptOptimiser(Optimiser):
         See :meth:`~bluemira.optimisation._optimiser.Optimiser.set_upper_bounds`.
         """
         bounds = np.array(bounds)
-        _check_bounds(self._opt.get_dimension(), bounds)
+        _check_bounds_dims(self._opt.get_dimension(), bounds)
+        _check_bounds_vals(self.algorithm, bounds)
         self._opt.set_upper_bounds(bounds)
         # As we use the optimisation variable bounds when calculating an
         # approximate derivative, we must set the new bounds on the
@@ -430,6 +437,24 @@ def _check_algorithm(algorithm: AlgorithmType) -> Algorithm:
         validated and converted algorithm
     """
     return Algorithm(algorithm)
+
+
+def _check_bounds_vals(algorithm: AlgorithmType, bounds: npt.ArrayLike) -> None:
+    """
+    Validate boundary values depending on the type of algorithm.
+    Local optimisations may have infinite bounds.
+    Global optimisations cannot.
+
+    Raises
+    ------
+    OptimisationParametersError
+        Invalid bounds for the specified algorithm.
+    """
+    if algorithm in NLOPT_GLOBAL and np.inf in bounds:
+        raise OptimisationParametersError(
+            f"Global optimisation algorithms, such as {algorithm.name}, "
+            "do not support infinite bounds. Please specify finite bounds."
+        )
 
 
 def _process_nlopt_result(opt: nlopt.opt, algorithm: Algorithm) -> None:

--- a/bluemira/optimisation/_scipy/optimiser.py
+++ b/bluemira/optimisation/_scipy/optimiser.py
@@ -18,7 +18,7 @@ from bluemira.optimisation._optimiser import Optimiser, OptimiserResult
 from bluemira.optimisation._scipy.parameters import _make_alg_params
 from bluemira.optimisation._scipy.registry import SCIPY_REGISTRY, ScipyAlgConfig
 from bluemira.optimisation._tools import (
-    _check_bounds,
+    _check_bounds_dims,
     _initial_guess_from_bounds,
     process_scipy_result,
 )
@@ -344,7 +344,7 @@ class ScipyOptimiser(Optimiser):
         ValueError
             Incorrect bounds dimensions.
         """
-        _check_bounds(self.n_variables, bounds)
+        _check_bounds_dims(self.n_variables, bounds)
         self._lower_bounds = bounds
 
     def set_upper_bounds(self, bounds: np.ndarray) -> None:
@@ -358,5 +358,5 @@ class ScipyOptimiser(Optimiser):
         ValueError
             Incorrect bounds dimensions.
         """
-        _check_bounds(self.n_variables, bounds)
+        _check_bounds_dims(self.n_variables, bounds)
         self._upper_bounds = bounds

--- a/bluemira/optimisation/_tools.py
+++ b/bluemira/optimisation/_tools.py
@@ -173,7 +173,7 @@ def process_scipy_result(res: OptimizeResult, alg: str) -> np.ndarray:
     raise OptimisationError(f"{res.message}\n{res!s}")
 
 
-def _check_bounds(n_dims: int, new_bounds: np.ndarray) -> None:
+def _check_bounds_dims(n_dims: int, new_bounds: np.ndarray) -> None:
     """Validate that the bounds have the correct dimensions.
 
     Raises


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4325

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
NLopt docs state that [global optimisation algorithms require bounds specified on constraints and parameters](https://nlopt.readthedocs.io/en/stable/NLopt_Algorithms/). These bounds must be also be finite since global optimisation algorithms randomly sample across the search space.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
