### PR TITLE
🧪 Test boolean split with wires

### DIFF
--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -573,6 +573,19 @@ class BackendApiTestsBase:
         sliced_coil = boolean_cut(boolean_cut_princeton, cut_tool)[0]
         assert sliced_coil.is_valid_deep()  # similar to ``test_boolean_cut_hollow_coil``
 
+    def test_boolean_cut_split_arg(self):
+
+        wire1 = make_polygon([[-1, 0, -1], [1, 0, 1]])
+        wire2 = make_polygon([[-1, 0, 1], [1, 0, -1]])
+
+        result = self.cadapi.boolean_cut(wire1.shape, wire2.shape, split=True)
+        assert len(result) == 2
+        assert all(r.Length() == pytest.approx(np.sqrt(2)) for r in result)
+
+        result = self.cadapi.boolean_cut(wire1.shape, wire2.shape, split=False)
+        assert len(result) == 1
+        assert result[0].Length == pytest.approx(2 * np.sqrt(2))
+
     def test_wire_tangent_at_complex(self):
         e1 = self.cadapi.make_polygon([(0, 0, 0), (10, 0, 0)])
 

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -584,7 +584,7 @@ class BackendApiTestsBase:
 
         result = self.cadapi.boolean_cut(wire1.shape, wire2.shape, split=False)
         assert len(result) == 1
-        assert result[0].Length == pytest.approx(2 * np.sqrt(2))
+        assert result[0].Length() == pytest.approx(2 * np.sqrt(2))
 
     def test_wire_tangent_at_complex(self):
         e1 = self.cadapi.make_polygon([(0, 0, 0), (10, 0, 0)])

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -40,6 +40,10 @@ class TestFreecadapi(BackendApiTestsBase):
     def offsetter(wire):
         return cadapi.offset_wire(wire, 0.05, join="intersect", open_wire=False)
 
+    test_boolean_cut_split_arg = pytest.mark.xfail(reason="freecad coplanar check")(
+        BackendApiTestsBase.test_boolean_cut_split_arg
+    )
+
     def test_multi_offset_wire_without_arranged_edges(self):
         """
         FreeCAD Topological naming bug


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #3914

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
In cadquery this works so I've added a test. in freecad this fails with a bad coplanar check (as in the check to me seems bad)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
