### PR TITLE
guard boolean_fuse coaxis alignment to planar faces only

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -1620,7 +1620,14 @@ def _align_faces_coaxis(faces: list) -> list:
     from boolean results routinely come out with a flipped normal relative to plain
     polygons, so we align them first — mirroring the FreeCAD backend's
     ``_make_shapes_coaxis``. Already-aligned inputs are returned unchanged.
+
+    Coaxis alignment only makes sense for planar faces: a curved face has no single
+    normal, so ``_face_normal`` (sampled at one point) can't judge its orientation.
+    If any face is non-planar the list is returned untouched, matching FreeCAD's
+    ``findPlane``-based check which applies only to planar shapes.
     """
+    if not all(face.geomType() == "PLANE" for face in faces):
+        return faces
     ref = _face_normal(faces[0])
     aligned = [faces[0]]
     reversed_any = False

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -1048,6 +1048,25 @@ class TestInternalHelpers:
         assert aligned[0] is a
         assert aligned[1] is b
 
+    def test_align_faces_coaxis_skips_non_planar(self):
+        """One non-planar face disables alignment for the whole list.
+
+        ``_face_normal`` samples the normal at one point; on a curved face that is
+        a meaningless coaxis criterion, so alignment is skipped. ``a`` and ``b`` are
+        anti-parallel (would normally be reversed to match) — the curved face is
+        what keeps ``b`` untouched here.
+        """
+        a = self._xz_face([[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]])
+        b = self._xz_face([[1, 0, 1], [1, 0, 3], [3, 0, 3], [3, 0, 1]])
+        assert np.dot(cadapi._face_normal(a), cadapi._face_normal(b)) < 0
+        curved = next(
+            f for f in cq.Solid.makeCylinder(1.0, 2.0).Faces() if f.geomType() != "PLANE"
+        )
+        aligned = cadapi._align_faces_coaxis([a, b, curved])
+        assert aligned[0] is a
+        assert aligned[1] is b  # not reversed — the curved face disabled alignment
+        assert aligned[2] is curved
+
     def test_boolean_fuse_faces_opposite_normals_single_face(self):
         """Overlapping coplanar faces with anti-parallel normals fuse to one face.
 


### PR DESCRIPTION
Follow-up to #4418: `_align_faces_coaxis` judges orientation from `normal_at` (a normal
sampled at one point), which is only meaningful for planar faces. This skips alignment
if any input face is non-planar (`geomType() != "PLANE"`) - mirroring FreeCAD's
`findPlane`-based check. 

It's a **no-op** for the all-planar fuses the reactor actually performs,  so the behaviour
on the EUDEMO demo is unchanged.

Let me know if there's anything else open...