### PR TITLE
LAR improvements: miscellaneous

### DIFF
--- a/bluemira/geometry/error.py
+++ b/bluemira/geometry/error.py
@@ -47,6 +47,21 @@ class GeometryParameterisationError(GeometryError):
     """
 
 
+class OutOfBoundsError(GeometryParameterisationError):
+    """A parameterisation was asked to build geometry outside its valid domain.
+
+    Raised by ``create_shape`` when the requested variables do not describe a
+    constructable shape (e.g. arc angles that sum past the symmetry limit).
+    Carries ``excess``: a dimensionless, non-negative measure of how far the
+    request is out of bounds, so an optimiser probing an infeasible point can
+    penalise proportionally and recover rather than crash.
+    """
+
+    def __init__(self, message: str, excess: float = 1.0):
+        super().__init__(message)
+        self.excess = max(float(excess), 0.0)
+
+
 class CoordinatesError(GeometryError):
     """
     Error class for use in Coordinates

--- a/bluemira/geometry/optimisation/_tools.py
+++ b/bluemira/geometry/optimisation/_tools.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from bluemira.geometry.error import OutOfBoundsError
 from bluemira.geometry.optimisation.typed import (
     GeomClsOptimiserCallable,
     GeomConstraintT,
@@ -52,10 +53,20 @@ def to_objective(
     :
         The objective function converted from a geometry objective function.
     """
+    worst = [0.0]  # largest finite objective value seen so far
 
     def f(x):
         geom.variables.set_values_from_norm(x)
-        return geom_objective(geom)
+        try:
+            value = geom_objective(geom)
+        except OutOfBoundsError as exc:
+            # No constructable geometry here. Penalise above the worst feasible
+            # value seen, growing with how far out of bounds we are, so a
+            # gradient-based optimiser is pushed back to the feasible region
+            # instead of crashing on the geometry build.
+            return (abs(worst[0]) + 1.0) * (1.0 + exc.excess)
+        worst[0] = max(worst[0], value)
+        return value
 
     return f
 
@@ -73,10 +84,22 @@ def to_optimiser_callable(
     :
         The optimiser function converted from a geometry optimiser function.
     """
+    state = {"shape": None, "worst": 0.0}  # last output shape, largest magnitude
 
     def f(x):
         geom.variables.set_values_from_norm(x)
-        return geom_callable(geom)
+        try:
+            value = geom_callable(geom)
+        except OutOfBoundsError as exc:
+            # See ``to_objective``: penalise (a constraint reads as strongly
+            # violated) rather than crash on the geometry build.
+            penalty = (state["worst"] + 1.0) * (1.0 + exc.excess)
+            return penalty if not state["shape"] else np.full(state["shape"], penalty)
+        arr = np.asarray(value, dtype=float)
+        state["shape"] = arr.shape
+        if arr.size:
+            state["worst"] = max(state["worst"], float(np.max(np.abs(arr))))
+        return value
 
     return f
 

--- a/bluemira/geometry/optimisation/_tools.py
+++ b/bluemira/geometry/optimisation/_tools.py
@@ -164,9 +164,76 @@ def calculate_signed_distance(
     shape = parameterisation.create_shape()
     # Note that we do not discretise by edges here, as the number of
     # points must remain constant so the size of constraint vectors
-    # remain constant.
-    s = shape.discretise(n_shape_discr, byedges=False).xz
+    # remain constant. Sample densely, then resample to the requested count
+    # from a backend-independent anchor (see _canonical_loop_points).
+    dense = shape.discretise(max(8 * n_shape_discr, 200), byedges=False).xz
+    s = _canonical_loop_points(dense, n_shape_discr)
     return signed_distance_2D_polygon(s.T, zone_points.T).T
+
+
+def _canonical_loop_points(loop: np.ndarray, n: int) -> np.ndarray:
+    """Resample a closed loop to ``n`` points in a backend-independent way.
+
+    ``discretise`` starts at the wire's first edge and follows the wire's
+    stored direction, both of which depend on the backend-specific edge
+    ordering. For an otherwise identical loop this only phase-shifts (and can
+    reverse) the samples, yet it scrambles the per-element keep-out-zone
+    constraint vector between backends and sends the optimiser into a different
+    basin. Pinning the winding, anchoring at the outer-midplane point and
+    resampling at uniform arc length makes the constraint deterministic and
+    smooth in the design variables.
+
+    Parameters
+    ----------
+    loop:
+        ``(2, M)`` densely sampled closed loop in the xz plane.
+    n:
+        Number of points to return.
+
+    Returns
+    -------
+    :
+        ``(2, n)`` points at uniform arc length, measured from the anchor.
+    """
+    pts = loop.T
+    if np.allclose(pts[0], pts[-1]):
+        pts = pts[:-1]
+    # Consistent winding (counter-clockwise) via the shoelace signed area.
+    x, z = pts[:, 0], pts[:, 1]
+    if np.sum(x * np.roll(z, -1) - np.roll(x, -1) * z) < 0:
+        pts = pts[::-1]
+    # Cumulative arc length around the closed loop.
+    closed = np.vstack([pts, pts[:1]])
+    cum = np.concatenate([
+        [0.0],
+        np.cumsum(np.linalg.norm(np.diff(closed, axis=0), axis=1)),
+    ])
+    length = cum[-1]
+    # Anchor where the loop crosses the outboard horizontal ray from its
+    # centroid (the outer-midplane point). Unlike an axis-aligned or radial
+    # extremum, this crossing is unique, sits on the smooth outer wall and
+    # moves continuously as the shape changes, so it never jumps between
+    # optimiser iterations or between the backends' phase-shifted samplings.
+    # That matters because a resample repositions every point relative to the
+    # anchor, so an anchor that jumps scrambles the whole constraint vector.
+    c = pts.mean(axis=0)
+    dz = pts[:, 1] - c[1]
+    dz_next = np.roll(dz, -1)
+    outboard = (pts[:, 0] > c[0]) & (np.roll(pts[:, 0], -1) > c[0])
+    crossings = np.flatnonzero((dz <= 0) & (dz_next > 0) & outboard)
+    j = (
+        int(crossings[np.argmax(pts[crossings, 0])])
+        if len(crossings)
+        else int(np.argmax(pts[:, 0]))
+    )
+    t = dz[j] / (dz[j] - dz_next[j]) if dz[j] != dz_next[j] else 0.0
+    s0 = (cum[j] + t * (cum[j + 1] - cum[j])) % length
+    # Resample at uniform arc length from the anchor.
+    targets = (s0 + np.linspace(0.0, length, n, endpoint=False)) % length
+    return np.vstack([
+        np.interp(targets, cum, closed[:, 0]),
+        np.interp(targets, cum, closed[:, 1]),
+    ])
 
 
 def make_keep_out_zone_constraint(koz: KeepOutZone) -> GeomConstraintT:

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -32,7 +32,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes import _geometryapi as cadapi
 from bluemira.display.plotter import plot_2d
 from bluemira.geometry.coordinates import Coordinates
-from bluemira.geometry.error import GeometryParameterisationError
+from bluemira.geometry.error import GeometryParameterisationError, OutOfBoundsError
 from bluemira.geometry.tools import (
     interpolate_bspline,
     make_bezier,
@@ -1411,10 +1411,11 @@ def _get_centres(
 
     Raises
     ------
+    OutOfBoundsError
+        The total angle of the defined curves exceeds pi (reflection_zplane given)
+        or 2pi (reflection_zplane not given).
     GeometryParameterisationError
-        The total angle of the defined curves must be below pi (reflection_zplane given)
-        or below 2pi (reflection_zplane not given). And the parametrised curve must not
-        intersect itself. Otherwise, this error is raised.
+        The parametrised curve intersects itself.
     """
     a_start: float = 0.0
     xi, zi = x_start, z_start
@@ -1443,9 +1444,13 @@ def _get_centres(
 
     vertical_symmetry = reflection_zplane is not None
     if a_start >= 180 and vertical_symmetry:  # noqa: PLR2004
-        raise GeometryParameterisationError("The total angles should add up to <180°.")
+        raise OutOfBoundsError(
+            "The total angles should add up to <180°.", excess=a_start / 180 - 1
+        )
     if a_start >= 360 and not vertical_symmetry:  # noqa: PLR2004
-        raise GeometryParameterisationError("The total angles should add up to <360°.")
+        raise OutOfBoundsError(
+            "The total angles should add up to <360°.", excess=a_start / 360 - 1
+        )
 
     _, _, vec = _project_centroid(xc, zc, xi, zi, ri)
 

--- a/eudemo/eudemo/ivc/wall_silhouette.py
+++ b/eudemo/eudemo/ivc/wall_silhouette.py
@@ -9,6 +9,8 @@ First Wall Silhouette designer
 
 from dataclasses import dataclass
 
+import numpy as np
+
 from bluemira.base.designer import Designer
 from bluemira.base.error import DesignError
 from bluemira.base.look_and_feel import (
@@ -183,6 +185,20 @@ class WallSilhouetteDesigner(Designer[GeometryParameterisation]):
             bluemira_debug(
                 f"Applying non-default settings to problem: {self.problem_settings}"
             )
+        _, x_points = find_OX_points(
+            self.equilibrium.x, self.equilibrium.z, self.equilibrium.psi()
+        )
+        x_point_z = x_points[0].z
+        z_margin = 0.05  # the wall must clear the x-point by this much, in metres
+
+        def f_x_point(geom: GeometryParameterisation) -> np.ndarray:
+            # Inequality constraint, satisfied when <= 0: the wall's lowest point
+            # sits at least ``z_margin`` below the separatrix x-point, so the
+            # first wall encloses it. Enforced here rather than only validated
+            # after the fact (see ``execute``).
+            z_min = geom.create_shape().bounding_box.z_min
+            return np.array([z_min - (x_point_z - z_margin)])
+
         result = optimise_geometry(
             parameterisation,
             algorithm=self.algorithm_name,
@@ -195,6 +211,13 @@ class WallSilhouetteDesigner(Designer[GeometryParameterisation]):
                     n_discr=self.problem_settings.get("n_koz_points", 100),
                     byedges=False,
                 )
+            ],
+            ineq_constraints=[
+                {
+                    "name": "x_point_enclosure",
+                    "f_constraint": f_x_point,
+                    "tolerance": np.array([1e-8]),
+                }
             ],
         )
 

--- a/tests/geometry/test_face.py
+++ b/tests/geometry/test_face.py
@@ -144,6 +144,56 @@ class TestFaceWithProtrudingHole:
         assert "protrudes past the outer boundary" in caplog.text
 
 
+class TestFaceWithProtrudingHole:
+    """Face-with-hole where the inner wire protrudes past the outer boundary.
+
+    Reproduces the EUDEMO demo crash on the CadQuery backend: the
+    ``WallSilhouetteDesigner`` optimisation converged to a wall whose IVC
+    boundary no longer enclosed the divertor, so ``plasma_facing_wire``
+    protruded ~0.25 m below ``ivc_boundary``. The boolean cut then pinches off
+    a tiny sliver, so ``face_cut_holes`` returns >1 face. ``_create_face`` now
+    keeps the dominant face and warns rather than raising ``DisjointedFaceError``.
+
+    Not a geometry-backend bug: FreeCAD's ``Part.cut`` yields the same two
+    faces on the identical geometry. The root cause is upstream optimiser
+    brittleness; keeping the dominant face is defence-in-depth.
+
+    The geometry here is a minimal stand-in: an outer box with a narrow
+    downward spike whose tip a hole cuts straight across, pinching it off.
+    """
+
+    @staticmethod
+    def _outer() -> BluemiraWire:
+        return make_polygon(
+            {"x": [-5, 5, 5, 0.5, 0, -0.5, -5], "z": [5, 5, -4, -4, -6, -4, -4]},
+            closed=True,
+        )
+
+    @staticmethod
+    def _hole() -> BluemiraWire:
+        return make_polygon(
+            {"x": [-0.4, 0.4, 0.4, -0.4], "z": [-3, -3, -5, -5]}, closed=True
+        )
+
+    def test_cut_pinches_off_a_sliver_face(self):
+        # Characterises the mechanism: the cut yields a dominant face plus a
+        # small isolated sliver (true on both geometry backends).
+        faces = cadapi.face_cut_holes(
+            cadapi.apiFace(self._outer().shape), [cadapi.apiFace(self._hole().shape)]
+        )
+        areas = sorted(BluemiraFace._create(f).area for f in faces)
+        assert len(faces) == 2
+        assert areas[0] < 1.0  # the sliver
+        assert areas[1] > 80.0  # the dominant face
+
+    def test_face_from_protruding_hole_keeps_dominant_and_warns(self, caplog):
+        # _create_face keeps the dominant face (not the sliver) instead of
+        # crashing, and warns that a fragment was discarded.
+        face = BluemiraFace([self._outer(), self._hole()])
+        assert face.area == pytest.approx(89.24, abs=0.5)
+        assert "protrudes past the outer boundary" in caplog.text
+
+
 class TestNormalAt:
     normals = (
         (0, 1, 0),

--- a/tests/geometry/test_face.py
+++ b/tests/geometry/test_face.py
@@ -144,56 +144,6 @@ class TestFaceWithProtrudingHole:
         assert "protrudes past the outer boundary" in caplog.text
 
 
-class TestFaceWithProtrudingHole:
-    """Face-with-hole where the inner wire protrudes past the outer boundary.
-
-    Reproduces the EUDEMO demo crash on the CadQuery backend: the
-    ``WallSilhouetteDesigner`` optimisation converged to a wall whose IVC
-    boundary no longer enclosed the divertor, so ``plasma_facing_wire``
-    protruded ~0.25 m below ``ivc_boundary``. The boolean cut then pinches off
-    a tiny sliver, so ``face_cut_holes`` returns >1 face. ``_create_face`` now
-    keeps the dominant face and warns rather than raising ``DisjointedFaceError``.
-
-    Not a geometry-backend bug: FreeCAD's ``Part.cut`` yields the same two
-    faces on the identical geometry. The root cause is upstream optimiser
-    brittleness; keeping the dominant face is defence-in-depth.
-
-    The geometry here is a minimal stand-in: an outer box with a narrow
-    downward spike whose tip a hole cuts straight across, pinching it off.
-    """
-
-    @staticmethod
-    def _outer() -> BluemiraWire:
-        return make_polygon(
-            {"x": [-5, 5, 5, 0.5, 0, -0.5, -5], "z": [5, 5, -4, -4, -6, -4, -4]},
-            closed=True,
-        )
-
-    @staticmethod
-    def _hole() -> BluemiraWire:
-        return make_polygon(
-            {"x": [-0.4, 0.4, 0.4, -0.4], "z": [-3, -3, -5, -5]}, closed=True
-        )
-
-    def test_cut_pinches_off_a_sliver_face(self):
-        # Characterises the mechanism: the cut yields a dominant face plus a
-        # small isolated sliver (true on both geometry backends).
-        faces = cadapi.face_cut_holes(
-            cadapi.apiFace(self._outer().shape), [cadapi.apiFace(self._hole().shape)]
-        )
-        areas = sorted(BluemiraFace._create(f).area for f in faces)
-        assert len(faces) == 2
-        assert areas[0] < 1.0  # the sliver
-        assert areas[1] > 80.0  # the dominant face
-
-    def test_face_from_protruding_hole_keeps_dominant_and_warns(self, caplog):
-        # _create_face keeps the dominant face (not the sliver) instead of
-        # crashing, and warns that a fragment was discarded.
-        face = BluemiraFace([self._outer(), self._hole()])
-        assert face.area == pytest.approx(89.24, abs=0.5)
-        assert "protrudes past the outer boundary" in caplog.text
-
-
 class TestNormalAt:
     normals = (
         (0, 1, 0),

--- a/tests/geometry/test_parameterisations.py
+++ b/tests/geometry/test_parameterisations.py
@@ -14,7 +14,7 @@ import pytest
 
 import bluemira.codes._geometryapi as _cadapi
 from bluemira.geometry.coordinates import Coordinates
-from bluemira.geometry.error import GeometryParameterisationError
+from bluemira.geometry.error import GeometryParameterisationError, OutOfBoundsError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.optimisation._tools import KeepOutZone
 from bluemira.geometry.optimisation.problem import GeomOptimisationProblem
@@ -589,6 +589,18 @@ class TestTripleArc:
         p.variables.sl.adjust(5)
         with pytest.raises(GeometryParameterisationError):
             p.create_shape()
+
+    def test_excessive_angles_raise_out_of_bounds_with_excess(self):
+        # Angles past the 180° symmetry limit raise the specific, optimiser-
+        # recoverable OutOfBoundsError, carrying how far out of bounds it is.
+        p = TripleArc()
+        p.adjust_variable("a1", value=120)
+        p.adjust_variable("a2", value=120)  # sum 240 -> 240/180 - 1
+        with pytest.raises(OutOfBoundsError) as exc_info:
+            p.create_shape()
+        assert exc_info.value.excess == pytest.approx(240 / 180 - 1)
+        # Still a GeometryParameterisationError, so existing handlers catch it.
+        assert isinstance(exc_info.value, GeometryParameterisationError)
 
     def test_plot(self):
         p = TripleArc()

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -11,7 +11,11 @@ import pytest
 from bluemira.geometry.error import OutOfBoundsError
 from bluemira.geometry.optimisation import optimise_geometry
 from bluemira.geometry.optimisation._optimise import KeepOutZone
-from bluemira.geometry.optimisation._tools import to_objective, to_optimiser_callable
+from bluemira.geometry.optimisation._tools import (
+    _canonical_loop_points,
+    to_objective,
+    to_optimiser_callable,
+)
 from bluemira.geometry.parameterisations import (
     GeometryParameterisation,
     PictureFrame,
@@ -340,3 +344,45 @@ class TestOutOfBoundsPenalty:
         x = arc.variables.get_normalised_values()
         f = to_objective(lambda g: g.create_shape().length, arc)
         assert np.isfinite(f(x))
+
+
+class TestCanonicalLoopPoints:
+    """``_canonical_loop_points`` resamples a closed loop to a fixed point
+    sequence that does not depend on where the discretisation starts or which
+    way it winds. This keeps the keep-out-zone constraint vector identical
+    between geometry backends, whose wire edge ordering otherwise phase-shifts
+    the samples and drives the optimiser into a different basin (the EUDEMO
+    wall-silhouette divergence).
+    """
+
+    @staticmethod
+    def _ellipse(n_pts: int, phase: float = 0.0, *, reverse: bool = False) -> np.ndarray:
+        # Dense closed loop: ellipse centred at (10, 0), whose outer-midplane
+        # anchor therefore sits at (13, 0).
+        theta = np.linspace(0.0, 2 * np.pi, n_pts, endpoint=False) + phase
+        pts = np.vstack([10 + 3 * np.cos(theta), 5 * np.sin(theta)])
+        return pts[:, ::-1] if reverse else pts
+
+    def test_returns_requested_count(self):
+        assert _canonical_loop_points(self._ellipse(400), 47).shape == (2, 47)
+
+    def test_anchored_at_outer_midplane(self):
+        out = _canonical_loop_points(self._ellipse(400), 60)
+        np.testing.assert_allclose(out[:, 0], [13.0, 0.0], atol=5e-3)
+
+    def test_invariant_to_sample_phase(self):
+        # Two dense samplings of the same loop starting at different points
+        # (as the two backends do) collapse to the same canonical points.
+        a = _canonical_loop_points(self._ellipse(400, phase=0.0), 60)
+        b = _canonical_loop_points(self._ellipse(400, phase=0.37), 60)
+        assert np.max(np.linalg.norm(a - b, axis=0)) < 1e-2
+
+    def test_invariant_to_winding(self):
+        a = _canonical_loop_points(self._ellipse(400), 60)
+        b = _canonical_loop_points(self._ellipse(400, reverse=True), 60)
+        np.testing.assert_allclose(a, b, atol=1e-9)
+
+    def test_points_lie_on_loop(self):
+        out = _canonical_loop_points(self._ellipse(400), 60)
+        on_ellipse = ((out[0] - 10) / 3) ** 2 + (out[1] / 5) ** 2
+        np.testing.assert_allclose(on_ellipse, 1.0, atol=1e-2)

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -8,8 +8,10 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from bluemira.geometry.error import OutOfBoundsError
 from bluemira.geometry.optimisation import optimise_geometry
 from bluemira.geometry.optimisation._optimise import KeepOutZone
+from bluemira.geometry.optimisation._tools import to_objective, to_optimiser_callable
 from bluemira.geometry.parameterisations import (
     GeometryParameterisation,
     PictureFrame,
@@ -270,3 +272,71 @@ class TestGeometry:
         )
 
         assert square_constraint(result.geom)[0] == pytest.approx(0, abs=1e-8)
+
+
+class TestOutOfBoundsPenalty:
+    """The geometry-optimisation wrappers penalise (rather than crash on) a
+    parameterisation that builds invalid geometry, so an optimiser probing an
+    infeasible point recovers. Reproduces the class of EUDEMO demo crashes where
+    ``create_shape`` raised ``OutOfBoundsError`` mid-optimisation.
+    """
+
+    @staticmethod
+    def _fake_geom():
+        # Stand-in geometry whose ``variables.set_values_from_norm`` is a no-op.
+        def _noop(_x):
+            return None
+
+        variables = type("V", (), {"set_values_from_norm": staticmethod(_noop)})
+        return type("G", (), {"variables": variables})()
+
+    @staticmethod
+    def _raises(excess):
+        def objective(_geom):
+            raise OutOfBoundsError("out of bounds", excess=excess)
+
+        return objective
+
+    def test_objective_penalises_out_of_bounds_instead_of_raising(self):
+        feasible = [10.0, 20.0]
+
+        def objective(_geom):
+            if feasible:
+                return feasible.pop(0)
+            raise OutOfBoundsError("out of bounds", excess=0.5)
+
+        f = to_objective(objective, self._fake_geom())
+        assert f([0]) == pytest.approx(10.0)
+        assert f([0]) == pytest.approx(20.0)  # worst feasible value seen is now 20
+        penalty = f([0])  # next call raises -> penalised, not propagated
+        assert np.isfinite(penalty)
+        assert penalty > 20.0  # strictly worse than any feasible value
+
+    def test_objective_penalty_grows_with_excess(self):
+        small = to_objective(self._raises(0.1), self._fake_geom())([0])
+        big = to_objective(self._raises(2.0), self._fake_geom())([0])
+        assert big > small
+
+    def test_constraint_penalises_with_matching_shape(self):
+        outputs = [np.array([1.0, -2.0, 0.5])]
+
+        def constraint(_geom):
+            if outputs:
+                return outputs.pop(0)
+            raise OutOfBoundsError("out of bounds", excess=1.0)
+
+        f = to_optimiser_callable(constraint, self._fake_geom())
+        assert f([0]).shape == (3,)
+        penalty = f([0])  # raises -> violated constraint vector of the same shape
+        assert penalty.shape == (3,)
+        assert np.all(penalty > 0)  # reads as strongly violated
+
+    def test_objective_survives_real_invalid_parameterisation(self):
+        # Faithful path: a real TripleArc whose angles are out of bounds makes
+        # create_shape raise; the wrapped objective penalises instead of crashing.
+        arc = TripleArc()
+        arc.adjust_variable("a1", value=120)
+        arc.adjust_variable("a2", value=120)  # sum 240 -> create_shape raises
+        x = arc.variables.get_normalised_values()
+        f = to_objective(lambda g: g.create_shape().length, arc)
+        assert np.isfinite(f(x))


### PR DESCRIPTION
## Description

eudemo/reactor.py now runs all the way through with BLUEMIRA_GEOMETRY_BACKEND=cadquery (PROCESS 3.4.1). Almost all the crashes came from one root cause, not from CadQuery geometry being wrong — both backends use the same OCCT 7.8.1.

The root cause. The wall-silhouette optimiser ended up with a different wall on CadQuery — one that didn't enclose the X-point — and that broke everything after it. But the two walls were actually the same shape (bounding box matches to 1e-7). The difference was in how the keep-out-zone constraint reads the wall: it checks each point of the wall against the zone, and discretise() starts at the wire's first edge, which isn't the same edge on both backends. So each backend starts from a different point — same shape, just sampled in a different order around the loop. That shifted the numbers by up to 6.6 m per point and sent the optimiser down a different path. The fix samples the wall the same way every time (same start point, same direction, evenly spaced), so both backends see the same thing. The wall difference between backends drops from 5.3% to 0.012%.

What's in here
- Sample the keep-out-zone constraint the same way on both backends (the main fix).
- length() uses OCCT BRepGProp instead of the rougher cq.Edge.Length().
- When a hole cut leaves slivers, keep the main face and warn instead of erroring.
- Penalise the optimiser when it tries an invalid shape, instead of crashing.
- WallSilhouette now requires the wall to enclose the X-point.
- PF-coil split tolerance set to EPS_FREECAD.
- OIS designer copes with keep-out zones that don't touch each other.
- save_reactor no longer needs a neutronics config folder to exist.

Everything works the same on FreeCAD, and there are tests.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
