### PR TITLE
Tidy up plasma current plotting

### DIFF
--- a/bluemira/equilibria/equilibrium.py
+++ b/bluemira/equilibria/equilibrium.py
@@ -491,7 +491,13 @@ class FixedPlasmaEquilibrium(MHDState):
 
         return self.plasma.psi(x, z)
 
-    def plot(self, ax: Axes | None = None, *, field: EqBPlotParam = EqBPlotParam.PSI):
+    def plot(
+        self,
+        ax: Axes | None = None,
+        *,
+        plasma: bool = True,
+        field: EqBPlotParam = EqBPlotParam.PSI,
+    ):
         """
         Plots the FixedPlasmaEquilibrium object onto `ax`
 
@@ -500,7 +506,7 @@ class FixedPlasmaEquilibrium(MHDState):
         :
             the plot axis
         """
-        return FixedPlasmaEquilibriumPlotter(self, ax, field=field)
+        return FixedPlasmaEquilibriumPlotter(self, ax, plasma=plasma, field=field)
 
 
 class CoilSetMHDState(MHDState):
@@ -2368,9 +2374,7 @@ class Equilibrium(CoilSetMHDState):  # noqa: PLR0904
         psi_2 = x_points[1].psi
         return abs(psi_1 - psi_2) < PSI_NORM_TOL
 
-    def plot(
-        self, ax: Axes | None = None, *, plasma: bool = False, show_ox: bool = True
-    ):
+    def plot(self, ax: Axes | None = None, *, plasma: bool = True, show_ox: bool = True):
         """
         Plot the equilibrium magnetic flux surfaces object onto `ax`.
 

--- a/bluemira/equilibria/plotting.py
+++ b/bluemira/equilibria/plotting.py
@@ -528,6 +528,7 @@ class PlasmaCoilPlotter(Plotter):
                 self.plasma_coil._j_tor,
                 cmap=cmap,
                 levels=levels,
+                zorder=Zorder.PLASMACURRENT.value,
             )
             self.ax.plot(sq_x, sq_z, linewidth=1.5, color="k")
 
@@ -609,6 +610,7 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
         self,
         equilibrium: FixedPlasmaEquilibrium,
         ax=None,
+        plasma=True,  # noqa: FBT002
         *,
         field: EqBPlotParam = EqBPlotParam.PSI,
     ):
@@ -617,7 +619,6 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
         self.psi = self.eq.psi(self.eq.x, self.eq.z)
 
         if field not in EqBPlotParam.FIELD:
-            self.plot_plasma_current()
             self.plot_psi()
         elif field is EqBPlotParam.BP:
             self.plot_B_component()
@@ -626,6 +627,8 @@ class FixedPlasmaEquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
                 "Toroidal field plot not available for fixed plasma."
                 "Plotting poloidal field."
             )
+        if plasma:
+            self.plot_plasma_current()
         self.plot_LCFS()
 
     def plot_LCFS(self):
@@ -662,7 +665,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
         equilibrium: Equilibrium,
         ax=None,
         *,
-        plasma=False,
+        plasma=True,
         show_ox=True,
         field: EqBPlotParam = EqBPlotParam.PSI,
     ):
@@ -697,7 +700,6 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
             self.op_psi = np.amin(self.psi)
 
         if field not in EqBPlotParam.FIELD:
-            self.plot_plasma_current()
             self.plot_psi()
         elif field is EqBPlotParam.BP:
             self.plot_B_component()
@@ -714,7 +716,7 @@ class EquilibriumPlotter(EquilibriumPlotterMixin, Plotter):
             self.plot_O_points()
 
         if plasma:
-            self.plot_plasma_coil()
+            self.plot_plasma_current()
 
     def plot_flux_surface(self, psi_norm, color="k"):
         """


### PR DESCRIPTION
## Linked Issues

Closes #4456

## Description

Equilibrium.plot() has a 'plasma' switch that appears to do nothing at the moment since j_tor is plotting whenever psi (default) is selected as the plot option for the 'field' param. 

I have moved plot_plasma_current() in the plotting classes,  so that it can be switched on and off. 

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
