### PR TITLE
Add divertor index function to PartialOpenFluxSurface class

### DIFF
--- a/bluemira/equilibria/flux_surfaces.py
+++ b/bluemira/equilibria/flux_surfaces.py
@@ -518,6 +518,50 @@ class PartialOpenFluxSurface(OpenFluxSurface):
             / (self.x_end * eq.Bp(self.x_end, self.z_end))
         )
 
+    def divertor_index(self, eq: Equilibrium) -> float:
+        """
+        Divertor Index (DI) of the PartialOpenFluxSurface.
+
+        DI > 1: flux surfaces are more flared than a standard divertor
+        DI < 1: flux surfaces are less flared than a standard divertor
+
+        Appropriate to use when the PartialOpenFluxSurface is a divertor leg.
+
+        \t:math:`DI = \\frac{d_{end}}{B_{p, start}}}{\\frac{d_{start}}{B_{p, end}}}`
+
+        Where Bp is the poloidal field, d_start is the distance from x-point to point
+        on a divertor leg flux line that is closest to the strike point and d_end is
+        the distance from x-point to strike point.
+
+        From Kotschenreuther et al., 'Magnetic geometry and physics of advanced
+        divertors: The X-divertor and the snowflake'.
+
+        Parameters
+        ----------
+        eq:
+            Equilibrium with which to calculate the DI
+
+        Returns
+        -------
+        :
+            Divertor Index
+        """
+        # Get the x-point location for the legs
+        if eq.is_double_null:
+            xpts = eq._x_points[:2]
+            xpts = xpts[np.argmin(np.abs(self.z_end - [x.z for x in xpts]))]
+        else:
+            xpts = eq._x_points[0]
+
+        # Calculate distances along fs to x-point
+        distances = self.coords.distance_to([xpts.x, 0, xpts.z]).flatten(order="C")
+        argmin = np.argmin(distances)
+
+        # Calculate and return the DI
+        return (distances[-1] * eq.Bp(self.x_start, self.z_start)) / (
+            distances[argmin] * eq.Bp(self.x_end, self.z_end)
+        )
+
 
 @dataclass
 class CoreResults:

--- a/tests/equilibria/test_flux_surfaces.py
+++ b/tests/equilibria/test_flux_surfaces.py
@@ -267,6 +267,10 @@ class TestOpenFluxSurfaceStuff:
                 angle_dict_intersected[key], expected_a_dict[key], rtol=5e-3
             )
 
+        po_fs = PartialOpenFluxSurface(leg_dict["lower_inner"][0])
+        assert po_fs.flux_expansion(self.eq) == pytest.approx(0.01833, rel=1e-3)
+        assert po_fs.divertor_index(self.eq) == pytest.approx(0.55824, rel=1e-3)
+
 
 class TestClosedFluxSurface:
     def test_bad_geometry(self):


### PR DESCRIPTION
## Linked Issues

## Description

Add a function that calculates the 'divertor index' according to Equation 1 in: https://pubs.aip.org/aip/pop/article/20/10/102507/318117/Magnetic-geometry-and-physics-of-advanced. 

Part of the PartialOpenFluxSurface class.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
