### PR TITLE
Length computation of shapes corrected, now in par with the freecad c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+eudemo/results*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -733,17 +733,22 @@ def _wire_is_planar(wire: apiWire) -> bool:
 
 
 def length(obj: apiShape) -> float:
-    """Total length of the shape (sum of all edge lengths).
+    """Total arc length of the shape.
 
-    Sum per-edge ``Length()`` rather than the composite ``cq.Wire.Length()``:
-    on CadQuery 2.7 / OCP 7.8 the composite-curve adaptor used by
-    ``cq.Wire.Length()`` segfaults on certain wires assembled from
-    ``BRepAlgoAPI_Section`` output (short, near-degenerate edges). Per-edge
-    ``BRepAdaptor_Curve``-based length is equivalent and stable.
+    Sums each edge's length from OCCT ``BRepGProp.LinearProperties`` — accurate
+    to machine precision and consistent across geometry backends, which matters
+    for shape optimisers that are sensitive to small length differences.
+    Iterating edges, rather than measuring the whole wire, avoids OCCT's
+    composite-curve adaptor, which can segfault on near-degenerate
+    section-derived wires.
     """
-    if isinstance(obj, cq.Edge):
-        return obj.Length()
-    return sum(e.Length() for e in obj.Edges())
+    edges = [obj] if isinstance(obj, cq.Edge) else obj.Edges()
+    total = 0.0
+    for edge in edges:
+        props = GProp_GProps()
+        BRepGProp.LinearProperties_s(edge.wrapped, props)
+        total += props.Mass()
+    return total
 
 
 def _occ_face_area(topods_face) -> float:

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -1597,3 +1597,47 @@ class TestCurves:
         # edge1's last point and edge2's first point are both (1, 0, 0).
         with pytest.raises(CadQueryError, match="identical endpoints"):
             cadapi.make_bspline_g1_blend(edge1, edge2)
+
+
+class TestPropertyAccuracy:
+    """``length`` matches the true arc length to machine precision.
+
+    Guards the per-edge ``BRepGProp`` length against a high-accuracy reference
+    (a quadrature of the arc-length integral) and the closed-form circle case.
+    """
+
+    # A cubic Bezier (no closed-form arc length) in the xz-plane.
+    CTRL_XZ = ((4.0, 2.0), (6.5, 5.5), (11.0, 4.0), (12.0, -1.0))
+
+    @classmethod
+    def _bezier(cls):
+        return cadapi.make_bezier([[x, 0.0, z] for x, z in cls.CTRL_XZ])
+
+    @classmethod
+    def _bezier_arc_length(cls):
+        # Independent ground truth: adaptive quadrature of the speed |B'(t)|.
+        from scipy.integrate import quad  # noqa: PLC0415
+
+        p = np.asarray(cls.CTRL_XZ, dtype=float)
+
+        def speed(t):
+            d = (
+                3 * (1 - t) ** 2 * (p[1] - p[0])
+                + 6 * (1 - t) * t * (p[2] - p[1])
+                + 3 * t**2 * (p[3] - p[2])
+            )
+            return float(np.hypot(*d))
+
+        value, _ = quad(speed, 0.0, 1.0, epsabs=1e-12, epsrel=1e-12)
+        return value
+
+    def test_bezier_length_matches_arc_length_integral(self):
+        # length must match the true arc-length integral to ~1e-8.
+        assert cadapi.length(self._bezier()) == pytest.approx(
+            self._bezier_arc_length(), rel=1e-7
+        )
+
+    def test_circle_length_is_exact(self):
+        # A circle's length equals its closed-form circumference 2*pi*r.
+        circle = cadapi.make_circle(radius=3.0, axis=(0, 1, 0))
+        assert cadapi.length(circle) == pytest.approx(2 * np.pi * 3.0, rel=1e-12)


### PR DESCRIPTION
…alculation using OCCTs BRepGProp.LinearProperties.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
