### PR TITLE
Use absolute value of `target_value` when calculating tolerance in MagneticConstraint

### DIFF
--- a/bluemira/equilibria/optimisation/constraints.py
+++ b/bluemira/equilibria/optimisation/constraints.py
@@ -428,7 +428,7 @@ class MagneticConstraint(UpdateableConstraint):
     ):
         self.target_value = target_value * np.ones(len(self))
         if tolerance is None:
-            tolerance = 1e-3 if target_value == 0 else 1e-3 * target_value
+            tolerance = 1e-3 if target_value == 0 else 1e-3 * np.abs(target_value)
         if is_num(tolerance):
             if f_constraint == L2NormConstraint:
                 tolerance *= np.ones(1)


### PR DESCRIPTION
## Linked Issues

<!-- Does this PR close or fix any Issues? Remember to create an Issue before starting work so that your fix / proposal can be addressed by the team. -->

We found that if you use a negative value for the `target_value` without specifying the tolerance, you get a failure when using the PicardIterator in an optimisation. Here is the failure when I use a `PsiBoundaryConstraint` with a negative target value and no tolerance specified :
<img width="533" height="97" alt="image" src="https://github.com/user-attachments/assets/b7b9b718-c5b5-4ba3-aa51-a17074dfdffd" />

<img width="949" height="686" alt="image" src="https://github.com/user-attachments/assets/c2c519b7-dd8f-49a7-994c-0d9054a3fcc6" />

With no tolerance specified, the tolerance is calculated as follows in MagneticConstraint:

<img width="691" height="54" alt="image" src="https://github.com/user-attachments/assets/1e5bf30b-c989-44f5-beef-ea754938ecf0" />

This default tolerance calculation should use the absolute value of the target instead, since tolerance cannot be negative and currently fails in this case.

Closes #{ID}

## Description

<!-- What is your PR trying to achieve? How did you go about achieving it? -->

## Interface Changes

<!-- If you've had to update an interface or introduce a new interface as part of your change then let us know here. -->

## Checklist

I confirm that I have completed the following checks:

- [ ] Tests run locally and pass `pytest tests --reactor`
- [ ] Code quality checks run locally and pass `pre-commit run --from-ref develop --to-ref HEAD`
- [ ] Documentation built locally and checked `sphinx-build -W documentation/source documentation/build`
