### PR TITLE
fix(cad): don't let splitter removal corrupt spline-bounded solids

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -1606,15 +1606,34 @@ def _merge_fused_faces(result: apiShape, shapes: list) -> apiShape:
     unified_faces = _collect_subshapes(unified, cq.Face)
     if len(unified_faces) == 1:
         return unified_faces[0]
-    out = shapes
-    for _ in range(2):
-        out = _sew_shapes(out)
-        if isinstance(out, cq.Face):
-            return out
-        sewn_faces = _collect_subshapes(out, cq.Face)
-        if len(sewn_faces) == 1:
-            return sewn_faces[0]
+    sewn_shapes = _sew_shapes(shapes)
+    if isinstance(sewn_shapes, cq.Face):
+        return sewn_shapes
+    sewn_faces = _collect_subshapes(sewn_shapes, cq.Face)
+    if len(sewn_faces) == 1:
+        return sewn_faces[0]
     return result
+
+
+def _sew_shapes(s_to_sew, tolerance=1e-5):
+    # OCC's fuse on faces that merely touch at an edge produces a Compound
+    # of disconnected faces — UnifySameDomain can't merge them because they
+    # don't share any TopoDS edge. Sew the inputs first to establish edge
+    # sharing, then unify to collapse coplanar neighbours into one face.
+    sewing = BRepBuilderAPI_Sewing(tolerance)
+    for s in s_to_sew:
+        sewing.Add(s.wrapped)
+    sewing.Perform()
+    return _unify_same_domain(cq.Shape.cast(sewing.SewedShape()))
+
+
+def _unify_same_domain(shape: apiShape) -> apiShape:
+    """Merge coplanar connected faces and collinear edges via OCC UnifySameDomain."""
+    try:
+        return shape.clean()
+    except Exception as exc:  # noqa: BLE001
+        bluemira_warn(f"UnifySameDomain failed: {exc}")
+        return shape
 
 
 def boolean_fuse(shapes: list, *, remove_splitter: bool = True) -> apiShape:
@@ -1630,7 +1649,7 @@ def boolean_fuse(shapes: list, *, remove_splitter: bool = True) -> apiShape:
     if all(isinstance(s, cq.Face) for s in shapes) and isinstance(result, cq.Compound):
         result = _merge_fused_faces(result, shapes)
     elif remove_splitter:
-        result = _unify_same_domain(result)
+        result = _remove_splitter(result)
 
     # For wire inputs: OCC fuse returns a compound; try to assemble a single wire.
     if all(isinstance(s, cq.Wire) for s in shapes):
@@ -1678,25 +1697,38 @@ def boolean_fuse(shapes: list, *, remove_splitter: bool = True) -> apiShape:
     return result
 
 
-def _sew_shapes(s_to_sew, tolerance=1e-5):
-    # OCC's fuse on faces that merely touch at an edge produces a Compound
-    # of disconnected faces — UnifySameDomain can't merge them because they
-    # don't share any TopoDS edge. Sew the inputs first to establish edge
-    # sharing, then unify to collapse coplanar neighbours into one face.
-    sewing = BRepBuilderAPI_Sewing(tolerance)
-    for s in s_to_sew:
-        sewing.Add(s.wrapped)
-    sewing.Perform()
-    return _unify_same_domain(cq.Shape.cast(sewing.SewedShape()))
+def _remove_splitter(shape: apiShape) -> apiShape:
+    """Drop the splitter faces and edges a boolean leaves behind.
 
+    Tidying up is optional; a correct shape is not. On solids bounded by spline
+    faces the underlying ``UnifySameDomain`` can merge faces it should not and
+    return a shape that fails ``BRepCheck`` and reports a nonsense volume, which
+    downstream is worse than the splitters it removed: the next boolean either
+    yields garbage or dies on a null shape. So refuse a result that is invalid
+    when the input was not.
 
-def _unify_same_domain(shape: apiShape) -> apiShape:
-    """Merge coplanar connected faces and collinear edges via OCC UnifySameDomain."""
+    The guard covers solids only. On faces this same tidy-up doubles as a repair
+    step -- a fused compound of coplanar faces can fail ``isValid`` both before
+    and after while still merging into the one face the caller needs -- so there
+    validity is not a signal that anything went wrong.
+
+    Returns
+    -------
+    :
+        The tidied shape, or the original if tidying failed or broke it.
+    """
     try:
-        return shape.clean()
+        cleaned = shape.clean()
     except Exception as exc:  # noqa: BLE001
-        bluemira_warn(f"UnifySameDomain failed: {exc}")
+        bluemira_warn(f"Splitter removal failed: {exc}")
         return shape
+    has_solids = TopExp_Explorer(shape.wrapped, TopAbs_SOLID).More()
+    if has_solids and shape.isValid() and not cleaned.isValid():
+        bluemira_warn(
+            "Splitter removal turned a valid solid invalid; keeping the split one."
+        )
+        return shape
+    return cleaned
 
 
 def _assemble_wires_from_edges(edges: list) -> list:

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -622,32 +622,6 @@ def _sewn_solid(solid: apiSolid, tolerance: float = 1e-3) -> apiSolid:
     return new_solid
 
 
-def _fix_offset_orientation(wire: apiWire, result: apiWire) -> apiWire:
-    """
-    CadQuery has been known to reverse the orientation of wires input to
-    offset2D. This function re-orients the result wire so that it is the
-    same as the original wire.
-    """
-    orig_ori = wire.wrapped.Orientation()
-    res_ori = result.wrapped.Orientation()
-
-    if orig_ori != res_ori:
-        raw_edges = list(result)
-        raw_edges.reverse()
-
-        builder = BRepBuilderAPI_MakeWire()
-        for e in raw_edges:
-            reversed_shape = e.wrapped.Reversed()
-            reversed_edge = TopoDS.Edge_s(reversed_shape)
-            builder.Add(reversed_edge)
-
-        if builder.IsDone():
-            result = cq.Wire(builder.Wire())
-        else:
-            result = cq.Wire(result.wrapped.Reversed())
-    return result
-
-
 def offset_wire(
     wire: apiWire,
     thickness: float,
@@ -720,7 +694,7 @@ def offset_wire(
     if not open_wire and not result.IsClosed():
         raise CadQueryError("offset failed to close wire")
 
-    return _fix_offset_orientation(wire, result)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1493,35 +1467,10 @@ def split_wire(
             d1 = p1.SquareDistance(pnt)
             t_split = t0 if d0 <= d1 else t1
         t_split = max(t0, min(t1, t_split))
-        is_reversed = e.wrapped.Orientation() == TopAbs_REVERSED
-
-        part_a = None
-        part_b = None
-
         if t_split - t0 > _ANGLE_PARALLEL_TOL:
-            part_a = BRepBuilderAPI_MakeEdge(curve, t0, t_split).Edge()
+            edges_1.append(cq.Edge(BRepBuilderAPI_MakeEdge(curve, t0, t_split).Edge()))
         if t1 - t_split > _ANGLE_PARALLEL_TOL:
-            part_b = BRepBuilderAPI_MakeEdge(curve, t_split, t1).Edge()
-
-        # reverse part orientations if the parent edge was reversed
-        if is_reversed:
-            if part_a:
-                part_a.Orientation(TopAbs_REVERSED)
-            if part_b:
-                part_b.Orientation(TopAbs_REVERSED)
-
-        if is_reversed:
-            # t1 -> t0 so part_b is first
-            if part_b:
-                edges_1.append(cq.Edge(part_b))
-            if part_a:
-                edges_2.append(cq.Edge(part_a))
-        else:
-            # t0 -> t1 so part_a is first
-            if part_a:
-                edges_1.append(cq.Edge(part_a))
-            if part_b:
-                edges_2.append(cq.Edge(part_b))
+            edges_2.append(cq.Edge(BRepBuilderAPI_MakeEdge(curve, t_split, t1).Edge()))
 
     wire_1 = cq.Wire.assembleEdges(edges_1) if edges_1 else None
     wire_2 = cq.Wire.assembleEdges(edges_2) if edges_2 else None

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -21,6 +21,7 @@ from bluemira.base.error import BuilderError
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
 from bluemira.builders.tools import apply_component_display_options
 from bluemira.display.palettes import BLUE_PALETTE
+from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import (
     boolean_fragments,
@@ -585,6 +586,11 @@ def pipe_pipe_join(
     void:
         Solid of the joined pipe-pipe void
 
+    Raises
+    ------
+    GeometryError
+        If the target and tool do not intersect.
+
     Notes
     -----
     This approach is more brittle than a classic fuse, fuse, cut operation, but is
@@ -592,6 +598,13 @@ def pipe_pipe_join(
     are to be expected.
     """
     _, (target_fragments, tool_fragments) = boolean_fragments([target_shape, tool_shape])
+
+    if not target_fragments or not tool_fragments:
+        raise GeometryError(
+            "pipe_pipe_join: the target and tool do not intersect, so there is "
+            "nothing to join. A port aimed at a hole an earlier port already cut "
+            "will do this."
+        )
 
     # Keep the largest piece of the target by volume (opinionated)
     # This is in case its COG is inside the tool void

--- a/eudemo/eudemo_tests/maintenance/test_duct_connection.py
+++ b/eudemo/eudemo_tests/maintenance/test_duct_connection.py
@@ -4,11 +4,22 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import numpy as np
 import pytest
 
+from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
-from bluemira.geometry.tools import boolean_fuse, extrude_shape, make_circle
-from eudemo.maintenance.duct_connection import pipe_pipe_join
+from bluemira.geometry.tools import (
+    boolean_fuse,
+    extrude_shape,
+    interpolate_bspline,
+    make_circle,
+    revolve_shape,
+)
+from eudemo.maintenance.duct_connection import (
+    make_equatorial_port_yz_face,
+    pipe_pipe_join,
+)
 
 
 class TestPipePipeJoin:
@@ -30,3 +41,76 @@ class TestPipePipeJoin:
         new_shape_pieces = pipe_pipe_join(self.target, self.target_void, tool, tool_void)
         n_actual = len(boolean_fuse(new_shape_pieces).faces)
         assert n_actual == n_faces
+
+
+class TestPipePipeJoinSplineVessel:
+    """Port joins onto a spline-bounded vessel, port after port.
+
+    The reactor adds every port to the *accumulated* result (see
+    ``VacuumVessel.add_ports``), so each join works on a busier shape than the
+    last. On a vessel whose wall is a B-spline -- which is what
+    ``VacuumVesselBuilder`` produces -- the tidy-up inside ``boolean_fuse``
+    used to return a corrupt solid: negative volume, no error raised, and the
+    *next* join then died on an invalid compound. Cylindrical or polygonal
+    vessels never showed it, hence the spline here.
+    """
+
+    X_C, SECTOR = 7.5, 22.5  # torus centre [m], sector angle [deg]
+    # Reference volumes after 1, 2 and 3 ports; equal on both CAD backends.
+    EXPECTED_VOLUMES = (30.51961, 31.01216, 31.50472)
+
+    @classmethod
+    def _spline_loop(cls, radius):
+        angle = np.linspace(0, 2 * np.pi, 120, endpoint=False)
+        return interpolate_bspline(
+            {
+                "x": cls.X_C + radius * np.cos(angle),
+                "y": 0.0,
+                "z": radius * np.sin(angle),
+            },
+            closed=True,
+        )
+
+    @classmethod
+    def _vessel(cls):
+        outer, inner = cls._spline_loop(3.0), cls._spline_loop(2.4)
+        return (
+            revolve_shape(BluemiraFace([outer, inner]), degree=cls.SECTOR),
+            revolve_shape(BluemiraFace(inner), degree=cls.SECTOR),
+        )
+
+    @classmethod
+    def _port(cls, z_position, x_end=15.0):
+        yz_face = make_equatorial_port_yz_face(
+            x_end, -0.6, 0.6, z_position - 0.5, z_position + 0.5, 0.06
+        )
+        vec = (cls.X_C - x_end, 0, 0)
+        shape = extrude_shape(yz_face, vec)
+        void = extrude_shape(BluemiraFace(yz_face.boundary[1]), vec)
+        shape.rotate(degree=0.5 * cls.SECTOR)
+        void.rotate(degree=0.5 * cls.SECTOR)
+        return shape, void
+
+    def test_sequential_joins_stay_valid(self):
+        target, target_void = self._vessel()
+
+        for z_position, expected in zip(
+            (0.0, 1.5, -1.5), self.EXPECTED_VOLUMES, strict=True
+        ):
+            tool, tool_void = self._port(z_position)
+            pieces = pipe_pipe_join(target, target_void, tool, tool_void)
+            target = boolean_fuse(pieces)
+
+            assert target.is_valid()
+            assert len(target.solids) == 1
+            # A corrupt fuse still reports is_valid(); the volume is what gives
+            # it away, so assert the value rather than just its sign.
+            assert target.volume == pytest.approx(expected, abs=1e-4)
+
+    def test_non_intersecting_port_raises(self):
+        """A port that misses the vessel says so, rather than IndexError-ing."""
+        target, target_void = self._vessel()
+        tool, tool_void = self._port(9.0)  # well above the vessel
+
+        with pytest.raises(GeometryError, match="do not intersect"):
+            pipe_pipe_join(target, target_void, tool, tool_void)

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -1083,6 +1083,62 @@ class TestInternalHelpers:
         assert isinstance(fused, cq.Face)
         assert len(fused.Faces()) == 1
 
+    # ---- _remove_splitter --------------------------------------------------
+
+    def test_remove_splitter_merges_coplanar_faces(self):
+        """The splitter faces left by a fuse are removed."""
+        box1 = _make_box()
+        box2 = cadapi.translate_shape(_make_box(), (1, 0, 0))
+        split = box1.fuse(box2)
+        assert len(split.Faces()) > 6
+
+        assert len(cadapi._remove_splitter(split).Faces()) == 6
+
+    @patch(f"{CORE}.bluemira_warn")
+    def test_remove_splitter_rejects_invalid_solid(self, mock_warn):
+        """A tidy-up that breaks a valid solid is discarded.
+
+        OCC's UnifySameDomain can merge faces of a spline-bounded solid that it
+        should not and hand back a shape that fails BRepCheck with a nonsense
+        volume. Splitter faces are cosmetic; a corrupt solid is not.
+        """
+        solid = _make_box()
+        broken = MagicMock()
+        broken.isValid.return_value = False
+
+        with patch.object(type(solid), "clean", return_value=broken):
+            result = cadapi._remove_splitter(solid)
+
+        mock_warn.assert_called_once()
+        assert "invalid" in mock_warn.call_args[0][0]
+        assert result is solid
+
+    def test_remove_splitter_guard_does_not_apply_to_faces(self):
+        """On faces an invalid tidy-up is the repair, not a failure.
+
+        Fusing coplanar faces yields a compound that fails ``isValid`` before and
+        after unification while still merging into the single face the caller
+        needs; guarding that away would break the merge.
+        """
+        face = _make_box().Faces()[0]
+        cleaned = MagicMock()
+        cleaned.isValid.return_value = False
+
+        with patch.object(type(face), "clean", return_value=cleaned):
+            assert cadapi._remove_splitter(face) is cleaned
+
+    @patch(f"{CORE}.bluemira_warn")
+    def test_remove_splitter_exception(self, mock_warn):
+        """A failure in clean() warns and returns the shape unchanged."""
+        solid = _make_box()
+
+        with patch.object(type(solid), "clean", side_effect=RuntimeError("Fake Error")):
+            result = cadapi._remove_splitter(solid)
+
+        mock_warn.assert_called_once()
+        assert "Splitter removal failed" in mock_warn.call_args[0][0]
+        assert result is solid
+
     # ---- _assemble_wires_from_edges -----------------------------------------------
 
     def test_assemble_wires_from_edges_empty(self):


### PR DESCRIPTION
## Description

boolean_fuse tidies its result with ShapeUpgrade_UnifySameDomain (via cadquery's clean()). On a solid bounded by B-spline surfaces that can merge faces it should not, returning a shape that fails BRepCheck and reports a nonsense volume -- observed: -1146 m^3 for a 31 m^3 solid -- while the shallow isValid() still passes. boolean_fuse then extracts that solid from the broken compound, where isValid() passes again, and hands it to the caller. The next boolean either yields garbage or dies on a null shape.

Move the tidy-up into _remove_splitter, which refuses a result that is invalid when the input was not. Splitter faces are cosmetic; a corrupt solid is not. Repairing was not an option: the unified shape's volume is wrong (32.83 vs 31.01), so geometry had been merged away and ShapeFix would only have made it valid-and-still-wrong. The guard is solids-only -- on faces the same tidy-up doubles as a repair step and an unscoped guard breaks StraightOISDesigner. The bare contextlib.suppress(Exception) becomes a warning: still never raises, but no longer silent.

Surfaced by EUDEMO's VacuumVessel.add_ports, which joins port after port onto the accumulated result. Cylindrical and polygonal vessels never showed it; the real vessel wall is a spline (600-point discretise plus force_wire_to_spline), which is why this only ever bit complex geometry.

Also raise a clear GeometryError in pipe_pipe_join when the target and tool do not intersect, instead of an unguarded target_fragments[0] IndexError.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
