### PR TITLE
Standardise Green's functions

### DIFF
--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -63,7 +63,7 @@ def clip_nb(
 
 @nb.njit(cache=True, inline="always")
 def _common_geometry(xc, zc, x, z):
-    r"""
+    """
     Calculate the geometry shared by the Green's functions.
 
     .. math::
@@ -96,7 +96,7 @@ def _elliptic_integrals(k2):
 
 @nb.njit(cache=True, inline="always")
 def _i1_i2(u, u2, k2, e, k):
-    r"""
+    """
     Calculate
 
     .. math::
@@ -117,7 +117,7 @@ def _i1_i2(u, u2, k2, e, k):
 
 @nb.njit(cache=True, inline="always")
 def _radial_term(xc, x, h, i1, i2):
-    r"""
+    """
     Calculate
 
     .. math::
@@ -136,7 +136,7 @@ def _radial_term(xc, x, h, i1, i2):
 
 @nb.njit(cache=True, inline="always")
 def _vertical_term(xc, x, h, i1, i2):
-    r"""
+    """
     Calculate
 
     .. math::
@@ -175,14 +175,14 @@ def _vertical_response(xc, zc, x, z):
 
 @nb.njit(cache=True, inline="always")
 def _axis_bz(xc, zc, z):
-    r"""
+    """
     Calculate the analytical vertical field on the symmetry axis.
 
     .. math::
 
         B_z(0,z)=
-        \frac{\mu_0x_c^2}
-        {2\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
+        \frac{\\mu_0x_c^2}
+        {2\\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
     """  # noqa: DOC201
     h = z - zc
     u2 = xc * xc + h * h
@@ -192,12 +192,12 @@ def _axis_bz(xc, zc, z):
 
 @nb.njit(cache=True, inline="always")
 def _elliptic_derivatives(e, k, k2):
-    r"""
+    """
     Calculate elliptic-integral derivatives with respect to ``k²``.
 
     .. math::
 
-        \frac{dE}{d(k^2)}=\frac{E-K}{2k^2},\qquad
+        \frac{dE}{d(k^2)}=\frac{E-K}{2k^2},\\qquad
         \frac{dK}{d(k^2)}
         =\frac{E-(1-k^2)K}{2k^2(1-k^2)}.
     """  # noqa: DOC201
@@ -500,7 +500,7 @@ def greens_dbz_dx(
     x: float | np.ndarray,
     z: float | np.ndarray,
 ) -> float | np.ndarray:
-    r"""
+    """
     Calculate the radial derivative of the vertical magnetic field.
 
     Parameters
@@ -523,11 +523,11 @@ def greens_dbz_dx(
     -----
     .. math::
 
-        \frac{\partial B_z}{\partial x}
-        =\frac{\partial B_x}{\partial z}
-        =\frac{\mu_0}{2\pi}
-        \left[
-            \frac{1}{u}\frac{\partial F}{\partial x}
+        \frac{\\partial B_z}{\\partial x}
+        =\frac{\\partial B_x}{\\partial z}
+        =\frac{\\mu_0}{2\\pi}
+        \\left[
+            \frac{1}{u}\frac{\\partial F}{\\partial x}
             -\frac{x+x_c}{u^3}F
         \right],
 

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Green's functions mappings for psi, Bx, and Bz
+"""
+
 import numba as nb
 import numpy as np
 
@@ -6,6 +16,8 @@ from bluemira.magnetostatics._ellipe import ellipe_nb
 from bluemira.magnetostatics._ellipk import ellipk_nb
 
 __all__ = [
+    "circular_coil_inductance_elliptic",
+    "circular_coil_inductance_kirchhoff",
     "greens_Bx",
     "greens_Bz",
     "greens_all",
@@ -13,6 +25,7 @@ __all__ = [
     "greens_dpsi_dx",
     "greens_dpsi_dz",
     "greens_psi",
+    "square_coil_inductance_kirchhoff",
 ]
 
 
@@ -58,7 +71,7 @@ def clip_nb(
     return val
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _common_geometry(xc, zc, x, z):
     r"""
     Calculate the geometry shared by the Green's functions.
@@ -85,13 +98,13 @@ def _common_geometry(xc, zc, x, z):
     return h, u, u2, k2
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _elliptic_integrals(k2):
     """Evaluate E(k²) and K(k²)."""
     return ellipe_nb(k2), ellipk_nb(k2)
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _i1_i2(u, u2, k2, e, k):
     r"""
     Calculate
@@ -112,7 +125,7 @@ def _i1_i2(u, u2, k2, e, k):
     return i1, i2
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _radial_term(xc, x, h, i1, i2):
     r"""
     Calculate
@@ -131,7 +144,7 @@ def _radial_term(xc, x, h, i1, i2):
     return i1 + w2 * i2
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _vertical_term(xc, x, h, i1, i2):
     r"""
     Calculate
@@ -150,7 +163,7 @@ def _vertical_term(xc, x, h, i1, i2):
     return i1 - v2 * i2
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _radial_response(xc, zc, x, z):
     """Calculate the term shared by dpsi/dx and Bz."""
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
@@ -160,7 +173,7 @@ def _radial_response(xc, zc, x, z):
     return _radial_term(xc, x, h, i1, i2)
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _vertical_response(xc, zc, x, z):
     """Calculate the quantities shared by dpsi/dz and Bx."""
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
@@ -170,7 +183,7 @@ def _vertical_response(xc, zc, x, z):
     return h, _vertical_term(xc, x, h, i1, i2)
 
 
-@nb.njit(cache=True, inline="always")
+@nb.njit(nopython=True, cache=True, inline="always")
 def _axis_bz(xc, zc, z):
     r"""
     Calculate the analytical vertical field on the symmetry axis.
@@ -187,8 +200,8 @@ def _axis_bz(xc, zc, z):
     return 0.5 * MU_0 * xc * xc / (u2 * np.sqrt(u2))
 
 
-@nb.njit(cache=True, inline="always")
-def _elliptic_parameter_derivatives(e, k, k2):
+@nb.njit(nopython=True, cache=True, inline="always")
+def _elliptic_derivatives(e, k, k2):
     r"""
     Calculate elliptic-integral derivatives with respect to ``k²``.
 
@@ -208,13 +221,13 @@ def _elliptic_parameter_derivatives(e, k, k2):
     one_minus_k2 = 1.0 - k2
     inv_2k2 = 0.5 / k2
 
-    dE_dk2 = (e - k) * inv_2k2
-    dK_dk2 = (e - one_minus_k2 * k) * inv_2k2 / one_minus_k2
+    dE_dk2 = (e - k) * inv_2k2  # noqa: N806
+    dK_dk2 = (e - one_minus_k2 * k) * inv_2k2 / one_minus_k2  # noqa: N806
 
     return dK_dk2, dE_dk2
 
 
-@nb.njit(cache=True)
+@nb.njit(nopython=True, cache=True)
 def greens_psi(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -224,9 +237,47 @@ def greens_psi(
     d_zc: float = 0,  # noqa: ARG001
 ) -> float | np.ndarray:
     """
-    Calculate poloidal flux due to a unit circular current filament.
+    Calculate poloidal flux at (x, z) due to a unit current at (xc, zc)
+    using a Greens function.
 
-    The analytical axis value is zero.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Poloidal magnetic flux per radian response at (x, z)
+
+    Raises
+    ------
+    ZeroDivisionError
+        if xc == x == 0
+
+    Notes
+    -----
+    \t:math:`G_{\\psi}(x_{c}, z_{c}; x, z) = \\dfrac{{\\mu}_{0}}{2{\\pi}}`
+    \t:math:`\\dfrac{\\sqrt{xx_{c}}}{k}`
+    \t:math:`[(2-\\mathbf{K}(k^2)-2\\mathbf{E}(k^2)]`\n
+    Where:
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+
+    The analytical axis value is 0.0. This is checked for as x <= 0.
+
+    Negative x or xc values should not be used.
     """
     axis = x <= 0.0
 
@@ -248,9 +299,47 @@ def greens_dpsi_dx(
     d_zc: float = 0,  # noqa: ARG001
 ) -> float | np.ndarray:
     """
-    Calculate the radial derivative of the poloidal flux.
+    Calculate the radial derivative of the poloidal flux at (x, z)
+    due to a unit current at (xc, zc) using a Greens function.
 
-    Its analytical axis value is zero.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Radial derivative of the poloidal flux response at (x, z)
+
+    Notes
+    -----
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}(x_{c}, z_{c}; x, z) =`
+    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
+    \t:math:`\\dfrac{1}{u}`
+    \t:math:`[\\dfrac{w^2}{d^2}\\mathbf{E}(k^2)+\\mathbf{K}(k^2)]`\n
+    Where:
+    \t:math:`h^{2}\\equiv z_{c}-z`\n
+    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
+    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
+    \t:math:`w^{2}\\equiv x^2 -x_{c}^2 - h^2`\n
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+
+    The implementation used here refactors the above to avoid some zero divisions.
+
+    Its analytical axis value is 0.0.
     """
     radial_term = _radial_response(xc, zc, x, z)
 
@@ -268,9 +357,47 @@ def greens_dpsi_dz(
     d_zc: float = 0,  # noqa: ARG001
 ) -> float | np.ndarray:
     """
-    Calculate the vertical derivative of the poloidal flux.
+    Calculate the vertical derivative of the poloidal flux at (x, z)
+    due to a unit current at (xc, zc) using a Greens function.
 
-    Its analytical axis value is zero.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Vertical derivative of the poloidal flux response at (x, z)
+
+    Notes
+    -----
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}(x_{c}, z_{c}; x, z) =`
+    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
+    \t:math:`\\dfrac{h}{u}`
+    \t:math:`[\\mathbf{K}(k^2) - \\dfrac{v^2}{d^2}\\mathbf{E}(k^2)]`\n
+    Where:
+    \t:math:`h^{2}\\equiv z_{c}-z`\n
+    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
+    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
+    \t:math:`v^{2}\\equiv x^2 +x_{c}^2 + h^2`\n
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+
+    The implementation used here refactors the above to avoid some zero divisions.
+
+    Its analytical axis value is 0.0.
     """
     axis = x <= 0.0
 
@@ -292,7 +419,35 @@ def greens_Bx(
     """
     Calculate the radial magnetic-field response.
 
-    The analytical axis value is zero.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Radial magnetic field response at (x, z)
+
+    Notes
+    -----
+    .. math::
+
+        G_{B_x}
+        =-\frac{\\mu_0}{2\\pi}\frac{h}{x}
+        \\left(I_1-v^2I_2\right).
+
+    The analytical axis value is 0.0.
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)
@@ -315,7 +470,41 @@ def greens_Bz(
     """
     Calculate the vertical magnetic-field response.
 
-    Axis entries use the analytical circular-filament field.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Vertical magnetic field response at (x, z)
+
+    Notes
+    -----
+    .. math::
+
+        G_{B_z}
+        =\frac{\\mu_0}{2\\pi}
+        \\left(I_1+w^2I_2\right).
+
+    On the symmetry axis,
+
+    .. math::
+
+        G_{B_z}(0,z)=
+        \frac{\\mu_0x_c^2}
+        {2\\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
     """
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
     e, k = _elliptic_integrals(k2)
@@ -337,10 +526,43 @@ def greens_dbz_dx(
     x: float | np.ndarray,
     z: float | np.ndarray,
 ) -> float | np.ndarray:
-    """
+    r"""
     Calculate the radial derivative of the vertical magnetic field.
 
-    The analytical axis value is zero.
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        The gradient of the vertical magnetic field
+
+    Notes
+    -----
+    .. math::
+
+        \frac{\partial B_z}{\partial x}
+        =\frac{\partial B_x}{\partial z}
+        =\frac{\mu_0}{2\pi}
+        \left[
+            \frac{1}{u}\frac{\partial F}{\partial x}
+            -\frac{x+x_c}{u^3}F
+        \right],
+
+    where :math:`F=K(k^2)+E(k^2)w^2/d^2` and
+    :math:`d^2=(x-x_c)^2+h^2`. The analytical axis value is zero.
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)
@@ -355,7 +577,7 @@ def greens_dbz_dx(
     w2 = xc * xc - x * x - h2
 
     e, k = _elliptic_integrals(k2)
-    dK_dk2, dE_dk2 = _elliptic_parameter_derivatives(
+    dK_dk2, dE_dk2 = _elliptic_derivatives(
         e,
         k,
         k2,

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -207,16 +207,9 @@ def _elliptic_derivatives(e, k, k2):
 
     .. math::
 
-        \frac{dE}{d(k^2)}
-        =
-        \frac{E-K}{2k^2},
-
-    .. math::
-
+        \frac{dE}{d(k^2)}=\frac{E-K}{2k^2},\qquad
         \frac{dK}{d(k^2)}
-        =
-        \frac{E-(1-k^2)K}
-        {2k^2(1-k^2)}.
+        =\frac{E-(1-k^2)K}{2k^2(1-k^2)}.
     """
     one_minus_k2 = 1.0 - k2
     inv_2k2 = 0.5 / k2
@@ -267,17 +260,12 @@ def greens_psi(
 
     Notes
     -----
-    \t:math:`G_{\\psi}(x_{c}, z_{c}; x, z) = \\dfrac{{\\mu}_{0}}{2{\\pi}}`
-    \t:math:`\\dfrac{\\sqrt{xx_{c}}}{k}`
-    \t:math:`[(2-\\mathbf{K}(k^2)-2\\mathbf{E}(k^2)]`\n
-    Where:
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+    .. math::
+        G_\psi=    \frac{\mu_0}{4\pi}[(2-k^2)K(k^2)-2E(k^2)]
 
     The analytical axis value is 0.0. This is checked for as x <= 0.
 
-    Negative x or xc values should not be used.
+    Negative x or xc values are outside the intended domain.
     """
     axis = x <= 0.0
 
@@ -324,22 +312,17 @@ def greens_dpsi_dx(
 
     Notes
     -----
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}(x_{c}, z_{c}; x, z) =`
-    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
-    \t:math:`\\dfrac{1}{u}`
-    \t:math:`[\\dfrac{w^2}{d^2}\\mathbf{E}(k^2)+\\mathbf{K}(k^2)]`\n
-    Where:
-    \t:math:`h^{2}\\equiv z_{c}-z`\n
-    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
-    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
-    \t:math:`w^{2}\\equiv x^2 -x_{c}^2 - h^2`\n
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+    .. math::
+
+        \frac{\partial G_\psi}{\partial x}
+        =\frac{\mu_0}{2\pi}x
+        \left(I_1+w^2I_2\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
-    Its analytical axis value is 0.0.
+    The analytical axis value is 0.0. This is checked for as x <= 0.
+
+    Negative x or xc values are outside the intended domain.
     """
     radial_term = _radial_response(xc, zc, x, z)
 
@@ -382,22 +365,17 @@ def greens_dpsi_dz(
 
     Notes
     -----
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}(x_{c}, z_{c}; x, z) =`
-    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
-    \t:math:`\\dfrac{h}{u}`
-    \t:math:`[\\mathbf{K}(k^2) - \\dfrac{v^2}{d^2}\\mathbf{E}(k^2)]`\n
-    Where:
-    \t:math:`h^{2}\\equiv z_{c}-z`\n
-    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
-    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
-    \t:math:`v^{2}\\equiv x^2 +x_{c}^2 + h^2`\n
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+    .. math::
+
+        \frac{\partial G_\psi}{\partial z}
+        =\frac{\mu_0}{2\pi}h
+        \left(I_1-v^2I_2\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
-    Its analytical axis value is 0.0.
+    The analytical axis value is 0.0. This is checked for as x <= 0.
+
+    Negative x or xc values are outside the intended domain.
     """
     axis = x <= 0.0
 
@@ -447,7 +425,9 @@ def greens_Bx(
         =-\frac{\\mu_0}{2\\pi}\frac{h}{x}
         \\left(I_1-v^2I_2\right).
 
-    The analytical axis value is 0.0.
+    The analytical axis value is 0.0. This is checked for as x <= 0.
+
+    Negative x or xc values are outside the intended domain.
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)
@@ -505,6 +485,10 @@ def greens_Bz(
         G_{B_z}(0,z)=
         \frac{\\mu_0x_c^2}
         {2\\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
+
+    The axis value is calculated analytically.
+
+    Negative x or xc values are outside the intended domain.
     """
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
     e, k = _elliptic_integrals(k2)
@@ -562,7 +546,11 @@ def greens_dbz_dx(
         \right],
 
     where :math:`F=K(k^2)+E(k^2)w^2/d^2` and
-    :math:`d^2=(x-x_c)^2+h^2`. The analytical axis value is zero.
+    :math:`d^2=(x-x_c)^2+h^2`.
+
+    The analytical axis value is 0.0. This is checked for as x <= 0.
+
+    Negative x or xc values are outside the intended domain.
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)
@@ -634,6 +622,17 @@ def greens_all(
     Calculate poloidal flux, radial field, and vertical field together.
 
     Geometry, masks, and elliptic integrals are each evaluated once.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -76,7 +76,7 @@ def _common_geometry(xc, zc, x, z):
 
     .. math::
 
-        k^2 = \frac{4xx_c}{u^2}.
+        k^2 = \\frac{4xx_c}{u^2}.
     """  # noqa: DOC201
     h = z - zc
     xp = x + xc
@@ -101,11 +101,11 @@ def _i1_i2(u, u2, k2, e, k):
 
     .. math::
 
-        I_1 = \frac{K(k^2)}{u},
+        I_1 = \\frac{K(k^2)}{u},
 
     .. math::
 
-        I_2 = \frac{E(k^2)}{u^3(1-k^2)}.
+        I_2 = \\frac{E(k^2)}{u^3(1-k^2)}.
     """  # noqa: DOC201
     inv_u = 1.0 / u
 
@@ -181,8 +181,8 @@ def _axis_bz(xc, zc, z):
     .. math::
 
         B_z(0,z)=
-        \frac{\\mu_0x_c^2}
-        {2\\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
+        \\frac{\\mu_0x_c^2}
+        {2\\left[x_c^2+(z-z_c)^2\\right]^{3/2}}.
     """  # noqa: DOC201
     h = z - zc
     u2 = xc * xc + h * h
@@ -197,9 +197,9 @@ def _elliptic_derivatives(e, k, k2):
 
     .. math::
 
-        \frac{dE}{d(k^2)}=\frac{E-K}{2k^2},\\qquad
-        \frac{dK}{d(k^2)}
-        =\frac{E-(1-k^2)K}{2k^2(1-k^2)}.
+        \\frac{dE}{d(k^2)}=\\frac{E-K}{2k^2},\\qquad
+        \\frac{dK}{d(k^2)}
+        =\\frac{E-(1-k^2)K}{2k^2(1-k^2)}.
     """  # noqa: DOC201
     one_minus_k2 = 1.0 - k2
     inv_2k2 = 0.5 / k2
@@ -251,7 +251,8 @@ def greens_psi(
     Notes
     -----
     .. math::
-        G_\\psi=    \frac{\\mu_0}{4\\pi}[(2-k^2)K(k^2)-2E(k^2)]
+
+        G_\\psi= \\frac{\\mu_0}{4\\pi}[(2-k^2)K(k^2)-2E(k^2)]
 
     The analytical axis value is 0.0. This is checked for as x <= 0.
 
@@ -304,9 +305,9 @@ def greens_dpsi_dx(
     -----
     .. math::
 
-        \frac{\\partial G_\\psi}{\\partial x}
-        =\frac{\\mu_0}{2\\pi}x
-        \\left(I_1+w^2I_2\right).
+        \\frac{\\partial G_\\psi}{\\partial x}
+        =\\frac{\\mu_0}{2\\pi}x
+        \\left(I_1+w^2I_2\\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
@@ -357,9 +358,9 @@ def greens_dpsi_dz(
     -----
     .. math::
 
-        \frac{\\partial G_\\psi}{\\partial z}
-        =\frac{\\mu_0}{2\\pi}h
-        \\left(I_1-v^2I_2\right).
+        \\frac{\\partial G_\\psi}{\\partial z}
+        =\\frac{\\mu_0}{2\\pi}h
+        \\left(I_1-v^2I_2\\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
@@ -412,8 +413,8 @@ def greens_Bx(
     .. math::
 
         G_{B_x}
-        =-\frac{\\mu_0}{2\\pi}\frac{h}{x}
-        \\left(I_1-v^2I_2\right).
+        =-\\frac{\\mu_0}{2\\pi}\\frac{h}{x}
+        \\left(I_1-v^2I_2\\right).
 
     The analytical axis value is 0.0. This is checked for as x <= 0.
 
@@ -465,16 +466,16 @@ def greens_Bz(
     .. math::
 
         G_{B_z}
-        =\frac{\\mu_0}{2\\pi}
-        \\left(I_1+w^2I_2\right).
+        =\\frac{\\mu_0}{2\\pi}
+        \\left(I_1+w^2I_2\\right).
 
     On the symmetry axis,
 
     .. math::
 
         G_{B_z}(0,z)=
-        \frac{\\mu_0x_c^2}
-        {2\\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
+        \\frac{\\mu_0x_c^2}
+        {2\\left[x_c^2+(z-z_c)^2\\right]^{3/2}}.
 
     The axis value is calculated analytically.
 
@@ -523,13 +524,13 @@ def greens_dbz_dx(
     -----
     .. math::
 
-        \frac{\\partial B_z}{\\partial x}
-        =\frac{\\partial B_x}{\\partial z}
-        =\frac{\\mu_0}{2\\pi}
+        \\frac{\\partial B_z}{\\partial x}
+        =\\frac{\\partial B_x}{\\partial z}
+        =\\frac{\\mu_0}{2\\pi}
         \\left[
-            \frac{1}{u}\frac{\\partial F}{\\partial x}
-            -\frac{x+x_c}{u^3}F
-        \right],
+            \\frac{1}{u}\\frac{\\partial F}{\\partial x}
+            -\\frac{x+x_c}{u^3}F
+        \\right],
 
     where :math:`F=K(k^2)+E(k^2)w^2/d^2` and
     :math:`d^2=(x-x_c)^2+h^2`.
@@ -678,6 +679,7 @@ def circular_coil_inductance_elliptic(
     The inductance is given by
 
     .. math::
+
         L = \\mu_{0} (2 r - r_c) \\Biggl((1 - k^2 / 2)~
         \\int_0^{\\frac{\\pi}{2}} \\frac{d\\theta}{\\sqrt{1 - k~
         \\sin (\\theta)^2}} - \\int_0^{\\frac{\\pi}{2}}~
@@ -687,6 +689,7 @@ def circular_coil_inductance_elliptic(
     permeability, and
 
     .. math::
+
         k = \\max\\left(10^{-8}, \\min~
         \\left(\\frac{4r(r - r_c)}{(2r - r_c)^2}~
         , 1.0 - 10^{-8}\\right)\\right)
@@ -716,6 +719,7 @@ def circular_coil_inductance_kirchhoff(
     -----
 
     .. math::
+
         Inductance = \\mu_{0} * radius * (log(8 * radius / rc) - 2 + 0.25)
 
     where :math:`\\mu_{0}` is the vacuum permeability

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -32,17 +32,7 @@ __all__ = [
 GREENS_ZERO = 1e-8
 
 
-@nb.vectorize(nopython=True, cache=True)
-def _clip_k2(k2):
-    """Keep the elliptic parameter strictly inside 0 < k² < 1."""
-    if k2 < GREENS_ZERO:
-        return GREENS_ZERO
-    if k2 > 1.0 - GREENS_ZERO:
-        return 1.0 - GREENS_ZERO
-    return k2
-
-
-@nb.vectorize(nopython=True, cache=True)
+@nb.vectorize(cache=True)
 def clip_nb(
     val: float | np.ndarray, val_min: float, val_max: float
 ) -> float | np.ndarray:
@@ -71,7 +61,7 @@ def clip_nb(
     return val
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _common_geometry(xc, zc, x, z):
     r"""
     Calculate the geometry shared by the Green's functions.
@@ -93,18 +83,18 @@ def _common_geometry(xc, zc, x, z):
 
     u2 = xp * xp + h * h
     u = np.sqrt(u2)
-    k2 = _clip_k2(4.0 * x * xc / u2)
+    k2 = clip_nb(4.0 * x * xc / u2, GREENS_ZERO, 1.0 - GREENS_ZERO)
 
     return h, u, u2, k2
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _elliptic_integrals(k2):
     """Evaluate E(k²) and K(k²)."""
     return ellipe_nb(k2), ellipk_nb(k2)
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _i1_i2(u, u2, k2, e, k):
     r"""
     Calculate
@@ -125,7 +115,7 @@ def _i1_i2(u, u2, k2, e, k):
     return i1, i2
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _radial_term(xc, x, h, i1, i2):
     r"""
     Calculate
@@ -144,7 +134,7 @@ def _radial_term(xc, x, h, i1, i2):
     return i1 + w2 * i2
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _vertical_term(xc, x, h, i1, i2):
     r"""
     Calculate
@@ -163,7 +153,7 @@ def _vertical_term(xc, x, h, i1, i2):
     return i1 - v2 * i2
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _radial_response(xc, zc, x, z):
     """Calculate the term shared by dpsi/dx and Bz."""
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
@@ -173,7 +163,7 @@ def _radial_response(xc, zc, x, z):
     return _radial_term(xc, x, h, i1, i2)
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _vertical_response(xc, zc, x, z):
     """Calculate the quantities shared by dpsi/dz and Bx."""
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
@@ -183,7 +173,7 @@ def _vertical_response(xc, zc, x, z):
     return h, _vertical_term(xc, x, h, i1, i2)
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _axis_bz(xc, zc, z):
     r"""
     Calculate the analytical vertical field on the symmetry axis.
@@ -200,7 +190,7 @@ def _axis_bz(xc, zc, z):
     return 0.5 * MU_0 * xc * xc / (u2 * np.sqrt(u2))
 
 
-@nb.njit(nopython=True, cache=True, inline="always")
+@nb.njit(cache=True, inline="always")
 def _elliptic_derivatives(e, k, k2):
     r"""
     Calculate elliptic-integral derivatives with respect to ``k²``.
@@ -220,7 +210,7 @@ def _elliptic_derivatives(e, k, k2):
     return dK_dk2, dE_dk2
 
 
-@nb.njit(nopython=True, cache=True)
+@nb.njit(cache=True)
 def greens_psi(
     xc: float | np.ndarray,
     zc: float | np.ndarray,
@@ -261,7 +251,7 @@ def greens_psi(
     Notes
     -----
     .. math::
-        G_\psi=    \frac{\mu_0}{4\pi}[(2-k^2)K(k^2)-2E(k^2)]
+        G_\\psi=    \frac{\\mu_0}{4\\pi}[(2-k^2)K(k^2)-2E(k^2)]
 
     The analytical axis value is 0.0. This is checked for as x <= 0.
 
@@ -314,9 +304,9 @@ def greens_dpsi_dx(
     -----
     .. math::
 
-        \frac{\partial G_\psi}{\partial x}
-        =\frac{\mu_0}{2\pi}x
-        \left(I_1+w^2I_2\right).
+        \frac{\\partial G_\\psi}{\\partial x}
+        =\frac{\\mu_0}{2\\pi}x
+        \\left(I_1+w^2I_2\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
@@ -367,9 +357,9 @@ def greens_dpsi_dz(
     -----
     .. math::
 
-        \frac{\partial G_\psi}{\partial z}
-        =\frac{\mu_0}{2\pi}h
-        \left(I_1-v^2I_2\right).
+        \frac{\\partial G_\\psi}{\\partial z}
+        =\frac{\\mu_0}{2\\pi}h
+        \\left(I_1-v^2I_2\right).
 
     The implementation used here refactors the above to avoid some zero divisions.
 
@@ -523,10 +513,6 @@ def greens_dbz_dx(
         Calculation x locations
     z:
         Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
 
     Returns
     -------
@@ -565,7 +551,7 @@ def greens_dbz_dx(
     w2 = xc * xc - x * x - h2
 
     e, k = _elliptic_integrals(k2)
-    dK_dk2, dE_dk2 = _elliptic_derivatives(
+    dK_dk2, dE_dk2 = _elliptic_derivatives(  # noqa: N806
         e,
         k,
         k2,
@@ -633,6 +619,15 @@ def greens_all(
         Calculation x locations
     z:
         Calculation z locations
+
+    Returns
+    -------
+    psi:
+        Poloidal flux response
+    Bx:
+        Radial magnetic field response
+    Bz:
+        Vertical magnetic field response
     """
     axis = x <= 0.0
     x_safe = np.where(axis, 1.0, x)
@@ -697,7 +692,7 @@ def circular_coil_inductance_elliptic(
         , 1.0 - 10^{-8}\\right)\\right)
     """
     k = 4 * radius * (radius - rc) / (2 * radius - rc) ** 2
-    k = _clip_k2(k)
+    k = clip_nb(k, GREENS_ZERO, 1.0 - GREENS_ZERO)
     return MU_0 * (2 * radius - rc) * ((1 - k**2 / 2) * ellipk_nb(k) - ellipe_nb(k))
 
 

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -1,13 +1,3 @@
-# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
-# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
-# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
-#
-# SPDX-License-Identifier: LGPL-2.1-or-later
-
-"""
-Green's functions mappings for psi, Bx, and Bz
-"""
-
 import numba as nb
 import numpy as np
 
@@ -16,8 +6,6 @@ from bluemira.magnetostatics._ellipe import ellipe_nb
 from bluemira.magnetostatics._ellipk import ellipk_nb
 
 __all__ = [
-    "ellipe_nb",
-    "ellipk_nb",
     "greens_Bx",
     "greens_Bz",
     "greens_all",
@@ -27,9 +15,18 @@ __all__ = [
     "greens_psi",
 ]
 
-# Offset from 0<x<1
-#     Used in calculating Green's functions to avoid np.nan
+
 GREENS_ZERO = 1e-8
+
+
+@nb.vectorize(nopython=True, cache=True)
+def _clip_k2(k2):
+    """Keep the elliptic parameter strictly inside 0 < k² < 1."""
+    if k2 < GREENS_ZERO:
+        return GREENS_ZERO
+    if k2 > 1.0 - GREENS_ZERO:
+        return 1.0 - GREENS_ZERO
+    return k2
 
 
 @nb.vectorize(nopython=True, cache=True)
@@ -61,124 +58,384 @@ def clip_nb(
     return val
 
 
-@nb.njit(cache=True)
-def _elliptic_derivatives(e, k, k2):
-    r"""Get :math:`\frac{dK}{dk}` and :math:`\frac{dE}{dk}` [dimensionless]
+@nb.njit(cache=True, inline="always")
+def _common_geometry(xc, zc, x, z):
+    r"""
+    Calculate the geometry shared by the Green's functions.
 
     .. math::
 
-        \frac{dK}{dk} &= \frac{E}{k}\frac{1}{1-k^2} - \frac{K}{k}
-
-        \frac{dE}{dk} &= \frac{E}{k} - \frac{K}{k}
-
-    Returns
-    -------
-    :
-        ellipk derivative
-    :
-        ellipe derivative
-    """
-    sqk2 = np.sqrt(k2)
-    e_sqk = e / sqk2
-    k_sqk = k / sqk2
-    dKdk = e_sqk / (1 - k2) - k_sqk  # noqa: N806
-    dEdk = e_sqk - k_sqk  # noqa: N806
-    return dKdk, dEdk
-
-
-@nb.njit(cache=True)
-def _dkdr(g3, xc, x):
-    r"""Get dkdr
+        h = z-z_c,
 
     .. math::
 
-        \text{dkdr} &= \frac{-2 x xc \frac{x+xc}{g_3^2} +
-                       \frac{x}{g_3}}{\sqrt{\frac{x xc}{g_3}}}
-
-            &= -2\sqrt{x xc} \sqrt{g_3}(\frac{x+xc}{g_3^2}) +
-                \sqrt{\frac{g_3}{x xc}}\frac{x}{g_3}
-
-            &= -2\sqrt{\frac{x xc}{g_3^3}} (x+xc) + \sqrt{\frac{xc}{g_3x}}
-
-            &= -2 \frac{(x+xc)\sqrt{x xc}}{g_3^{\frac{3}{2}}}  + \sqrt{\frac{xc}{g_3x}}
-
-    unit: [m^(-1)]
-
-    Returns
-    -------
-    :
-        dkdr
-
-    """
-    # old_expression = (-2 * x * xc * (x + xc) / (g3**2) + x / g3) / sqrt(x * xc / g3)
-    term_1 = -2 * (x + xc) * np.sqrt(x * xc) / g3**1.5
-    term_2 = np.sqrt(xc / (g3 * x))
-    return term_1 + term_2
-
-
-@nb.njit(cache=True)
-def _g(xc, zc, x, z):
-    r"""Get the tuple of (:math:`g_1, g_2, g_3, g_4`)
-
-    unit: [m^2]
+        u^2 = (x+x_c)^2+h^2,
 
     .. math::
 
-        g_1 &= xc^2 - x^2 - z^2
-        g_2 &= (xc - x)^2 + z^2
-        g_3 &= (xc + x)^2 + z^2
-        g_4 &= xc^2 + x^2 + z^2
-
-    Returns
-    -------
-    :
-        g1
-    :
-        g2
-    :
-        g3
-    :
-        g4
+        k^2 = \frac{4xx_c}{u^2}.
     """
-    x2 = x**2
-    xc2 = xc**2
-    z2 = (zc - z) ** 2
-    g1 = xc2 - x2 - z2
-    g2 = (xc - x) ** 2 + z2
-    g3 = (xc + x) ** 2 + z2
-    g4 = xc2 + x2 + z2
-    return g1, g2, g3, g4
+    h = z - zc
+    xp = x + xc
+
+    u2 = xp * xp + h * h
+    u = np.sqrt(u2)
+    k2 = _clip_k2(4.0 * x * xc / u2)
+
+    return h, u, u2, k2
 
 
-@nb.njit(cache=True)
-def _g_r(xc, x):
-    r"""Get the tuple of (:math:`g_{1r}, g_{2r}, g_{3r}`)
+@nb.njit(cache=True, inline="always")
+def _elliptic_integrals(k2):
+    """Evaluate E(k²) and K(k²)."""
+    return ellipe_nb(k2), ellipk_nb(k2)
 
-    unit: [m]
+
+@nb.njit(cache=True, inline="always")
+def _i1_i2(u, u2, k2, e, k):
+    r"""
+    Calculate
 
     .. math::
 
-        g_{1r} &= \frac{dg_1}{dxc} = -2xc
-        g_{2r} &= \frac{dg_2}{dxc} = 2xc - 2x
-        g_{3r} &= \frac{dg_3}{dxc} = 2xc + 2x
+        I_1 = \frac{K(k^2)}{u},
 
-    :math:`g_{4r}` is not used anywhere so is not computed.
+    .. math::
 
-    Returns
-    -------
-    :
-        g1r
-    :
-        g2r
-    :
-        g3r
+        I_2 = \frac{E(k^2)}{u^3(1-k^2)}.
     """
-    xc2 = 2 * xc
-    x2 = 2 * x
-    g1r = -xc2
-    g2r = xc2 - x2
-    g3r = xc2 + x2
-    return g1r, g2r, g3r
+    inv_u = 1.0 / u
+
+    i1 = k * inv_u
+    i2 = e * inv_u / (u2 * (1.0 - k2))
+
+    return i1, i2
+
+
+@nb.njit(cache=True, inline="always")
+def _radial_term(xc, x, h, i1, i2):
+    r"""
+    Calculate
+
+    .. math::
+
+        R = I_1+w^2I_2,
+
+    where
+
+    .. math::
+
+        w^2=x_c^2-x^2-h^2.
+    """
+    w2 = xc * xc - x * x - h * h
+    return i1 + w2 * i2
+
+
+@nb.njit(cache=True, inline="always")
+def _vertical_term(xc, x, h, i1, i2):
+    r"""
+    Calculate
+
+    .. math::
+
+        Z = I_1-v^2I_2,
+
+    where
+
+    .. math::
+
+        v^2=x^2+x_c^2+h^2.
+    """
+    v2 = x * x + xc * xc + h * h
+    return i1 - v2 * i2
+
+
+@nb.njit(cache=True, inline="always")
+def _radial_response(xc, zc, x, z):
+    """Calculate the term shared by dpsi/dx and Bz."""
+    h, u, u2, k2 = _common_geometry(xc, zc, x, z)
+    e, k = _elliptic_integrals(k2)
+    i1, i2 = _i1_i2(u, u2, k2, e, k)
+
+    return _radial_term(xc, x, h, i1, i2)
+
+
+@nb.njit(cache=True, inline="always")
+def _vertical_response(xc, zc, x, z):
+    """Calculate the quantities shared by dpsi/dz and Bx."""
+    h, u, u2, k2 = _common_geometry(xc, zc, x, z)
+    e, k = _elliptic_integrals(k2)
+    i1, i2 = _i1_i2(u, u2, k2, e, k)
+
+    return h, _vertical_term(xc, x, h, i1, i2)
+
+
+@nb.njit(cache=True, inline="always")
+def _axis_bz(xc, zc, z):
+    r"""
+    Calculate the analytical vertical field on the symmetry axis.
+
+    .. math::
+
+        B_z(0,z)=
+        \frac{\mu_0x_c^2}
+        {2\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
+    """
+    h = z - zc
+    u2 = xc * xc + h * h
+
+    return 0.5 * MU_0 * xc * xc / (u2 * np.sqrt(u2))
+
+
+@nb.njit(cache=True, inline="always")
+def _elliptic_parameter_derivatives(e, k, k2):
+    r"""
+    Calculate elliptic-integral derivatives with respect to ``k²``.
+
+    .. math::
+
+        \frac{dE}{d(k^2)}
+        =
+        \frac{E-K}{2k^2},
+
+    .. math::
+
+        \frac{dK}{d(k^2)}
+        =
+        \frac{E-(1-k^2)K}
+        {2k^2(1-k^2)}.
+    """
+    one_minus_k2 = 1.0 - k2
+    inv_2k2 = 0.5 / k2
+
+    dE_dk2 = (e - k) * inv_2k2
+    dK_dk2 = (e - one_minus_k2 * k) * inv_2k2 / one_minus_k2
+
+    return dK_dk2, dE_dk2
+
+
+@nb.njit(cache=True)
+def greens_psi(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate poloidal flux due to a unit circular current filament.
+
+    The analytical axis value is zero.
+    """
+    axis = x <= 0.0
+
+    _, u, _, k2 = _common_geometry(xc, zc, x, z)
+    e, k = _elliptic_integrals(k2)
+
+    result = MU_0_4PI * u * ((2.0 - k2) * k - 2.0 * e)
+
+    return np.where(axis, 0.0, result)
+
+
+@nb.njit(cache=True)
+def greens_dpsi_dx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the radial derivative of the poloidal flux.
+
+    Its analytical axis value is zero.
+    """
+    radial_term = _radial_response(xc, zc, x, z)
+
+    # The explicit factor of x supplies the exact axis value for mixed arrays.
+    return MU_0_2PI * x * radial_term
+
+
+@nb.njit(cache=True)
+def greens_dpsi_dz(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the vertical derivative of the poloidal flux.
+
+    Its analytical axis value is zero.
+    """
+    axis = x <= 0.0
+
+    h, vertical_term = _vertical_response(xc, zc, x, z)
+    result = MU_0_2PI * h * vertical_term
+
+    return np.where(axis, 0.0, result)
+
+
+@nb.njit(cache=True)
+def greens_Bx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the radial magnetic-field response.
+
+    The analytical axis value is zero.
+    """
+    axis = x <= 0.0
+    x_safe = np.where(axis, 1.0, x)
+
+    h, vertical_term = _vertical_response(xc, zc, x, z)
+    result = -MU_0_2PI * h * vertical_term / x_safe
+
+    return np.where(axis, 0.0, result)
+
+
+@nb.njit(cache=True)
+def greens_Bz(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the vertical magnetic-field response.
+
+    Axis entries use the analytical circular-filament field.
+    """
+    h, u, u2, k2 = _common_geometry(xc, zc, x, z)
+    e, k = _elliptic_integrals(k2)
+    i1, i2 = _i1_i2(u, u2, k2, e, k)
+
+    xc2 = xc * xc
+    w2 = xc2 - x * x - h * h
+
+    bz = MU_0_2PI * (i1 + w2 * i2)
+    bz_axis = 0.5 * MU_0 * xc2 / (u2 * u)
+
+    return np.where(x <= 0.0, bz_axis, bz)
+
+
+@nb.njit(cache=True)
+def greens_dbz_dx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+) -> float | np.ndarray:
+    """
+    Calculate the radial derivative of the vertical magnetic field.
+
+    The analytical axis value is zero.
+    """
+    axis = x <= 0.0
+    x_safe = np.where(axis, 1.0, x)
+
+    h, u, u2, k2 = _common_geometry(xc, zc, x, z)
+
+    xm = x - xc
+    h2 = h * h
+
+    # Calculate d² directly to avoid cancellation near the filament.
+    d2 = xm * xm + h2
+    w2 = xc * xc - x * x - h2
+
+    e, k = _elliptic_integrals(k2)
+    dK_dk2, dE_dk2 = _elliptic_parameter_derivatives(
+        e,
+        k,
+        k2,
+    )
+
+    d2_is_zero = np.isclose(d2, 0.0)
+    u2_is_zero = np.isclose(u2, 0.0)
+
+    singular = np.logical_or(d2_is_zero, u2_is_zero)
+    invalid = np.logical_or(axis, singular)
+
+    d2_safe = np.where(d2_is_zero, GREENS_ZERO, d2)
+    u2_safe = np.where(u2_is_zero, GREENS_ZERO, u2)
+    u_safe = np.where(u2_is_zero, np.sqrt(u2_safe), u)
+
+    inv_d2 = 1.0 / d2_safe
+    inv_d2_2 = inv_d2 * inv_d2
+    inv_u = 1.0 / u_safe
+    inv_u3 = inv_u / u2_safe
+
+    w2_over_d2 = w2 * inv_d2
+    elliptic_term = k + e * w2_over_d2
+
+    # Differentiate the underlying geometric parameter. The elliptic
+    # functions themselves continue to use the clipped parameter.
+    k2_geometric = 4.0 * x * xc / u2_safe
+
+    dk2_dx = k2_geometric * (1.0 / x_safe - 2.0 * (x + xc) / u2_safe)
+
+    d_elliptic_term_dx = (
+        dK_dk2 * dk2_dx
+        + dE_dk2 * dk2_dx * w2_over_d2
+        - 2.0 * e * x * inv_d2
+        - 2.0 * e * w2 * xm * inv_d2_2
+    )
+
+    result = MU_0_2PI * (d_elliptic_term_dx * inv_u - elliptic_term * (x + xc) * inv_u3)
+
+    return np.where(invalid, 0.0, result)
+
+
+@nb.njit(cache=True)
+def greens_all(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+) -> tuple[
+    float | np.ndarray,
+    float | np.ndarray,
+    float | np.ndarray,
+]:
+    """
+    Calculate poloidal flux, radial field, and vertical field together.
+
+    Geometry, masks, and elliptic integrals are each evaluated once.
+    """
+    axis = x <= 0.0
+    x_safe = np.where(axis, 1.0, x)
+
+    h, u, u2, k2 = _common_geometry(xc, zc, x, z)
+    e, k = _elliptic_integrals(k2)
+    i1, i2 = _i1_i2(u, u2, k2, e, k)
+
+    radial_term = _radial_term(xc, x, h, i1, i2)
+    vertical_term = _vertical_term(xc, x, h, i1, i2)
+
+    psi = MU_0_4PI * u * ((2.0 - k2) * k - 2.0 * e)
+
+    bx = -MU_0_2PI * h * vertical_term / x_safe
+
+    bz = MU_0_2PI * radial_term
+
+    axis_bz = _axis_bz(xc, zc, z)
+
+    psi = np.where(axis, 0.0, psi)
+    bx = np.where(axis, 0.0, bx)
+    bz = np.where(axis, axis_bz, bz)
+
+    return psi, bx, bz
 
 
 @nb.njit(cache=True)
@@ -219,7 +476,7 @@ def circular_coil_inductance_elliptic(
         , 1.0 - 10^{-8}\\right)\\right)
     """
     k = 4 * radius * (radius - rc) / (2 * radius - rc) ** 2
-    k = clip_nb(k, GREENS_ZERO, 1.0 - GREENS_ZERO)
+    k = _clip_k2(k)
     return MU_0 * (2 * radius - rc) * ((1 - k**2 / 2) * ellipk_nb(k) - ellipe_nb(k))
 
 
@@ -278,448 +535,29 @@ def square_coil_inductance_kirchhoff(
     return MU_0 * radius * (np.log(8 * radius / (width + height)) - 0.5)
 
 
-@nb.njit(cache=True)
-def greens_psi(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-    d_xc: float = 0,  # noqa: ARG001
-    d_zc: float = 0,  # noqa: ARG001
-) -> float | np.ndarray:
-    """
-    Calculate poloidal flux at (x, z) due to a unit current at (xc, zc)
-    using a Greens function.
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
 
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
+    from bluemira.magnetostatics.greens_old import greens_Bz as old_greens_Bz
 
-    Returns
-    -------
-    :
-        Poloidal magnetic flux per radian response at (x, z)
+    x = np.linspace(0, 0.1, 500)
+    z = np.zeros_like(x)
+    coil_x, coil_z = 4, 4
 
-    Raises
-    ------
-    ZeroDivisionError
-        if xc <= 0
+    psi = greens_psi(coil_x, coil_z, x, z)
+    dpsi_dx = greens_dpsi_dx(coil_x, coil_z, x, z)
+    dpsi_dz = greens_dpsi_dz(coil_x, coil_x, x, z)
+    bx = greens_Bx(coil_x, coil_z, x, z)
+    bz = greens_Bz(coil_x, coil_z, x, z)
+    old_bz = old_greens_Bz(coil_x, coil_z, x, z)
 
-    Notes
-    -----
-    \t:math:`G_{\\psi}(x_{c}, z_{c}; x, z) = \\dfrac{{\\mu}_{0}}{2{\\pi}}`
-    \t:math:`\\dfrac{\\sqrt{xx_{c}}}{k}`
-    \t:math:`[(2-\\mathbf{K}(k^2)-2\\mathbf{E}(k^2)]`\n
-    Where:
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
-    """
-    _, k2 = calc_a_k2(xc, zc, x, z)
-    e = ellipe_nb(k2)
-    k = ellipk_nb(k2)
-    return MU_0_2PI * np.sqrt(x * xc) * ((2 - k2) * k - 2 * e) / np.sqrt(k2)
+    for r in [psi, dpsi_dx, dpsi_dz, bx]:
+        f, ax = plt.subplots()
+        ax.plot(x, 1e6 * r)
+        plt.show()
 
-
-@nb.njit(cache=True)
-def greens_dpsi_dx(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-    d_xc: float = 0,  # noqa: ARG001
-    d_zc: float = 0,  # noqa: ARG001
-) -> float | np.ndarray:
-    """
-    Calculate the radial derivative of the poloidal flux at (x, z)
-    due to a unit current at (xc, zc) using a Greens function.
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
-
-    Returns
-    -------
-    :
-        Radial derivative of the poloidal flux response at (x, z)
-
-    Notes
-    -----
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}(x_{c}, z_{c}; x, z) =`
-    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
-    \t:math:`\\dfrac{1}{u}`
-    \t:math:`[\\dfrac{w^2}{d^2}\\mathbf{E}(k^2)+\\mathbf{K}(k^2)]`\n
-    Where:
-    \t:math:`h^{2}\\equiv z_{c}-z`\n
-    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
-    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
-    \t:math:`w^{2}\\equiv x^2 -x_{c}^2 - h^2`\n
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
-
-    The implementation used here refactors the above to avoid some zero divisions.
-    """
-    a, k2 = calc_a_k2(xc, zc, x, z)
-    i1, i2 = calc_i1_i2(a, k2)
-    return MU_0_2PI * x * ((xc**2 - (z - zc) ** 2 - x**2) * i2 + i1)
-
-
-@nb.njit(cache=True)
-def greens_dbz_dx(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-) -> float | np.ndarray:
-    r"""
-    Calculate :math:`\frac{dB_z}{dx}` (= :math:`\frac{dB_x}{dz}` for vacuum)
-
-    Get the radial gradient of the vertical magnetic field due to a circular filament.
-
-    unit: [N/A/m^2]
-
-    .. math::
-
-        \frac{dB_z}{dx} = \frac{dB_x}{dz} = \frac{\mu_0 I}{2 \pi}\left(
-            - \frac{(K+E\frac{g_1}{g_2}) g_{3r}}{2 g_3^{\frac{3}{2}}}
-            + \frac{- E \frac{g_{1r}}{g_2} - E \frac{g_1 g_{2r}}{g_2^2}
-                    + \frac{dE}{dk} \frac{g_1}{g_2} \text{dkdr}
-                    + \frac{dK}{dk} \text{dkdr}
-                    }{\sqrt{g_3}}
-        \right)
-
-    where :math:`K = K(k^2), E = E(k^2)`.
-
-    Returns
-    -------
-    :
-        the gradient to the magnetic field
-    """
-    _, k2 = calc_a_k2(xc, zc, x, z)
-    e = ellipe_nb(k2)
-    k = ellipk_nb(k2)
-    kdk, edk = _elliptic_derivatives(e, k, k2)
-    g1, g2, g3, _ = _g(xc, zc, x, z)
-    g1r, g2r, g3r = _g_r(x, xc)
-    dkdr = _dkdr(g3, xc, x)
-
-    # Avoid divide by 0
-    g2 = np.where(np.isclose(g2, 0), GREENS_ZERO, g2)
-    g3 = np.where(np.isclose(g3, 0), GREENS_ZERO, g3)
-    logic_or = np.logical_or(np.isclose(g2, 0), np.isclose(g3, 0))
-    inv_g2 = g2**-1
-    inv_g2_2 = g2**-2
-
-    p1 = np.where(
-        logic_or,
-        0,
-        -MU_0_4PI * (k + e * g1 * inv_g2) * g3r * g3**-1.5,
-    )
-    p2 = np.where(
-        logic_or,
-        0,
-        MU_0_2PI
-        * (
-            e * g1r * inv_g2
-            - e * g1 * g2r * inv_g2_2
-            + (g1 * edk * dkdr) * inv_g2
-            + kdk * dkdr
-        )
-        * g3**-0.5,
-    )
-    return p1 + p2
-
-
-@nb.njit(cache=True)
-def greens_dpsi_dz(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-    d_xc: float = 0,  # noqa: ARG001
-    d_zc: float = 0,  # noqa: ARG001
-) -> float | np.ndarray:
-    """
-    Calculate the vertical derivative of the poloidal flux at (x, z)
-    due to a unit current at (xc, zc) using a Greens function.
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
-
-    Returns
-    -------
-    :
-        Vertical derivative of the poloidal flux response at (x, z)
-
-    Notes
-    -----
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}(x_{c}, z_{c}; x, z) =`
-    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
-    \t:math:`\\dfrac{h}{u}`
-    \t:math:`[\\mathbf{K}(k^2) - \\dfrac{v^2}{d^2}\\mathbf{E}(k^2)]`\n
-    Where:
-    \t:math:`h^{2}\\equiv z_{c}-z`\n
-    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
-    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
-    \t:math:`v^{2}\\equiv x^2 +x_{c}^2 + h^2`\n
-    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
-    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
-
-    The implementation used here refactors the above to avoid some zero divisions.
-    """
-    a, k2 = calc_a_k2(xc, zc, x, z)
-    i1, i2 = calc_i1_i2(a, k2)
-    return MU_0_2PI * ((z - zc) * (i1 - i2 * ((z - zc) ** 2 + x**2 + xc**2)))
-
-
-@nb.njit(cache=True)
-def calc_a_k2(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-):
-    """
-    Find xc, zc, x, z terms which are repeatedly used in greens calculations.
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-
-    Returns
-    -------
-    a:
-        \t:math:`\\sqrt{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    k2:
-        \t:math:`\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    """
-    a = np.hypot((x + xc), (z - zc))
-    k2 = 4 * x * xc / a**2
-    # Avoid NaN when coil on grid point
-    k2 = clip_nb(k2, GREENS_ZERO, 1.0 - GREENS_ZERO)
-    return a, k2
-
-
-@nb.njit(cache=True)
-def calc_i1_i2(
-    a: float | np.ndarray,
-    k2: float | np.ndarray,
-    e: float | np.ndarray | None = None,
-    k: float | np.ndarray | None = None,
-):
-    """
-    Find a, k2, e, k terms which are repeatedly used in greens calculations.
-
-    Parameters
-    ----------
-    a:
-        \t:math:`\\sqrt{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    k2:
-        \t:math:`\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
-    e:
-        elliptic integral of the second kind
-    k:
-        elliptic integral of the first kind
-
-    Returns
-    -------
-    i1:
-        \t:math:`\\dfrac{\\mathbf{K}}/{a}
-    i2:
-        \t:math:`\\dfrac{\\mathbf{E}}/{a^{3} (1-k^{2})}
-
-    """
-    if (e is None) or (k is None):
-        e = ellipe_nb(k2)
-        k = ellipk_nb(k2)
-    i1 = k / a
-    i2 = e / (a**3 * (1 - k2))
-    return i1, i2
-
-
-@nb.njit(cache=True)
-def greens_Bx(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-    d_xc: float = 0,
-    d_zc: float = 0,
-) -> float | np.ndarray:
-    """
-    Calculate radial magnetic field at (x, z) due to unit current at (xc, zc)
-    using a Greens function.
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
-
-    Returns
-    -------
-    :
-        Radial magnetic field response at (x, z)
-
-    Raises
-    ------
-    ZeroDivisionError
-        if x == 0
-
-    Notes
-    -----
-    \t:math:`G_{B_{x}}(x_{c}, z_{c}; x, z) = -\\dfrac{1}{x}`
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}`
-    \t:math:`(x_{c}, z_{c}; x, z)`
-    """
-    return -1 / x * greens_dpsi_dz(xc, zc, x, z, d_xc, d_zc)
-
-
-@nb.njit(cache=True)
-def greens_Bz(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-    d_xc: float = 0,
-    d_zc: float = 0,
-) -> float | np.ndarray:
-    """
-    Calculate vertical magnetic field at (x, z) due to unit current at (xc, zc)
-    using a Greens function.
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-    d_xc:
-        The coil half-width (overload argument)
-    d_zc:
-        The coil half-height (overload argument)
-
-    Returns
-    -------
-    :
-        Vertical magnetic field response at (x, z)
-
-    Raises
-    ------
-    ZeroDivisionError
-        if x == 0
-
-    Notes
-    -----
-    \t:math:`G_{B_{z}}(x_{c}, z_{c}; x, z) = \\dfrac{1}{x}`
-    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}`
-    \t:math:`(x_{c}, z_{c}; x, z)`
-    """
-    return 1 / x * greens_dpsi_dx(xc, zc, x, z, d_xc, d_zc)
-
-
-@nb.njit(cache=True)
-def greens_all(
-    xc: float | np.ndarray,
-    zc: float | np.ndarray,
-    x: float | np.ndarray,
-    z: float | np.ndarray,
-) -> tuple[float | np.ndarray, float | np.ndarray, float | np.ndarray]:
-    """
-    Speed optimisation of Green's functions for psi, Bx, and Bz
-
-    Parameters
-    ----------
-    xc:
-        Coil x coordinates [m]
-    zc:
-        Coil z coordinates [m]
-    x:
-        Calculation x locations
-    z:
-        Calculation z locations
-
-    Returns
-    -------
-    psi:
-        Poloidal magnetic flux per radian response at (x, z)
-    Bx:
-        Radial magnetic field response at (x, z)
-    Bz:
-        Vertical magnetic field response at (x, z)
-
-    Raises
-    ------
-    ZeroDivisionError
-        if xc <= 0
-        if x <= 0
-    """
-    a, k2 = calc_a_k2(xc, zc, x, z)
-    e = ellipe_nb(k2)
-    k = ellipk_nb(k2)
-    i1, i2 = calc_i1_i2(a, k2, e, k)
-    i1 *= 4
-    i2 *= 4
-    a_part = (z - zc) ** 2 + x**2 + xc**2
-    inv_b_part = 1 / (-2 * x * xc)
-    x_b_part = x * inv_b_part
-    g_bx = MU_0_4PI * xc * (z - zc) * (i1 - i2 * a_part) * inv_b_part
-    g_bz = MU_0_4PI * xc * ((xc + a_part * x_b_part) * i2 - i1 * x_b_part)
-    g_psi = MU_0_4PI * a * ((2 - k2) * k - 2 * e)
-    return g_psi, g_bx, g_bz
+    f, ax = plt.subplots()
+    ax.plot(x, bz, label="Bz")
+    ax.plot(x, old_bz, ls="--", label="old Bz")
+    ax.legend()
+    plt.show()

--- a/bluemira/magnetostatics/greens.py
+++ b/bluemira/magnetostatics/greens.py
@@ -77,7 +77,7 @@ def _common_geometry(xc, zc, x, z):
     .. math::
 
         k^2 = \frac{4xx_c}{u^2}.
-    """
+    """  # noqa: DOC201
     h = z - zc
     xp = x + xc
 
@@ -90,7 +90,7 @@ def _common_geometry(xc, zc, x, z):
 
 @nb.njit(cache=True, inline="always")
 def _elliptic_integrals(k2):
-    """Evaluate E(k²) and K(k²)."""
+    """Evaluate E(k²) and K(k²)."""  # noqa: DOC201
     return ellipe_nb(k2), ellipk_nb(k2)
 
 
@@ -106,7 +106,7 @@ def _i1_i2(u, u2, k2, e, k):
     .. math::
 
         I_2 = \frac{E(k^2)}{u^3(1-k^2)}.
-    """
+    """  # noqa: DOC201
     inv_u = 1.0 / u
 
     i1 = k * inv_u
@@ -129,7 +129,7 @@ def _radial_term(xc, x, h, i1, i2):
     .. math::
 
         w^2=x_c^2-x^2-h^2.
-    """
+    """  # noqa: DOC201
     w2 = xc * xc - x * x - h * h
     return i1 + w2 * i2
 
@@ -148,14 +148,14 @@ def _vertical_term(xc, x, h, i1, i2):
     .. math::
 
         v^2=x^2+x_c^2+h^2.
-    """
+    """  # noqa: DOC201
     v2 = x * x + xc * xc + h * h
     return i1 - v2 * i2
 
 
 @nb.njit(cache=True, inline="always")
 def _radial_response(xc, zc, x, z):
-    """Calculate the term shared by dpsi/dx and Bz."""
+    """Calculate the term shared by dpsi/dx and Bz."""  # noqa: DOC201
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
     e, k = _elliptic_integrals(k2)
     i1, i2 = _i1_i2(u, u2, k2, e, k)
@@ -165,7 +165,7 @@ def _radial_response(xc, zc, x, z):
 
 @nb.njit(cache=True, inline="always")
 def _vertical_response(xc, zc, x, z):
-    """Calculate the quantities shared by dpsi/dz and Bx."""
+    """Calculate the quantities shared by dpsi/dz and Bx."""  # noqa: DOC201
     h, u, u2, k2 = _common_geometry(xc, zc, x, z)
     e, k = _elliptic_integrals(k2)
     i1, i2 = _i1_i2(u, u2, k2, e, k)
@@ -183,7 +183,7 @@ def _axis_bz(xc, zc, z):
         B_z(0,z)=
         \frac{\mu_0x_c^2}
         {2\left[x_c^2+(z-z_c)^2\right]^{3/2}}.
-    """
+    """  # noqa: DOC201
     h = z - zc
     u2 = xc * xc + h * h
 
@@ -200,7 +200,7 @@ def _elliptic_derivatives(e, k, k2):
         \frac{dE}{d(k^2)}=\frac{E-K}{2k^2},\qquad
         \frac{dK}{d(k^2)}
         =\frac{E-(1-k^2)K}{2k^2(1-k^2)}.
-    """
+    """  # noqa: DOC201
     one_minus_k2 = 1.0 - k2
     inv_2k2 = 0.5 / k2
 

--- a/tests/magnetostatics/greens_old.py
+++ b/tests/magnetostatics/greens_old.py
@@ -1,0 +1,772 @@
+# SPDX-FileCopyrightText: 2021-present M. Coleman, J. Cook, F. Franza
+# SPDX-FileCopyrightText: 2021-present I.A. Maione, S. McIntosh
+# SPDX-FileCopyrightText: 2021-present J. Morris, D. Short
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Green's functions mappings for psi, Bx, and Bz
+"""
+
+import numba as nb
+import numpy as np
+
+from bluemira.base.constants import MU_0, MU_0_2PI, MU_0_4PI
+from bluemira.magnetostatics._ellipe import ellipe_nb
+from bluemira.magnetostatics._ellipk import ellipk_nb
+
+__all__ = [
+    "ellipe_nb",
+    "ellipk_nb",
+    "greens_Bx",
+    "greens_Bz",
+    "greens_all",
+    "greens_dbz_dx",
+    "greens_dpsi_dx",
+    "greens_dpsi_dz",
+    "greens_psi",
+]
+
+# Offset from 0<x<1
+#     Used in calculating Green's functions to avoid np.nan
+GREENS_ZERO = 1e-8
+
+
+@nb.vectorize(nopython=True, cache=True)
+def clip_nb(
+    val: float | np.ndarray, val_min: float, val_max: float
+) -> float | np.ndarray:
+    """
+    Clips (limits) val between val_min and val_max. Vectorised for speed and
+    compatibility with numba.
+
+    Parameters
+    ----------
+    val:
+        The value to be clipped.
+    val_min:
+        The minimum value.
+    val_max:
+        The maximum value.
+
+    Returns
+    -------
+    :
+        The clipped values.
+    """
+    if val < val_min:
+        return val_min
+    if val > val_max:
+        return val_max
+    return val
+
+
+@nb.njit(cache=True)
+def _elliptic_derivatives(e, k, k2):
+    r"""Get :math:`\frac{dK}{dk}` and :math:`\frac{dE}{dk}` [dimensionless]
+
+    .. math::
+
+        \frac{dK}{dk} &= \frac{E}{k}\frac{1}{1-k^2} - \frac{K}{k}
+
+        \frac{dE}{dk} &= \frac{E}{k} - \frac{K}{k}
+
+    Returns
+    -------
+    :
+        ellipk derivative
+    :
+        ellipe derivative
+    """
+    sqk2 = np.sqrt(k2)
+    e_sqk = e / sqk2
+    k_sqk = k / sqk2
+    dKdk = e_sqk / (1 - k2) - k_sqk  # noqa: N806
+    dEdk = e_sqk - k_sqk  # noqa: N806
+    return dKdk, dEdk
+
+
+@nb.njit(cache=True)
+def _dkdr(g3, xc, x):
+    r"""Get dkdr
+
+    .. math::
+
+        \text{dkdr} &= \frac{-2 x xc \frac{x+xc}{g_3^2} +
+                       \frac{x}{g_3}}{\sqrt{\frac{x xc}{g_3}}}
+
+            &= -2\sqrt{x xc} \sqrt{g_3}(\frac{x+xc}{g_3^2}) +
+                \sqrt{\frac{g_3}{x xc}}\frac{x}{g_3}
+
+            &= -2\sqrt{\frac{x xc}{g_3^3}} (x+xc) + \sqrt{\frac{xc}{g_3x}}
+
+            &= -2 \frac{(x+xc)\sqrt{x xc}}{g_3^{\frac{3}{2}}}  + \sqrt{\frac{xc}{g_3x}}
+
+    unit: [m^(-1)]
+
+    Returns
+    -------
+    :
+        dkdr
+
+    """
+    # old_expression = (-2 * x * xc * (x + xc) / (g3**2) + x / g3) / sqrt(x * xc / g3)
+    term_1 = -2 * (x + xc) * np.sqrt(x * xc) / g3**1.5
+    term_2 = np.sqrt(xc / (g3 * x))
+    return term_1 + term_2
+
+
+@nb.njit(cache=True)
+def _g(xc, zc, x, z):
+    r"""Get the tuple of (:math:`g_1, g_2, g_3, g_4`)
+
+    unit: [m^2]
+
+    .. math::
+
+        g_1 &= xc^2 - x^2 - z^2
+        g_2 &= (xc - x)^2 + z^2
+        g_3 &= (xc + x)^2 + z^2
+        g_4 &= xc^2 + x^2 + z^2
+
+    Returns
+    -------
+    :
+        g1
+    :
+        g2
+    :
+        g3
+    :
+        g4
+    """
+    x2 = x**2
+    xc2 = xc**2
+    z2 = (zc - z) ** 2
+    g1 = xc2 - x2 - z2
+    g2 = (xc - x) ** 2 + z2
+    g3 = (xc + x) ** 2 + z2
+    g4 = xc2 + x2 + z2
+    return g1, g2, g3, g4
+
+
+@nb.njit(cache=True)
+def _g_r(xc, x):
+    r"""Get the tuple of (:math:`g_{1r}, g_{2r}, g_{3r}`)
+
+    unit: [m]
+
+    .. math::
+
+        g_{1r} &= \frac{dg_1}{dxc} = -2xc
+        g_{2r} &= \frac{dg_2}{dxc} = 2xc - 2x
+        g_{3r} &= \frac{dg_3}{dxc} = 2xc + 2x
+
+    :math:`g_{4r}` is not used anywhere so is not computed.
+
+    Returns
+    -------
+    :
+        g1r
+    :
+        g2r
+    :
+        g3r
+    """
+    xc2 = 2 * xc
+    x2 = 2 * x
+    g1r = -xc2
+    g2r = xc2 - x2
+    g3r = xc2 + x2
+    return g1r, g2r, g3r
+
+
+@nb.njit(cache=True)
+def circular_coil_inductance_elliptic(
+    radius: float | np.ndarray, rc: float | np.ndarray
+) -> float | np.ndarray:
+    """
+    Calculate the inductance of a circular coil by elliptic integrals.
+
+    Parameters
+    ----------
+    radius:
+        The radius of the circular coil
+    rc:
+        The radius of the coil cross-section
+
+    Returns
+    -------
+    :
+        The self-inductance of the circular coil [H]
+
+    Notes
+    -----
+    The inductance is given by
+
+    .. math::
+        L = \\mu_{0} (2 r - r_c) \\Biggl((1 - k^2 / 2)~
+        \\int_0^{\\frac{\\pi}{2}} \\frac{d\\theta}{\\sqrt{1 - k~
+        \\sin (\\theta)^2}} - \\int_0^{\\frac{\\pi}{2}}~
+        \\sqrt{1 - k \\sin (\\theta)^2} \\, d\\theta\\Biggr)
+
+    where :math:`r` is the radius, :math:`\\mu_{0}` is the vacuum
+    permeability, and
+
+    .. math::
+        k = \\max\\left(10^{-8}, \\min~
+        \\left(\\frac{4r(r - r_c)}{(2r - r_c)^2}~
+        , 1.0 - 10^{-8}\\right)\\right)
+    """
+    k = 4 * radius * (radius - rc) / (2 * radius - rc) ** 2
+    k = clip_nb(k, GREENS_ZERO, 1.0 - GREENS_ZERO)
+    return MU_0 * (2 * radius - rc) * ((1 - k**2 / 2) * ellipk_nb(k) - ellipe_nb(k))
+
+
+def circular_coil_inductance_kirchhoff(
+    radius: float | np.ndarray, rc: float | np.ndarray
+) -> float | np.ndarray:
+    """
+    Calculate the inductance of a circular coil by Kirchhoff's approximation.
+
+    radius:
+        The radius of the circular coil
+    rc:
+        The radius of the coil cross-section
+
+    Returns
+    -------
+    :
+        The self-inductance of the circular coil [H]
+
+    Notes
+    -----
+
+    .. math::
+        Inductance = \\mu_{0} * radius * (log(8 * radius / rc) - 2 + 0.25)
+
+    where :math:`\\mu_{0}` is the vacuum permeability
+    """
+    return MU_0 * radius * (np.log(8 * radius / rc) - 2 + 0.25)
+
+
+def square_coil_inductance_kirchhoff(
+    radius: float | np.ndarray, width: float | np.ndarray, height: float | np.ndarray
+) -> float | np.ndarray:
+    """
+    Calculate the inductance of a square coil by Kirchhoff's approximation.
+
+    radius:
+        The radius of the square coil
+    width:
+        The width of the coil cross-section
+    height
+        The height of the coil cross-section
+
+    Returns
+    -------
+    The self-inductance of the square coil [H]
+
+    Notes
+    -----
+    .. math::
+
+        Inductance = \\mu_0 radius (ln(8\\frac{radius}{width + height}) - 0.5)
+
+    where :math:`\\mu_{0}` is the vacuum permeability
+    """
+    return MU_0 * radius * (np.log(8 * radius / (width + height)) - 0.5)
+
+
+@nb.njit(cache=True)
+def greens_psi(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate poloidal flux at (x, z) due to a unit current at (xc, zc)
+    using a Greens function.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Poloidal magnetic flux per radian response at (x, z)
+
+    Raises
+    ------
+    ZeroDivisionError
+        if xc <= 0
+
+    Notes
+    -----
+    \t:math:`G_{\\psi}(x_{c}, z_{c}; x, z) = \\dfrac{{\\mu}_{0}}{2{\\pi}}`
+    \t:math:`\\dfrac{\\sqrt{xx_{c}}}{k}`
+    \t:math:`[(2-\\mathbf{K}(k^2)-2\\mathbf{E}(k^2)]`\n
+    Where:
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+    """
+    _, k2 = _calc_a_k2(xc, zc, x, z)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
+    return MU_0_2PI * np.sqrt(x * xc) * ((2 - k2) * k - 2 * e) / np.sqrt(k2)
+
+
+@nb.njit(cache=True)
+def greens_dpsi_dx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the radial derivative of the poloidal flux at (x, z)
+    due to a unit current at (xc, zc) using a Greens function.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Radial derivative of the poloidal flux response at (x, z)
+
+    Notes
+    -----
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}(x_{c}, z_{c}; x, z) =`
+    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
+    \t:math:`\\dfrac{1}{u}`
+    \t:math:`[\\dfrac{w^2}{d^2}\\mathbf{E}(k^2)+\\mathbf{K}(k^2)]`\n
+    Where:
+    \t:math:`h^{2}\\equiv z_{c}-z`\n
+    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
+    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
+    \t:math:`w^{2}\\equiv x^2 -x_{c}^2 - h^2`\n
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+
+    The implementation used here refactors the above to avoid some zero divisions.
+    """
+    a, k2 = _calc_a_k2(xc, zc, x, z)
+    i1, i2 = _calc_i1_i2(a, k2)
+    return MU_0_2PI * x * ((xc**2 - (z - zc) ** 2 - x**2) * i2 + i1)
+
+
+@nb.njit(cache=True)
+def greens_dbz_dx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+) -> float | np.ndarray:
+    r"""
+    Calculate :math:`\frac{dB_z}{dx}` (= :math:`\frac{dB_x}{dz}` for vacuum)
+
+    Get the radial gradient of the vertical magnetic field due to a circular filament.
+
+    unit: [N/A/m^2]
+
+    .. math::
+
+        \frac{dB_z}{dx} = \frac{dB_x}{dz} = \frac{\mu_0 I}{2 \pi}\left(
+            - \frac{(K+E\frac{g_1}{g_2}) g_{3r}}{2 g_3^{\frac{3}{2}}}
+            + \frac{- E \frac{g_{1r}}{g_2} - E \frac{g_1 g_{2r}}{g_2^2}
+                    + \frac{dE}{dk} \frac{g_1}{g_2} \text{dkdr}
+                    + \frac{dK}{dk} \text{dkdr}
+                    }{\sqrt{g_3}}
+        \right)
+
+    where :math:`K = K(k^2), E = E(k^2)`.
+
+    Returns
+    -------
+    :
+        the gradient to the magnetic field
+    """
+    _, k2 = _calc_a_k2(xc, zc, x, z)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
+    kdk, edk = _elliptic_derivatives(e, k, k2)
+    g1, g2, g3, _ = _g(xc, zc, x, z)
+    g1r, g2r, g3r = _g_r(x, xc)
+    dkdr = _dkdr(g3, xc, x)
+
+    # Avoid divide by 0
+    g2 = np.where(np.isclose(g2, 0), GREENS_ZERO, g2)
+    g3 = np.where(np.isclose(g3, 0), GREENS_ZERO, g3)
+    logic_or = np.logical_or(np.isclose(g2, 0), np.isclose(g3, 0))
+    inv_g2 = g2**-1
+    inv_g2_2 = g2**-2
+
+    p1 = np.where(
+        logic_or,
+        0,
+        -MU_0_4PI * (k + e * g1 * inv_g2) * g3r * g3**-1.5,
+    )
+    p2 = np.where(
+        logic_or,
+        0,
+        MU_0_2PI
+        * (
+            e * g1r * inv_g2
+            - e * g1 * g2r * inv_g2_2
+            + (g1 * edk * dkdr) * inv_g2
+            + kdk * dkdr
+        )
+        * g3**-0.5,
+    )
+    return p1 + p2
+
+
+@nb.njit(cache=True)
+def greens_dpsi_dz(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,  # noqa: ARG001
+    d_zc: float = 0,  # noqa: ARG001
+) -> float | np.ndarray:
+    """
+    Calculate the vertical derivative of the poloidal flux at (x, z)
+    due to a unit current at (xc, zc) using a Greens function.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Vertical derivative of the poloidal flux response at (x, z)
+
+    Notes
+    -----
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}(x_{c}, z_{c}; x, z) =`
+    \t:math:`\\dfrac{\\mu_0}{2\\pi}`
+    \t:math:`\\dfrac{h}{u}`
+    \t:math:`[\\mathbf{K}(k^2) - \\dfrac{v^2}{d^2}\\mathbf{E}(k^2)]`\n
+    Where:
+    \t:math:`h^{2}\\equiv z_{c}-z`\n
+    \t:math:`u^2\\equiv(x+x_{c})^2+h^2`\n
+    \t:math:`d^{2}\\equiv (x - x_{c})^2 + h^2`\n
+    \t:math:`v^{2}\\equiv x^2 +x_{c}^2 + h^2`\n
+    \t:math:`k^{2}\\equiv\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    \t:math:`\\mathbf{K} \\equiv` complete elliptic integral of the first kind\n
+    \t:math:`\\mathbf{E} \\equiv` complete elliptic integral of the second kind
+
+    The implementation used here refactors the above to avoid some zero divisions.
+    """
+    a, k2 = _calc_a_k2(xc, zc, x, z)
+    i1, i2 = _calc_i1_i2(a, k2)
+    return MU_0_2PI * ((z - zc) * (i1 - i2 * ((z - zc) ** 2 + x**2 + xc**2)))
+
+
+@nb.njit(cache=True)
+def _calc_a_k2(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+):
+    """
+    Find xc, zc, x, z terms which are repeatedly used in greens calculations.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+
+    Returns
+    -------
+    a:
+        \t:math:`\\sqrt{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    k2:
+        \t:math:`\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    """
+    a = np.hypot((x + xc), (z - zc))
+    k2 = 4 * x * xc / a**2
+    # Avoid NaN when coil on grid point
+    k2 = clip_nb(k2, GREENS_ZERO, 1.0 - GREENS_ZERO)
+    return a, k2
+
+
+@nb.njit(cache=True)
+def _calc_i1_i2(
+    a: float | np.ndarray,
+    k2: float | np.ndarray,
+    e: float | np.ndarray | None = None,
+    k: float | np.ndarray | None = None,
+):
+    """
+    Find a, k2, e, k terms which are repeatedly used in greens calculations.
+
+    Parameters
+    ----------
+    a:
+        \t:math:`\\sqrt{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    k2:
+        \t:math:`\\dfrac{4xx_{c}}{(x+x_{c})^{2}+(z-z_{c})^{2}}`\n
+    e:
+        elliptic integral of the second kind
+    k:
+        elliptic integral of the first kind
+
+    Returns
+    -------
+    i1:
+        \t:math:`\\dfrac{\\mathbf{K}}/{a}
+    i2:
+        \t:math:`\\dfrac{\\mathbf{E}}/{a^{3} (1-k^{2})}
+
+    """
+    if (e is None) or (k is None):
+        e = ellipe_nb(k2)
+        k = ellipk_nb(k2)
+    i1 = k / a
+    i2 = e / (a**3 * (1 - k2))
+    return i1, i2
+
+
+@nb.njit(cache=True)
+def greens_Bx(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,
+    d_zc: float = 0,
+) -> float | np.ndarray:
+    """
+    Calculate radial magnetic field at (x, z) due to unit current at (xc, zc)
+    using a Greens function.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Radial magnetic field response at (x, z)
+
+    Raises
+    ------
+    ZeroDivisionError
+        if x == 0
+
+    Notes
+    -----
+    \t:math:`G_{B_{x}}(x_{c}, z_{c}; x, z) = -\\dfrac{1}{x}`
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial z}}`
+    \t:math:`(x_{c}, z_{c}; x, z)`
+    """
+    return -1 / x * greens_dpsi_dz(xc, zc, x, z, d_xc, d_zc)
+
+
+@nb.njit(cache=True)
+def greens_Bz(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+    d_xc: float = 0,
+    d_zc: float = 0,
+) -> float | np.ndarray:
+    """
+    Calculate vertical magnetic field at (x, z) due to unit current at (xc, zc)
+    using a Greens function.
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+    d_xc:
+        The coil half-width (overload argument)
+    d_zc:
+        The coil half-height (overload argument)
+
+    Returns
+    -------
+    :
+        Vertical magnetic field response at (x, z)
+
+    Raises
+    ------
+    ZeroDivisionError
+        if x == 0
+
+    Notes
+    -----
+    \t:math:`G_{B_{z}}(x_{c}, z_{c}; x, z) = \\dfrac{1}{x}`
+    \t:math:`G_{\\dfrac{\\partial \\psi}{\\partial x}}`
+    \t:math:`(x_{c}, z_{c}; x, z)`
+    """
+    return 1 / x * greens_dpsi_dx(xc, zc, x, z, d_xc, d_zc)
+
+
+@nb.njit(cache=True)
+def greens_all(
+    xc: float | np.ndarray,
+    zc: float | np.ndarray,
+    x: float | np.ndarray,
+    z: float | np.ndarray,
+) -> tuple[float | np.ndarray, float | np.ndarray, float | np.ndarray]:
+    """
+    Speed optimisation of Green's functions for psi, Bx, and Bz
+
+    Parameters
+    ----------
+    xc:
+        Coil x coordinates [m]
+    zc:
+        Coil z coordinates [m]
+    x:
+        Calculation x locations
+    z:
+        Calculation z locations
+
+    Returns
+    -------
+    psi:
+        Poloidal magnetic flux per radian response at (x, z)
+    Bx:
+        Radial magnetic field response at (x, z)
+    Bz:
+        Vertical magnetic field response at (x, z)
+
+    Raises
+    ------
+    ZeroDivisionError
+        if xc <= 0
+        if x <= 0
+    """
+    a, k2 = _calc_a_k2(xc, zc, x, z)
+    e = ellipe_nb(k2)
+    k = ellipk_nb(k2)
+    i1, i2 = _calc_i1_i2(a, k2, e, k)
+    i1 *= 4
+    i2 *= 4
+    a_part = (z - zc) ** 2 + x**2 + xc**2
+    inv_b_part = 1 / (-2 * x * xc)
+    x_b_part = x * inv_b_part
+    g_bx = MU_0_4PI * xc * (z - zc) * (i1 - i2 * a_part) * inv_b_part
+    g_bz = MU_0_4PI * xc * ((xc + a_part * x_b_part) * i2 - i1 * x_b_part)
+    g_psi = MU_0_4PI * a * ((2 - k2) * k - 2 * e)
+    return g_psi, g_bx, g_bz
+
+
+if __name__ == "__main__":
+    # Feel free to delete; this is to faciltate review
+    import matplotlib.pyplot as plt
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+    from bluemira.magnetostatics.greens import greens_Bx as new_greens_Bx
+    from bluemira.magnetostatics.greens import greens_Bz as new_greens_Bz
+    from bluemira.magnetostatics.greens import greens_dbz_dx as new_greens_dbz_dx
+    from bluemira.magnetostatics.greens import greens_psi as new_greens_psi
+
+    xc, zc = 4, 4
+    x = np.linspace(3.98, 4.02, 100)
+    z = np.linspace(3.98, 4.02, 100)
+    xx, zz = np.meshgrid(x, z, indexing="ij")
+
+    for func_pair in zip(
+        [greens_psi, greens_Bx, greens_Bz, greens_dbz_dx],
+        [new_greens_psi, new_greens_Bx, new_greens_Bz, new_greens_dbz_dx],
+        strict=True,
+    ):
+        old, new = func_pair
+        r1 = old(xc, zc, xx, zz)
+        r2 = new(xc, zc, xx, zz)
+
+        f, ax = plt.subplots(1, 3, figsize=(15, 8))
+
+        ax[0].contourf(xx, zz, r1)
+        ax[0].set_title(f"Old {old.__name__}")
+        ax[1].contourf(xx, zz, r2)
+        ax[1].set_title(f"New {new.__name__}")
+        rel_diff = 100 * (r2 - r1) / r1
+        cm = ax[2].contourf(xx, zz, rel_diff, cmap="RdBu")
+        ax[2].set_title("Relative difference [%]")
+
+        # Create a colorbar axis that doesn't resize the subplot
+        divider = make_axes_locatable(ax[2])
+        cax = divider.append_axes("right", size="5%", pad=0.08)
+        f.colorbar(cm, cax=cax, label="Relative difference [%]")
+
+        for a in ax:
+            a.set_xlabel("x [m]")
+            a.set_ylabel("z [m]")
+            a.set_aspect("equal")
+
+        plt.show()

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -269,7 +269,10 @@ class TestGreenFieldsRegression2:
     ):
         self.runner(new_greens_func, old_greens_func, case, xc, zc, x, z)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(
+        reason="Approaching logarithmic singularity - differences in"
+        " numerical implementation."
+    )
     @pytest.mark.parametrize(
         ("new_greens_func", "old_greens_func", "case", "xc", "zc", "x", "z"),
         [

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -235,7 +235,7 @@ class TestGreensEdgeCases:
     )
     @pytest.mark.parametrize("axis_point", [[1, 1, 0, 0]])
     def test_greens_on_axis(self, func, axis_point):
-        assert func(*axis_point) == 0.0
+        assert func(*axis_point) == 0.0  # noqa: RUF069
 
     def test_greens_Bz_axis(self):
         assert greens_Bz(1, 1, 0, 0) > 0.0

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -25,6 +25,12 @@ from bluemira.magnetostatics.greens import (
     greens_dpsi_dz,
     greens_psi,
 )
+from tests.magnetostatics.greens_old import greens_Bx as old_greens_Bx
+from tests.magnetostatics.greens_old import greens_Bz as old_greens_Bz
+from tests.magnetostatics.greens_old import greens_dbz_dx as old_greens_dbz_dx
+from tests.magnetostatics.greens_old import greens_dpsi_dx as old_greens_dpsi_dx
+from tests.magnetostatics.greens_old import greens_dpsi_dz as old_greens_dpsi_dz
+from tests.magnetostatics.greens_old import greens_psi as old_greens_psi
 
 # Regression testing
 
@@ -220,6 +226,158 @@ class TestGreenFieldsRegression:
         new = new_greens_func(xc, zc, x, z)
         old = old_greens_func(xc, zc, x, z)
         np.testing.assert_allclose(1e7 * new, 1e7 * old, atol=EPS)
+
+
+class TestGreenFieldsRegression2:
+    rng = np.random.default_rng(84602342)
+    fixtures = []  # noqa: RUF012
+    for i in range(5):  # Tested with 8000, 8 failures, see below
+        fixtures.append(  # noqa: PERF401
+            (
+                i,
+                10 * np.clip(rng.random(), 0.01, None),
+                10 - 5 * rng.random(),
+                10 * np.clip(rng.random(), 0.01, None),
+                10 - 5 * rng.random(),
+            )
+        )
+
+    @pytest.mark.parametrize(
+        ("case", "xc", "zc", "x", "z"),
+        fixtures,
+    )
+    @pytest.mark.parametrize(
+        ("new_greens_func", "old_greens_func"),
+        [
+            (greens_psi, old_greens_psi),
+            (greens_Bx, old_greens_Bx),
+            (greens_Bz, old_greens_Bz),
+            (greens_dbz_dx, old_greens_dbz_dx),
+            (greens_dpsi_dx, old_greens_dpsi_dx),
+            (greens_dpsi_dz, old_greens_dpsi_dz),
+        ],
+    )
+    def test_greens_func(
+        self,
+        case,
+        xc,
+        zc,
+        x,
+        z,
+        new_greens_func,
+        old_greens_func,
+    ):
+        self.runner(new_greens_func, old_greens_func, case, xc, zc, x, z)
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(
+        ("new_greens_func", "old_greens_func", "case", "xc", "zc", "x", "z"),
+        [
+            (
+                greens_psi,
+                old_greens_psi,
+                0,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_dpsi_dx,
+                old_greens_dpsi_dx,
+                1,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_dpsi_dz,
+                old_greens_dpsi_dz,
+                2,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_Bx,
+                old_greens_Bx,
+                3,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_Bz,
+                old_greens_Bz,
+                4,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_dbz_dx,
+                old_greens_dbz_dx,
+                5,
+                9.6286576367563210,
+                8.1240150987258204,
+                9.6257638186005128,
+                8.1325033392959813,
+            ),
+            (
+                greens_dpsi_dx,
+                old_greens_dpsi_dx,
+                6,
+                9.5983221038397453,
+                6.1333202772184414,
+                9.64806483606313318,
+                6.1604391248090558,
+            ),
+            (
+                greens_dpsi_dz,
+                old_greens_dpsi_dz,
+                8,
+                9.5983221038397453,
+                6.1333202772184414,
+                9.64806483606313318,
+                6.1604391248090558,
+            ),
+        ],
+    )
+    def test_regression_failures(
+        self, new_greens_func, old_greens_func, case, xc, zc, x, z
+    ):
+        """
+        This is to document some regression failures, which all occur xhen xc, zc -> x, z
+        The maximum relative and absolute errors are still very low
+        This is due to the alternative treatment of some calculations, which are more
+        robust in the new implementation
+        """
+        self.runner(new_greens_func, old_greens_func, case, xc, zc, x, z)
+
+    def runner(self, new_greens_func, old_greens_func, case, xc, zc, x, z):
+        new = new_greens_func(xc, zc, x, z)
+        old = old_greens_func(xc, zc, x, z)
+
+        np.testing.assert_allclose(
+            new,
+            old,
+            rtol=0.0,
+            atol=EPS,
+            equal_nan=True,
+            err_msg=(
+                f"{new_greens_func.__name__} failed on case {case}\n"
+                f"xc  = {xc:.16e}\n"
+                f"zc  = {zc:.16e}\n"
+                f"x   = {x:.16e}\n"
+                f"z   = {z:.16e}\n"
+                f"new = {new:.16e}\n"
+                f"old = {old:.16e}"
+            ),
+        )
 
 
 class TestGreensEdgeCases:

--- a/tests/magnetostatics/test_greens.py
+++ b/tests/magnetostatics/test_greens.py
@@ -230,20 +230,31 @@ class TestGreensEdgeCases:
             greens_dpsi_dz,
             greens_dpsi_dx,
             greens_Bx,
+            greens_dbz_dx,
+        ],
+    )
+    @pytest.mark.parametrize("axis_point", [[1, 1, 0, 0]])
+    def test_greens_on_axis(self, func, axis_point):
+        assert func(*axis_point) == 0.0
+
+    def test_greens_Bz_axis(self):
+        assert greens_Bz(1, 1, 0, 0) > 0.0
+
+    @pytest.mark.parametrize(
+        "func",
+        [
+            greens_psi,
+            greens_dpsi_dz,
+            greens_dpsi_dx,
+            greens_Bx,
             greens_Bz,
             greens_dbz_dx,
         ],
     )
-    @pytest.mark.parametrize("fail_point", [[0, 0, 0, 0]])
-    def test_greens_on_axis(self, func, fail_point):
+    @pytest.mark.parametrize("origin_point", [[0, 0, 0, 0]])
+    def test_greens_origin_singularity(self, func, origin_point):
         with pytest.raises(ZeroDivisionError):
-            func(*fail_point)
-
-    @pytest.mark.parametrize("func", [greens_Bx, greens_Bz, greens_dbz_dx])
-    @pytest.mark.parametrize("fail_point", [[1, 1, 0, 10], [-1, -1, 0, 10]])
-    def test_greens_on_axis_field(self, func, fail_point):
-        with pytest.raises(ZeroDivisionError):
-            func(*fail_point)
+            func(*origin_point)
 
     @pytest.mark.parametrize("func", [greens_Bx, greens_dpsi_dz, greens_dbz_dx])
     @pytest.mark.parametrize("zero_point", [[1, 1, 1, 1], [-1, -1, -1, -1]])


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4259 

Unified mathematical notation and use of helper functions.

Slightly cheaper arithmetic and better treatment of masking and dodging of ZeroDivisionErrors (less frequent now).

Slightly different behaviour due to improvements related to handling near k2 clipping

Also changes `greens_all` to share behaviour with  other calculations (was not the case before)

Also adds explicit analytical treatment of x == 0
Bz:
<img width="565" height="424" alt="image" src="https://github.com/user-attachments/assets/740fdb16-ac55-4e8e-9ad2-a8159749c187" />


These are probably slightly slower, which could be mitigated by element-wise calculations and vectorisation of all greens_funcs. This would be even harder to review...

Sorry for the horrible diff... I've tried to make up for it with a proper set of regression tests and some plots of the comparisons.

Comparison of differences when xc, zc -> x, z:

<img width="1597" height="510" alt="image" src="https://github.com/user-attachments/assets/a7e1552e-ac00-4410-aa75-014c973360d8" />
<img width="1597" height="510" alt="image" src="https://github.com/user-attachments/assets/b92aec7c-1080-4a0c-9648-298255683af4" />
<img width="1597" height="510" alt="image" src="https://github.com/user-attachments/assets/a99fe13c-4d68-4794-80dc-19a82e070262" />
<img width="1597" height="510" alt="image" src="https://github.com/user-attachments/assets/156ea10f-eefc-42ee-b59e-dadc61721661" />


## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
