### PR TITLE
Fix mislabelled f_n_* neutron power fraction long_names

### DIFF
--- a/eudemo/config/params.json
+++ b/eudemo/config/params.json
@@ -1315,21 +1315,21 @@
     "value": 0.1,
     "unit": "",
     "source": "Input",
-    "long_name": "Fraction of neutron power that goes into the blanket",
+    "long_name": "Fraction of neutron power that goes into the divertor",
     "description": "Used in 0-D neutronics model"
   },
   "f_n_vessel": {
     "value": 0.04,
     "unit": "",
     "source": "Input",
-    "long_name": "Fraction of neutron power that goes into the blanket",
+    "long_name": "Fraction of neutron power that goes into the vacuum vessel",
     "description": "Used in 0-D neutronics model"
   },
   "f_n_aux": {
     "value": 0.05,
     "unit": "",
     "source": "Input",
-    "long_name": "Fraction of neutron power that goes into the blanket",
+    "long_name": "Fraction of neutron power that goes into auxiliary systems",
     "description": "Used in 0-D neutronics model"
   },
   "tk_bb_fw_ib": {


### PR DESCRIPTION
## Description

f_n_divertor, f_n_vessel and f_n_aux all carried f_n_blanket's long_name (\"Fraction of neutron power that goes into the blanket\") — a copy-paste artifact. The long_names now match the code.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
