### PR TITLE
fix(geometry): keep dominant face when hole cut yields disjoint pieces

### DIFF
--- a/bluemira/geometry/face.py
+++ b/bluemira/geometry/face.py
@@ -13,12 +13,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import bluemira.codes._geometryapi as cadapi
-
-# import from bluemira
+from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.geometry.base import BluemiraGeo
 from bluemira.geometry.coordinates import Coordinates
-
-# import from error
 from bluemira.geometry.error import DisjointedFaceError, NotClosedWireError
 from bluemira.geometry.wire import BluemiraWire
 
@@ -133,7 +130,7 @@ class BluemiraFace(BluemiraGeo):
         Raises
         ------
         DisjointedFaceError
-            More than 1 face created
+            Cutting the holes produced no face
         """
         external: BluemiraWire = self.boundary[0]
         face = cadapi.apiFace(external._create_wire(check_reverse=False))
@@ -141,10 +138,23 @@ class BluemiraFace(BluemiraGeo):
         if len(self.boundary) > 1:
             fholes = [cadapi.apiFace(h.shape) for h in self.boundary[1:]]
             _faces = cadapi.face_cut_holes(face, fholes)
-            if len(_faces) == 1:
-                face = _faces[0]
-            else:
-                raise DisjointedFaceError("Any or more than one face has been created.")
+            if not _faces:
+                raise DisjointedFaceError("Cutting the holes produced no face.")
+            if len(_faces) > 1:
+                # Cutting the holes pinched the region into disjoint pieces
+                # (typically an inner boundary protruding past the outer one).
+                # Keep the dominant face rather than crashing, but warn so the
+                # suspect input geometry is not silently accepted.
+                _faces = sorted(_faces, key=cadapi.area, reverse=True)
+                discarded = sum(cadapi.area(f) for f in _faces[1:])
+                bluemira_warn(
+                    f"BluemiraFace: cutting holes produced {len(_faces)} disjoint "
+                    f"faces; keeping the largest (area {cadapi.area(_faces[0]):.4g}) "
+                    f"and discarding {len(_faces) - 1} fragment(s) totalling "
+                    f"{discarded:.4g}. An inner boundary likely protrudes past the "
+                    "outer boundary."
+                )
+            face = _faces[0]
 
         if not cadapi.is_valid(face):
             cadapi.fix_shape(face)

--- a/tests/geometry/test_face.py
+++ b/tests/geometry/test_face.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
+from bluemira.codes import _geometryapi as cadapi
 from bluemira.geometry.coordinates import Coordinates
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import (
@@ -86,6 +87,56 @@ class TestBluemiraFace:
         face = BluemiraFace(wire)
         vertices = face.vertexes
         assert len(vertices) == len(points) - 1
+
+
+class TestFaceWithProtrudingHole:
+    """Face-with-hole where the inner wire protrudes past the outer boundary.
+
+    Reproduces the EUDEMO demo crash on the CadQuery backend: the
+    ``WallSilhouetteDesigner`` optimisation converged to a wall whose IVC
+    boundary no longer enclosed the divertor, so ``plasma_facing_wire``
+    protruded ~0.25 m below ``ivc_boundary``. The boolean cut then pinches off
+    a tiny sliver, so ``face_cut_holes`` returns >1 face. ``_create_face`` now
+    keeps the dominant face and warns rather than raising ``DisjointedFaceError``.
+
+    Not a geometry-backend bug: FreeCAD's ``Part.cut`` yields the same two
+    faces on the identical geometry. The root cause is upstream optimiser
+    brittleness; keeping the dominant face is defence-in-depth.
+
+    The geometry here is a minimal stand-in: an outer box with a narrow
+    downward spike whose tip a hole cuts straight across, pinching it off.
+    """
+
+    @staticmethod
+    def _outer() -> BluemiraWire:
+        return make_polygon(
+            {"x": [-5, 5, 5, 0.5, 0, -0.5, -5], "z": [5, 5, -4, -4, -6, -4, -4]},
+            closed=True,
+        )
+
+    @staticmethod
+    def _hole() -> BluemiraWire:
+        return make_polygon(
+            {"x": [-0.4, 0.4, 0.4, -0.4], "z": [-3, -3, -5, -5]}, closed=True
+        )
+
+    def test_cut_pinches_off_a_sliver_face(self):
+        # Characterises the mechanism: the cut yields a dominant face plus a
+        # small isolated sliver (true on both geometry backends).
+        faces = cadapi.face_cut_holes(
+            cadapi.apiFace(self._outer().shape), [cadapi.apiFace(self._hole().shape)]
+        )
+        areas = sorted(BluemiraFace._create(f).area for f in faces)
+        assert len(faces) == 2
+        assert areas[0] < 1.0  # the sliver
+        assert areas[1] > 80.0  # the dominant face
+
+    def test_face_from_protruding_hole_keeps_dominant_and_warns(self, caplog):
+        # _create_face keeps the dominant face (not the sliver) instead of
+        # crashing, and warns that a fragment was discarded.
+        face = BluemiraFace([self._outer(), self._hole()])
+        assert face.area == pytest.approx(89.24, abs=0.5)
+        assert "protrudes past the outer boundary" in caplog.text
 
 
 class TestNormalAt:


### PR DESCRIPTION
When an inner boundary protrudes past the outer one, the boolean cut pinches off extra sliver faces. _create_face now keeps the largest face and warns (reporting the discarded area) instead of raising DisjointedFaceError,▎ while still raising when no face is produced. Fixes the EUDEMO CadQuery demo crash in PlasmaFaceDesigner.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
