### PR TITLE
fix for closed flux surface in charged particle solver

### DIFF
--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -171,9 +171,13 @@ class ChargedParticleSolver:
     ]:
         """
         Get arrays of flux surface values.
+        Removes any flux surfaces that do not intersect the first wall (a warning will
+        print if this is the case, see flux_surfaces.py).
 
         Returns
         -------
+        flux_surfaces:
+            the array of flux surfaces
         x_mp:
             the array of mid-plane intersection point x-coordinate for each flux surface
         z_mp:
@@ -185,12 +189,28 @@ class ChargedParticleSolver:
         alpha:
             the array of alpha angle for each flux surface
         """
+        alpha = np.array([fs.alpha for fs in flux_surfaces])
+
+        # Remove flux surfaces that do not intersect the first wall.
+        no_cross = alpha == None  # noqa: E711
+        if any(no_cross):
+            alpha = [
+                value
+                for (value, remove) in zip(alpha, no_cross, strict=False)
+                if not remove
+            ]
+            flux_surfaces = [
+                value
+                for (value, remove) in zip(flux_surfaces, no_cross, strict=False)
+                if not remove
+            ]
+
         x_mp = np.array([fs.x_start for fs in flux_surfaces])
         z_mp = np.array([fs.z_start for fs in flux_surfaces])
         x_fw = np.array([fs.x_end for fs in flux_surfaces])
         z_fw = np.array([fs.z_end for fs in flux_surfaces])
-        alpha = np.array([fs.alpha for fs in flux_surfaces])
-        return x_mp, z_mp, x_fw, z_fw, alpha
+
+        return flux_surfaces, x_mp, z_mp, x_fw, z_fw, alpha
 
     def _make_flux_surfaces_ob(self):
         """
@@ -359,11 +379,11 @@ class ChargedParticleSolver:
         # Find the intersections of the flux surfaces with the first wall
         self._clip_flux_surfaces(self.first_wall)
 
-        x_omp, z_omp, x_lfs_inter, z_lfs_inter, alpha_lfs = self._get_arrays(
-            self.flux_surfaces_ob_down
+        self.flux_surfaces_ob_down, x_omp, z_omp, x_lfs_inter, z_lfs_inter, alpha_lfs = (
+            self._get_arrays(self.flux_surfaces_ob_down)
         )
-        _, _, x_hfs_inter, z_hfs_inter, alpha_hfs = self._get_arrays(
-            self.flux_surfaces_ob_up
+        self.flux_surfaces_ob_up, _, _, x_hfs_inter, z_hfs_inter, alpha_hfs = (
+            self._get_arrays(self.flux_surfaces_ob_up)
         )
 
         # Calculate values at OMP
@@ -432,17 +452,27 @@ class ChargedParticleSolver:
         # Find the intersections of the flux surfaces with the first wall
         self._clip_flux_surfaces(self.first_wall)
 
-        (x_omp, z_omp, x_lfs_down_inter, z_lfs_down_inter, alpha_lfs_down) = (
-            self._get_arrays(self.flux_surfaces_ob_down)
+        (
+            self.flux_surfaces_ob_down,
+            x_omp,
+            z_omp,
+            x_lfs_down_inter,
+            z_lfs_down_inter,
+            alpha_lfs_down,
+        ) = self._get_arrays(self.flux_surfaces_ob_down)
+        self.flux_surfaces_ob_up, _, _, x_lfs_up_inter, z_lfs_up_inter, alpha_lfs_up = (
+            self._get_arrays(self.flux_surfaces_ob_up)
         )
-        _, _, x_lfs_up_inter, z_lfs_up_inter, alpha_lfs_up = self._get_arrays(
-            self.flux_surfaces_ob_up
-        )
-        (x_imp, z_imp, x_hfs_down_inter, z_hfs_down_inter, alpha_hfs_down) = (
-            self._get_arrays(self.flux_surfaces_ib_down)
-        )
-        _, _, x_hfs_up_inter, z_hfs_up_inter, alpha_hfs_up = self._get_arrays(
-            self.flux_surfaces_ib_up
+        (
+            self.flux_surfaces_ib_down,
+            x_imp,
+            z_imp,
+            x_hfs_down_inter,
+            z_hfs_down_inter,
+            alpha_hfs_down,
+        ) = self._get_arrays(self.flux_surfaces_ib_down)
+        self.flux_surfaces_ib_up, _, _, x_hfs_up_inter, z_hfs_up_inter, alpha_hfs_up = (
+            self._get_arrays(self.flux_surfaces_ib_up)
         )
 
         # Calculate values at OMP

--- a/bluemira/radiation_transport/advective_transport.py
+++ b/bluemira/radiation_transport/advective_transport.py
@@ -163,16 +163,14 @@ class ChargedParticleSolver:
     def _get_arrays(
         flux_surfaces,
     ) -> tuple[
-        npt.NDArray[float],
-        npt.NDArray[float],
-        npt.NDArray[float],
-        npt.NDArray[float],
-        npt.NDArray[float],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
     ]:
         """
         Get arrays of flux surface values.
-        Removes any flux surfaces that do not intersect the first wall (a warning will
-        print if this is the case, see flux_surfaces.py).
 
         Returns
         -------
@@ -190,27 +188,12 @@ class ChargedParticleSolver:
             the array of alpha angle for each flux surface
         """
         alpha = np.array([fs.alpha for fs in flux_surfaces])
-
-        # Remove flux surfaces that do not intersect the first wall.
-        no_cross = alpha == None  # noqa: E711
-        if any(no_cross):
-            alpha = [
-                value
-                for (value, remove) in zip(alpha, no_cross, strict=False)
-                if not remove
-            ]
-            flux_surfaces = [
-                value
-                for (value, remove) in zip(flux_surfaces, no_cross, strict=False)
-                if not remove
-            ]
-
         x_mp = np.array([fs.x_start for fs in flux_surfaces])
         z_mp = np.array([fs.z_start for fs in flux_surfaces])
         x_fw = np.array([fs.x_end for fs in flux_surfaces])
         z_fw = np.array([fs.z_end for fs in flux_surfaces])
 
-        return flux_surfaces, x_mp, z_mp, x_fw, z_fw, alpha
+        return x_mp, z_mp, x_fw, z_fw, alpha
 
     def _make_flux_surfaces_ob(self):
         """
@@ -379,11 +362,11 @@ class ChargedParticleSolver:
         # Find the intersections of the flux surfaces with the first wall
         self._clip_flux_surfaces(self.first_wall)
 
-        self.flux_surfaces_ob_down, x_omp, z_omp, x_lfs_inter, z_lfs_inter, alpha_lfs = (
-            self._get_arrays(self.flux_surfaces_ob_down)
+        x_omp, z_omp, x_lfs_inter, z_lfs_inter, alpha_lfs = self._get_arrays(
+            self.flux_surfaces_ob_down
         )
-        self.flux_surfaces_ob_up, _, _, x_hfs_inter, z_hfs_inter, alpha_hfs = (
-            self._get_arrays(self.flux_surfaces_ob_up)
+        _, _, x_hfs_inter, z_hfs_inter, alpha_hfs = self._get_arrays(
+            self.flux_surfaces_ob_up
         )
 
         # Calculate values at OMP
@@ -453,26 +436,24 @@ class ChargedParticleSolver:
         self._clip_flux_surfaces(self.first_wall)
 
         (
-            self.flux_surfaces_ob_down,
             x_omp,
             z_omp,
             x_lfs_down_inter,
             z_lfs_down_inter,
             alpha_lfs_down,
         ) = self._get_arrays(self.flux_surfaces_ob_down)
-        self.flux_surfaces_ob_up, _, _, x_lfs_up_inter, z_lfs_up_inter, alpha_lfs_up = (
-            self._get_arrays(self.flux_surfaces_ob_up)
+        _, _, x_lfs_up_inter, z_lfs_up_inter, alpha_lfs_up = self._get_arrays(
+            self.flux_surfaces_ob_up
         )
         (
-            self.flux_surfaces_ib_down,
             x_imp,
             z_imp,
             x_hfs_down_inter,
             z_hfs_down_inter,
             alpha_hfs_down,
         ) = self._get_arrays(self.flux_surfaces_ib_down)
-        self.flux_surfaces_ib_up, _, _, x_hfs_up_inter, z_hfs_up_inter, alpha_hfs_up = (
-            self._get_arrays(self.flux_surfaces_ib_up)
+        _, _, x_hfs_up_inter, z_hfs_up_inter, alpha_hfs_up = self._get_arrays(
+            self.flux_surfaces_ib_up
         )
 
         # Calculate values at OMP

--- a/bluemira/radiation_transport/flux_surfaces_maker.py
+++ b/bluemira/radiation_transport/flux_surfaces_maker.py
@@ -331,10 +331,21 @@ def _get_sep_out_intersection(
 
 
 def _make_flux_surfaces(
-    x, z, equilibrium, o_point, yz_plane, dl: float | None = None
-) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface]:
+    x, z, equilibrium, o_point, yz_plane, closed_perimiter, dl: float | None = None
+) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface] | None:
     """
     Make individual PartialOpenFluxSurface through a point.
+
+    Check if flux surfaces are closed and:
+
+    - Open any closed flux surfaces that are actually open.
+    At this stage we have no knowledge of the first wall so
+    a flux surface that does not extend off the grid will be
+    classed as open.
+
+    - Ignore any genuinely closed flux surfaces resulting
+    from the errors associated with finding a contour line
+    on a grid.
 
     Returns
     -------
@@ -347,9 +358,12 @@ def _make_flux_surfaces(
     coords = Coordinates({"x": coords_arr[0], "z": coords_arr[1]})
     if dl is not None:
         coords = coords.interpolate(dl=dl, preserve_points=True)
-    if coords.closed:
-        coords.open()
-    return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
+    if not coords.closed:
+        return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
+    coords.open()
+    if coords.length > 1.05 * closed_perimiter:
+        return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
+    return None
 
 
 def _make_flux_surfaces_ibob(
@@ -366,6 +380,11 @@ def _make_flux_surfaces_ibob(
     """
     Make the flux surfaces on the inboard or outboard.
 
+    Note: this function opens flux surfaces outside the LCFS
+    with closed coords. This is too avoid errors resulting from
+    open flux surfaces that appear closed because
+    they do not extend off the grid.
+
     Returns
     -------
     flux_surfaces_lfs:
@@ -373,12 +392,18 @@ def _make_flux_surfaces_ibob(
     flux_surfaces_hfs:
         outboard flux surfaces
     """
+    lcfs_perimter = equilibrium.get_LCFS().length
     sign = 1 if outboard else -1
     flux_surfaces = [
-        _make_flux_surfaces(x, o_point.z, equilibrium, o_point, yz_plane, dl)
+        fs
         for x in np.arange(
             x_sep_mp + (sign * dx_mp), x_out_mp - (sign * EPS), (sign * dx_mp)
         )
+        if (
+            fs := _make_flux_surfaces(
+                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, dl
+            )
+        )
+        is not None
     ]
-
     return tuple(map(list, zip(*flux_surfaces, strict=True)))

--- a/tests/radiation_transport/test_advective_transport.py
+++ b/tests/radiation_transport/test_advective_transport.py
@@ -195,6 +195,7 @@ class TestChargedParticleRecursionSN:
                 self.solver.eq,
                 self.solver._o_point,
                 self.solver._yz_plane,
+                self.solver.eq.get_LCFS().length,
             )
 
             self.solver.flux_surfaces_ob_down.append(lfs)
@@ -266,6 +267,7 @@ class TestChargedParticleRecursionDN:
                 self.solver.eq,
                 self.solver._o_point,
                 self.solver._yz_plane,
+                self.solver.eq.get_LCFS().length,
             )
 
             self.solver.flux_surfaces_ob_down.append(lfs)


### PR DESCRIPTION
## Linked Issues

https://gitlab.ukaea.uk/step-bluemira-reactor-design/step-bluemira-reactor-design/-/issues/745

~~Note: we need to figure out the cause of the issue, this will temporarily fix the problem for the STEP study that is affected.~~
Grid related - use of find_flux_surface_through_point can result in open/closed error when finding nearest contour line. 

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
