### PR TITLE
fix(cad): refuse a splitter removal that moved the volume

### DIFF
--- a/bluemira/codes/cadapi/_cadquery/core.py
+++ b/bluemira/codes/cadapi/_cadquery/core.py
@@ -64,6 +64,7 @@ from OCP.GeomAbs import (
 )
 from OCP.ShapeAnalysis import ShapeAnalysis_FreeBounds, ShapeAnalysis_Surface
 from OCP.ShapeFix import ShapeFix_Shape, ShapeFix_Wire
+from OCP.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
 from OCP.TopAbs import (
     TopAbs_FACE,
     TopAbs_IN,
@@ -101,6 +102,7 @@ from bluemira.codes.cadapi._cadquery.aliases import (
     apiWire,
 )
 from bluemira.codes.error import CADError, CadQueryError, InvalidCADInputsError
+from bluemira.geometry.constants import SPLITTER_VOLUME_TOL
 from bluemira.geometry.error import GeometryError
 
 if TYPE_CHECKING:
@@ -1725,35 +1727,120 @@ def boolean_fuse(shapes: list, *, remove_splitter: bool = True) -> apiShape:
 def _remove_splitter(shape: apiShape) -> apiShape:
     """Drop the splitter faces and edges a boolean leaves behind.
 
-    Tidying up is optional; a correct shape is not. On solids bounded by spline
-    faces the underlying ``UnifySameDomain`` can merge faces it should not and
-    return a shape that fails ``BRepCheck`` and reports a nonsense volume, which
-    downstream is worse than the splitters it removed: the next boolean either
-    yields garbage or dies on a null shape. So refuse a result that is invalid
-    when the input was not.
+    Tidying up is optional; a correct shape is not. Splitter removal is
+    topological -- merge coplanar faces, merge collinear edges -- so it must
+    leave the volume alone. ``UnifySameDomain`` does not always manage that on
+    solids bounded by spline faces, in two distinct ways: it can return a shape
+    that fails ``BRepCheck``, and it can return a perfectly valid shape of a
+    different size. Both are refused here.
 
-    The guard covers solids only. On faces this same tidy-up doubles as a repair
+    The guards cover solids only. On faces this same tidy-up doubles as a repair
     step -- a fused compound of coplanar faces can fail ``isValid`` both before
     and after while still merging into the one face the caller needs -- so there
-    validity is not a signal that anything went wrong.
+    neither validity nor size is a signal that anything went wrong.
 
     Returns
     -------
     :
-        The tidied shape, or the original if tidying failed or broke it.
+        The tidied shape, or the closest tidy-up that preserved it.
     """
     try:
         cleaned = shape.clean()
     except Exception as exc:  # noqa: BLE001
         bluemira_warn(f"Splitter removal failed: {exc}")
         return shape
-    has_solids = TopExp_Explorer(shape.wrapped, TopAbs_SOLID).More()
-    if has_solids and shape.isValid() and not cleaned.isValid():
+
+    if not TopExp_Explorer(shape.wrapped, TopAbs_SOLID).More():
+        return cleaned
+
+    if shape.isValid() and not cleaned.isValid():
         bluemira_warn(
             "Splitter removal turned a valid solid invalid; keeping the split one."
         )
         return shape
-    return cleaned
+
+    # Nothing merged, nothing to check. Edges count too: unifying them refits the
+    # boundary curves, which can move the wall while the face count stands still.
+    if len(cleaned.Faces()) == len(shape.Faces()) and len(cleaned.Edges()) == len(
+        shape.Edges()
+    ):
+        return cleaned
+
+    objection = _volume_objection(shape, cleaned)
+    if objection is None:
+        return cleaned
+
+    # Face unification is the culprit: it merges two spline patches whose
+    # support surfaces are only nearly identical, keeps one of them, and
+    # re-projects the shared boundary onto it, so the wall moves. Merging
+    # collinear edges touches no surface and is safe.
+    # The fallback runs the same upgrade, so it earns no more trust than the
+    # full one: it has to clear both guards too.
+    edges_only = _unify_edges(shape)
+    if (
+        edges_only is not None
+        and not (shape.isValid() and not edges_only.isValid())
+        and _volume_objection(shape, edges_only) is None
+    ):
+        bluemira_warn(
+            f"Splitter removal moved the volume by {objection:.4e} m³; merging "
+            "edges only, which leaves the faces split."
+        )
+        return edges_only
+
+    bluemira_warn(
+        f"Splitter removal moved the volume by {objection:.4e} m³; keeping the "
+        "split shape."
+    )
+    return shape
+
+
+def _volume_objection(before: apiShape, after: apiShape) -> float | None:
+    """The reason not to keep a tidy-up, if there is one.
+
+    Returns
+    -------
+    :
+        The signed volume difference when it exceeds
+        :data:`~bluemira.geometry.constants.SPLITTER_VOLUME_TOL` of the larger
+        operand, else None. An unmeasurable *input* yields None -- a check that
+        cannot run must not veto the tidy-up, it simply cannot vouch for it --
+        but an unmeasurable *result* is evidence against itself and objects.
+    """
+    try:
+        v_before = before.Volume()
+    except Exception as exc:  # noqa: BLE001
+        bluemira_warn(f"Could not measure the shape before splitter removal: {exc}")
+        return None
+    try:
+        v_after = after.Volume()
+    except Exception as exc:  # noqa: BLE001
+        # A tidied shape that cannot be measured is evidence against itself.
+        bluemira_warn(f"Could not measure the shape after splitter removal: {exc}")
+        return math.inf
+    delta = v_after - v_before
+    scale = max(abs(v_before), abs(v_after))
+    if abs(delta) <= SPLITTER_VOLUME_TOL * scale:
+        return None
+    return delta
+
+
+def _unify_edges(shape: apiShape) -> apiShape | None:
+    """Merge collinear edges, leaving every face as it is.
+
+    Returns
+    -------
+    :
+        The tidied shape, or None if the upgrade failed.
+    """
+    try:
+        upgrader = ShapeUpgrade_UnifySameDomain(shape.wrapped, True, False, False)
+        upgrader.AllowInternalEdges(False)
+        upgrader.Build()
+        return cq.Shape.cast(upgrader.Shape())
+    except Exception as exc:  # noqa: BLE001
+        bluemira_warn(f"Edge unification failed: {exc}")
+        return None
 
 
 def _assemble_wires_from_edges(edges: list) -> list:

--- a/bluemira/codes/cadapi/_freecad/api.py
+++ b/bluemira/codes/cadapi/_freecad/api.py
@@ -44,7 +44,11 @@ from bluemira.base.file import force_file_extension
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes.cadapi._freecad.config import _freecad_save_config
 from bluemira.codes.error import CADError, FreeCADError, InvalidCADInputsError
-from bluemira.geometry.constants import EPS_FREECAD, MINIMUM_LENGTH
+from bluemira.geometry.constants import (
+    EPS_FREECAD,
+    MINIMUM_LENGTH,
+    SPLITTER_VOLUME_TOL,
+)
 from bluemira.utilities.tools import ColourDescriptor, floatify, qtapp_instance
 
 if TYPE_CHECKING:
@@ -2436,6 +2440,44 @@ def join_connect(shapes: Iterable[apiShape], dist_tolerance: float) -> apiShape:
 # ======================================================================================
 # Boolean operations
 # ======================================================================================
+def _remove_splitter(shape: apiShape) -> apiShape:
+    """
+    Drop the splitter faces and edges a boolean leaves behind.
+
+    Returns
+    -------
+    Result of the refinement, or the original shape when refining a solid moved
+    its volume.
+
+    Notes
+    -----
+    Splitter removal is topological -- merge coplanar faces, merge collinear
+    edges -- so it must leave the volume alone. On solids bounded by spline
+    faces it does not always manage that: adjacent patches whose support
+    surfaces are only nearly identical get merged onto one of them, the shared
+    boundary is re-projected, and the wall moves. The result stays valid and
+    says nothing, which is worse than the splitters it removed.
+
+    Solids only. On faces this same call doubles as a repair step, so there a
+    change in size is not a signal that anything went wrong.
+    """
+    refined = shape.removeSplitter()
+    if not shape.Solids:
+        return refined
+    # Nothing merged, nothing to check. Edges count too: refining them refits the
+    # boundary curves, which can move the wall while the face count stands still.
+    if len(refined.Faces) == len(shape.Faces) and len(refined.Edges) == len(shape.Edges):
+        return refined
+    delta = refined.Volume - shape.Volume
+    scale = max(abs(shape.Volume), abs(refined.Volume))
+    if abs(delta) <= SPLITTER_VOLUME_TOL * scale:
+        return refined
+    bluemira_warn(
+        f"Splitter removal moved the volume by {delta:.4e} m³; keeping the split shape."
+    )
+    return shape
+
+
 def boolean_fuse(
     shapes: Iterable[apiShape], *, remove_splitter: bool = True
 ) -> apiShape:
@@ -2448,8 +2490,10 @@ def boolean_fuse(
         List of FreeCAD shape objects to be fused together. All the objects in the
         list must be of the same type.
     remove_splitter:
-        if True, shape is refined removing extra edges.
+        if True, solids are refined removing extra edges.
         See(https://wiki.freecadweb.org/Part_RefineShape)
+        Faces are always refined -- there it is the step that yields the single
+        face the caller expects.
 
 
     Returns
@@ -2497,8 +2541,11 @@ def boolean_fuse(
 
         if _type == apiFace:
             merged_shape = shapes[0].fuse(shapes[1:])
-            if remove_splitter:
-                merged_shape = merged_shape.removeSplitter()
+            # Not gated on ``remove_splitter``: on faces the refinement is what
+            # turns the fused compound into the single face the caller asked
+            # for, and the check below rejects anything else. The CadQuery
+            # backend merges faces unconditionally for the same reason.
+            merged_shape = merged_shape.removeSplitter()
             if len(merged_shape.Faces) > 1:
                 raise FreeCADError(  # noqa: TRY301
                     f"Boolean fuse operation on {shapes} gives more than one face."
@@ -2508,7 +2555,7 @@ def boolean_fuse(
         if _type == apiSolid:
             merged_shape = shapes[0].fuse(shapes[1:])
             if remove_splitter:
-                merged_shape = merged_shape.removeSplitter()
+                merged_shape = _remove_splitter(merged_shape)
             if len(merged_shape.Solids) > 1:
                 raise FreeCADError(  # noqa: TRY301
                     f"Boolean fuse operation on {shapes} gives more than one solid."

--- a/bluemira/geometry/constants.py
+++ b/bluemira/geometry/constants.py
@@ -13,6 +13,13 @@ import numpy as np
 # Absolute tolerance for equality in distances
 D_TOLERANCE = 1e-5  # [m]
 
+# Relative slack for the volume a splitter removal may move. Merging faces
+# re-approximates the surfaces involved, and on a shape reassembled from
+# fragments it also closes seam gaps, so small movements are legitimate: ~1e-8
+# of the volume on a revolved spline vessel, ~2e-6 when it heals the seams of a
+# fragment fuse. A wall that has actually moved is ~1e-3 and up.
+SPLITTER_VOLUME_TOL = 1e-5
+
 # FreeCAD's default tolerance is 1E-7, so correspondingly, we need a larger epsilon.
 # The following value happens to equal 1.1920929E-7, which satisifies the requirement.
 # We think that FreeCAD stores number as float 32 but we're not sure.

--- a/bluemira/geometry/tools.py
+++ b/bluemira/geometry/tools.py
@@ -2051,7 +2051,12 @@ def make_compound(shapes: Iterable[BluemiraGeo], label: str = "") -> BluemiraCom
 # ======================================================================================
 # Boolean operations
 # ======================================================================================
-def boolean_fuse(shapes: Iterable[BluemiraGeo], label: str = "") -> BluemiraGeo:
+def boolean_fuse(
+    shapes: Iterable[BluemiraGeo],
+    label: str = "",
+    *,
+    remove_splitter: bool = True,
+) -> BluemiraGeo:
     """
     Fuse two or more shapes together. Internal splitter are removed.
 
@@ -2061,6 +2066,12 @@ def boolean_fuse(shapes: Iterable[BluemiraGeo], label: str = "") -> BluemiraGeo:
         List of shape objects to be saved
     label:
         Label for the resulting shape
+    remove_splitter:
+        Whether to drop the splitter faces and edges the fuse leaves behind.
+        Applies to solids: there the tidy-up is refused, or reduced to merging
+        edges, when it would move the volume. Faces are merged either way, since
+        for them it is the step that yields the single face expected. Turn it
+        off to keep the topology the fuse produced, at the cost of extra faces.
 
     Returns
     -------
@@ -2085,7 +2096,7 @@ def boolean_fuse(shapes: Iterable[BluemiraGeo], label: str = "") -> BluemiraGeo:
 
     api_shapes = [s.shape for s in shapes]
     try:
-        merged_shape = cadapi.boolean_fuse(api_shapes)
+        merged_shape = cadapi.boolean_fuse(api_shapes, remove_splitter=remove_splitter)
         return convert(merged_shape, label)
     except Exception as e:
         raise GeometryError(f"Boolean fuse operation failed: {e}") from e

--- a/tests/codes/_shared/backend_api_tests.py
+++ b/tests/codes/_shared/backend_api_tests.py
@@ -625,3 +625,24 @@ class BackendApiTestsBase:
 
         tan2 = self.cadapi.wire_tangent_at(wire, 0.75)
         assert np.allclose(tan2, (0.0, 1.0, 0.0))
+
+    def _unit_cube(self, x_origin: float = 0.0):
+        face = BluemiraFace(
+            make_polygon(
+                [
+                    [x_origin, 0, 0],
+                    [x_origin + 1, 0, 0],
+                    [x_origin + 1, 1, 0],
+                    [x_origin, 1, 0],
+                ],
+                closed=True,
+            )
+        )
+        return extrude_shape(face, (0, 0, 1)).shape
+
+    def test_splitter_removal_keeps_the_volume(self):
+        """Merging the faces a boolean left behind must not resize the solid."""
+        fused = self.cadapi.boolean_fuse([self._unit_cube(), self._unit_cube(1.0)])
+
+        volume = fused.Volume() if callable(fused.Volume) else fused.Volume
+        assert volume == pytest.approx(2.0, rel=1e-9)

--- a/tests/codes/test_cadqueryapi.py
+++ b/tests/codes/test_cadqueryapi.py
@@ -28,11 +28,17 @@ from OCP.BRep import BRep_Builder  # noqa: E402
 from OCP.TopoDS import TopoDS_Wire  # noqa: E402
 from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt, gp_Trsf  # noqa: E402
 
+from bluemira.codes.cadapi._cadquery import core as cq_core  # noqa: E402
 from bluemira.codes.error import CadQueryError  # noqa: E402
 from bluemira.geometry.coordinates import Coordinates  # noqa: E402
 from bluemira.geometry.error import GeometryError  # noqa: E402
+from bluemira.geometry.face import BluemiraFace  # noqa: E402
 from bluemira.geometry.parameterisations import TripleArc  # noqa: E402
-from bluemira.geometry.tools import convert  # noqa: E402
+from bluemira.geometry.tools import (  # noqa: E402
+    convert,
+    extrude_shape,
+    make_polygon,
+)
 from tests.codes._shared.backend_api_tests import BackendApiTestsBase  # noqa: E402
 
 E1, E2, E3, E4 = "e1", "e2", "e3", "e4"
@@ -1845,3 +1851,76 @@ class TestPropertyAccuracy:
         # A circle's length equals its closed-form circumference 2*pi*r.
         circle = cadapi.make_circle(radius=3.0, axis=(0, 1, 0))
         assert cadapi.length(circle) == pytest.approx(2 * np.pi * 3.0, rel=1e-12)
+
+
+class TestRemoveSplitterGuard:
+    """``_remove_splitter`` drops a tidy-up that resized the solid.
+
+    Face unification can merge spline patches whose support surfaces are only
+    nearly identical and re-project the shared boundary, which moves the wall
+    while ``isValid`` still passes. The geometry that provokes it for real is a
+    whole reactor, so ``clean`` is made to misbehave instead.
+    """
+
+    @staticmethod
+    def _cube(x_origin=0.0):
+        face = BluemiraFace(
+            make_polygon(
+                [
+                    [x_origin, 0, 0],
+                    [x_origin + 1, 0, 0],
+                    [x_origin + 1, 1, 0],
+                    [x_origin, 1, 0],
+                ],
+                closed=True,
+            )
+        )
+        return extrude_shape(face, (0, 0, 1)).shape
+
+    @staticmethod
+    def _two_cubes_fused():
+        """The raw fuse, splitter face and all."""
+        return cadapi.boolean_fuse(
+            [
+                TestRemoveSplitterGuard._cube(0.0),
+                TestRemoveSplitterGuard._cube(1.0),
+            ],
+            remove_splitter=False,
+        )
+
+    def test_a_size_preserving_tidy_up_is_kept(self):
+        fused = self._two_cubes_fused()
+
+        tidied = cq_core._remove_splitter(fused)
+
+        assert tidied is not fused
+        assert tidied.Volume() == pytest.approx(2.0, rel=1e-9)
+        assert len(tidied.Faces()) < len(fused.Faces())
+
+    def test_a_resized_tidy_up_falls_back_to_merging_edges(self, monkeypatch):
+        fused = self._two_cubes_fused()
+        monkeypatch.setattr(cq.Shape, "clean", lambda _self: self._cube())
+
+        tidied = cq_core._remove_splitter(fused)
+
+        assert tidied is not fused
+        assert tidied.Volume() == pytest.approx(2.0, rel=1e-9)
+        # The faces are left split -- only the edges were merged.
+        assert len(tidied.Faces()) == len(fused.Faces())
+
+    def test_the_split_shape_survives_when_the_fallback_fails_too(self, monkeypatch):
+        fused = self._two_cubes_fused()
+        monkeypatch.setattr(cq.Shape, "clean", lambda _self: self._cube())
+        monkeypatch.setattr(cq_core, "_unify_edges", lambda _shape: None)
+
+        assert cq_core._remove_splitter(fused) is fused
+
+    def test_an_unmeasurable_result_is_refused(self):
+        """A tidied shape that cannot be measured is evidence against itself."""
+        fused = self._two_cubes_fused()
+
+        class _Unmeasurable:
+            def Volume(self):
+                raise RuntimeError("no volume here")
+
+        assert cq_core._volume_objection(fused, _Unmeasurable()) == math.inf

--- a/tests/codes/test_freecadapi.py
+++ b/tests/codes/test_freecadapi.py
@@ -460,3 +460,50 @@ class TestCADFiletype:
                     assert isinstance(objs[0].Shape, cadapi.apiCompound)
                 else:
                     assert isinstance(objs[0].Shape, cadapi.apiShell)
+
+
+class TestRemoveSplitterGuard:
+    """``_remove_splitter`` drops a refinement that resized the solid.
+
+    On spline-bounded solids the refinement can merge patches whose support
+    surfaces are only nearly identical and re-project the shared boundary,
+    which moves the wall while every validity check still passes. The geometry
+    that provokes it for real is a whole reactor, so the refinement is faked.
+    """
+
+    class _Shape:
+        def __init__(self, volume, faces, edges=None, refined=None):
+            self.Volume = volume
+            self.Faces = ["f"] * faces
+            self.Edges = ["e"] * (faces if edges is None else edges)
+            self.Solids = ["s"]
+            self._refined = refined
+
+        def removeSplitter(self):
+            return self._refined
+
+    def test_a_resized_refinement_is_refused(self):
+        refined = self._Shape(90.0, 8)
+        shape = self._Shape(100.0, 12, refined=refined)
+
+        assert cadapi._remove_splitter(shape) is shape
+
+    def test_a_size_preserving_refinement_is_kept(self):
+        refined = self._Shape(100.0, 8)
+        shape = self._Shape(100.0, 12, refined=refined)
+
+        assert cadapi._remove_splitter(shape) is refined
+
+    def test_nothing_merged_skips_the_volume_check(self):
+        """The volumes cost more to evaluate than the refinement itself."""
+        refined = self._Shape(90.0, 12)
+        shape = self._Shape(100.0, 12, refined=refined)
+
+        assert cadapi._remove_splitter(shape) is refined
+
+    def test_merged_edges_alone_are_still_checked(self):
+        """Refitting the boundary curves can move the wall on its own."""
+        refined = self._Shape(90.0, 12, edges=20)
+        shape = self._Shape(100.0, 12, edges=24, refined=refined)
+
+        assert cadapi._remove_splitter(shape) is shape

--- a/tests/geometry/test_tools.py
+++ b/tests/geometry/test_tools.py
@@ -1136,3 +1136,56 @@ class TestBooleanCutShell:
         assert len(result) >= 1
         for piece in result:
             assert isinstance(piece, BluemiraShell)
+
+
+class TestBooleanFuseSplitterRemoval:
+    """``remove_splitter`` reaches the backend, and neither setting resizes."""
+
+    @staticmethod
+    def _cube(x_origin):
+        face = BluemiraFace(
+            make_polygon(
+                [
+                    [x_origin, 0, 0],
+                    [x_origin + 1, 0, 0],
+                    [x_origin + 1, 1, 0],
+                    [x_origin, 1, 0],
+                ],
+                closed=True,
+            )
+        )
+        return extrude_shape(face, (0, 0, 1))
+
+    def test_the_splitter_faces_are_dropped_by_default(self):
+        fused = boolean_fuse([self._cube(0.0), self._cube(1.0)])
+
+        assert fused.volume == pytest.approx(2.0, rel=1e-9)
+        assert len(fused.faces) == 6
+
+    def test_faces_are_merged_either_way(self):
+        """The flag is about solids.
+
+        For faces the merge is what yields the single face the caller expects,
+        so both backends run it regardless -- they used to disagree, one
+        returning the merged face and the other raising.
+        """
+        face_a = BluemiraFace(
+            make_polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], closed=True)
+        )
+        face_b = BluemiraFace(
+            make_polygon([[1, 0, 0], [2, 0, 0], [2, 1, 0], [1, 1, 0]], closed=True)
+        )
+
+        for flag in (True, False):
+            fused = boolean_fuse([face_a, face_b], remove_splitter=flag)
+
+            assert isinstance(fused, BluemiraFace)
+            assert fused.area == pytest.approx(2.0, rel=1e-9)
+            assert len(fused.boundary[0].edges) == 4
+
+    def test_they_are_kept_when_asked(self):
+        """The seam between the two cubes survives, and costs only faces."""
+        fused = boolean_fuse([self._cube(0.0), self._cube(1.0)], remove_splitter=False)
+
+        assert fused.volume == pytest.approx(2.0, rel=1e-9)
+        assert len(fused.faces) > 6


### PR DESCRIPTION
## Description

Splitter removal is topological, so it must leave the volume alone. On spline-bounded solids neither backend manages that, and both call the result valid: FreeCAD's removeSplitter takes 0.059 m³ off the fused EU-DEMO vessel, CadQuery's clean 0.408 m³ off the incremental port join.

- Refuse a refinement that moved the volume, in both backends; on CadQuery fall back to unifying edges only, which touches no surface.
- Refine faces regardless of remove_splitter on FreeCAD, as CadQuery does.
- Pass remove_splitter through geometry.tools.boolean_fuse, keyword only.

The backends now agree to the digit on the real reactor geometry, and the joined vessel feeds the DAGMC model -- neutronics results from an earlier build no longer match the geometry that produced them.

## Checklist

I confirm that I have completed the following checks:

- [x] Tests run locally and pass `pytest tests --reactor`
- [x] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [x] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
