### PR TITLE
feat(cad): carry component colours into glTF/GLB export

### DIFF
--- a/bluemira/base/tools.py
+++ b/bluemira/base/tools.py
@@ -16,6 +16,7 @@ from enum import Enum
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NotRequired, TypeVar, TypedDict
 
+from matplotlib import colors
 from matproplib.library.fluids import Void
 
 from bluemira.base.components import (
@@ -359,8 +360,8 @@ def save_components_cad(
     cad_format:
         CAD file format
     """
-    shapes, names, mats = get_properties_from_components(
-        components, ("shape", "name", "material"), extract=False
+    shapes, names, mats, cad_options = get_properties_from_components(
+        components, ("shape", "name", "material", "display_cad_options"), extract=False
     )
 
     if cad_format == "dagmc":
@@ -375,7 +376,8 @@ def save_components_cad(
             converter_config=kwargs.get("converter_config"),
         )
     else:
-        save_cad(shapes, filename, cad_format, names, **kwargs)
+        colours = [None if o is None else colors.to_rgb(o.colour) for o in cad_options]
+        save_cad(shapes, filename, cad_format, names, colours=colours, **kwargs)
 
 
 def show_components_cad(components: ComponentT | Iterable[ComponentT], **kwargs):

--- a/bluemira/codes/cadapi/_cadquery/io.py
+++ b/bluemira/codes/cadapi/_cadquery/io.py
@@ -29,6 +29,7 @@ from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.IFSelect import IFSelect_RetDone
 from OCP.Interface import Interface_Static
 from OCP.Message import Message_ProgressRange
+from OCP.Quantity import Quantity_Color, Quantity_TOC_sRGB
 from OCP.RWGltf import RWGltf_CafWriter
 from OCP.STEPCAFControl import STEPCAFControl_Writer
 from OCP.STEPControl import STEPControl_AsIs, STEPControl_Reader, STEPControl_Writer
@@ -46,7 +47,7 @@ from OCP.TopLoc import TopLoc_Location
 from OCP.TopTools import TopTools_HSequenceOfShape
 from OCP.TopoDS import TopoDS_Compound
 from OCP.XCAFApp import XCAFApp_Application
-from OCP.XCAFDoc import XCAFDoc_DocumentTool
+from OCP.XCAFDoc import XCAFDoc_ColorType, XCAFDoc_DocumentTool
 from OCP.gp import gp_Ax1, gp_Dir, gp_Pnt, gp_Trsf, gp_Vec
 
 from bluemira.codes.cadapi._cadquery.aliases import (
@@ -244,6 +245,7 @@ def _write_gltf(
     filename: str,
     *,
     is_binary: bool,
+    colours: list[tuple[float, float, float] | None] | None = None,
     lin_deflection: float = _DEFAULT_LIN_DEFLECTION,
     ang_deflection: float = _DEFAULT_ANG_DEFLECTION,
 ) -> None:
@@ -251,18 +253,31 @@ def _write_gltf(
 
     Triangulation must be precomputed on each shape before ``Perform`` —
     ``RWGltf_CafWriter`` does not auto-tessellate.
+
+    ``colours`` are sRGB ``(r, g, b)`` tuples in ``[0, 1]``, one per shape
+    (``None`` entries are skipped). Set as XCAF surface colours so the
+    writer emits glTF PBR materials.
     """
     app = XCAFApp_Application.GetApplication_s()
     doc = TDocStd_Document(TCollection_ExtendedString("MDTV-XCAF"))
     app.NewDocument(TCollection_ExtendedString("MDTV-XCAF"), doc)
     shape_tool = XCAFDoc_DocumentTool.ShapeTool_s(doc.Main())
+    colour_tool = XCAFDoc_DocumentTool.ColorTool_s(doc.Main())
     used_labels = (
         labels if labels is not None else [f"shape_{i}" for i in range(len(shapes))]
     )
-    for s, name in zip(shapes, used_labels, strict=True):
+    used_colours = colours if colours is not None else [None] * len(shapes)
+    for s, name, colour in zip(shapes, used_labels, used_colours, strict=True):
         _ensure_meshed(s, lin_deflection, ang_deflection)
         lbl = shape_tool.AddShape(s.wrapped, False)
         TDataStd_Name.Set_s(lbl, TCollection_ExtendedString(str(name)))
+        if colour is not None:
+            r, g, b = colour
+            colour_tool.SetColor(
+                lbl,
+                Quantity_Color(r, g, b, Quantity_TOC_sRGB),
+                XCAFDoc_ColorType.XCAFDoc_ColorSurf,
+            )
 
     writer = RWGltf_CafWriter(TCollection_AsciiString(str(filename)), is_binary)
     file_info = TColStd_IndexedDataMapOfStringString()
@@ -276,9 +291,14 @@ def save_cad(
     filename: str,
     cad_format: str | CADFileType = "stp",
     labels: Iterable[str] | None = None,
+    colours: list[tuple[float, float, float] | None] | None = None,
     **kwargs,
 ):
-    """Save CAD shapes to a file."""
+    """Save CAD shapes to a file.
+
+    ``colours`` are per-shape sRGB ``(r, g, b)`` tuples, currently only
+    honoured by the glTF/GLB export (written as PBR materials).
+    """
     if not isinstance(shapes, list):
         shapes = list(shapes)
     labels_list = list(labels) if labels is not None else None
@@ -320,7 +340,7 @@ def save_cad(
         _write_stl(shapes, filename)
     elif cad_format == CADFileType.GLTRANSMISSION:
         is_binary = str(filename).lower().endswith(".glb")
-        _write_gltf(shapes, labels_list, filename, is_binary=is_binary)
+        _write_gltf(shapes, labels_list, filename, is_binary=is_binary, colours=colours)
     else:
         raise CadQueryError(
             f"CAD format not supported by CadQuery backend: {cad_format}"

--- a/bluemira/codes/cadapi/_freecad/api.py
+++ b/bluemira/codes/cadapi/_freecad/api.py
@@ -1967,6 +1967,7 @@ def save_cad(
     cad_format: str | CADFileType = "stp",
     labels: Iterable[str] | None = None,
     doc_name: str = "Bluemira_FreeCAD_wrapper",
+    colours: Iterable[tuple[float, float, float] | None] | None = None,
     **kwargs,
 ):
     """
@@ -1996,6 +1997,12 @@ def save_cad(
     consistent with our units
     """
     cad_format = CADFileType(cad_format)
+
+    if colours is not None:
+        bluemira_warn(
+            "save_cad: per-shape colours are not supported by the FreeCAD "
+            "backend; exporting without them."
+        )
 
     filename = force_file_extension(filename, f".{cad_format.ext}")
 

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -1690,6 +1690,7 @@ def save_cad(
     filename: str | Path,
     cad_format: str | cadapi.CADFileType = "stp",
     names: str | list[str] | None = None,
+    colours: list[tuple[float, float, float] | None] | None = None,
     **kwargs,
 ):
     """
@@ -1705,6 +1706,9 @@ def save_cad(
         file format to save as
     names:
         Names of shapes to save
+    colours:
+        Per-shape sRGB ``(r, g, b)`` tuples in ``[0, 1]``. Currently only
+        the glTF/GLB export honours them (written as PBR materials).
     kwargs:
         arguments passed to cadapi save function
     """
@@ -1718,6 +1722,7 @@ def save_cad(
         Path(filename).as_posix(),
         cad_format=cad_format,
         labels=names,
+        colours=colours,
         **kwargs,
     )
 

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -289,6 +289,53 @@ class TestSaveCadMeshFormats:
             f"label not found in glTF node names: {node_names}"
         )
 
+    @staticmethod
+    def _glb_json(data: bytes) -> dict:
+        """Decode the JSON chunk of a binary GLB (12-byte header, then chunk)."""
+        chunk_len, chunk_type = struct.unpack_from("<I4s", data, 12)
+        assert chunk_type == b"JSON"
+        return json.loads(data[20 : 20 + chunk_len])
+
+    @staticmethod
+    def _srgb_to_linear(c: float) -> float:
+        # glTF ``baseColorFactor`` is linear; OCCT decodes the sRGB input.
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    def test_save_glb_writes_colours_as_materials(self, box, tmp_path):
+        small = cadapi.extrude_shape(
+            cadapi.make_polygon([(2, 0, 0), (3, 0, 0), (3, 1, 0), (2, 1, 0), (2, 0, 0)]),
+            (0, 0, 1),
+        )
+        colours = [(0.2, 0.4, 0.8), (0.8, 0.1, 0.1)]
+        path = tmp_path / "coloured.glb"
+        cadapi.save_cad(
+            [box, small], str(path), cad_format="glb", labels=["a", "b"], colours=colours
+        )
+
+        doc = self._glb_json(path.read_bytes())
+        mats = doc.get("materials", [])
+        assert len(mats) == 2, "one PBR material per coloured shape"
+
+        got = sorted(
+            tuple(m["pbrMetallicRoughness"]["baseColorFactor"][:3]) for m in mats
+        )
+        expected = sorted(tuple(self._srgb_to_linear(c) for c in rgb) for rgb in colours)
+        for g, e in zip(got, expected, strict=True):
+            assert g == pytest.approx(e, abs=1e-6)
+        # Default fully opaque alpha on every material.
+        for m in mats:
+            assert m["pbrMetallicRoughness"]["baseColorFactor"][3] == pytest.approx(1.0)
+
+    def test_save_glb_without_colours_has_no_materials(self, box, tmp_path):
+        # Regression: the export is unchanged when no colours are passed —
+        # geometry is written, but no PBR materials are emitted.
+        path = tmp_path / "plain.glb"
+        cadapi.save_cad([box], str(path), cad_format="glb", labels=["box"])
+
+        doc = self._glb_json(path.read_bytes())
+        assert doc.get("meshes"), "geometry should still be exported"
+        assert not doc.get("materials"), "no colours given → no materials emitted"
+
     # ---- Dispatcher edge cases --------------------------------------------
 
     def test_save_cad_rejects_unsupported_format(self, box, tmp_path):


### PR DESCRIPTION
## Description

save_components_cad now resolves each component's display colour and threads it through save_cad to the CadQuery glTF writer, which sets XCAF surface colours so RWGltf_CafWriter emits PBR materials. Exported reactors are coloured instead of grey. The FreeCAD backend absorbs the new colours arg with a warning (unsupported there). Backward compatible — no colours given means unchanged, material-free output.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
