### PR TITLE
_make_flux_surfaces to use same split function as in LegFlux class

### DIFF
--- a/bluemira/radiation_transport/flux_surfaces_maker.py
+++ b/bluemira/radiation_transport/flux_surfaces_maker.py
@@ -17,7 +17,7 @@ from bluemira.base.constants import EPS
 from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.equilibria.equilibrium import Equilibrium
 from bluemira.equilibria.find import find_flux_surface_through_point
-from bluemira.equilibria.find_legs import LegFlux, NumNull, SortSplit
+from bluemira.equilibria.find_legs import LegFlux, NumNull, SortSplit, split
 from bluemira.equilibria.flux_surfaces import OpenFluxSurface, PartialOpenFluxSurface
 from bluemira.geometry.coordinates import Coordinates, coords_plane_intersect
 from bluemira.geometry.plane import BluemiraPlane
@@ -315,7 +315,7 @@ def _get_sep_out_intersection(
     else:
         # separatrix list is sorted by loop length when found,
         # so separatrix[0] will have the intersection
-        sep_intersections = coords_plane_intersect(sep.separatrix, yz_plane)
+        sep_intersections = coords_plane_intersect(sep.separatrix[0], yz_plane)
         if isinstance(sep_intersections, Coordinates):
             sep_arg = np.argmin(np.abs(sep_intersections.T[0] - sep.o_point.x))
             x_sep_mp = sep_intersections.T[0][sep_arg]
@@ -331,7 +331,14 @@ def _get_sep_out_intersection(
 
 
 def _make_flux_surfaces(
-    x, z, equilibrium, o_point, yz_plane, closed_perimiter, dl: float | None = None
+    x,
+    z,
+    equilibrium,
+    o_point,
+    yz_plane,
+    closed_perimiter,
+    outboard: bool | None = None,  # noqa: FBT001
+    dl: float | None = None,
 ) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface] | None:
     """
     Make individual PartialOpenFluxSurface through a point.
@@ -360,8 +367,12 @@ def _make_flux_surfaces(
         coords = coords.interpolate(dl=dl, preserve_points=True)
     if not coords.closed:
         return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
-    coords.open()
     if coords.length > 1.05 * closed_perimiter:
+        coords = split(coords, NumNull.DN if equilibrium.is_double_null else NumNull.SN)
+        # Sort IB then OB
+        if isinstance(coords, list):
+            coords.sort(key=lambda coords: coords.x[0])
+            coords = coords[1] if outboard else coords[0]
         return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
     return None
 
@@ -401,7 +412,7 @@ def _make_flux_surfaces_ibob(
         )
         if (
             fs := _make_flux_surfaces(
-                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, dl
+                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, outboard, dl
             )
         )
         is not None

--- a/bluemira/radiation_transport/flux_surfaces_maker.py
+++ b/bluemira/radiation_transport/flux_surfaces_maker.py
@@ -337,8 +337,9 @@ def _make_flux_surfaces(
     o_point,
     yz_plane,
     closed_perimiter,
-    outboard: bool | None = None,  # noqa: FBT001
     dl: float | None = None,
+    *, 
+    outboard: bool,
 ) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface] | None:
     """
     Make individual PartialOpenFluxSurface through a point.
@@ -371,7 +372,7 @@ def _make_flux_surfaces(
         coords = split(coords, NumNull.DN if equilibrium.is_double_null else NumNull.SN)
         # Sort IB then OB
         if isinstance(coords, list):
-            coords.sort(key=lambda coords: coords.x[0])
+            coords.sort(key=lambda coords: coords.x.min())
             coords = coords[1] if outboard else coords[0]
         return OpenFluxSurface(coords).split(o_point, plane=yz_plane)
     return None
@@ -412,7 +413,7 @@ def _make_flux_surfaces_ibob(
         )
         if (
             fs := _make_flux_surfaces(
-                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, outboard, dl
+                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, dl, outboard=outboard
             )
         )
         is not None

--- a/bluemira/radiation_transport/flux_surfaces_maker.py
+++ b/bluemira/radiation_transport/flux_surfaces_maker.py
@@ -338,7 +338,7 @@ def _make_flux_surfaces(
     yz_plane,
     closed_perimiter,
     dl: float | None = None,
-    *, 
+    *,
     outboard: bool,
 ) -> tuple[PartialOpenFluxSurface, PartialOpenFluxSurface] | None:
     """
@@ -413,7 +413,14 @@ def _make_flux_surfaces_ibob(
         )
         if (
             fs := _make_flux_surfaces(
-                x, o_point.z, equilibrium, o_point, yz_plane, lcfs_perimter, dl, outboard=outboard
+                x,
+                o_point.z,
+                equilibrium,
+                o_point,
+                yz_plane,
+                lcfs_perimter,
+                dl,
+                outboard=outboard,
             )
         )
         is not None

--- a/tests/radiation_transport/test_advective_transport.py
+++ b/tests/radiation_transport/test_advective_transport.py
@@ -196,6 +196,7 @@ class TestChargedParticleRecursionSN:
                 self.solver._o_point,
                 self.solver._yz_plane,
                 self.solver.eq.get_LCFS().length,
+                outboard=True,
             )
 
             self.solver.flux_surfaces_ob_down.append(lfs)
@@ -268,6 +269,7 @@ class TestChargedParticleRecursionDN:
                 self.solver._o_point,
                 self.solver._yz_plane,
                 self.solver.eq.get_LCFS().length,
+                outboard=True,
             )
 
             self.solver.flux_surfaces_ob_down.append(lfs)


### PR DESCRIPTION
## Description

_make_flux_surfaces needs to use 'split' and 'sort' in the same way as the LegFlux class for equilibrium with separatrices that loop around the coils. N.B. Flux surface appears 'closed' because at this stage the code has no knowledge of the first wall. 

Steps:
- Add artificial break(s) at the largest z-coordinate(s) of the 'closed' flux line that loops around the divertor(s) coils. 
- If the equilibrium is DN then sort the split flux surfaces by IB then OB and select appropriate

There was also a typo - missing '[0]' was found and added.

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
