### PR TITLE
🎨 Viewer backend selection robustness

### DIFF
--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -62,22 +62,26 @@ class ViewerBackend(Enum):
                 name = self.name.lower()
                 bluemira_warn(
                     f"Unable to import {name.capitalize()} viewer\n"
-                    f"Please 'pip install {name}' to use, falling back to FreeCAD."
+                    f"Please 'pip install {name}' to use,"
+                    f" falling back to {self.DEFAULT.name.lower()}."
                 )
-                return get_module(type(self).DEFAULT.value)
+                return get_module(self.DEFAULT.value)
             raise
 
     @classmethod
     def _missing_(cls, value):
         if isinstance(value, str):
             try:
-                backend = ViewerBackend[value.upper()]
+                backend = cls[value.upper()]
             except KeyError:
-                bluemira_warn(f"Unknown viewer backend '{value}' defaulting to FreeCAD")
-                backend = ViewerBackend.DEFAULT
+                bluemira_warn(
+                    f"Unknown viewer backend '{value}',"
+                    f" defaulting to {cls.DEFAULT.name.lower()}"
+                )
+                backend = cls.DEFAULT
             return backend
         bluemira_debug(f"No viewer '{value}' selecting default")
-        return ViewerBackend.DEFAULT
+        return cls.DEFAULT
 
 
 def get_default_options(backend=ViewerBackend.DEFAULT):

--- a/bluemira/display/displayer.py
+++ b/bluemira/display/displayer.py
@@ -33,6 +33,12 @@ class ViewerBackend(Enum):
     POLYSCOPE = "bluemira.codes._polyscope"
     CADQUERY = "bluemira.codes.cadapi._cadquery"
 
+    @classmethod
+    @property
+    def DEFAULT(cls):  # noqa: N802
+        """Default viewer based on backend availability"""
+        return cls[os.environ.get("BLUEMIRA_GEOMETRY_BACKEND", "freecad").upper()]
+
     @lru_cache(2)
     def get_module(self):
         """Load viewer module
@@ -52,17 +58,29 @@ class ViewerBackend(Enum):
         try:
             return get_module(self.value)
         except (ModuleNotFoundError, FileNotFoundError):
-            if self.name != "FREECAD":
+            if self.name != self.DEFAULT.name:
                 name = self.name.lower()
                 bluemira_warn(
                     f"Unable to import {name.capitalize()} viewer\n"
                     f"Please 'pip install {name}' to use, falling back to FreeCAD."
                 )
-                return get_module(type(self).FREECAD.value)
+                return get_module(type(self).DEFAULT.value)
             raise
 
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            try:
+                backend = ViewerBackend[value.upper()]
+            except KeyError:
+                bluemira_warn(f"Unknown viewer backend '{value}' defaulting to FreeCAD")
+                backend = ViewerBackend.DEFAULT
+            return backend
+        bluemira_debug(f"No viewer '{value}' selecting default")
+        return ViewerBackend.DEFAULT
 
-def get_default_options(backend=ViewerBackend.FREECAD):
+
+def get_default_options(backend=ViewerBackend.DEFAULT):
     """
     Returns
     -------
@@ -84,7 +102,7 @@ class DisplayCADOptions(Options):
 
     __slots__ = ()
 
-    def __init__(self, backend=ViewerBackend.FREECAD, **kwargs):
+    def __init__(self, backend=ViewerBackend.DEFAULT, **kwargs):
         self._options = get_default_options(backend)
         super().__init__(**kwargs)
 
@@ -159,15 +177,7 @@ def show_cad(
     kwargs
         Passed on to modifications to the plotting style options and backend
     """
-    if backend is None:
-        backend = os.environ.get("BLUEMIRA_GEOMETRY_BACKEND", "freecad")
-    if isinstance(backend, str):
-        try:
-            backend = ViewerBackend[backend.upper()]
-        except KeyError:
-            bluemira_warn(f"Unknown viewer backend '{backend}' defaulting to FreeCAD")
-            backend = ViewerBackend.FREECAD
-
+    backend = ViewerBackend(backend)
     parts, options, labels = _validate_display_inputs(parts, options, labels)
 
     # Split kwargs by whether they correspond to a DisplayCADOptions field.

--- a/tests/display/test_displayer.py
+++ b/tests/display/test_displayer.py
@@ -94,7 +94,7 @@ class TestComponentDisplayer:
     @pytest.mark.parametrize(
         "viewer",
         [
-            "freecad",
+            _ACTIVE_BACKEND_REF,
             pytest.param(
                 "polyscope",
                 marks=pytest.mark.skipif(_skip_polyscope(), reason="Not installed"),
@@ -142,7 +142,7 @@ class TestGeometryDisplayer:
     @pytest.mark.parametrize(
         "viewer",
         [
-            "freecad",
+            _ACTIVE_BACKEND_REF,
             pytest.param(
                 "polyscope",
                 marks=pytest.mark.skipif(_skip_polyscope(), reason="Not installed"),


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Sets the default viewer backend to the default cad backend

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
