### PR TITLE
LAR improvement: Join all ports in one boolean pass instead of one at a time

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -31,6 +31,7 @@ from OCP.BRepAdaptor import (
 from OCP.BRepAlgoAPI import (
     BRepAlgoAPI_BuilderAlgo,
     BRepAlgoAPI_Check,
+    BRepAlgoAPI_Common,
     BRepAlgoAPI_Section,
     BRepAlgoAPI_Splitter,
 )
@@ -1928,6 +1929,41 @@ def boolean_cut(shape: apiShape, tools: list, *, split: bool = True) -> list[api
     return [result]
 
 
+def boolean_common(shape: apiShape, tools: list) -> list[apiShape]:
+    """Boolean intersection — return list of result shapes.
+
+    Empty when the operands only touch: shared faces are not an intersection.
+    Uses ``BRepAlgoAPI_Common`` rather than ``cq.Shape.intersect``, whose
+    unconditional cast turns the empty result into a ``ValueError``.
+    """
+    if not isinstance(tools, list):
+        tools = [tools]
+
+    args = TopTools_ListOfShape()
+    args.Append(shape.wrapped)
+    tool_list = TopTools_ListOfShape()
+    for t in tools:
+        tool_list.Append(t.wrapped)
+
+    op = BRepAlgoAPI_Common()
+    op.SetArguments(args)
+    op.SetTools(tool_list)
+    op.Build()
+    if not op.IsDone() or op.Shape().IsNull():
+        return []
+
+    result = cq.Shape.cast(op.Shape())
+    if isinstance(shape, apiSolid):
+        return _collect_subshapes(result, cq.Solid)
+    if isinstance(shape, cq.Shell):
+        return _collect_subshapes(result, cq.Shell)
+    if isinstance(shape, apiFace):
+        return _collect_subshapes(result, cq.Face)
+    if isinstance(shape, apiWire):
+        return _collect_subshapes(result, cq.Wire)
+    return [result]
+
+
 def face_cut_holes(face: apiFace, holes: list) -> list:
     """Cut hole faces out of an outer face.
 
@@ -2640,6 +2676,7 @@ __all__ = [
     "apiFace",
     "area",
     "arrange_edges",
+    "boolean_common",
     "boolean_cut",
     "boolean_fragments",
     "boolean_fuse",

--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -1948,6 +1948,9 @@ def boolean_common(shape: apiShape, tools: list) -> list[apiShape]:
     op = BRepAlgoAPI_Common()
     op.SetArguments(args)
     op.SetTools(tool_list)
+    # Off by default, and then the operands come back modified: a second
+    # intersection against the same shape reports no overlap at all.
+    op.SetNonDestructive(True)
     op.Build()
     if not op.IsDone() or op.Shape().IsNull():
         return []

--- a/bluemira/codes/cadapi/_freecad/api.py
+++ b/bluemira/codes/cadapi/_freecad/api.py
@@ -2566,6 +2566,42 @@ def boolean_cut(
     return output
 
 
+def boolean_common(shape: apiShape, tools: list[apiShape]) -> list[apiShape]:
+    """
+    Intersection of shape and a given (list of) topo shape.
+
+    Parameters
+    ----------
+    shape:
+        the reference object
+    tools:
+        List of FreeCAD shape objects to intersect with.
+
+    Returns
+    -------
+    Result of the boolean operation, of the same dimension as ``shape``. Empty
+    when the operands only touch: shared faces are not an intersection.
+    """
+    _type = type(shape)
+
+    if not isinstance(tools, list):
+        tools = [tools]
+
+    common = shape.common(tools)
+    if common.isNull():
+        return []
+
+    if _type == apiWire:
+        return common.Wires
+    if _type == apiFace:
+        return common.Faces
+    if _type == apiShell:
+        return common.Shells
+    if _type == apiSolid:
+        return common.Solids
+    raise NotImplementedError(f"Common function not implemented for {_type} objects.")
+
+
 def face_cut_holes(face: apiFace, holes: list[apiFace]) -> list[apiFace]:
     """Cut hole faces out of an outer face without the coplanar guard.
 

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -2138,6 +2138,39 @@ def boolean_cut(
     return convert(cut_shape, shape.label)
 
 
+def boolean_common(
+    shape: BluemiraGeoT, tools: BluemiraGeoT | Iterable[BluemiraGeoT]
+) -> list[BluemiraGeoT]:
+    """
+    Intersect a shape with a (list of) topo shape(s).
+
+    Parameters
+    ----------
+    shape:
+        the reference object
+    tools:
+        List of BluemiraGeo shape objects to intersect with
+
+    Returns
+    -------
+    :
+        The shared parts, empty when the operands only touch: a hollow body and
+        its own cavity share faces but no volume.
+
+    Notes
+    -----
+    Prefer small, local operands. On a large spline-bounded solid OCC can report
+    no intersection for shapes that demonstrably overlap.
+    """
+    apishape = shape.shape
+    if not isinstance(tools, Iterable):
+        tools = [tools]
+    apitools = [t.shape for t in tools]
+    return [
+        convert(obj, shape.label) for obj in cadapi.boolean_common(apishape, apitools)
+    ]
+
+
 def boolean_fragments(
     shapes: Iterable[BluemiraSolid], tolerance: float = 0.0
 ) -> tuple[BluemiraCompound, list[list[BluemiraSolid]]]:

--- a/eudemo/eudemo/comp_managers.py
+++ b/eudemo/eudemo/comp_managers.py
@@ -23,7 +23,7 @@ from bluemira.builders.tools import apply_component_display_options
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.tools import boolean_cut, boolean_fuse
 from bluemira.materials.basic import vacuum_void
-from eudemo.maintenance.duct_connection import pipe_pipe_join
+from eudemo.maintenance.duct_connection import join_ports
 from eudemo.tools import make_2d_view_components
 
 if TYPE_CHECKING:
@@ -230,22 +230,16 @@ class ThermalShield(PortManagerMixin, ComponentManager):
         if isinstance(ports, Component):
             ports = [ports]
 
+        tool_shapes = []
         tool_voids = []
-        new_shape_pieces = []
         for port in ports:
             port_xyz = port.get_component("xyz")
-            tool_shape = port_xyz.get_component(port.name).shape
-            tool_void = port_xyz.get_component(port.name + " voidspace").shape
-            tool_voids.append(tool_void)
-            result_pieces = pipe_pipe_join(
-                vvts_target_shape, vvts_target_void, tool_shape, tool_void
-            )
-            # Assume the body is the biggest piece
-            result_pieces.sort(key=lambda solid: -solid.volume)
-            vvts_target_shape = result_pieces[0]
-            new_shape_pieces.extend(result_pieces[1:])
+            tool_shapes.append(port_xyz.get_component(port.name).shape)
+            tool_voids.append(port_xyz.get_component(port.name + " voidspace").shape)
 
-        final_shape = boolean_fuse([vvts_target_shape, *new_shape_pieces])
+        final_shape = join_ports(
+            vvts_target_shape, vvts_target_void, tool_shapes, tool_voids
+        )
         final_void = boolean_fuse([vvts_target_void, *tool_voids])
         return final_shape, final_void, tool_voids
 
@@ -276,6 +270,11 @@ class ThermalShield(PortManagerMixin, ComponentManager):
             ports, vvts_target_shape, vvts_target_void
         )
 
+        # TODO @s-oli: both cuts below assume the body is the biggest piece and
+        # drop the remainder silently. Now that the port join itself is exact,
+        # decide whether that heuristic should stay -- and if so, at least make
+        # it consistent: the second cut takes [0] without sorting, and
+        # boolean_cut does not order its result.
         temp = boolean_cut(final_shape, cts_target_shape)
         temp.sort(key=lambda solid: -solid.volume)
         final_shape = temp[0]

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -18,12 +18,14 @@ import numpy as np
 from bluemira.base.builder import Builder
 from bluemira.base.components import Component, PhysicalComponent
 from bluemira.base.error import BuilderError
+from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.base.parameter_frame import Parameter, ParameterFrame
 from bluemira.builders.tools import apply_component_display_options
 from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import (
+    boolean_cut,
     boolean_fragments,
     boolean_fuse,
     extrude_shape,
@@ -559,6 +561,8 @@ def make_equatorial_port_yz_face(
     return BluemiraFace([outer, inner])
 
 
+# TODO @s-oli: no production caller left -- decide whether to delete this and
+# its test, or keep it around as the fast-but-lossy option.
 def pipe_pipe_join(
     target_shape: BluemiraSolid,
     target_void: BluemiraSolid,
@@ -596,6 +600,11 @@ def pipe_pipe_join(
     This approach is more brittle than a classic fuse, fuse, cut operation, but is
     substantially faster. If the parts do not fully intersect, undesired results
     are to be expected.
+
+    It is also lossy: the returned pieces are interior-disjoint, so fusing them
+    should reproduce their combined volume, but it does not -- on the EU-DEMO
+    vessel the union comes out smaller than its largest operand. Prefer
+    :func:`join_ports`, which is exact and agrees across CAD backends.
     """
     _, (target_fragments, tool_fragments) = boolean_fragments([target_shape, tool_shape])
 
@@ -631,3 +640,58 @@ def pipe_pipe_join(
             ])
 
     return new_shape_pieces
+
+
+def join_ports(
+    target_shape: BluemiraSolid,
+    target_void: BluemiraSolid,
+    tool_shapes: list[BluemiraSolid],
+    tool_voids: list[BluemiraSolid],
+) -> BluemiraSolid:
+    """
+    Join hollow port ducts onto a hollow target in one boolean pass.
+
+    Parameters
+    ----------
+    target_shape:
+        Solid of the target shape, e.g. the vacuum vessel wall
+    target_void:
+        Solid of the target void, e.g. the plasma chamber
+    tool_shapes:
+        Solids of the port duct walls
+    tool_voids:
+        Solids of the port duct voids
+
+    Returns
+    -------
+    :
+        Solid of the joined shape: the wall left once every opening is cut.
+
+    Raises
+    ------
+    GeometryError
+        If cutting the voids leaves nothing behind.
+
+    Notes
+    -----
+    Fuses the target with every duct at once and removes both sets of voids
+    afterwards, rather than fragmenting and reassembling one duct at a time.
+    The intermediate results of the incremental approach never become inputs to
+    the next boolean, so nothing accumulates, and OCC sees the whole problem in
+    one go instead of a chain of partial ones.
+    """
+    fused = boolean_fuse([target_shape, *tool_shapes])
+    pieces = boolean_cut(fused, [target_void, *tool_voids])
+
+    if not pieces:
+        raise GeometryError("join_ports: cutting the voids left nothing behind.")
+
+    pieces.sort(key=lambda solid: -solid.volume)
+    if len(pieces) > 1:
+        dropped = sum(piece.volume for piece in pieces[1:])
+        bluemira_warn(
+            f"join_ports: the cut left {len(pieces)} disconnected solids. Keeping "
+            f"the largest and discarding {dropped:.4f} m³ -- check that no port "
+            f"pierces the far side of the target."
+        )
+    return pieces[0]

--- a/eudemo/eudemo/maintenance/duct_connection.py
+++ b/eudemo/eudemo/maintenance/duct_connection.py
@@ -25,6 +25,7 @@ from bluemira.display.palettes import BLUE_PALETTE
 from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.tools import (
+    boolean_common,
     boolean_cut,
     boolean_fragments,
     boolean_fuse,
@@ -674,14 +675,27 @@ def join_ports(
 
     Notes
     -----
-    Fuses the target with every duct at once and removes both sets of voids
-    afterwards, rather than fragmenting and reassembling one duct at a time.
-    The intermediate results of the incremental approach never become inputs to
-    the next boolean, so nothing accumulates, and OCC sees the whole problem in
-    one go instead of a chain of partial ones.
+    Fuses the target with every duct at once and removes the duct voids
+    afterwards, rather than fragmenting and reassembling one duct at a time, so
+    no intermediate result feeds the next boolean.
+
+    ``target_void`` never cuts the body; only the duct parts reaching into it
+    do. See the comment there.
     """
-    fused = boolean_fuse([target_shape, *tool_shapes])
-    pieces = boolean_cut(fused, [target_void, *tool_voids])
+    # The wall is built around its void, so the two only share faces, and OCC
+    # does not survive cutting one by the other: 4 m^3 where 96 m^3 is right, or
+    # nothing at all, reported as valid either way. Cut with the duct intrusions
+    # instead -- small local solids, and per duct, because on the fused body OCC
+    # reports no intersection at all.
+    intrusions = [
+        piece for shape in tool_shapes for piece in boolean_common(shape, [target_void])
+    ]
+
+    # ``boolean_fuse`` wants two shapes; no ports is a no-op, not an error.
+    fused = boolean_fuse([target_shape, *tool_shapes]) if tool_shapes else target_shape
+
+    cutters = [*tool_voids, *intrusions]
+    pieces = boolean_cut(fused, cutters) if cutters else [fused]
 
     if not pieces:
         raise GeometryError("join_ports: cutting the voids left nothing behind.")

--- a/eudemo/eudemo/maintenance/lower_port/duct_designer.py
+++ b/eudemo/eudemo/maintenance/lower_port/duct_designer.py
@@ -268,7 +268,7 @@ class LowerPortKOZDesigner(Designer):
         # main body
         angle = np.deg2rad(self.params.lower_port_angle.value)
         direction = np.array([np.cos(angle), 0, np.sin(angle)])
-        duct_inner_xy.translate(-1 * direction)
+        duct_inner_xy.translate(-0.1 * direction)
         return duct_inner_xy
 
     def _duct_xz_shapes(self, ib_div_pt_padded: tuple, ob_div_pt_padded: tuple):

--- a/eudemo/eudemo/vacuum_vessel.py
+++ b/eudemo/eudemo/vacuum_vessel.py
@@ -32,7 +32,7 @@ from bluemira.geometry.tools import (
 )
 from bluemira.materials.basic import vacuum_void
 from eudemo.comp_managers import PortManagerMixin
-from eudemo.maintenance.duct_connection import pipe_pipe_join
+from eudemo.maintenance.duct_connection import join_ports
 
 if TYPE_CHECKING:
     from bluemira.geometry.wire import BluemiraWire
@@ -91,21 +91,14 @@ class VacuumVessel(PortManagerMixin, ComponentManager):
         if isinstance(ports, Component):
             ports = [ports]
 
+        tool_shapes = []
         tool_voids = []
-        new_shape_pieces = []
-        for i, port in enumerate(ports):
-            if i > 0:
-                target_shape = boolean_fuse(new_shape_pieces)
-
+        for port in ports:
             port_xyz = port.get_component("xyz")
-            tool_shape = port_xyz.get_component(port.name).shape
-            tool_void = port_xyz.get_component(port.name + " voidspace").shape
-            tool_voids.append(tool_void)
-            new_shape_pieces = pipe_pipe_join(
-                target_shape, target_void, tool_shape, tool_void
-            )
+            tool_shapes.append(port_xyz.get_component(port.name).shape)
+            tool_voids.append(port_xyz.get_component(port.name + " voidspace").shape)
 
-        final_shape = boolean_fuse(new_shape_pieces)
+        final_shape = join_ports(target_shape, target_void, tool_shapes, tool_voids)
         final_void = boolean_fuse([target_void, *tool_voids])
 
         sector_body = PhysicalComponent(

--- a/eudemo/eudemo_tests/maintenance/test_duct_connection.py
+++ b/eudemo/eudemo_tests/maintenance/test_duct_connection.py
@@ -13,6 +13,8 @@ from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.parameterisations import PictureFrame
 from bluemira.geometry.tools import (
+    boolean_common,
+    boolean_cut,
     boolean_fuse,
     extrude_shape,
     interpolate_bspline,
@@ -20,6 +22,7 @@ from bluemira.geometry.tools import (
     make_polygon,
     revolve_shape,
 )
+from eudemo.maintenance import duct_connection
 from eudemo.maintenance.duct_connection import (
     VVEquatorialPortDuctBuilder,
     join_ports,
@@ -214,3 +217,165 @@ class TestJoinPorts:
         incremental = boolean_fuse(pieces)
 
         assert incremental.volume < self.joined.volume
+
+    def test_a_hollow_target_shares_no_volume_with_its_own_void(self):
+        """The property that makes ``target_void`` a hazard as a cutting tool.
+
+        The wall is built around the chamber, so however intricate the shared
+        surface is, the two are interior-disjoint.
+        """
+        assert boolean_common(self.target, [self.target_void]) == []
+
+    def test_the_body_is_never_cut_by_the_target_void(self, monkeypatch):
+        """``target_void`` may trim a duct, but must not cut the joined body.
+
+        Cutting the body by its own chamber is what corrupts the result: OCC
+        hands back a solid of negative volume, or none at all, depending on
+        which tools accompany it.
+        """
+        calls = []
+        real_cut = duct_connection.boolean_cut
+
+        def spy(shape, tools, *args, **kwargs):
+            calls.append((shape, list(tools)))
+            return real_cut(shape, tools, *args, **kwargs)
+
+        monkeypatch.setattr(duct_connection, "boolean_cut", spy)
+        join_ports(self.target, self.target_void, self.tool_shapes, self.tool_voids)
+
+        assert calls, "join_ports made no cut at all"
+        for shape, tools in calls:
+            if any(tool is self.target_void for tool in tools):
+                assert shape.volume < self.target.volume, (
+                    "the target void was used to cut the body, not a duct"
+                )
+
+    def test_a_duct_reaching_into_the_chamber_is_removed(self):
+        """These ducts do reach in, so the intrusion cut must remove something."""
+        assert any(boolean_common(tool, [self.target_void]) for tool in self.tool_shapes)
+        assert (
+            self.joined.volume
+            < boolean_fuse([
+                self.target,
+                *self.tool_shapes,
+            ]).volume
+        )
+
+    def test_join_ports_with_a_single_port(self):
+        joined = join_ports(
+            self.target, self.target_void, self.tool_shapes[:1], self.tool_voids[:1]
+        )
+        assert joined.is_valid()
+        assert len(joined.solids) == 1
+        # The opening costs more wall than the thin duct adds back...
+        assert joined.volume < boolean_fuse([self.target, self.tool_shapes[0]]).volume
+        # ... and one port leaves more of the vessel than three do.
+        assert self.joined.volume < joined.volume
+
+
+class TestJoinPortsSplineVessel:
+    """One-pass joins on the spline-bounded vessel.
+
+    Regression for the crash reported on PR #4437: cutting a spline-bounded
+    body by the chamber void hands back a solid that fails validation, whether
+    or not the void removes any material. The volumes are the ones
+    ``TestPipePipeJoinSplineVessel`` pins for the incremental route, so this
+    also checks the two routes agree on a shape where the incremental one is
+    sound.
+    """
+
+    Z_POSITIONS = (0.0, 1.5, -1.5)
+    EXPECTED_VOLUME = 31.50472
+
+    @classmethod
+    def setup_class(cls):
+        cls.target, cls.target_void = TestPipePipeJoinSplineVessel._vessel()
+        cls.tool_shapes, cls.tool_voids = [], []
+        for z_position in cls.Z_POSITIONS:
+            shape, void = TestPipePipeJoinSplineVessel._port(z_position)
+            cls.tool_shapes.append(shape)
+            cls.tool_voids.append(void)
+
+    def test_all_ports_joined_in_one_pass(self):
+        joined = join_ports(
+            self.target, self.target_void, self.tool_shapes, self.tool_voids
+        )
+
+        assert joined.is_valid()
+        assert len(joined.solids) == 1
+        assert joined.volume == pytest.approx(self.EXPECTED_VOLUME, abs=1e-4)
+
+    def test_cutting_the_body_by_the_chamber_is_what_breaks(self):
+        """Pin the failure this design avoids, so the reason cannot be lost.
+
+        The void here *does* remove material -- these ducts reach into the
+        chamber -- and the cut is still unusable. Trimming the ducts instead is
+        not an optimisation for the degenerate case, it is the only route that
+        survives.
+        """
+        fused = boolean_fuse([self.target, *self.tool_shapes])
+
+        # The message wraps differently per backend, hence the loose whitespace.
+        with pytest.raises(GeometryError, match=r"is not\s+valid"):
+            boolean_cut(fused, [self.target_void])
+
+
+class TestJoinPortsOtherGeometries:
+    """Joins on shapes the reactor does not build, and odd port arrangements."""
+
+    @staticmethod
+    def _tube(inner_radius=2.0, outer_radius=2.2):
+        inner = make_circle(radius=inner_radius, center=(5, -5, 0), axis=(0, 1, 0))
+        outer = make_circle(radius=outer_radius, center=(5, -5, 0), axis=(0, 1, 0))
+        return (
+            extrude_shape(BluemiraFace([outer, inner]), vec=(0, 10, 0)),
+            extrude_shape(BluemiraFace(inner), vec=(0, 10, 0)),
+        )
+
+    @staticmethod
+    def _stub(length, inner_radius=1.0, outer_radius=1.1):
+        inner = make_circle(radius=inner_radius, center=(5, 0, 5), axis=(0, 0, 1))
+        outer = make_circle(radius=outer_radius, center=(5, 0, 5), axis=(0, 0, 1))
+        return (
+            extrude_shape(BluemiraFace([outer, inner]), vec=(0, 0, -length)),
+            extrude_shape(BluemiraFace(inner), vec=(0, 0, -length)),
+        )
+
+    @pytest.mark.parametrize("length", [5, 10])
+    def test_a_stub_onto_a_tube(self, length):
+        """A stub that stops inside the bore, and one that pierces the far wall."""
+        target, target_void = self._tube()
+        tool, tool_void = self._stub(length)
+
+        joined = join_ports(target, target_void, [tool], [tool_void])
+
+        assert joined.is_valid()
+        assert len(joined.solids) == 1
+        # The opening is cut.
+        assert joined.volume < boolean_fuse([target, tool]).volume
+
+    def test_a_duct_flush_with_the_bore_leaves_the_chamber_untouched(self):
+        """The EU-DEMO arrangement: nothing reaches in, so nothing is trimmed."""
+        target, target_void = self._tube()
+        tool, tool_void = self._stub(5)
+        flush_tool = max(boolean_cut(tool, [target_void]), key=lambda s: s.volume)
+        flush_void = max(boolean_cut(tool_void, [target_void]), key=lambda s: s.volume)
+
+        assert boolean_common(flush_tool, [target_void]) == []
+
+        joined = join_ports(target, target_void, [flush_tool], [flush_void])
+        expected = max(
+            boolean_cut(boolean_fuse([target, flush_tool]), [flush_void]),
+            key=lambda s: s.volume,
+        )
+
+        assert joined.is_valid()
+        assert joined.volume == pytest.approx(expected.volume, rel=1e-9)
+
+    def test_a_join_without_ports_returns_the_target(self):
+        target, target_void = self._tube()
+
+        joined = join_ports(target, target_void, [], [])
+
+        assert joined.is_valid()
+        assert joined.volume == pytest.approx(target.volume, rel=1e-9)

--- a/eudemo/eudemo_tests/maintenance/test_duct_connection.py
+++ b/eudemo/eudemo_tests/maintenance/test_duct_connection.py
@@ -4,22 +4,29 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from typing import ClassVar
+
 import numpy as np
 import pytest
 
 from bluemira.geometry.error import GeometryError
 from bluemira.geometry.face import BluemiraFace
+from bluemira.geometry.parameterisations import PictureFrame
 from bluemira.geometry.tools import (
     boolean_fuse,
     extrude_shape,
     interpolate_bspline,
     make_circle,
+    make_polygon,
     revolve_shape,
 )
 from eudemo.maintenance.duct_connection import (
+    VVEquatorialPortDuctBuilder,
+    join_ports,
     make_equatorial_port_yz_face,
     pipe_pipe_join,
 )
+from eudemo.vacuum_vessel import VacuumVesselBuilder
 
 
 class TestPipePipeJoin:
@@ -114,3 +121,96 @@ class TestPipePipeJoinSplineVessel:
 
         with pytest.raises(GeometryError, match="do not intersect"):
             pipe_pipe_join(target, target_void, tool, tool_void)
+
+
+class TestJoinPorts:
+    """Port joins on a vessel built the way the reactor builds it.
+
+    ``pipe_pipe_join`` loses material here: it fragments and reassembles once per
+    port, and the union of its (interior-disjoint) pieces comes out smaller than
+    their combined volume. The loss grows with every port and differs between CAD
+    backends, so pin the volume rather than a face count.
+    """
+
+    VV_PARAMS: ClassVar = {
+        "r_vv_ib_in": {"value": 5.1, "unit": "m"},
+        "r_vv_ob_in": {"value": 14.5, "unit": "m"},
+        "tk_vv_in": {"value": 0.6, "unit": "m"},
+        "tk_vv_out": {"value": 1.1, "unit": "m"},
+        "g_vv_bb": {"value": 0.02, "unit": "m"},
+        "n_TF": {"value": 16, "unit": ""},
+        "vv_in_off_deg": {"value": 80, "unit": "deg"},
+        "vv_out_off_deg": {"value": 160, "unit": "deg"},
+    }
+    EP_PARAMS: ClassVar = {
+        "R_0": {"value": 9.0, "unit": "m"},
+        "n_TF": {"value": 16, "unit": ""},
+        "g_cr_ts": {"value": 0.2, "unit": "m"},
+        "ep_z_position": {"value": 0.0, "unit": "m"},
+        "ep_width": {"value": 1.4, "unit": "m"},
+        "ep_height": {"value": 1.2, "unit": "m"},
+        "tk_vv_single_wall": {"value": 0.06, "unit": "m"},
+    }
+    Z_POSITIONS = (0.0, 2.0, -2.0)
+    # Both CAD backends agree to ~1e-7, but the value shifts by ~0.02% with
+    # upstream geometry changes, so pin it loosely. The incremental route is
+    # 0.2% low, well outside this band.
+    EXPECTED_VOLUME = 96.42
+
+    @classmethod
+    def setup_class(cls):
+        ivc_koz = PictureFrame({
+            "x1": {"value": 2},
+            "ro": {"value": 3.5},
+            "ri": {"value": 3},
+            "x2": {"value": 10},
+        }).create_shape()
+        sector = (
+            VacuumVesselBuilder(cls.VV_PARAMS, {}, ivc_koz)
+            .build()
+            .get_component("xyz")
+            .get_component("Sector 1")
+        )
+        cls.target = sector.get_component("Body 1").shape
+        cls.target_void = sector.get_component("Vessel voidspace 1").shape
+
+        # Only the bounding box of this wire is read, for the duct's outer end.
+        cryostat_xz = make_polygon(
+            {"x": [1.0, 17.0, 17.0, 1.0], "z": [-14.0, -14.0, 14.0, 14.0]}, closed=True
+        )
+        cls.tool_shapes, cls.tool_voids = [], []
+        for z_position in cls.Z_POSITIONS:
+            params = dict(cls.EP_PARAMS)
+            params["ep_z_position"] = {"value": z_position, "unit": "m"}
+            xyz = (
+                VVEquatorialPortDuctBuilder(
+                    params, {"name": f"EP{z_position}"}, cryostat_xz
+                )
+                .build()
+                .get_component("xyz")
+            )
+            cls.tool_shapes.append(xyz.get_component(f"EP{z_position}").shape)
+            cls.tool_voids.append(xyz.get_component(f"EP{z_position} voidspace").shape)
+
+        cls.joined = join_ports(
+            cls.target, cls.target_void, cls.tool_shapes, cls.tool_voids
+        )
+
+    def test_join_ports_conserves_volume(self):
+        assert self.joined.is_valid()
+        assert len(self.joined.solids) == 1
+        assert self.joined.volume == pytest.approx(self.EXPECTED_VOLUME, rel=1e-3)
+
+    def test_join_ports_beats_the_incremental_route(self):
+        """The incremental route must not be silently preferred again.
+
+        It is not merely different -- it drops material that a union cannot drop.
+        """
+        target, pieces = self.target, None
+        for tool, void in zip(self.tool_shapes, self.tool_voids, strict=True):
+            if pieces is not None:
+                target = boolean_fuse(pieces)
+            pieces = pipe_pipe_join(target, self.target_void, tool, void)
+        incremental = boolean_fuse(pieces)
+
+        assert incremental.volume < self.joined.volume

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -32,6 +32,7 @@ from bluemira.geometry.plane import BluemiraPlane
 from bluemira.geometry.shell import BluemiraShell
 from bluemira.geometry.tools import (
     _signed_distance_2D,
+    boolean_common,
     boolean_cut,
     boolean_fragments,
     boolean_fuse,
@@ -1136,3 +1137,63 @@ class TestBooleanCutShell:
         assert len(result) >= 1
         for piece in result:
             assert isinstance(piece, BluemiraShell)
+
+
+class TestBooleanCommon:
+    """``boolean_common`` separates overlap from mere contact.
+
+    The distinction matters because cutting by a tool that only touches the body
+    removes nothing, yet OCC does not reliably return the body unchanged -- it
+    can hand back a negative-volume solid that reports itself valid.
+    """
+
+    @staticmethod
+    def _box(origin, lengths=(1.0, 1.0, 1.0)):
+        x, y, z = origin
+        dx, dy, dz = lengths
+        face = BluemiraFace(
+            make_polygon(
+                [[x, y, z], [x + dx, y, z], [x + dx, y + dy, z], [x, y + dy, z]],
+                closed=True,
+            )
+        )
+        return extrude_shape(face, (0, 0, dz))
+
+    def test_overlapping_solids_share_volume(self):
+        common = boolean_common(self._box((0, 0, 0)), [self._box((0.5, 0, 0))])
+        assert len(common) == 1
+        assert common[0].volume == pytest.approx(0.5, rel=1e-9)
+
+    def test_a_contained_solid_shares_volume(self):
+        outer = self._box((0, 0, 0))
+        inner = self._box((0.2, 0.2, 0.2), (0.6, 0.6, 0.6))
+        assert boolean_common(outer, [inner])[0].volume == pytest.approx(
+            inner.volume, rel=1e-9
+        )
+        assert boolean_common(inner, [outer])[0].volume == pytest.approx(
+            inner.volume, rel=1e-9
+        )
+
+    def test_solids_meeting_on_a_face_do_not(self):
+        assert boolean_common(self._box((0, 0, 0)), [self._box((1.0, 0, 0))]) == []
+
+    def test_solids_meeting_on_an_edge_do_not(self):
+        assert boolean_common(self._box((0, 0, 0)), [self._box((1.0, 1.0, 0.0))]) == []
+
+    def test_disjoint_solids_do_not(self):
+        assert boolean_common(self._box((0, 0, 0)), [self._box((5.0, 0, 0))]) == []
+
+    def test_a_hollow_body_and_its_own_cavity_do_not(self):
+        """A wall built around its void is interior-disjoint from it, however
+        intricate the shared surface.
+        """
+        outer = make_circle(radius=2.2, center=(5, -5, 0), axis=(0, 1, 0))
+        inner = make_circle(radius=2.0, center=(5, -5, 0), axis=(0, 1, 0))
+        wall = extrude_shape(BluemiraFace([outer, inner]), (0, 10, 0))
+        cavity = extrude_shape(BluemiraFace(inner), (0, 10, 0))
+
+        assert boolean_common(wall, [cavity]) == []
+        # ... and the cut it would drive is therefore a no-op on the volume.
+        assert boolean_cut(wall, [cavity])[0].volume == pytest.approx(
+            wall.volume, rel=1e-9
+        )


### PR DESCRIPTION
## Description

`VacuumVessel.add_ports` and `PortManagerMixin._join_ports_to_vvts` joined port
ducts to the vessel **one at a time**, fragmenting and reassembling the target on
every iteration and feeding each intermediate result into the next boolean. That
loop silently loses material.

### The evidence

No reference implementation is needed. The pieces `pipe_pipe_join` returns are
interior-disjoint — `boolean_cut(b, [a])` returns `b` unchanged, overlap
`0.000000`, on both backends — so their union must equal their combined volume.
It does not:

fuse(a, c) = 96.082 m³<a = 96.131 m³

**A union cannot be smaller than one of its operands.** (`fuse(a, b)` correctly
raises "more than one solid" — `a` and `b` never touch. The three-way fuse only
"succeeds" because `c` bridges them.)

Measured against the classic fuse-then-cut route on a vessel built by
`VacuumVesselBuilder` with real equatorial ports:

| Ports | FreeCAD | CadQuery |                                                                                                                               
  |------:|--------:|---------:|                                                                                                                               
  | 1 | -0.061 m³ (0.06 %) | -0.192 m³ (0.20 %) |                                                                                                              
  | 3 | -0.199 m³ (0.21 %) | -0.445 m³ (0.46 %) |                                                                                                              
  | 5 | -0.240 m³ (0.25 %) | -0.515 m³ (0.53 %) |                                                                                                              
  | 7 | -0.260 m³ (0.27 %) | -0.549 m³ (0.56 %) |

That is 0.06 – 0.56 % of the vacuum vessel, growing with port count, differing
per backend, and reported by nothing. This is **not** a CadQuery issue: the
classic route agrees across backends to ~1e-6 here, so the kernels are fine and
the algorithm is not. On the full reactor the raw booleans still agree
bit-for-bit across backends; the residual spread comes from `boolean_fuse`'s
splitter removal, not from the join.

### The change

`join_ports(target_shape, target_void, tool_shapes, tool_voids)` — one
`boolean_fuse([target, *tools])`, one `boolean_cut(fused, [target_void,
*tool_voids])`. Both call sites switched. It raises a `GeometryError` if the cut
leaves nothing, and warns **with the discarded volume** if it leaves more than one
solid, which means a port pierces the far side of the target.

Removing the loop also removes two assumptions that only lived in
`_join_ports_to_vvts`: that the reactor body is always the largest fragment, and
that a port may be fragmented against a target that does not yet contain the
previously added ducts.

## Interface Changes

New public function `join_ports` in `eudemo.maintenance.duct_connection`.

`pipe_pipe_join` is unchanged and still exported, but has **no production caller
left**. Its docstring now records that it is lossy.

**This changes reactor output.** The joined vessel volume rises by 0.06 – 0.56 %
on the harness above, and by 0.263 m³ (0.27 %) on the full EU-DEMO reactor —
measured with splitter removal off, since that step perturbs each route by more
than the difference between them. The old figures were too small. Anything consuming VV geometry or mass —
neutronics, thermal, inventory — shifts accordingly, and stored reference results
need regenerating.

## Trade-offs

- **Slower on FreeCAD**: 6.7 s vs 5.1 s at seven ports (~1.3×). **Faster on
CadQuery**: 5.5 s vs 6.7 s. The "substantially faster" claim in
`pipe_pipe_join`'s docstring no longer holds on the backend the project is
moving to.
- **More faces**: 102 vs 74 at seven ports. The classic route leaves splitter
faces that the fragment classification removed — partly by removing material
with them.

## Open questions for review

Both are marked with `TODO @s-oli` in the diff, happy to fold either into this PR:

1. **Delete `pipe_pipe_join` and its test?** Nothing calls it now. Kept for the
moment because it was a deliberate speed-over-exactness decision by someone
who may know constraints I do not.
2. **The "biggest piece" heuristic in `ThermalShield.add_ports`.** Two
`boolean_cut` results are reduced to `[0]`, dropping the remainder silently —
and the second does it *without sorting*, while `boolean_cut` does not order
its result. Untouched here because it is a separate concern and would need its
own measurements.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`

