### PR TITLE
🐛 TNC doesnt have a maxiter argument

### DIFF
--- a/bluemira/optimisation/_scipy/parameters.py
+++ b/bluemira/optimisation/_scipy/parameters.py
@@ -59,7 +59,6 @@ class LBFGSBParams:
 class TNCParams:
     """Options for TNC."""
 
-    maxiter: int | None = None
     eps: float | Any | None = None
     scale: list[float] | None = None
     offset: float | None = None

--- a/bluemira/optimisation/_scipy/registry.py
+++ b/bluemira/optimisation/_scipy/registry.py
@@ -68,7 +68,7 @@ SCIPY_REGISTRY: dict[Algorithm, ScipyAlgConfig] = {
         alg_name="tnc",
         param_cls=TNCParams,
         condition_overrides={
-            "max_eval": "maxiter",
+            "max_eval": "maxfun",
             "ftol_rel": "ftol",
             "ftol_abs": "ftol",
         },


### PR DESCRIPTION
## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->
One of our warnings is that maxiter is not an available scipy.optimize option (for TNC after some digging).

I've changed this to number of function evaluations (maxfun), this is not strictly the same thing but otherwise there is no mapping to some limit on iterations.

See https://docs.scipy.org/doc/scipy/reference/optimize.minimize-tnc.html and https://github.com/scipy/scipy/blob/v1.18.0/scipy/optimize/_tnc.py

this fixes the last warning on pytest (at the moment...)

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
