### PR TITLE
Remove unused parameters from RadiationSourceParams

### DIFF
--- a/bluemira/radiation_transport/radiation_profile.py
+++ b/bluemira/radiation_transport/radiation_profile.py
@@ -127,10 +127,6 @@ class RadiationSourceParams(ParameterFrame):
     """Electron temperature pedestal height"""
     T_e_sep: Parameter[float]
     """Electron temperature at separatrix"""
-    theta_inner_target: Parameter[float]
-    """Inner divertor poloidal angle with the separatrix flux line"""
-    theta_outer_target: Parameter[float]
-    """Outer divertor poloidal angle with the separatrix flux line"""
 
 
 class Radiation:
@@ -1083,7 +1079,6 @@ class ScrapeOffLayerRadiation(Radiation):
             b_pol_tar = self.b_pol_out_tar
             b_pol_u = self.b_pol_sep_omp
             r_sep_mp = self.r_sep_omp
-            # alpha = self.params.theta_outer_target.value
             alpha = self.alpha_lfs
             b_tot_tar = self.b_tot_out_tar
             fw_lambda_q_near = self.params.fw_lambda_q_near_omp.value
@@ -1093,7 +1088,6 @@ class ScrapeOffLayerRadiation(Radiation):
             b_pol_tar = self.b_pol_inn_tar
             b_pol_u = self.b_pol_sep_imp
             r_sep_mp = self.r_sep_imp
-            # alpha = self.params.theta_inner_target.value
             alpha = self.alpha_hfs
             b_tot_tar = self.b_tot_inn_tar
             fw_lambda_q_near = self.params.fw_lambda_q_near_imp.value

--- a/eudemo/eudemo_tests/template.json
+++ b/eudemo/eudemo_tests/template.json
@@ -1931,18 +1931,6 @@
       }
     }
   },
-  "theta_inner_target": {
-    "name": "Angle between flux line tangent at inner strike point and SOL side of inner target",
-    "value": 20,
-    "unit": "deg",
-    "source": "Input"
-  },
-  "theta_outer_target": {
-    "name": "Angle between flux line tangent at outer strike point and SOL side of outer target",
-    "value": 20,
-    "unit": "deg",
-    "source": "Input"
-  },
   "tk_bb_arm": {
     "name": "Tungsten armour thickness",
     "value": 0.002,

--- a/examples/radiation_transport/radiation_calculation_solver_DEMO.ex.py
+++ b/examples/radiation_transport/radiation_calculation_solver_DEMO.ex.py
@@ -125,8 +125,6 @@ params = {
     "T_e_0": {"value": 21.442, "unit": "keV"},
     "T_e_ped": {"value": 5.059, "unit": "keV"},
     "T_e_sep": {"value": 0.16, "unit": "keV"},
-    "theta_inner_target": {"value": 5.0, "unit": "deg"},
-    "theta_outer_target": {"value": 5.0, "unit": "deg"},
 }
 
 # %%

--- a/tests/radiation_transport/test_radiation_profile.py
+++ b/tests/radiation_transport/test_radiation_profile.py
@@ -86,8 +86,6 @@ class TestCoreRadiation:
             "k_0": {"value": 2000.0, "unit": "dimensionless"},
             "lfs_p_fraction": {"value": 0.9, "unit": "dimensionless"},
             "P_sep": {"value": 100, "unit": "MW"},
-            "theta_inner_target": {"value": 5.0, "unit": "deg"},
-            "theta_outer_target": {"value": 5.0, "unit": "deg"},
             **midplane_params,
         }
 
@@ -273,7 +271,7 @@ class TestCoreRadiation:
             f_ion_t,
             self.source.sol_rad.b_pol_out_tar,
             self.source.sol_rad.b_pol_sep_omp,
-            self.source.params.theta_outer_target.value,
+            self.source.sol_rad.alpha_lfs,
             self.source.sol_rad.r_sep_omp,
             self.source.sol_rad.x_strike_lfs,
             self.source.params.fw_lambda_q_near_omp.value,
@@ -289,7 +287,7 @@ class TestCoreRadiation:
             f_ion_t,
             self.source.sol_rad.b_pol_out_tar,
             self.source.sol_rad.b_pol_sep_omp,
-            self.source.params.theta_outer_target.value,
+            self.source.sol_rad.alpha_lfs,
             self.source.sol_rad.r_sep_omp,
             self.source.sol_rad.x_strike_lfs,
             self.source.params.fw_lambda_q_near_omp.value,


### PR DESCRIPTION
## Description

theta_inner_target and theta_outer_target are no longer used and have been replaced.

## Interface Changes

The STEP radiation example will need these params removed from the inputs.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
