### PR TITLE
Papercut: Fix pytest iterator deprecation warning

### DIFF
--- a/eudemo/eudemo_tests/maintenance/test_eq_port.py
+++ b/eudemo/eudemo_tests/maintenance/test_eq_port.py
@@ -27,7 +27,11 @@ class TestEquatorialPortKOZDesigner:
 
     @pytest.mark.parametrize(
         ("xi", "xo", "zh"),
-        zip([9.0, 9.0, 6.0], [16.0, 15.0, 9.0], [5.0, 4.0, 2.0], strict=False),
+        [
+            (9.0, 16.0, 5.0),
+            (9.0, 15.0, 4.0),
+            (6.0, 9.0, 2.0),
+        ],
     )
     def test_ep_designer(self, xi, xo, zh):
         """Test Equatorial Port KOZ Designer"""
@@ -59,15 +63,12 @@ class TestEquatorialPortDuctBuilder:
 
     @pytest.mark.parametrize(
         ("xi", "xo", "z", "y", "th"),
-        zip(
-            [9.0, 9.0, 6.0],  # x_inboard
-            [16.0, 15.0, 9.0],  # x_outboard
-            [5.0, 4.0, 2.0],  # z_height
-            [3.0, 2.0, 1.0],  # y_widths
-            [0.5, 0.5, 0.25],  # thickness
-            strict=False,
+        [
+            (9.0, 16.0, 5.0, 3.0, 0.5),
+            (9.0, 15.0, 4.0, 2.0, 0.5),
+            (6.0, 9.0, 2.0, 1.0, 0.25),
             # expected volumes: [63, 42, 5.25]
-        ),
+        ],
     )
     def test_ep_builder(self, xi, xo, z, y, th):
         """Test Equatorial Port Duct Builder"""

--- a/eudemo/eudemo_tests/maintenance/test_port_plug.py
+++ b/eudemo/eudemo_tests/maintenance/test_port_plug.py
@@ -17,16 +17,18 @@ class TestCastellationBuilder:
 
     @pytest.mark.parametrize(
         ("xi", "xo", "zh", "yw", "vec", "x_offsets", "c_offsets", "exp_v"),
-        zip(
-            [9.0, 9.0, 6.0],  # x_inboard
-            [16.0, 15.0, 9.0],  # x_outboard
-            [5.0, 4.0, 2.0],  # z_height
-            [3.0, 2.0, 1.0],  # y_widths
-            [(1, 0, 0), (1, 0, 0), (1, 0, 0.5)],  # extrusion vectors
-            [[1.0], [1.0, 1.0], [0.5]],  # y/z castellation_offsets
-            [[3.0], [2.0, 4.0], [1.0]],  # x castellation_positions
-            [185.0, 160.0, 12.521980674],  # volume check value of Eq. Ports
-            strict=False,
+        list(
+            zip(
+                [9.0, 9.0, 6.0],  # x_inboard
+                [16.0, 15.0, 9.0],  # x_outboard
+                [5.0, 4.0, 2.0],  # z_height
+                [3.0, 2.0, 1.0],  # y_widths
+                [(1, 0, 0), (1, 0, 0), (1, 0, 0.5)],  # extrusion vectors
+                [[1.0], [1.0, 1.0], [0.5]],  # y/z castellation_offsets
+                [[3.0], [2.0, 4.0], [1.0]],  # x castellation_positions
+                [185.0, 160.0, 12.521980674],  # volume check value of Eq. Ports
+                strict=False,
+            )
         ),
     )
     def test_cst_builder(self, xi, xo, zh, yw, vec, x_offsets, c_offsets, exp_v):

--- a/eudemo/eudemo_tests/test_tf_coils.py
+++ b/eudemo/eudemo_tests/test_tf_coils.py
@@ -196,7 +196,7 @@ class TestTFCoilBuilder:
     }
 
     @pytest.mark.parametrize(
-        ("centreline", "wp_xs"), zip(*centreline_setup(), strict=False)
+        ("centreline", "wp_xs"), list(zip(*centreline_setup(), strict=False))
     )
     def test_components_and_segments(self, centreline, wp_xs):
         builder = TFCoilBuilder(self.params, {}, centreline, wp_xs)

--- a/tests/base/parameterframe/test_parameterframe.py
+++ b/tests/base/parameterframe/test_parameterframe.py
@@ -348,10 +348,12 @@ class TestParameterFrame:
 
     @pytest.mark.parametrize(
         ("head_keys", "result"),
-        zip(
-            [None, ["name", "value"]],
-            [ParamDictT.__annotations__.keys(), ["name", "value"]],
-            strict=False,
+        list(
+            zip(
+                [None, ["name", "value"]],
+                [ParamDictT.__annotations__.keys(), ["name", "value"]],
+                strict=False,
+            )
         ),
     )
     def test_tabulate_headers(self, head_keys, result):

--- a/tests/builders/test_tools.py
+++ b/tests/builders/test_tools.py
@@ -62,7 +62,8 @@ class TestGetNSectors:
     }
 
     @pytest.mark.parametrize(
-        ("ttl", "sector_degree"), zip(np.arange(1, 16), sector_degree, strict=False)
+        ("ttl", "sector_degree"),
+        list(zip(np.arange(1, 16), sector_degree, strict=False)),
     )
     @pytest.mark.parametrize("degree", np.arange(0, 361, step=60))
     def test_get_n_sectors_degree(self, degree, ttl, sector_degree):
@@ -70,7 +71,9 @@ class TestGetNSectors:
         assert np.isclose(s_deg, sector_degree)
 
     @pytest.mark.parametrize("ttl", n_sectors.keys())
-    @pytest.mark.parametrize(("ind", "degree"), enumerate(np.arange(0, 361, step=60)))
+    @pytest.mark.parametrize(
+        ("ind", "degree"), list(enumerate(np.arange(0, 361, step=60)))
+    )
     def test_get_n_sectors_amount(self, ind, degree, ttl):
         _, n_sec = get_n_sectors(ttl, degree)
         assert np.isclose(n_sec, self.n_sectors[ttl][ind])

--- a/tests/codes/plasmod/test_params.py
+++ b/tests/codes/plasmod/test_params.py
@@ -16,6 +16,8 @@ PARAM_FILE = Path(Path(__file__).parent, "data", "params.json").as_posix()
 class TestProcessSolverParams:
     params = PlasmodSolverParams.from_json(PARAM_FILE)
 
-    @pytest.mark.parametrize("param", params, ids=lambda p: p.name)
+    @pytest.mark.parametrize(
+        "param", tuple(PlasmodSolverParams.from_json(PARAM_FILE)), ids=lambda p: p.name
+    )
     def test_mapping_defined_for_param(self, param):
         assert isinstance(self.params.mappings[param.name], ParameterMapping)

--- a/tests/codes/process/test_params.py
+++ b/tests/codes/process/test_params.py
@@ -13,6 +13,10 @@ from tests.codes.process.utilities import PARAM_FILE
 class TestProcessSolverParams:
     params = ProcessSolverParams.from_json(PARAM_FILE)
 
-    @pytest.mark.parametrize("param", params, ids=lambda p: p.name)
+    @pytest.mark.parametrize(
+        "param",
+        tuple(ProcessSolverParams.from_json(PARAM_FILE)),
+        ids=lambda p: p.name,
+    )
     def test_mapping_defined_for_param(self, param):
         assert isinstance(self.params.mappings[param.name], ParameterMapping)

--- a/tests/codes/test_param.py
+++ b/tests/codes/test_param.py
@@ -19,10 +19,12 @@ class TestParameterMapping:
 
     @pytest.mark.parametrize(
         ("attr", "value"),
-        zip(
-            ["name", "mynewattr", "_frozen", "unit"],
-            ["NewName", "Hello", ["custom", "list"], "MW"],
-            strict=False,
+        list(
+            zip(
+                ["name", "mynewattr", "_frozen", "unit"],
+                ["NewName", "Hello", ["custom", "list"], "MW"],
+                strict=False,
+            )
         ),
     )
     def test_no_keyvalue_change(self, attr, value):

--- a/tests/equilibria/test_coils.py
+++ b/tests/equilibria/test_coils.py
@@ -274,11 +274,13 @@ class TestSemiAnalytic:
 
     @pytest.mark.parametrize(
         ("fd", "gfunc", "anfunc"),
-        zip(
-            ["Bx", "Bz"],
-            [greens_Bx, greens_Bz],
-            [semianalytic_Bx, semianalytic_Bz],
-            strict=False,
+        list(
+            zip(
+                ["Bx", "Bz"],
+                [greens_Bx, greens_Bz],
+                [semianalytic_Bx, semianalytic_Bz],
+                strict=False,
+            )
         ),
     )
     def test_bfield(self, fd, gfunc, anfunc):

--- a/tests/geometry/test_inscribed_rect.py
+++ b/tests/geometry/test_inscribed_rect.py
@@ -45,7 +45,9 @@ class TestInscribedRectangle:
 
     MIN_AREA = MINIMUM_LENGTH**2
 
-    @pytest.mark.parametrize(("shape", "convex"), zip(shapes, convex, strict=False))
+    @pytest.mark.parametrize(
+        ("shape", "convex"), list(zip(shapes, convex, strict=False))
+    )
     def test_inscribed_rectangle(self, shape, convex):
         x = y = 5
         self.r = False

--- a/tests/magnetostatics/test_circuits.py
+++ b/tests/magnetostatics/test_circuits.py
@@ -160,7 +160,7 @@ class TestArbitraryPlanarXSCircuit:
 
     @pytest.mark.parametrize(
         ("parameterisation", "inputs", "clockwise"),
-        zip(parameterisations, p_inputs, clockwises, strict=False),
+        list(zip(parameterisations, p_inputs, clockwises, strict=False)),
     )
     def test_circuits_are_continuous_and_chained(
         self, parameterisation, inputs, clockwise

--- a/tests/structural/test_model.py
+++ b/tests/structural/test_model.py
@@ -41,7 +41,10 @@ class TestFEModel:
         self.ss316 = SS316()
         self.op_cond = STPConditions()
 
-    @pytest.mark.parametrize(("sup", "dof"), zip([False, True], [5, 6], strict=False))
+    @pytest.mark.parametrize(
+        ("sup", "dof"),
+        [(False, 5), (True, 6)],
+    )
     def test_errors(self, sup, dof):
         """
         Checks rigid-body motion detection (insufficient constraints)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #4415 

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
