### PR TITLE
Geometry optimisation robustness: penalty function and OutOfBoundsError

### DIFF
--- a/bluemira/geometry/error.py
+++ b/bluemira/geometry/error.py
@@ -47,6 +47,21 @@ class GeometryParameterisationError(GeometryError):
     """
 
 
+class OutOfBoundsError(GeometryParameterisationError):
+    """A parameterisation was asked to build geometry outside its valid domain.
+
+    Raised by ``create_shape`` when the requested variables do not describe a
+    constructable shape (e.g. arc angles that sum past the symmetry limit).
+    Carries ``excess``: a dimensionless, non-negative measure of how far the
+    request is out of bounds, so an optimiser probing an infeasible point can
+    penalise proportionally and recover rather than crash.
+    """
+
+    def __init__(self, message: str, excess: float = 1.0):
+        super().__init__(message)
+        self.excess = max(float(excess), 0.0)
+
+
 class CoordinatesError(GeometryError):
     """
     Error class for use in Coordinates

--- a/bluemira/geometry/optimisation/_tools.py
+++ b/bluemira/geometry/optimisation/_tools.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from bluemira.geometry.error import OutOfBoundsError
 from bluemira.geometry.optimisation.typed import (
     GeomClsOptimiserCallable,
     GeomConstraintT,
@@ -52,10 +53,20 @@ def to_objective(
     :
         The objective function converted from a geometry objective function.
     """
+    worst = [0.0]  # largest finite objective value seen so far
 
     def f(x):
         geom.variables.set_values_from_norm(x)
-        return geom_objective(geom)
+        try:
+            value = geom_objective(geom)
+        except OutOfBoundsError as exc:
+            # No constructable geometry here. Penalise above the worst feasible
+            # value seen, growing with how far out of bounds we are, so a
+            # gradient-based optimiser is pushed back to the feasible region
+            # instead of crashing on the geometry build.
+            return (abs(worst[0]) + 1.0) * (1.0 + exc.excess)
+        worst[0] = max(worst[0], value)
+        return value
 
     return f
 
@@ -73,10 +84,22 @@ def to_optimiser_callable(
     :
         The optimiser function converted from a geometry optimiser function.
     """
+    state = {"shape": None, "worst": 0.0}  # last output shape, largest magnitude
 
     def f(x):
         geom.variables.set_values_from_norm(x)
-        return geom_callable(geom)
+        try:
+            value = geom_callable(geom)
+        except OutOfBoundsError as exc:
+            # See ``to_objective``: penalise (a constraint reads as strongly
+            # violated) rather than crash on the geometry build.
+            penalty = (state["worst"] + 1.0) * (1.0 + exc.excess)
+            return penalty if not state["shape"] else np.full(state["shape"], penalty)
+        arr = np.asarray(value, dtype=float)
+        state["shape"] = arr.shape
+        if arr.size:
+            state["worst"] = max(state["worst"], float(np.max(np.abs(arr))))
+        return value
 
     return f
 

--- a/bluemira/geometry/parameterisations.py
+++ b/bluemira/geometry/parameterisations.py
@@ -32,7 +32,7 @@ from bluemira.base.look_and_feel import bluemira_warn
 from bluemira.codes import _geometryapi as cadapi
 from bluemira.display.plotter import plot_2d
 from bluemira.geometry.coordinates import Coordinates
-from bluemira.geometry.error import GeometryParameterisationError
+from bluemira.geometry.error import GeometryParameterisationError, OutOfBoundsError
 from bluemira.geometry.tools import (
     interpolate_bspline,
     make_bezier,
@@ -1411,10 +1411,11 @@ def _get_centres(
 
     Raises
     ------
+    OutOfBoundsError
+        The total angle of the defined curves exceeds pi (reflection_zplane given)
+        or 2pi (reflection_zplane not given).
     GeometryParameterisationError
-        The total angle of the defined curves must be below pi (reflection_zplane given)
-        or below 2pi (reflection_zplane not given). And the parametrised curve must not
-        intersect itself. Otherwise, this error is raised.
+        The parametrised curve intersects itself.
     """
     a_start: float = 0.0
     xi, zi = x_start, z_start
@@ -1443,9 +1444,13 @@ def _get_centres(
 
     vertical_symmetry = reflection_zplane is not None
     if a_start >= 180 and vertical_symmetry:  # noqa: PLR2004
-        raise GeometryParameterisationError("The total angles should add up to <180°.")
+        raise OutOfBoundsError(
+            "The total angles should add up to <180°.", excess=a_start / 180 - 1
+        )
     if a_start >= 360 and not vertical_symmetry:  # noqa: PLR2004
-        raise GeometryParameterisationError("The total angles should add up to <360°.")
+        raise OutOfBoundsError(
+            "The total angles should add up to <360°.", excess=a_start / 360 - 1
+        )
 
     _, _, vec = _project_centroid(xc, zc, xi, zi, ri)
 

--- a/tests/geometry/test_parameterisations.py
+++ b/tests/geometry/test_parameterisations.py
@@ -14,7 +14,7 @@ import pytest
 
 import bluemira.codes._geometryapi as _cadapi
 from bluemira.geometry.coordinates import Coordinates
-from bluemira.geometry.error import GeometryParameterisationError
+from bluemira.geometry.error import GeometryParameterisationError, OutOfBoundsError
 from bluemira.geometry.face import BluemiraFace
 from bluemira.geometry.optimisation._tools import KeepOutZone
 from bluemira.geometry.optimisation.problem import GeomOptimisationProblem
@@ -589,6 +589,18 @@ class TestTripleArc:
         p.variables.sl.adjust(5)
         with pytest.raises(GeometryParameterisationError):
             p.create_shape()
+
+    def test_excessive_angles_raise_out_of_bounds_with_excess(self):
+        # Angles past the 180° symmetry limit raise the specific, optimiser-
+        # recoverable OutOfBoundsError, carrying how far out of bounds it is.
+        p = TripleArc()
+        p.adjust_variable("a1", value=120)
+        p.adjust_variable("a2", value=120)  # sum 240 -> 240/180 - 1
+        with pytest.raises(OutOfBoundsError) as exc_info:
+            p.create_shape()
+        assert exc_info.value.excess == pytest.approx(240 / 180 - 1)
+        # Still a GeometryParameterisationError, so existing handlers catch it.
+        assert isinstance(exc_info.value, GeometryParameterisationError)
 
     def test_plot(self):
         p = TripleArc()

--- a/tests/optimisation/geometry/test_geometry.py
+++ b/tests/optimisation/geometry/test_geometry.py
@@ -8,8 +8,10 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from bluemira.geometry.error import OutOfBoundsError
 from bluemira.geometry.optimisation import optimise_geometry
 from bluemira.geometry.optimisation._optimise import KeepOutZone
+from bluemira.geometry.optimisation._tools import to_objective, to_optimiser_callable
 from bluemira.geometry.parameterisations import (
     GeometryParameterisation,
     PictureFrame,
@@ -270,3 +272,71 @@ class TestGeometry:
         )
 
         assert square_constraint(result.geom)[0] == pytest.approx(0, abs=1e-8)
+
+
+class TestOutOfBoundsPenalty:
+    """The geometry-optimisation wrappers penalise (rather than crash on) a
+    parameterisation that builds invalid geometry, so an optimiser probing an
+    infeasible point recovers. Reproduces the class of EUDEMO demo crashes where
+    ``create_shape`` raised ``OutOfBoundsError`` mid-optimisation.
+    """
+
+    @staticmethod
+    def _fake_geom():
+        # Stand-in geometry whose ``variables.set_values_from_norm`` is a no-op.
+        def _noop(_x):
+            return None
+
+        variables = type("V", (), {"set_values_from_norm": staticmethod(_noop)})
+        return type("G", (), {"variables": variables})()
+
+    @staticmethod
+    def _raises(excess):
+        def objective(_geom):
+            raise OutOfBoundsError("out of bounds", excess=excess)
+
+        return objective
+
+    def test_objective_penalises_out_of_bounds_instead_of_raising(self):
+        feasible = [10.0, 20.0]
+
+        def objective(_geom):
+            if feasible:
+                return feasible.pop(0)
+            raise OutOfBoundsError("out of bounds", excess=0.5)
+
+        f = to_objective(objective, self._fake_geom())
+        assert f([0]) == pytest.approx(10.0)
+        assert f([0]) == pytest.approx(20.0)  # worst feasible value seen is now 20
+        penalty = f([0])  # next call raises -> penalised, not propagated
+        assert np.isfinite(penalty)
+        assert penalty > 20.0  # strictly worse than any feasible value
+
+    def test_objective_penalty_grows_with_excess(self):
+        small = to_objective(self._raises(0.1), self._fake_geom())([0])
+        big = to_objective(self._raises(2.0), self._fake_geom())([0])
+        assert big > small
+
+    def test_constraint_penalises_with_matching_shape(self):
+        outputs = [np.array([1.0, -2.0, 0.5])]
+
+        def constraint(_geom):
+            if outputs:
+                return outputs.pop(0)
+            raise OutOfBoundsError("out of bounds", excess=1.0)
+
+        f = to_optimiser_callable(constraint, self._fake_geom())
+        assert f([0]).shape == (3,)
+        penalty = f([0])  # raises -> violated constraint vector of the same shape
+        assert penalty.shape == (3,)
+        assert np.all(penalty > 0)  # reads as strongly violated
+
+    def test_objective_survives_real_invalid_parameterisation(self):
+        # Faithful path: a real TripleArc whose angles are out of bounds makes
+        # create_shape raise; the wrapped objective penalises instead of crashing.
+        arc = TripleArc()
+        arc.adjust_variable("a1", value=120)
+        arc.adjust_variable("a2", value=120)  # sum 240 -> create_shape raises
+        x = arc.variables.get_normalised_values()
+        f = to_objective(lambda g: g.create_shape().length, arc)
+        assert np.isfinite(f(x))


### PR DESCRIPTION
…appers, so an optimiser probing infeasible geometry is penalised rather than crashing (fixed the TF-coil TripleArc-angle crash).

## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
