### PR TITLE
proposal to solve boolean fuse problems for faces with flipped orientation

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -1594,28 +1594,75 @@ def extrude_shape(shape: apiShape, vec) -> apiShape:
 # ---------------------------------------------------------------------------
 
 
+def _face_normal(face: apiFace) -> np.ndarray:
+    """Oriented unit normal of a planar face (accounts for face orientation)."""
+    normal = normal_at(face)
+    if face.wrapped.Orientation() == TopAbs_REVERSED:
+        normal = -normal
+    return normal
+
+
+def _align_faces_coaxis(faces: list) -> list:
+    """Reverse planar faces whose normal is anti-parallel to the first face.
+
+    OCC's boolean fuse treats coplanar faces of opposite orientation as separate
+    domains and refuses to merge them, yielding a multi-face compound. Faces built
+    from boolean results routinely come out with a flipped normal relative to plain
+    polygons, so we align them first — mirroring the FreeCAD backend's
+    ``_make_shapes_coaxis``. Already-aligned inputs are returned unchanged.
+    """
+    ref = _face_normal(faces[0])
+    aligned = [faces[0]]
+    reversed_any = False
+    for face in faces[1:]:
+        if np.dot(_face_normal(face), ref) < 0:
+            aligned.append(reverse_shape(face))
+            reversed_any = True
+        else:
+            aligned.append(face)
+    if reversed_any:
+        bluemira_warn(
+            "Boolean fuse on faces that are not co-axis. Reversing to align normals."
+        )
+    return aligned
+
+
+def _merge_fused_faces(result: apiShape, shapes: list) -> apiShape:
+    """Collapse a compound of fused coplanar faces into a single face.
+
+    Overlapping co-axis faces merge via UnifySameDomain; faces that merely touch
+    at an edge need sewing first to establish shared edges. Returns the merged
+    face, or the unchanged compound if neither approach yields a single face.
+    """
+    unified = _unify_same_domain(result)
+    if isinstance(unified, cq.Face):
+        return unified
+    unified_faces = _collect_subshapes(unified, cq.Face)
+    if len(unified_faces) == 1:
+        return unified_faces[0]
+    out = shapes
+    for _ in range(2):
+        out = _sew_shapes(out)
+        if isinstance(out, cq.Face):
+            return out
+        sewn_faces = _collect_subshapes(out, cq.Face)
+        if len(sewn_faces) == 1:
+            return sewn_faces[0]
+    return result
+
+
 def boolean_fuse(shapes: list, *, remove_splitter: bool = True) -> apiShape:
     """Boolean union of a list of shapes."""
     if not isinstance(shapes, list):
         raise TypeError(f"{shapes} is not a list.")
     if len(shapes) < 2:  # noqa: PLR2004
         raise ValueError("At least 2 shapes required.")
+    if all(isinstance(s, cq.Face) for s in shapes):
+        shapes = _align_faces_coaxis(shapes)
     result = shapes[0].fuse(*shapes[1:])
 
     if all(isinstance(s, cq.Face) for s in shapes) and isinstance(result, cq.Compound):
-        out = shapes
-        for _ in range(2):
-            out = _sew_shapes(out)
-            if isinstance(out, cq.Face):
-                result = out
-                break
-            unified_faces = _collect_subshapes(out, cq.Face)
-            if len(unified_faces) == 1:
-                out = unified_faces[0]
-                if isinstance(out, cq.Face):
-                    result = out
-                    break
-
+        result = _merge_fused_faces(result, shapes)
     elif remove_splitter:
         result = _unify_same_domain(result)
 

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -1010,19 +1010,59 @@ class TestInternalHelpers:
         assert len(unified.Edges()) == len(clean.Edges())
 
     @patch(f"{CORE}.bluemira_warn")
-    @patch(f"{CORE}.ShapeUpgrade_UnifySameDomain")
-    def test_unify_same_domain_exception(self, mock_unify, mock_warn):
-        """Exceptions are caught."""
-        unifier = MagicMock()
-        unifier.Build.side_effect = RuntimeError("Fake Error")
-        mock_unify.return_value = unifier
+    def test_unify_same_domain_exception(self, mock_warn):
+        """A failure in clean() is caught and the input shape returned unchanged."""
+        shape = MagicMock()
+        shape.clean.side_effect = RuntimeError("Fake Error")
 
-        box = _make_box()
-        result = cadapi._unify_same_domain(box)
+        result = cadapi._unify_same_domain(shape)
 
         mock_warn.assert_called_once()
         assert "UnifySameDomain failed" in mock_warn.call_args[0][0]
-        assert result is box
+        assert result is shape
+
+    # ---- _align_faces_coaxis / co-axis boolean_fuse -----------------------------
+
+    @staticmethod
+    def _xz_face(pts):
+        """Planar face in the xz-plane from a list of (x, 0, z) points."""
+        return cadapi.make_face(cadapi.make_polygon(pts).close())
+
+    def test_align_faces_coaxis_reverses_antiparallel(self):
+        """A face whose normal is anti-parallel to the first is reversed to match."""
+        a = self._xz_face([[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]])
+        b = self._xz_face([[1, 0, 1], [1, 0, 3], [3, 0, 3], [3, 0, 1]])
+        assert np.dot(cadapi.normal_at(a), cadapi.normal_at(b)) < 0
+
+        aligned = cadapi._align_faces_coaxis([a, b])
+        ref = cadapi._face_normal(aligned[0])
+        assert np.dot(cadapi._face_normal(aligned[1]), ref) > 0
+
+    def test_align_faces_coaxis_leaves_aligned_unchanged(self):
+        """Already co-axis faces are returned unchanged (same objects, no reversal)."""
+        a = self._xz_face([[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]])
+        b = self._xz_face([[1, 0, 0], [3, 0, 0], [3, 0, 2], [1, 0, 2]])
+        assert np.dot(cadapi.normal_at(a), cadapi.normal_at(b)) > 0
+
+        aligned = cadapi._align_faces_coaxis([a, b])
+        assert aligned[0] is a
+        assert aligned[1] is b
+
+    def test_boolean_fuse_faces_opposite_normals_single_face(self):
+        """Overlapping coplanar faces with anti-parallel normals fuse to one face.
+
+        Regression: faces built from boolean results come out with a flipped
+        normal relative to plain polygons (e.g. the lower-port KOZ vs the
+        upper/eq-port KOZs). OCC's fuse then yields a multi-face compound and
+        boolean_fuse used to raise "gives more than one face".
+        """
+        a = self._xz_face([[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]])
+        b = self._xz_face([[1, 0, 1], [1, 0, 3], [3, 0, 3], [3, 0, 1]])
+        assert np.dot(cadapi.normal_at(a), cadapi.normal_at(b)) < 0
+
+        fused = cadapi.boolean_fuse([a, b])
+        assert isinstance(fused, cq.Face)
+        assert len(fused.Faces()) == 1
 
     # ---- _assemble_wires_from_edges -----------------------------------------------
 


### PR DESCRIPTION
The CadQuery backend's boolean_fuse produced a multi-face compound ("gives
more than one face") for coplanar faces whose normals are anti-parallel.

Mirror the FreeCAD backend's _make_shapes_coaxis: reverse anti-parallel faces
to a common normal before fusing, then collapse the overlap via clean().
The sew pass stays as a fallback for edge-only-touching faces.

Includes regression tests and updates the stale _unify_same_domain exception
test to the clean() path.