### PR TITLE
Fix for upper port test

### DIFF
--- a/bluemira/builders/coil_supports.py
+++ b/bluemira/builders/coil_supports.py
@@ -762,8 +762,8 @@ class StraightOISDesigner(Designer[list[BluemiraWire]]):
                 algorithm="COBYLA",
                 opt_conditions={"ftol_rel": 1e-6, "max_eval": 1000},
             ).x
-            p1 = region.value_at(result[0])
-            p2 = region.value_at(result[1])
+            p1 = region.value_at(np.min(result))
+            p2 = region.value_at(np.max(result))
             wire = self._make_ois_wire(p1, p2)
             ois_wires.append(wire)
         return ois_wires

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -625,6 +625,32 @@ def _sewn_solid(solid: apiSolid, tolerance: float = 1e-3) -> apiSolid:
     return new_solid
 
 
+def _fix_offset_orientation(wire: apiWire, result: apiWire) -> apiWire:
+    """
+    CadQuery has been known to reverse the orientation of wires input to
+    offset2D. This function re-orients the result wire so that it is the
+    same as the original wire.
+    """
+    orig_ori = wire.wrapped.Orientation()
+    res_ori = result.wrapped.Orientation()
+
+    if orig_ori != res_ori:
+        raw_edges = list(result)
+        raw_edges.reverse()
+
+        builder = BRepBuilderAPI_MakeWire()
+        for e in raw_edges:
+            reversed_shape = e.wrapped.Reversed()
+            reversed_edge = TopoDS.Edge_s(reversed_shape)
+            builder.Add(reversed_edge)
+
+        if builder.IsDone():
+            result = cq.Wire(builder.Wire())
+        else:
+            result = cq.Wire(result.wrapped.Reversed())
+    return result
+
+
 def offset_wire(
     wire: apiWire,
     thickness: float,
@@ -697,7 +723,7 @@ def offset_wire(
     if not open_wire and not result.IsClosed():
         raise CadQueryError("offset failed to close wire")
 
-    return result
+    return _fix_offset_orientation(wire, result)
 
 
 # ---------------------------------------------------------------------------

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -34,6 +34,7 @@ from OCP.BRepAlgoAPI import (
     BRepAlgoAPI_Section,
     BRepAlgoAPI_Splitter,
 )
+from OCP.BRepBndLib import BRepBndLib
 from OCP.BRepBuilderAPI import (
     BRepBuilderAPI_MakeEdge,
     BRepBuilderAPI_MakeFace,
@@ -52,6 +53,7 @@ from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.BRepOffsetAPI import BRepOffsetAPI_MakePipeShell, BRepOffsetAPI_ThruSections
 from OCP.BRepPrimAPI import BRepPrimAPI_MakePrism, BRepPrimAPI_MakeRevol
 from OCP.BRepTools import BRepTools_WireExplorer
+from OCP.Bnd import Bnd_Box
 from OCP.GCPnts import GCPnts_AbscissaPoint, GCPnts_UniformAbscissa
 from OCP.GProp import GProp_GProps
 from OCP.GeomAPI import GeomAPI_ProjectPointOnCurve, GeomAPI_ProjectPointOnSurf
@@ -1107,9 +1109,20 @@ def is_same(obj1: apiShape, obj2: apiShape) -> bool:
 
 
 def bounding_box(obj: apiShape) -> tuple[float, float, float, float, float, float]:
-    """Return (xmin, ymin, zmin, xmax, ymax, zmax)."""
+    """
+    Implementation is identical to FreeCAD, although the default CadQuery function
+    is arguably better - should move back to it once FreeCAD is removed.
+
     bb = obj.BoundingBox()
-    return bb.xmin, bb.ymin, bb.zmin, bb.xmax, bb.ymax, bb.zmax
+
+    Return (xmin, ymin, zmin, xmax, ymax, zmax).
+    """
+    bbox = Bnd_Box()
+    BRepBndLib.Add_s(obj.wrapped, bbox, True)
+    bbox.SetGap(0.0)
+
+    xmin, ymin, zmin, xmax, ymax, zmax = bbox.Get()
+    return (xmin, ymin, zmin, xmax, ymax, zmax)
 
 
 def optimal_bounding_box(
@@ -1460,8 +1473,8 @@ def split_wire(
             if part_b:
                 edges_2.append(cq.Edge(part_b))
 
-    wire_1 = wire_from_wires(edges_1) if edges_1 else None
-    wire_2 = wire_from_wires(edges_2) if edges_2 else None
+    wire_1 = cq.Wire.assembleEdges(edges_1) if edges_1 else None
+    wire_2 = cq.Wire.assembleEdges(edges_2) if edges_2 else None
     return wire_1, wire_2
 
 

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -34,7 +34,6 @@ from OCP.BRepAlgoAPI import (
     BRepAlgoAPI_Section,
     BRepAlgoAPI_Splitter,
 )
-from OCP.BRepBndLib import BRepBndLib
 from OCP.BRepBuilderAPI import (
     BRepBuilderAPI_MakeEdge,
     BRepBuilderAPI_MakeFace,
@@ -53,7 +52,6 @@ from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.BRepOffsetAPI import BRepOffsetAPI_MakePipeShell, BRepOffsetAPI_ThruSections
 from OCP.BRepPrimAPI import BRepPrimAPI_MakePrism, BRepPrimAPI_MakeRevol
 from OCP.BRepTools import BRepTools_WireExplorer
-from OCP.Bnd import Bnd_Box
 from OCP.GCPnts import GCPnts_AbscissaPoint, GCPnts_UniformAbscissa
 from OCP.GProp import GProp_GProps
 from OCP.GeomAPI import GeomAPI_ProjectPointOnCurve, GeomAPI_ProjectPointOnSurf
@@ -1135,20 +1133,9 @@ def is_same(obj1: apiShape, obj2: apiShape) -> bool:
 
 
 def bounding_box(obj: apiShape) -> tuple[float, float, float, float, float, float]:
-    """
-    Implementation is identical to FreeCAD, although the default CadQuery function
-    is arguably better - should move back to it once FreeCAD is removed.
-
+    """Return (xmin, ymin, zmin, xmax, ymax, zmax)."""
     bb = obj.BoundingBox()
-
-    Return (xmin, ymin, zmin, xmax, ymax, zmax).
-    """
-    bbox = Bnd_Box()
-    BRepBndLib.Add_s(obj.wrapped, bbox, True)
-    bbox.SetGap(0.0)
-
-    xmin, ymin, zmin, xmax, ymax, zmax = bbox.Get()
-    return (xmin, ymin, zmin, xmax, ymax, zmax)
+    return bb.xmin, bb.ymin, bb.zmin, bb.xmax, bb.ymax, bb.zmax
 
 
 def optimal_bounding_box(

--- a/eudemo/eudemo_tests/maintenance/test_upper_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_upper_port.py
@@ -123,16 +123,24 @@ class TestDuctConnection:
 
         # is the bigger wire inside the smaller wire
         assert diff > 0
-
-        for no, (e1, e2) in enumerate(
+        once = twice = 0
+        for _no, (e1, e2) in enumerate(
             zip(
                 sorted(
                     xy.wires[0].edges,
-                    key=lambda x: (*tuple(-x.start_point().xy.flatten()), -x.length),
+                    key=lambda x: np.sum([
+                        *tuple(-x.start_point().y.flatten()),
+                        *tuple(-x.end_point().y.flatten()),
+                        -x.length,
+                    ]),
                 ),
                 sorted(
                     xy.wires[1].edges,
-                    key=lambda x: (*tuple(-x.start_point().xy.flatten()), -x.length),
+                    key=lambda x: np.sum([
+                        *tuple(-x.start_point().y.flatten()),
+                        *tuple(-x.end_point().y.flatten()),
+                        -x.length,
+                    ]),
                 ),
                 strict=False,
             )
@@ -143,10 +151,18 @@ class TestDuctConnection:
             assert np.isclose(cross_2d(v1, v2), 0)
 
             # Are they the right distance apart
-            if no in {0, 3}:
-                assert np.isclose(distance_to(e1, e2)[0], port_wall * 2)
-            else:
-                assert np.isclose(distance_to(e1, e2)[0], port_wall)
+            if np.isclose(distance_to(e1, e2)[0], port_wall * 2):
+                twice += 1
+            elif np.isclose(distance_to(e1, e2)[0], port_wall):
+                once += 1
+
+        if _no == 2:
+            assert once == 2
+            assert twice == 1
+        elif _no == 3:
+            assert once == twice == 2
+        else:
+            raise ValueError("Some wires are the wrong distance apart")
 
         o_sector, i_sector, o_wires, o_c = self._make_sectors(port_koz, angle)
 


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
This is not a great fix but it works locally with both backends.

We're try to match the sorting of both the inner and outer wires and check they are the right distance apart. This was reliably done by index before but now that doesnt seem to work (at least in my naiive attempts).

The sum of the y coordinate of the start and end and the length reliably gets the parallel wires but separating the distances is not trivial. Ideas welcomed..
## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
