### PR TITLE
Rollback feature branch to cadquery 2.7.0

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -38,7 +38,7 @@ dependencies:
   - vtk==9.3.1
   - libopenblas
   - pythonocc-core
-  - cadquery=2.8.0
+  - cadquery=2.7.0
   - nlopt=2.10.0
   - pip
   - pip:


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

This is due to some dependency bound clashing with fenics and FreeCAD on a couple of core C++ dependencies.

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
