### PR TITLE
fix(eudemo): relax PF coil split tolerance to EPS_FREECAD

### DIFF
--- a/eudemo/eudemo/pf_coils/tools.py
+++ b/eudemo/eudemo/pf_coils/tools.py
@@ -8,11 +8,10 @@
 import numpy as np
 import numpy.typing as npt
 
-from bluemira.base.constants import EPS
 from bluemira.base.error import BuilderError
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.coils import Coil, CoilSet
-from bluemira.geometry.constants import VERY_BIG
+from bluemira.geometry.constants import EPS_FREECAD, VERY_BIG
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import (
     boolean_cut,
@@ -348,9 +347,9 @@ def _split_segment(segment, split_positions) -> list[BluemiraWire]:
     """
     sub_segs = []
     for split_pos in split_positions:
-        split = segment.parameter_at(split_pos, tolerance=10 * EPS)
+        split = segment.parameter_at(split_pos, tolerance=EPS_FREECAD)
         sub_seg_1, segment = split_wire(
-            segment, segment.value_at(alpha=split), tolerance=10 * EPS
+            segment, segment.value_at(alpha=split), tolerance=EPS_FREECAD
         )
         if sub_seg_1:
             sub_segs.append(sub_seg_1)


### PR DESCRIPTION
_split_segment checked the value_at→parameter_at round-trip at 10*EPS (~2e-15), below OCCT's achievable precision. EPS_FREECAD is the standard geometric tolerance and the parameter_at default.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
