### PR TITLE
fix(eudemo): don't require a neutronics config dir when saving the re…

### DIFF
--- a/eudemo/eudemo/reactor.py
+++ b/eudemo/eudemo/reactor.py
@@ -630,13 +630,11 @@ def save_reactor(reactor, reactor_config, folder_name):
     filename = f"{root}/BLUEMIRA_OUT.json"
     json_writer(reactor_config.global_params.to_dict(use_last=True), filename, indent=2)
 
-    n_conf_path = Path(config_folder, "neutronics")
-    if n_conf_path.exists():
-        # Save neutronics
-        n_root = Path(root, "neutronics")
-        n_root.mkdir(parents=True, exist_ok=True)
-
-        shutil.copytree(n_conf_path, n_root, dirs_exist_ok=True)
+    n_root = Path(root, "neutronics")
+    n_root.mkdir(parents=True, exist_ok=True)
+    config_neutronics = Path(config_folder, "neutronics")
+    if config_neutronics.is_dir():
+        shutil.copytree(config_neutronics, n_root, dirs_exist_ok=True)
 
         # CSG
         csg_root = Path(n_root, "csg")


### PR DESCRIPTION
…actor

save_reactor copied config/neutronics into the output before creating the target dir, so it crashed when neutronics is disabled and the source dir is absent. Create the output dir first and copy only if the config dir exists.

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
