### PR TITLE
🧑‍💻 Remove erronious process warnings

### DIFF
--- a/bluemira/codes/process/_teardown.py
+++ b/bluemira/codes/process/_teardown.py
@@ -219,6 +219,14 @@ class Teardown(CodesTeardown):
         return output_value
 
 
+ONLY_READ_FROM_FILE = (
+    "dz_blkt_upper",
+    "a_tf_wp_no_insulation",
+    "f_j_cs_start_end_flat_top",
+    "f_ster_div_single",
+)
+
+
 class _MFileWrapper:
     """
     Utility class to wrap a PROCESS MFile, and map its data to bluemira
@@ -248,7 +256,11 @@ class _MFileWrapper:
         """
         self.data = {}
         for process_param_name, value in self.mfile.data.items():
-            param_name = update_obsolete_vars(process_param_name)
+            param_name = (
+                process_param_name
+                if process_param_name in ONLY_READ_FROM_FILE
+                else update_obsolete_vars(process_param_name)
+            )
             if param_name is None:
                 bluemira_warn(
                     f"{self._name} parameter '{process_param_name}' is obsolete and has"


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
Removes some obsolete variable names because process obs_var doesnt have a mechanism for 'this variable is now only output' therefore because we check on in and out for obsolete variable names we get some false positives. This excludes known false positives.

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
