### PR TITLE
fix(cad): keep edge orientation when splitting a reversed edge

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -1467,10 +1467,25 @@ def split_wire(
             d1 = p1.SquareDistance(pnt)
             t_split = t0 if d0 <= d1 else t1
         t_split = max(t0, min(t1, t_split))
+
+        is_reversed = e.wrapped.Orientation() == TopAbs_REVERSED
+        part_a = part_b = None
         if t_split - t0 > _ANGLE_PARALLEL_TOL:
-            edges_1.append(cq.Edge(BRepBuilderAPI_MakeEdge(curve, t0, t_split).Edge()))
+            part_a = BRepBuilderAPI_MakeEdge(curve, t0, t_split).Edge()
         if t1 - t_split > _ANGLE_PARALLEL_TOL:
-            edges_2.append(cq.Edge(BRepBuilderAPI_MakeEdge(curve, t_split, t1).Edge()))
+            part_b = BRepBuilderAPI_MakeEdge(curve, t_split, t1).Edge()
+
+        if is_reversed:
+            for part in (part_a, part_b):
+                if part:
+                    part.Orientation(TopAbs_REVERSED)
+            first, second = part_b, part_a
+        else:
+            first, second = part_a, part_b
+        if first:
+            edges_1.append(cq.Edge(first))
+        if second:
+            edges_2.append(cq.Edge(second))
 
     wire_1 = cq.Wire.assembleEdges(edges_1) if edges_1 else None
     wire_2 = cq.Wire.assembleEdges(edges_2) if edges_2 else None


### PR DESCRIPTION
## Description

`TestPatches::test_wire_parameter_at_checks_reverse_orientation` is currently red on 
`feature/cadquery`. Bisected: green at `78b6b145`, red at `b93e64bd`.                                                                                        
                                                                                                                                                               
 `split_wire` cuts its parts from the underlying curve, which carries no orientation.                                                                         
 A `REVERSED` parent edge is walked `t1 -> t0`, so its parts have to carry the flag                                                                           
 too and swap sides — otherwise the halves no longer chain and                                                                                                
 `cq.Wire.assembleEdges` raises `StdFail_NotDone`. Reachable from                                                                                             
 `wire_parameter_at` on any wire containing a reversed edge, which is legal input:                                                                            
                                                                                                                                                               
 freecad   len=20.000  param=0.6250      <- what the test asserts                                                                                             
 cadquery  StdFail_NotDone                                                                                                                                    
                                                                                                                                                               
 So the test is right and the code regressed — hence a fix rather than an updated                                                                             
 expectation.                                                                                                                                                 
                                                                                                                                                               
 This restores **only** the `split_wire` half of `b93e64bd`. The `offset_wire` /                                                                              
 `_fix_offset_orientation` change there is left alone. 

## Interface Changes

None

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
