### PR TITLE
Add an unfix coil size option

### DIFF
--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from bluemira.base.constants import CoilType
-from bluemira.base.look_and_feel import bluemira_debug
+from bluemira.base.look_and_feel import bluemira_debug, bluemira_print
 from bluemira.equilibria.coils._field import CoilFieldsMixin
 from bluemira.equilibria.coils._tools import get_max_current
 from bluemira.equilibria.constants import COIL_DISCR, NBTI_B_MAX, NBTI_J_MAX
@@ -109,6 +109,10 @@ class Coil(CoilFieldsMixin):
         discretise the coil, value in [m]. The minimum size is COIL_DISCR
     n_turns:
         Number of turns
+    fix_size:
+        Whether or not to fix the coil size.
+        Default is True if coil size is input and False if no size is input.
+        You can not choose to fix the size if you have not chosen the size.
 
     Notes
     -----
@@ -154,6 +158,7 @@ class Coil(CoilFieldsMixin):
         psi_analytic: bool = False,
         Bx_analytic: bool = True,
         Bz_analytic: bool = True,
+        fix_size: bool | None = None,
     ):
         self._dx = None
         self._dz = None
@@ -186,6 +191,10 @@ class Coil(CoilFieldsMixin):
         if not self._flag_sizefix and None in {self.dx, self.dz}:
             self._dx, self._dz = 0, 0
             self._re_discretise()
+
+        # Default unless chosen by user
+        if fix_size is not None:
+            self.fix_size = fix_size
 
         super().__init__(
             psi_analytic=psi_analytic, Bx_analytic=Bx_analytic, Bz_analytic=Bz_analytic
@@ -357,6 +366,11 @@ class Coil(CoilFieldsMixin):
             self._quad_x, self._quad_z, self._quad_dx, self._quad_dz
         )
 
+    @property
+    def fix_size(self):
+        """Boolean representing if the coil size is fixed or not."""
+        return self._flag_sizefix
+
     @x.setter
     def x(self, value: float):
         """Set coil x position"""
@@ -435,6 +449,29 @@ class Coil(CoilFieldsMixin):
         self._discretisation = np.clip(floatify(value), COIL_DISCR, None)
         self._discretise()
 
+    @fix_size.setter
+    def fix_size(self, value: bool):
+        if value:
+            bluemira_debug(
+                "Coil size fixed\n"
+                "Adjusting the current or max current density will no"
+                " longer change the coil size."
+            )
+        else:
+            bluemira_debug(
+                "Coil size unfixed\n"
+                "Adjusting the current or max current density will now"
+                "change the coil size."
+            )
+        if value and None in {self.dx, self.dz}:
+            bluemira_print(
+                "Cannot fix the coil size if there is no size specified."
+                "Keeping coil sizes unfixed."
+            )
+            self._flag_sizefix = False
+        else:
+            self._flag_sizefix = value
+
     def assign_material(
         self,
         j_max: float = NBTI_J_MAX,
@@ -506,7 +543,7 @@ class Coil(CoilFieldsMixin):
         if dxdz_spec:
             # If dx and dz are specified, we presume the coil size should
             # remain fixed
-            self.fix_size()
+            self.fix_size = True
 
             self._set_coil_attributes()
             self._discretise()
@@ -515,7 +552,7 @@ class Coil(CoilFieldsMixin):
                 # Check there is a viable way to size the coil
                 raise EquilibriaError("Must specify either dx and dz or j_max.")
 
-            self._flag_sizefix = False
+            self.fix_size = False
 
     def _set_coil_attributes(self):
         self._current_radius = 0.5 * np.hypot(self.dx, self.dz)
@@ -546,28 +583,6 @@ class Coil(CoilFieldsMixin):
             self._quad_dz = np.full(x_sc.size, sc_dz)
 
             self._quad_weighting = np.ones(x_sc.size) / x_sc.size
-
-    def fix_size(self):
-        """
-        Fixes the size of the coil
-        """
-        self._flag_sizefix = True
-        bluemira_debug(
-            "Coil size fixed\n"
-            "Adjusting the current or max current density will no"
-            " longer change the coil size."
-        )
-
-    def unfix_size(self):
-        """
-        Unfixes the size of the coil
-        """
-        self._flag_sizefix = False
-        bluemira_debug(
-            "Coil size unfixed\n"
-            "Adjusting the current or max current density will now"
-            "change the coil size."
-        )
 
     def resize(self, current: float | None = None):
         """Resize coil given a current"""

--- a/bluemira/equilibria/coils/_coil.py
+++ b/bluemira/equilibria/coils/_coil.py
@@ -558,6 +558,17 @@ class Coil(CoilFieldsMixin):
             " longer change the coil size."
         )
 
+    def unfix_size(self):
+        """
+        Unfixes the size of the coil
+        """
+        self._flag_sizefix = False
+        bluemira_debug(
+            "Coil size unfixed\n"
+            "Adjusting the current or max current density will now"
+            "change the coil size."
+        )
+
     def resize(self, current: float | None = None):
         """Resize coil given a current"""
         if not self._flag_sizefix:

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -187,6 +187,12 @@ class CoilGroup(CoilGroupFieldsMixin):
         """
         self.__run_func("fix_size")
 
+    def unfix_sizes(self):
+        """
+        Fix the sizes of coils in CoilGroup
+        """
+        self.__run_func("unfix_size")
+
     def resize(self, currents: float | list | np.ndarray):
         """
         Resize coils based on their current if their size is not fixed
@@ -1131,6 +1137,18 @@ class SymmetricCircuit(Circuit):
             self._get_primary_group_x_centre(),
             self._get_primary_group_z_centre(),
         ])
+
+    def fix_sizes(self):
+        """
+        Fix the sizes of coils in CoilGroup
+        """
+        self.__run_func("fix_size")
+
+    def unfix_sizes(self):
+        """
+        Fix the sizes of coils in CoilGroup
+        """
+        self.__run_func("unfix_size")
 
 
 @dataclass

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -109,6 +109,7 @@ class CoilGroup(CoilGroupFieldsMixin):
         psi_analytic: bool = False,
         Bx_analytic: bool = True,
         Bz_analytic: bool = True,
+        fix_size: bool | None = None,
     ):
         if any(not isinstance(c, Coil | CoilGroup) for c in coils) or not coils:
             raise TypeError("Not all arguments are a Coil or CoilGroup.")
@@ -117,6 +118,7 @@ class CoilGroup(CoilGroupFieldsMixin):
         super().__init__(
             psi_analytic=psi_analytic, Bx_analytic=Bx_analytic, Bz_analytic=Bz_analytic
         )
+        self.fix_size = fix_size
 
     def __repr__(self):
         """
@@ -180,18 +182,6 @@ class CoilGroup(CoilGroupFieldsMixin):
         return CoilGroupPlotter(
             self, ax=ax, subcoil=subcoil, label=label, force=force, **kwargs
         )
-
-    def fix_sizes(self):
-        """
-        Fix the sizes of coils in CoilGroup
-        """
-        self.__run_func("fix_size")
-
-    def unfix_sizes(self):
-        """
-        Fix the sizes of coils in CoilGroup
-        """
-        self.__run_func("unfix_size")
 
     def resize(self, currents: float | list | np.ndarray):
         """
@@ -334,7 +324,6 @@ class CoilGroup(CoilGroupFieldsMixin):
                     j_max=0,
                     b_max=0,
                 )
-                coil.fix_size()
                 pfcoils.append(coil)
             coils = pfcoils
             bluemira_warn(
@@ -393,7 +382,6 @@ class CoilGroup(CoilGroupFieldsMixin):
                     ctype=ct or CoilType.PF,
                     name=cn,
                 )
-                coil.fix_size()  # Oh ja
                 pfcoils.append(coil)
 
         coils = pfcoils
@@ -781,6 +769,11 @@ class CoilGroup(CoilGroupFieldsMixin):
         return self.__getter("_flag_sizefix")
 
     @property
+    def fix_size(self):
+        """Get if coil size is fixed (True) or not (False)"""
+        return self.__getter("fix_size")
+
+    @property
     def _current_radius(self) -> np.ndarray:
         """Get coil current radius"""
         return self.__getter("_current_radius")
@@ -864,6 +857,13 @@ class CoilGroup(CoilGroupFieldsMixin):
     def j_max(self, values: float | Iterable[float]):
         """Set coil max current densities"""
         self.__setter("j_max", values)
+
+    @fix_size.setter
+    def fix_size(self, values: bool | Iterable[bool] | None):
+        """Get if coil size is fixed (True) or not (False)"""
+        if values is None:
+            self.__setter("fix_size", self.__getter("_flag_sizefix"))
+        self.__setter("fix_size", values)
 
     @b_max.setter
     def b_max(self, values: float | Iterable[float]):
@@ -1138,18 +1138,6 @@ class SymmetricCircuit(Circuit):
             self._get_primary_group_z_centre(),
         ])
 
-    def fix_sizes(self):
-        """
-        Fix the sizes of coils in CoilGroup
-        """
-        self.__run_func("fix_size")
-
-    def unfix_sizes(self):
-        """
-        Fix the sizes of coils in CoilGroup
-        """
-        self.__run_func("unfix_size")
-
 
 @dataclass
 class CoilSetOptimisationState:
@@ -1213,12 +1201,14 @@ class CoilSet(CoilSetFieldsMixin, CoilGroup):
         psi_analytic: bool = False,
         Bx_analytic: bool = True,
         Bz_analytic: bool = True,
+        fix_size: bool | None = None,
     ):
         super().__init__(
             *coils,
             psi_analytic=psi_analytic,
             Bx_analytic=Bx_analytic,
             Bz_analytic=Bz_analytic,
+            fix_size=fix_size,
         )
         self.control = control_names
 

--- a/bluemira/equilibria/coils/_grouping.py
+++ b/bluemira/equilibria/coils/_grouping.py
@@ -118,7 +118,9 @@ class CoilGroup(CoilGroupFieldsMixin):
         super().__init__(
             psi_analytic=psi_analytic, Bx_analytic=Bx_analytic, Bz_analytic=Bz_analytic
         )
-        self.fix_size = fix_size
+        # Default unless chosen by user
+        if fix_size is not None:
+            self.fix_size = fix_size
 
     def __repr__(self):
         """
@@ -859,10 +861,8 @@ class CoilGroup(CoilGroupFieldsMixin):
         self.__setter("j_max", values)
 
     @fix_size.setter
-    def fix_size(self, values: bool | Iterable[bool] | None):
+    def fix_size(self, values: bool | Iterable[bool]):
         """Get if coil size is fixed (True) or not (False)"""
-        if values is None:
-            self.__setter("fix_size", self.__getter("_flag_sizefix"))
         self.__setter("fix_size", values)
 
     @b_max.setter

--- a/bluemira/equilibria/run.py
+++ b/bluemira/equilibria/run.py
@@ -822,13 +822,13 @@ class OptimisedPulsedCoilsetDesign(PulsedCoilsetDesign):
         for problem in sub_opt_problems:
             pf_coils = problem.eq.coilset.get_coiltype("PF").get_control_coils()
             pf_coils.resize(max_pf_currents)
-            pf_coils.fix_sizes()
+            pf_coils.fix_size = True
             pf_coils.discretisation = self.eq_config.coil_mesh_size
             problem.set_current_bounds(
                 np.concatenate([max_pf_currents, max_cs_currents])
             )
 
         consolidated_coilset = deepcopy(problem.eq.coilset)
-        consolidated_coilset.fix_sizes()
+        consolidated_coilset.fix_size = True
         consolidated_coilset.get_control_coils().current = 0
         return consolidated_coilset

--- a/eudemo/eudemo/pf_coils/tools.py
+++ b/eudemo/eudemo/pf_coils/tools.py
@@ -201,7 +201,7 @@ def make_coilset(
     z_max = bb.z_max
     solenoid = make_solenoid(r_cs, tk_cs, z_min, z_max, g_cs, tk_cs_ins, tk_cs_cas, n_CS)
     for s in solenoid:
-        s.fix_size()
+        s.fix_size = True
 
     tf_track = offset_wire(
         tf_boundary, 1, fallback_method="miter", fallback_force_spline=True

--- a/examples/design/optimised_reactor.ex.py
+++ b/examples/design/optimised_reactor.ex.py
@@ -115,7 +115,7 @@ def ref_eq(R_0, A) -> Equilibrium:  # noqa: D103
     coilset.assign_material("PF", j_max=12.5e6, b_max=11.0)
 
     cs = coilset.get_coiltype("CS")
-    cs.fix_sizes()
+    cs.fix_size = True
     cs.discretisation = 0.3
 
     B_0 = 4.8901  # T

--- a/examples/equilibria/eudemo_2017.ex.py
+++ b/examples/equilibria/eudemo_2017.ex.py
@@ -113,7 +113,7 @@ coilset = CoilSet(*coils)
 # Assign current density and peak field constraints
 coilset.assign_material("CS", j_max=16.5e6, b_max=12.5)
 coilset.assign_material("PF", j_max=12.5e6, b_max=11)
-coilset.fix_sizes()
+coilset.fix_size = True
 coilset.discretisation = 0.3
 
 coilset.plot()

--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -126,7 +126,7 @@ coilset.assign_material("PF", j_max=12.5e6, b_max=11.0)
 # and mesh them already.
 
 cs = coilset.get_coiltype("CS")
-cs.fix_sizes()
+cs.fix_size = True
 cs.discretisation = 0.3
 
 # %% [markdown]

--- a/examples/equilibria/single_null.ex.py
+++ b/examples/equilibria/single_null.ex.py
@@ -468,7 +468,7 @@ max_currents = np.concatenate([max_pf_currents, max_cs_currents])
 for problem in [current_opt_problem_sof, current_opt_problem_eof]:
     for pf_name, max_current in zip(pf_coil_names, max_pf_currents, strict=False):
         problem.eq.coilset[pf_name].resize(max_current)
-        problem.eq.coilset[pf_name].fix_size()
+        problem.eq.coilset[pf_name].fix_size = True
         problem.eq.coilset[pf_name].discretisation = 0.3
     problem.set_current_bounds(max_currents)
 

--- a/tests/equilibria/setup_methods.py
+++ b/tests/equilibria/setup_methods.py
@@ -61,7 +61,7 @@ def _coilset_setup(self, *, materials=False):
         # Max PF currents / sizes don't stack up in the CREATE document...
         self.coilset.assign_material("PF", j_max=12.5e6, b_max=12.5)
         self.coilset.assign_material("CS", j_max=12.5e6, b_max=12.5)
-        self.coilset.fix_sizes()
+        self.coilset.fix_size = True
 
     self.no_coils = len(names)
     self.coil_names = names

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -337,7 +337,7 @@ class TestCoilGroup:
         initdx = self.group.dx
         initdz = self.group.dz
 
-        self.group.fix_sizes()
+        self.group.fix_size = True
         self.group.resize(10)
 
         np.testing.assert_allclose(self.group.dx, initdx)

--- a/tests/equilibria/test_optimisation.py
+++ b/tests/equilibria/test_optimisation.py
@@ -42,7 +42,7 @@ def coilset_setup(*, materials=False):
     if materials:
         coilset.assign_material("PF", j_max=12.5e6, b_max=12.5)
         coilset.assign_material("CS", j_max=12.5e6, b_max=12.5)
-        coilset.fix_sizes()
+        coilset.fix_size = True
 
     return coilset
 


### PR DESCRIPTION
It is sometimes useful to be able to unfix coil sizes even if you have previously chosen dimensions. Creating a new option to unfix the coil sizes without having to create a whole new coilset and equilibria. 

This will be done via a boolean property called 'fix_coils' that can be set to True or False (or an array of T/F values if you want a mix of coils with fix and unfixed sizes). Default is None, which will behave as it did before, automatically fixing the coil sizes if they are specified or unfixing them if they are not specified.  

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
